### PR TITLE
Gate every chat start on durable owner questions

### DIFF
--- a/backend/app/chat_start.py
+++ b/backend/app/chat_start.py
@@ -23,6 +23,7 @@ from app.chat import (
 )
 from app.chat_writer import (
   StartTurn,
+  StartTurnBlockedByPendingQuestion,
   alloc_run_token,
   await_ack,
   get_writer,
@@ -40,9 +41,10 @@ async def start_programmatic_chat_turn(
   boundary owns the claim, writer command, Stop-generation fence, broadcast,
   task creation, and failure cleanup so those steps cannot drift by caller.
 
-  Returns ``False`` when the claim fails or a Stop wins while ``StartTurn`` is
-  committing.  Unexpected failures propagate after releasing the transient
-  claim; the durable run remains available to normal reconciliation.
+  Returns ``False`` when the claim fails, an owner question is pending, or a
+  Stop wins while ``StartTurn`` is committing. Unexpected failures propagate
+  after releasing the transient claim; the durable run remains available to
+  normal reconciliation.
   """
   if not mark_starting(chat_id):
     return False
@@ -63,6 +65,10 @@ async def start_programmatic_chat_turn(
       default_provider=provider,
       initiated_by_app_id=initiated_by_app_id,
     )))
+
+    if isinstance(result, StartTurnBlockedByPendingQuestion):
+      discard_starting(chat_id)
+      return False
 
     if current_run_generation(chat_id) != start_gen:
       discard_starting(chat_id)

--- a/backend/app/chat_writer.py
+++ b/backend/app/chat_writer.py
@@ -386,6 +386,13 @@ class ReconcileStartupChat(_Command):
 # (chat_id, run_token) key on submit.
 
 
+@dataclass(frozen=True)
+class StartTurnBlockedByPendingQuestion:
+  """Expected non-start when the chat is waiting for its owner."""
+
+  question_id: str
+
+
 @dataclass
 class StartTurn(_Command):
   """Initial send: append the user message, set title/provider, mark run.
@@ -395,7 +402,8 @@ class StartTurn(_Command):
   first message, sets `provider` when the chat had no messages, stamps
   `updated_at`, and sets the durable run marker — all in one commit.
   Returns `{"history", "session_id", "provider"}` for the caller to spawn
-  the runner; `history` is a list of `schemas.ChatMessage` (run_chat reads
+  the runner, or ``StartTurnBlockedByPendingQuestion`` when an owner question
+  is open. `history` is a list of `schemas.ChatMessage` (run_chat reads
   `messages[-1].content`), built exactly as the production initial-send path.
   """
 
@@ -2047,7 +2055,9 @@ class ChatWriterActor:
           f"thinking_id={thinking_id}"
         )
 
-  def _start_turn(self, db, cmd: StartTurn) -> dict:
+  def _start_turn(
+    self, db, cmd: StartTurn,
+  ) -> dict | StartTurnBlockedByPendingQuestion:
     """Append the initial user message, set title/provider, mark the run.
 
     Replicates the fresh-start branch of `send_message`: builds the agent
@@ -2094,6 +2104,13 @@ class ChatWriterActor:
             "session_id": chat.session_id,
             "provider": chat.provider,
           }
+    # The actor owns the durable StartTurn transition, so every caller gets
+    # the same question gate and a question cannot open in a caller's
+    # check-to-commit window. Duplicate retries above remain acknowledgements.
+    if chat.pending_question_id is not None:
+      question_id = chat.pending_question_id
+      db.rollback()  # End the actor's read transaction on this non-write path.
+      return StartTurnBlockedByPendingQuestion(question_id)
     if not existing:
       chat.provider = cmd.default_provider or "claude"
     # Build the agent history as schemas.ChatMessage objects, exactly as the

--- a/backend/app/delegations.py
+++ b/backend/app/delegations.py
@@ -455,8 +455,9 @@ async def _deliver_parent_wake(parent_chat_id: str) -> bool:
   """Coalesce every wake-eligible child for one parent into a single notice and
   deliver it under the parent's queue lock.
 
-  Idle parent -> start a fresh turn; running or question-blocked parent -> queue
-  the notice so its own next continuation promotes it. The `parent_woken_at`
+  Idle parent -> try a fresh turn; running parent -> queue the notice. If the
+  actor rejects the start (including for an open owner question), queue it so
+  the parent's next continuation promotes it. The `parent_woken_at`
   retry latch is stamped only after delivery succeeds. A crash between those
   transactions can redeliver, which is preferable to silently losing a child
   result; the ordinary in-process path is serialized by the queue lock.
@@ -481,10 +482,9 @@ async def _deliver_parent_wake(parent_chat_id: str) -> bool:
       if parent_chat is None:
         return False
       provider = parent_chat.provider or "claude"
-      has_pending_question = parent_chat.pending_question_id is not None
 
     delivered = False
-    if has_pending_question or is_chat_running(parent_chat_id):
+    if is_chat_running(parent_chat_id):
       delivered = await _append_wake_pending(content, parent_chat_id)
     else:
       delivered = await start_programmatic_chat_turn(
@@ -495,8 +495,8 @@ async def _deliver_parent_wake(parent_chat_id: str) -> bool:
         initiated_by_app_id=None,
       )
       if not delivered:
-        # A real turn claimed the parent in the check->start window; queue the
-        # notice so it rides that turn's drain instead of being lost.
+        # The actor refused the start (for example, an owner question opened or
+        # a real turn claimed the parent); queue the notice instead.
         delivered = await _append_wake_pending(content, parent_chat_id)
 
     if not delivered:

--- a/backend/app/routes/chats_stream.py
+++ b/backend/app/routes/chats_stream.py
@@ -28,6 +28,7 @@ from app.chat_writer import (
   AppendPending,
   CancelPending,
   StartTurn,
+  StartTurnBlockedByPendingQuestion,
   alloc_run_token,
   await_ack,
   cid_of,
@@ -53,6 +54,10 @@ from app.resource_access import (
 router = APIRouter(prefix="/api/chats", tags=["chats"])
 
 log = logging.getLogger(__name__)
+
+_PENDING_QUESTION_SEND_DETAIL = (
+  "Answer the pending question, or Stop the turn, before sending."
+)
 
 # Keepalive interval for the SSE stream to prevent proxy timeouts.
 _KEEPALIVE_INTERVAL = 30  # seconds
@@ -735,7 +740,7 @@ async def send_message(
   if not body.force_steer and chat.pending_question_id is not None:
     raise HTTPException(
       status_code=409,
-      detail="Answer the pending question, or Stop the turn, before sending.",
+      detail=_PENDING_QUESTION_SEND_DETAIL,
     )
 
   # A pending question parks the provider's control channel inside the
@@ -1051,6 +1056,10 @@ async def _send_message_locked(
       result = await await_ack(ack)
     except Exception as exc:
       raise _message_persist_unavailable(exc, chat_id=chat_id) from exc
+    if isinstance(result, StartTurnBlockedByPendingQuestion):
+      # The question opened after the route's early check but before the
+      # actor-owned transition. The outer cleanup releases this route's claim.
+      raise HTTPException(status_code=409, detail=_PENDING_QUESTION_SEND_DETAIL)
     if result.get("duplicate"):
       # The first POST committed but its acknowledgement was lost. The actor
       # found this cid in durable state, so the retry is complete without a

--- a/backend/tests/test_chat_start.py
+++ b/backend/tests/test_chat_start.py
@@ -6,7 +6,7 @@ from types import SimpleNamespace
 import pytest
 
 from app import chat_start
-from app.chat_writer import StartTurn
+from app.chat_writer import StartTurn, StartTurnBlockedByPendingQuestion
 
 
 class _Writer:
@@ -18,7 +18,9 @@ class _Writer:
     return "ack"
 
 
-def _install_start_fakes(monkeypatch, *, generations=(7, 7)):
+def _install_start_fakes(
+  monkeypatch, *, generations=(7, 7), ack_result=None,
+):
   writer = _Writer()
   generation_values = iter(generations)
   discarded = []
@@ -42,7 +44,7 @@ def _install_start_fakes(monkeypatch, *, generations=(7, 7)):
 
   async def fake_await_ack(ack):
     assert ack == "ack"
-    return {
+    return ack_result if ack_result is not None else {
       "history": ["prepared-message"],
       "session_id": "session-1",
       "provider": "claude",
@@ -147,6 +149,25 @@ async def test_programmatic_start_does_nothing_when_claim_is_busy(monkeypatch):
   assert await chat_start.start_programmatic_chat_turn(
     chat_id="busy", title="t", content="c", provider="codex",
   ) is False
+
+
+@pytest.mark.asyncio
+async def test_programmatic_start_yields_to_pending_owner_question(monkeypatch):
+  state = _install_start_fakes(
+    monkeypatch,
+    ack_result=StartTurnBlockedByPendingQuestion("owner-decision"),
+  )
+
+  started = await chat_start.start_programmatic_chat_turn(
+    chat_id="blocked", title="t", content="c", provider="codex",
+  )
+
+  assert started is False
+  assert len(state.writer.commands) == 1
+  assert state.created_broadcasts == []
+  assert state.scheduled == []
+  assert state.system_events == []
+  assert state.discarded == ["blocked"]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_chat_writer_contention.py
+++ b/backend/tests/test_chat_writer_contention.py
@@ -40,6 +40,7 @@ from app.chat_writer import (
   RecoverWedgedRun,
   ReplaceTranscript,
   StartTurn,
+  StartTurnBlockedByPendingQuestion,
 )
 from app.database import SessionLocal
 
@@ -635,7 +636,11 @@ def test_start_turn_retry_after_completion_is_idempotent(actor):
   original = {
     "role": "user", "content": "build it", "ts": 5, "cid": "cid-stable",
   }
-  _seed_chat(messages=[original], session_id="sess-x")
+  _seed_chat(
+    messages=[original],
+    session_id="sess-x",
+    pending_question_id="later-question",
+  )
 
   result = _await(actor.submit(
     StartTurn(
@@ -655,9 +660,34 @@ def test_start_turn_retry_after_completion_is_idempotent(actor):
   assert result["message"] == original
   chat = _load_chat()
   assert chat["messages"] == [original]
+  assert chat["pending_question_id"] == "later-question"
   assert chat["running_status"] is None
   assert chat["running_started_at"] is None
   assert _load_run("retry-run") is None
+
+
+def test_start_turn_does_not_bypass_pending_owner_question(actor):
+  question = _question_msg("owner-decision", content="Choose a direction.")
+  _seed_chat(
+    messages=[question],
+    pending_question_id="owner-decision",
+  )
+
+  result = _await(actor.submit(StartTurn(
+    chat_id="c1",
+    run_token="blocked-run",
+    user_msg={"role": "user", "content": "Continue automatically", "ts": 5},
+    title_source="Continue automatically",
+    default_provider="codex",
+  )))
+
+  assert result == StartTurnBlockedByPendingQuestion("owner-decision")
+  chat = _load_chat()
+  assert chat["messages"] == [question]
+  assert chat["pending_question_id"] == "owner-decision"
+  assert chat["live_assistant"] is None
+  assert chat["running_status"] is None
+  assert _load_run("blocked-run") is None
 
 
 def test_persist_session_id_updates_chat_without_touching_transcript(actor):

--- a/backend/tests/test_contribution_autopilot.py
+++ b/backend/tests/test_contribution_autopilot.py
@@ -366,6 +366,60 @@ def test_followup_chat_hidden_on_close_out(db):
   assert _visible_in_owner_drawer(_chat()) is False
 
 
+@pytest.mark.asyncio
+async def test_round_turn_does_not_bypass_pending_owner_question(
+  db, monkeypatch,
+):
+  """An escalated Autopilot chat stays parked until its owner answers."""
+  from app import chat as chat_mod
+
+  question = {
+    "role": "assistant",
+    "content": "Choose a direction.",
+    "blocks": [{
+      "type": "question",
+      "question_id": "owner-decision",
+      "questions": [{
+        "id": "owner-decision", "question": "Which direction?",
+      }],
+    }],
+  }
+  chat = models.Chat(
+    id="autopilot-question-blocked",
+    title="Autopilot follow-up",
+    messages=[question],
+    pending_messages=[],
+    provider="claude",
+    pending_question_id="owner-decision",
+  )
+  db.add(chat)
+  db.commit()
+  monkeypatch.setattr(chat_mod, "is_chat_running", lambda _chat_id: False)
+  starts = []
+
+  async def blocked_start(**kwargs):
+    starts.append(kwargs)
+    return False
+
+  monkeypatch.setattr(autopilot, "start_programmatic_chat_turn", blocked_start)
+
+  started = await autopilot.spawn_round_turn(
+    db,
+    chat.id,
+    title="Autopilot follow-up",
+    content="Continue automatically",
+    provider="claude",
+  )
+
+  assert started is False
+  assert [start["chat_id"] for start in starts] == [chat.id]
+  db.expire_all()
+  parked = db.get(models.Chat, chat.id)
+  assert parked.messages == [question]
+  assert parked.pending_question_id == "owner-decision"
+  assert db.query(models.ChatRun).filter_by(chat_id=chat.id).count() == 0
+
+
 def test_failed_surfacing_leaves_escalation_retryable(db):
   """A crash while surfacing must not consume the one-shot escalate latch.
 

--- a/backend/tests/test_delegations.py
+++ b/backend/tests/test_delegations.py
@@ -413,25 +413,37 @@ def test_running_parent_gets_appended_not_started(db, monkeypatch):
 
 
 def test_question_blocked_parent_gets_appended_not_started(db, monkeypatch):
-  """A durable owner question is a busy parent even without a live runner."""
+  """The actor rejects the start and delegation falls back to the queue."""
   parent_id, child_id, delegation_id = _seed_delegation(
     db,
     suffix="question",
     result_blocks=[{"type": "text", "content": "Result while blocked."}],
     parent_pending_question_id="owner-decision",
   )
-  starts = _capture_starts(monkeypatch, running=False)
+  monkeypatch.setattr(chat_mod, "is_chat_running", lambda _cid: False)
+  starts = []
+  queued = []
+
+  async def blocked_start(**kwargs):
+    starts.append(kwargs)
+    return False
+
+  async def append_pending(content, chat_id):
+    queued.append((content, chat_id))
+    return True
+
+  monkeypatch.setattr(chat_start_mod, "start_programmatic_chat_turn", blocked_start)
+  monkeypatch.setattr(delegations_mod, "_append_wake_pending", append_pending)
 
   asyncio.run(delegations_mod.wake_parent_after_child_settled(child_id))
 
-  assert starts == []
+  assert [start["chat_id"] for start in starts] == [parent_id]
+  assert len(queued) == 1
+  assert queued[0][1] == parent_id
+  assert "task-question" in queued[0][0]
   db.expire_all()
   parent = db.get(models.Chat, parent_id)
   assert parent.pending_question_id == "owner-decision"
-  assert any(
-    "task-question" in (message.get("content") or "")
-    for message in (parent.pending_messages or [])
-  )
   assert db.get(models.Delegation, delegation_id).parent_woken_at is not None
 
 


### PR DESCRIPTION
Moves the pending-question invariant to the ChatWriter StartTurn transition so interactive sends, programmatic starts, delegation wakeups, and Autopilot share one atomic gate. Callers receive one typed non-start result; the duplicate delegation precheck is removed. Focused actor/programmatic tests: 12 passed; delegation/autopilot tests: 2 passed; pre-push syntax/privacy checks passed.