### PR TITLE
Make provider switches accept modern Codex efforts and report failures safely

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -521,7 +521,13 @@ class ChatProviderSwitch(BaseModel):
       raise ValueError("target model does not belong to target provider")
     self.agent_settings_json.model = model
     allowed_efforts = {
-      "codex": {"none", "minimal", "low", "medium", "high", "xhigh"},
+      # Codex's newer model catalogs extend the original ReasoningEffort
+      # scale with max/ultra. AgentSettingsOverride already accepts both and
+      # the model picker only offers levels advertised by the selected model,
+      # so the atomic provider-switch boundary must accept them too.
+      "codex": {
+        "none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra",
+      },
       "claude": {"low", "medium", "high", "xhigh", "max", "ultracode"},
     }
     if effort not in allowed_efforts[self.provider]:

--- a/backend/tests/test_chat_compact.py
+++ b/backend/tests/test_chat_compact.py
@@ -573,6 +573,36 @@ def test_switch_requires_coherent_target_settings(client, auth):
   assert response.status_code == 422
 
 
+@pytest.mark.parametrize("effort", ["max", "ultra"])
+def test_switch_accepts_newer_codex_catalog_efforts(
+  client, auth, monkeypatch, effort,
+):
+  """A picker-valid Sol effort must reach synthesis instead of 422ing."""
+  _connect_codex(monkeypatch)
+
+  async def _stub(_messages, **_kwargs):
+    return "portable Sol handoff"
+
+  monkeypatch.setattr(compaction, "summarize_chat", _stub)
+  chat_id = _make_chat_with_messages(client, auth, [
+    {"role": "user", "content": "hi"},
+    {"role": "assistant", "content": "hello"},
+  ])
+  payload = _payload(switch_id=f"sol-{effort}")
+  payload["agent_settings_json"].update({
+    "model": "gpt-5.6-sol",
+    "effort": effort,
+    "effort_by_provider": {"claude": "ultracode", "codex": effort},
+  })
+
+  response = client.post(
+    f"/api/chats/{chat_id}/provider-switch", headers=auth, json=payload,
+  )
+
+  assert response.status_code == 200, response.text
+  assert response.json()["effective"]["effort"] == effort
+
+
 def test_build_transcript_text_skips_handoffs_and_tail_caps():
   messages = [
     {"role": "user", "content": "first"},

--- a/frontend/src/components/ChatView/ChatSettingsPanel.jsx
+++ b/frontend/src/components/ChatView/ChatSettingsPanel.jsx
@@ -763,7 +763,7 @@ export default function ChatSettingsPanel({
                       onClick={handleConfirmProviderSwitch}
                       disabled={switchBusy}
                     >
-                      Switch provider
+                      {switchBusy ? 'Preparing…' : 'Switch provider'}
                     </button>
                     <button
                       type="button"
@@ -774,6 +774,9 @@ export default function ChatSettingsPanel({
                       Cancel
                     </button>
                   </div>
+                  {error && (
+                    <p className="csp__error" role="alert">{error}</p>
+                  )}
                 </div>
               )}
             </div>
@@ -834,7 +837,12 @@ export default function ChatSettingsPanel({
           )}
         </div>
       )}
-      {(appProviderLocked || codexSwitchWarning || switchBusy || error) && (
+      {(
+        appProviderLocked
+        || codexSwitchWarning
+        || switchBusy
+        || (error && !pendingSwitch)
+      ) && (
         <div className="csp__foot" aria-live="polite">
           {appProviderLocked && (
             <p className="csp__note">
@@ -853,7 +861,9 @@ export default function ChatSettingsPanel({
               reply — may briefly affect that turn.
             </p>
           )}
-          {error && <p className="csp__error" role="alert">{error}</p>}
+          {error && !pendingSwitch && (
+            <p className="csp__error" role="alert">{error}</p>
+          )}
         </div>
       )}
     </div>

--- a/frontend/src/components/ChatView/ChatSettingsPanel.jsx
+++ b/frontend/src/components/ChatView/ChatSettingsPanel.jsx
@@ -90,6 +90,7 @@ import {
   resolveProviderAvailability,
   visibleProviderModels,
 } from '../../lib/providerAvailability.js'
+import { detailToMessage } from '../../lib/errorDetail.js'
 import './ChatSettingsPanel.css'
 
 /** Claude product mark — four-petal flower / starburst silhouette,
@@ -396,8 +397,11 @@ export default function ChatSettingsPanel({
         })),
       })
       if (!res.ok) {
+        // A validation failure (incompatible target model/effort) returns a
+        // Pydantic `detail` ARRAY; normalize it to a string so it can never
+        // reach `<p>{error}</p>` and crash the shell with React error #31.
         let detail = ''
-        try { detail = (await res.json()).detail || '' } catch {}
+        try { detail = detailToMessage((await res.json())?.detail) } catch {}
         failProviderSwitch(
           chatId,
           request,

--- a/frontend/src/components/LoginForm/LoginForm.jsx
+++ b/frontend/src/components/LoginForm/LoginForm.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import { api, setToken } from '../../api/client.js'
+import { detailToMessage } from '../../lib/errorDetail.js'
 import './LoginForm.css'
 
 export default function LoginForm({ onLogin }) {
@@ -26,7 +27,7 @@ export default function LoginForm({ onLogin }) {
       const res = await api.auth.login({ username, password })
       if (!res.ok) {
         let detail = ''
-        try { detail = (await res.json())?.detail || '' } catch {}
+        try { detail = detailToMessage((await res.json())?.detail) } catch {}
         setError(res.status === 401
           ? 'Incorrect username or password.'
           : (detail || 'Sign-in is unavailable. Please try again.'))

--- a/frontend/src/components/ProviderAuth/CodexAuth.jsx
+++ b/frontend/src/components/ProviderAuth/CodexAuth.jsx
@@ -3,6 +3,7 @@ import { useQueryClient } from '@tanstack/react-query'
 import { api } from '../../api/client.js'
 import { authQueries } from '../../hooks/queries.js'
 import { closeAuthWindow, navigateAuthWindow, reserveAuthWindow } from '../../utils/authWindow.js'
+import { detailToMessage } from '../../lib/errorDetail.js'
 
 const CHATGPT_SECURITY_URL = 'https://chatgpt.com/#settings/Security'
 const OPENAI_DATA_CONTROLS_URL = 'https://help.openai.com/en/articles/7730893-data-controls-faq'
@@ -154,7 +155,7 @@ export default function CodexAuth({ onConnected, showSetupHint = true }) {
       }
       if (!res.ok) {
         const data = await res.json()
-        setError(data.detail || 'Could not start Codex login.')
+        setError(detailToMessage(data.detail, 'Could not start Codex login.'))
         setStatus('idle')
         releaseAuthWindow()
         return

--- a/frontend/src/components/ProviderAuth/ProviderAuth.jsx
+++ b/frontend/src/components/ProviderAuth/ProviderAuth.jsx
@@ -3,6 +3,7 @@ import { useQueryClient } from '@tanstack/react-query'
 import { api } from '../../api/client.js'
 import { authQueries } from '../../hooks/queries.js'
 import { closeAuthWindow, navigateAuthWindow, reserveAuthWindow } from '../../utils/authWindow.js'
+import { detailToMessage } from '../../lib/errorDetail.js'
 import './ProviderAuth.css'
 
 /**
@@ -54,7 +55,7 @@ export default function ProviderAuth({ authenticated, onDone, compact = false, c
       const res = await api.auth.provider.claude.startLogin()
       if (!res.ok) {
         const data = await res.json()
-        setError(data.detail || 'Could not start auth.')
+        setError(detailToMessage(data.detail, 'Could not start auth.'))
         releaseAuthWindow()
         return
       }
@@ -83,7 +84,7 @@ export default function ProviderAuth({ authenticated, onDone, compact = false, c
       const res = await api.auth.provider.claude.submitCode(authCode.trim())
       if (!res.ok) {
         const data = await res.json()
-        setError(data.detail || 'Failed to submit code.')
+        setError(detailToMessage(data.detail, 'Failed to submit code.'))
         return
       }
       // A 200 from /provider/code is authoritative: the backend only returns

--- a/frontend/src/lib/__tests__/errorDetail.test.js
+++ b/frontend/src/lib/__tests__/errorDetail.test.js
@@ -1,0 +1,68 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { detailToMessage } from '../errorDetail.js'
+
+test('passes a plain string detail through, trimmed', () => {
+  assert.equal(detailToMessage('  App chats cannot change provider.  '), 'App chats cannot change provider.')
+})
+
+test('empty/whitespace string falls back', () => {
+  assert.equal(detailToMessage('', 'fallback'), 'fallback')
+  assert.equal(detailToMessage('   ', 'fallback'), 'fallback')
+})
+
+test('a Pydantic 422 validation array becomes the joined msg text — never an object', () => {
+  // This is the exact shape FastAPI returns when ChatProviderSwitch's
+  // after-validator rejects an incompatible target effort. Rendering the raw
+  // array as a React child is what caused React error #31 and crashed the shell.
+  const detail = [
+    {
+      type: 'value_error',
+      loc: ['body'],
+      msg: 'Value error, target effort does not belong to target provider',
+      input: { provider: 'codex' },
+      ctx: { error: {} },
+    },
+  ]
+  const result = detailToMessage(detail, 'fallback')
+  assert.equal(typeof result, 'string')
+  assert.equal(result, 'Value error, target effort does not belong to target provider')
+})
+
+test('joins multiple validation entries', () => {
+  const detail = [
+    { type: 'value_error', loc: ['body', 'a'], msg: 'first problem' },
+    { type: 'value_error', loc: ['body', 'b'], msg: 'second problem' },
+  ]
+  assert.equal(detailToMessage(detail), 'first problem; second problem')
+})
+
+test('validation array with no usable msg falls back', () => {
+  assert.equal(detailToMessage([{ type: 'x', loc: ['body'] }], 'fallback'), 'fallback')
+  assert.equal(detailToMessage([], 'fallback'), 'fallback')
+})
+
+test('single validation-entry object surfaces its msg', () => {
+  assert.equal(
+    detailToMessage({ type: 'value_error', loc: ['body'], msg: 'bad target model' }),
+    'bad target model',
+  )
+})
+
+test('nested error envelopes resolve to a string', () => {
+  assert.equal(detailToMessage({ message: 'nope' }), 'nope')
+  assert.equal(detailToMessage({ detail: 'wrapped string' }), 'wrapped string')
+  assert.equal(detailToMessage({ detail: [{ msg: 'nested msg' }] }), 'nested msg')
+})
+
+test('null/undefined/number detail fall back to the provided default', () => {
+  assert.equal(detailToMessage(null, 'fallback'), 'fallback')
+  assert.equal(detailToMessage(undefined, 'fallback'), 'fallback')
+  assert.equal(detailToMessage(42, 'fallback'), 'fallback')
+})
+
+test('default fallback is an empty string, guaranteeing a renderable value', () => {
+  assert.equal(detailToMessage(null), '')
+  assert.equal(detailToMessage([{ type: 'x' }]), '')
+})

--- a/frontend/src/lib/errorDetail.js
+++ b/frontend/src/lib/errorDetail.js
@@ -1,0 +1,52 @@
+/**
+ * Normalize a FastAPI/HTTP error body's `detail` into a human-readable string.
+ *
+ * FastAPI returns `detail` in two shapes. A raised `HTTPException` gives
+ * `{detail: "<string>"}`, but a request-validation failure (a Pydantic model
+ * validator raising `ValueError`, e.g. a provider switch whose target effort
+ * does not belong to the target provider) gives
+ * `{detail: [{type, loc, msg, input, ctx}, ...]}` — an ARRAY of error objects.
+ *
+ * That array shape was being stored verbatim and rendered as a React child
+ * (`<p>{error}</p>`), which throws React error #31 ("objects are not valid as
+ * a React child") and takes down the whole ChatView/shell. Every boundary that
+ * turns a response body into user-facing error text must funnel `detail`
+ * through here so a validation array can never reach the DOM.
+ *
+ * @param {unknown} detail - the `detail` field of a parsed error body
+ * @param {string} [fallback] - returned when `detail` yields no usable text
+ * @returns {string} always a string, never an object or array
+ */
+export function detailToMessage(detail, fallback = '') {
+  if (typeof detail === 'string') {
+    return detail.trim() || fallback
+  }
+
+  // Pydantic/FastAPI validation error list: surface the human `msg` fields.
+  if (Array.isArray(detail)) {
+    const msgs = detail
+      .map(item => (item && typeof item.msg === 'string' ? item.msg.trim() : ''))
+      .filter(Boolean)
+    return msgs.length ? msgs.join('; ') : fallback
+  }
+
+  // A single object — either one validation entry (`msg`) or a nested error
+  // envelope (`message`/`detail`/`error`). Recurse the nested cases so a
+  // `{detail: [...]}` wrapper is normalized too.
+  if (detail && typeof detail === 'object') {
+    if (typeof detail.msg === 'string' && detail.msg.trim()) {
+      return detail.msg.trim()
+    }
+    for (const key of ['message', 'detail', 'error']) {
+      const nested = detail[key]
+      if (typeof nested === 'string' && nested.trim()) return nested.trim()
+      if (nested && typeof nested === 'object') {
+        const resolved = detailToMessage(nested, '')
+        if (resolved) return resolved
+      }
+    }
+    return fallback
+  }
+
+  return fallback
+}


### PR DESCRIPTION
## Problem

Switching an existing chat across providers could fail in two related ways:

1. FastAPI request-validation failures return `detail` as a list of Pydantic error objects. `ChatSettingsPanel` assumed that value was a string and rendered it directly, causing React error #31 and blanking the chat view.
2. `ChatProviderSwitch` still allowed only the older Codex effort set even though the model registry, picker, and `AgentSettingsOverride` support the `max` and `ultra` levels advertised by newer Codex models. A handoff to GPT-5.6-Sol or Terra using a saved Max/Ultra choice therefore returned 422 even though the picker had offered it.

The progress or rejection message also appeared below the model list while the confirmation button kept its idle label, so a failed or longer handoff could look like a dead button.

## Fix

- Add a shared `detailToMessage(detail, fallback)` helper that normalizes string details, Pydantic validation arrays, and nested error envelopes into display text.
- Route the provider switch, Claude auth, Codex auth, and owner login error boundaries through that helper.
- Accept `max` and `ultra` at the atomic Codex provider-switch boundary while preserving model/provider mismatch validation.
- Cover both newer effort levels with route-level handoff tests that assert the stored effective effort.
- Keep switch progress and failure feedback beside the confirmation action: the button reads `Preparing…` while the handoff runs, and a rejection appears inline instead of below the visible menu.

## Tests

- `pytest -q tests/test_chat_compact.py` — 29 passed
- Focused frontend error, effort, and provider-switch tests — 21 passed
- ESLint on all touched frontend files — no errors
