### PR TITLE
CI: promote main through managed core releases

### DIFF
--- a/.github/workflows/core-digest-image.yml
+++ b/.github/workflows/core-digest-image.yml
@@ -19,6 +19,7 @@ on:
         type: string
 
 permissions:
+  actions: write
   contents: read
   packages: write
 
@@ -484,3 +485,17 @@ jobs:
             --repository "$MOBIUS_IMAGE_REPOSITORY" \
             --prerequisite-revision "$FROZEN_COMPATIBILITY_SHA" \
             --prerequisite-digest "$FROZEN_COMPATIBILITY_DIGEST"
+
+      # The next automatic promotion must name the release that has just
+      # completed.  Keep this after the controller and registry proofs: an
+      # interrupted or failed publication may never become a prerequisite.
+      - name: Record completed core as the next prerequisite
+        if: steps.current.outputs.mode != 'replay'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          IMAGE_DIGEST: ${{ steps.selected.outputs.digest }}
+        run: |
+          gh variable set MOBIUS_MANAGED_CORE_PREREQUISITE_SHA \
+            --repo "$GITHUB_REPOSITORY" --body "$CANDIDATE_SHA"
+          gh variable set MOBIUS_MANAGED_CORE_PREREQUISITE_DIGEST \
+            --repo "$GITHUB_REPOSITORY" --body "$IMAGE_DIGEST"

--- a/.github/workflows/promote-main-managed-core.yml
+++ b/.github/workflows/promote-main-managed-core.yml
@@ -14,7 +14,8 @@ concurrency:
 
 permissions:
   actions: write
-  contents: read
+  # Required to enqueue the protected release PR; the workflow never pushes it.
+  contents: write
   pull-requests: write
 
 jobs:
@@ -105,5 +106,5 @@ jobs:
           RELEASE_SHA: ${{ steps.merged.outputs.sha }}
         run: |
           gh workflow run "$RELEASE_WORKFLOW" --repo "$GITHUB_REPOSITORY" \
-            --ref "$RELEASE_REF"
+            --ref "$RELEASE_REF" -f candidate_sha="$RELEASE_SHA"
           echo "Dispatched managed-core publication for $RELEASE_SHA"

--- a/.github/workflows/promote-main-managed-core.yml
+++ b/.github/workflows/promote-main-managed-core.yml
@@ -1,0 +1,109 @@
+name: Promote main to managed core
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# The opt-in is deliberately a protected repository variable. It lets the
+# workflow land before it is armed, and gives operators a one-switch pause
+# without weakening the branch or image-release contracts.
+concurrency:
+  group: mobius-main-managed-core-promotion
+  cancel-in-progress: false
+
+permissions:
+  actions: write
+  contents: read
+  pull-requests: write
+
+jobs:
+  promote:
+    if: vars.MOBIUS_MANAGED_CORE_AUTOPROMOTION_ENABLED == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 240
+    env:
+      GH_TOKEN: ${{ github.token }}
+      RELEASE_REF: stack/external-recovery-v1
+      RELEASE_WORKFLOW: core-digest-image.yml
+    steps:
+      - name: Wait for the previous managed-core publication
+        run: |
+          deadline=$(($(date -u +%s) + 10800))
+          while true; do
+            active=$(gh run list --repo "$GITHUB_REPOSITORY" \
+              --workflow "$RELEASE_WORKFLOW" --limit 100 \
+              --json status --jq '[.[] | select(.status == "queued" or .status == "in_progress" or .status == "waiting" or .status == "pending")] | length')
+            if [ "$active" = 0 ]; then
+              break
+            fi
+            if [ "$(date -u +%s)" -ge "$deadline" ]; then
+              echo "Timed out waiting for the preceding managed-core publication" >&2
+              exit 1
+            fi
+            echo "A managed-core publication is still active"
+            sleep 15
+          done
+
+      - name: Open or reuse the protected release pull request
+        id: release_pr
+        run: |
+          ahead=$(gh api "repos/$GITHUB_REPOSITORY/compare/$RELEASE_REF...main" \
+            --jq .ahead_by)
+          if [ "$ahead" = 0 ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "The protected release already contains main"
+            exit 0
+          fi
+          number=$(gh pr list --repo "$GITHUB_REPOSITORY" \
+            --base "$RELEASE_REF" --head main --state open \
+            --json number --jq '.[0].number // empty')
+          if [ -z "$number" ]; then
+            number=$(gh pr create --repo "$GITHUB_REPOSITORY" \
+              --base "$RELEASE_REF" --head main \
+              --title 'Promote current main to managed core' \
+              --body 'Automated protected-release promotion from main. The existing required checks and digest-bound publish workflow remain mandatory.')
+            number=${number##*/}
+          fi
+          gh pr merge "$number" --repo "$GITHUB_REPOSITORY" --auto --merge
+          echo "number=$number" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for the protected release merge
+        if: steps.release_pr.outputs.skip != 'true'
+        id: merged
+        env:
+          PR_NUMBER: ${{ steps.release_pr.outputs.number }}
+        run: |
+          deadline=$(($(date -u +%s) + 10800))
+          while true; do
+            state=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
+              --json state --jq .state)
+            if [ "$state" = MERGED ]; then
+              sha=$(gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/$RELEASE_REF" \
+                --jq .object.sha)
+              case "$sha" in
+                *[!0-9a-f]*|'') exit 1 ;;
+              esac
+              test "${#sha}" -eq 40
+              echo "sha=$sha" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            if [ "$state" = CLOSED ] || [ "$(date -u +%s)" -ge "$deadline" ]; then
+              echo "The protected release pull request did not merge" >&2
+              exit 1
+            fi
+            sleep 15
+          done
+
+      # A PR merged with GITHUB_TOKEN does not emit a follow-on push workflow.
+      # Dispatch the existing governed publisher explicitly; it still performs
+      # the controller prerequisite, immutable GHCR build, bind, and fleet
+      # rollout checks against the just-merged protected branch.
+      - name: Dispatch the digest-bound core publisher
+        if: steps.release_pr.outputs.skip != 'true'
+        env:
+          RELEASE_SHA: ${{ steps.merged.outputs.sha }}
+        run: |
+          gh workflow run "$RELEASE_WORKFLOW" --repo "$GITHUB_REPOSITORY" \
+            --ref "$RELEASE_REF"
+          echo "Dispatched managed-core publication for $RELEASE_SHA"

--- a/backend/tests/test_verify_test_runtime.py
+++ b/backend/tests/test_verify_test_runtime.py
@@ -743,7 +743,12 @@ def test_recurring_core_digest_workflow_keeps_dynamic_and_frozen_identity_separa
   )
   assert postpublish < final_current
 
-  assert "permissions:\n  contents: read\n  packages: write\n" in workflow
+  # The publisher dispatches its governed follow-on workflow, so it needs
+  # Actions write in addition to the read-only repository and registry grants.
+  assert (
+    "permissions:\n  actions: write\n  contents: read\n  packages: write\n"
+    in workflow
+  )
   assert "environment: external-recovery-release" in workflow
   assert "group: mobius-core-image-publication" in workflow
   assert "cancel-in-progress: false" in workflow


### PR DESCRIPTION
Adds a guarded main-to-managed-core promotion workflow. Each main push opens or reuses a protected release PR, waits for its required checks and merge, then dispatches the existing digest-bound GHCR publisher. Completed releases record the exact next prerequisite.