### PR TITLE
connectors: add BYO OAuth clients and Google Cloud sign-in

### DIFF
--- a/backend/app/connector_oauth.py
+++ b/backend/app/connector_oauth.py
@@ -25,6 +25,8 @@ from dataclasses import dataclass, field
 from datetime import timedelta
 from urllib.parse import urlencode, urlparse, urlunparse
 
+import httpx
+
 from app import connectors as core
 from app.config import get_settings
 from app.timeutil import now_naive_utc
@@ -58,6 +60,22 @@ def _refresh_lock(connector_id: int) -> asyncio.Lock:
 
 class OAuthError(core.ConnectorError):
   """A sign-in step failed in a way worth showing the owner."""
+
+
+class ClientSetupRequired(OAuthError):
+  """The authorization server offers neither a client-metadata document nor
+  dynamic registration, and no owner-supplied client is stored yet.
+
+  Not a failure: the owner must register their own OAuth app at the provider
+  and paste its client_id/secret (``mode="byo"``). Carries the issuer so the
+  start route can tell the app which provider needs setup.
+  """
+
+  def __init__(self, issuer: str):
+    super().__init__(
+      "This connection needs your own OAuth app credentials to sign in."
+    )
+    self.issuer = issuer
 
 
 @dataclass(frozen=True)
@@ -150,12 +168,50 @@ def _wellknown_candidates(url: str, kind: str) -> list[str]:
   return ordered
 
 
+async def oauth_json_request(
+  method: str,
+  url: str,
+  **kwargs,
+) -> tuple[int, dict, dict[str, str]]:
+  """Run one OAuth request with transport failures in the domain boundary.
+
+  ``connectors.pinned_json_request`` deliberately owns SSRF pinning and bounded
+  reads, but its low-level httpx/asyncio transport exceptions are not
+  ``ConnectorError`` instances. OAuth routes consistently catch the domain
+  error, so normalize those failures here instead of letting a transient
+  network problem become an unhandled 500 (or strand a consumed auth code).
+  Cancellation remains untouched.
+  """
+  try:
+    return await core.pinned_json_request(method, url, **kwargs)
+  except (TimeoutError, httpx.HTTPError) as exc:
+    raise core.ConnectorError(
+      "Could not reach the authorization server.", transient=True,
+    ) from exc
+
+
 async def _fetch_json(url: str) -> dict | None:
   try:
-    status, body, _ = await core.pinned_json_request("GET", url, timeout_seconds=10.0)
+    status, body, _ = await oauth_json_request(
+      "GET", url, timeout_seconds=10.0,
+    )
   except core.ConnectorError:
     return None
   return body if status == 200 and body else None
+
+
+def _normalize_issuer(value: str) -> str:
+  """Canonicalize an origin-only issuer's bare trailing slash.
+
+  Google's protected-resource metadata names ``https://accounts.google.com/``
+  while its authorization-server metadata round-trips ``…google.com`` without
+  the slash — the same authority by RFC 3986 origin form. Issuers with a real
+  path keep RFC 8414 exact-match semantics untouched.
+  """
+  parsed = urlparse(value)
+  if parsed.path in ("", "/") and not parsed.query and not parsed.fragment:
+    return f"{parsed.scheme}://{parsed.netloc}"
+  return value
 
 
 # ── discovery ─────────────────────────────────────────────────────────────
@@ -184,7 +240,7 @@ async def discover(resource_url: str, www_authenticate: str) -> Discovery:
   servers = prm.get("authorization_servers")
   if not isinstance(servers, list) or not servers:
     raise OAuthError("The service's sign-in metadata names no authorization server.")
-  issuer = str(servers[0]).strip()
+  issuer = _normalize_issuer(str(servers[0]).strip())
   if not issuer.startswith("https://"):
     raise OAuthError("The authorization server address is not valid HTTPS.")
 
@@ -192,7 +248,7 @@ async def discover(resource_url: str, www_authenticate: str) -> Discovery:
   meta: dict | None = None
   for candidate in _wellknown_candidates(issuer, "oauth-authorization-server"):
     fetched = await _fetch_json(candidate)
-    if fetched and str(fetched.get("issuer") or "") == issuer:
+    if fetched and _normalize_issuer(str(fetched.get("issuer") or "")) == issuer:
       meta = fetched
       break
   if meta is None:
@@ -291,9 +347,13 @@ async def ensure_client(db, discovery: Discovery) -> tuple[str, str | None]:
     return existing.client_id, secret
 
   if not discovery.registration_endpoint:
-    raise OAuthError("This service needs a pre-registered app; sign-in isn't available yet.")
+    # No self-registration and no stored owner credentials for this issuer.
+    # The owner supplies their own OAuth client (bring-your-own) via
+    # POST /api/connectors/{id}/oauth/client, which writes a mode="byo" row
+    # that the issuer lookup above then returns on the next start.
+    raise ClientSetupRequired(discovery.issuer)
 
-  status, body, _ = await core.pinned_json_request(
+  status, body, _ = await oauth_json_request(
     "POST",
     discovery.registration_endpoint,
     json_body={
@@ -401,6 +461,15 @@ def authorization_url(
   scope = _requested_scopes(discovery)
   if scope:
     params["scope"] = scope
+  # Google issues a refresh token ONLY when the authorize request carries
+  # access_type=offline (it ignores the offline_access scope), and
+  # prompt=consent forces it to re-issue one on re-auth. Without this a Google
+  # connection would latch signed-out at the first ~1h access-token expiry.
+  # Gated purely on the issuer host — one conditional param, not a provider
+  # registry; other providers are unaffected.
+  if urlparse(discovery.issuer).hostname == "accounts.google.com":
+    params["access_type"] = "offline"
+    params["prompt"] = "consent"
   sep = "&" if "?" in discovery.authorization_endpoint else "?"
   return discovery.authorization_endpoint + sep + urlencode(params)
 
@@ -423,7 +492,7 @@ async def exchange_code(
   }
   if client_secret:
     form["client_secret"] = client_secret
-  status, body, _ = await core.pinned_json_request(
+  status, body, _ = await oauth_json_request(
     "POST", discovery.token_endpoint, form=form, timeout_seconds=15.0,
   )
   if status != 200 or not body.get("access_token"):
@@ -434,10 +503,18 @@ async def exchange_code(
 def _client_for_refresh(db, oauth_row):
   """Resolve stored client identity for an existing connection's refresh.
 
-  A signed-in connection already has its client identity: either a stored DCR
-  registration keyed by issuer, or (implicitly) this instance's CIMD URL.
+  A signed-in connection already has its client identity, resolved in this
+  precedence: a per-connection client sealed on the grant row (the gcloud
+  installed-app client — kept off the issuer-shared table so a later
+  bring-your-own Google client cannot collide), then a stored DCR/BYO
+  registration keyed by issuer, then (implicitly) this instance's CIMD URL.
   """
   from app import models
+
+  if oauth_row.client_id:
+    secret = (core.decrypt_oauth(oauth_row.client_secret_encrypted)
+              if oauth_row.client_secret_encrypted else None)
+    return oauth_row.client_id, secret
 
   reg = (
     db.query(models.OAuthClientRegistration)
@@ -470,7 +547,25 @@ def _store_tokens(oauth_row, tokens: dict) -> None:
     oauth_row.scopes_granted = granted.split()
 
 
-async def usable_access_token(db, connector_id: int) -> str | None:
+def _store_authorization_tokens(oauth_row, tokens: dict) -> None:
+  """Replace a grant from an authorization-code response.
+
+  A refresh response commonly omits ``refresh_token`` and ``scope``; preserving
+  the stored values in ``_store_tokens`` is therefore correct on that path. An
+  authorization-code response may also omit either field, but preserving them
+  there can mix grants: access token for newly selected account B plus refresh
+  token/scopes from prior account A. Clear the old grant-only fields first, then
+  let the shared writer store whatever the new authorization actually issued.
+  """
+  oauth_row.refresh_token_encrypted = None
+  oauth_row.scopes_granted = []
+  oauth_row.access_expires_at = None
+  _store_tokens(oauth_row, tokens)
+
+
+async def usable_access_token(
+  db, connector_id: int, *, generation: str | None = None,
+) -> str | None:
   """Return a valid access token for a signed-in OAuth connector, or None.
 
   Refresh-before-attach: if the stored token is near expiry it is refreshed
@@ -482,14 +577,28 @@ async def usable_access_token(db, connector_id: int) -> str | None:
   whatever validity remains (the provider will 401 if truly expired).
   """
   from app import models
+  from app.database import SessionLocal
 
-  oauth_row = (
-    db.query(models.ConnectorOAuth)
-    .filter(models.ConnectorOAuth.connector_id == connector_id)
-    .first()
-  )
+  def load_grant(session, expected_generation: str | None):
+    query = (
+      session.query(models.Connector, models.ConnectorOAuth)
+      .join(
+        models.ConnectorOAuth,
+        models.ConnectorOAuth.connector_id == models.Connector.id,
+      )
+      .filter(models.Connector.id == connector_id)
+    )
+    if expected_generation is not None:
+      query = query.filter(
+        models.Connector.capability_id == expected_generation,
+      )
+    pair = query.first()
+    return pair if pair is not None else (None, None)
+
+  connector, oauth_row = load_grant(db, generation)
   if oauth_row is None or not oauth_row.access_token_encrypted:
     return None
+  expected_generation = str(connector.capability_id)
 
   fresh_enough = (
     oauth_row.access_expires_at is not None
@@ -503,45 +612,83 @@ async def usable_access_token(db, connector_id: int) -> str | None:
     # what we have; a still-valid token works, an expired one 401s upstream.
     return core.decrypt_oauth(oauth_row.access_token_encrypted)
 
+  # A refresh may wait on another turn and then on the remote token endpoint.
+  # Release the request Session before either await; otherwise a burst of
+  # near-expiry connectors can pin every connection in the bounded DB pool.
+  db.close()
   async with _refresh_lock(connector_id):
-    # Re-read under the lock: a concurrent turn may have just refreshed.
-    db.refresh(oauth_row)
-    if (
-      oauth_row.access_expires_at is not None
-      and oauth_row.access_expires_at - now_naive_utc() > _REFRESH_SKEW
-    ):
-      return core.decrypt_oauth(oauth_row.access_token_encrypted)
+    # Re-read under the lock using a short-lived Session: a concurrent turn may
+    # have refreshed, disconnected, or replaced this generation while we
+    # waited. Copy everything needed by the token request, then release again.
+    snapshot = SessionLocal()
+    try:
+      connector, oauth_row = load_grant(snapshot, expected_generation)
+      if oauth_row is None or not oauth_row.access_token_encrypted:
+        return None
+      if (
+        oauth_row.access_expires_at is not None
+        and oauth_row.access_expires_at - now_naive_utc() > _REFRESH_SKEW
+      ):
+        return core.decrypt_oauth(oauth_row.access_token_encrypted)
+      if not oauth_row.refresh_token_encrypted:
+        return core.decrypt_oauth(oauth_row.access_token_encrypted)
+      discovery = Discovery.from_row(oauth_row)
+      client_id, client_secret = _client_for_refresh(snapshot, oauth_row)
+      credential_fingerprint = (
+        oauth_row.access_token_encrypted,
+        oauth_row.refresh_token_encrypted,
+      )
+      refresh_token = core.decrypt_oauth(oauth_row.refresh_token_encrypted)
+    finally:
+      snapshot.close()
 
-    discovery = Discovery.from_row(oauth_row)
-    client_id, client_secret = _client_for_refresh(db, oauth_row)
-    refresh_token = core.decrypt_oauth(oauth_row.refresh_token_encrypted)
+    outcome = "success"
+    tokens: dict | None = None
     try:
       tokens = await refresh_tokens(
         discovery, client_id, client_secret, refresh_token,
       )
     except OAuthError:
-      # Definitive: the owner revoked access. Latch signed-out.
-      oauth_row.access_token_encrypted = None
-      oauth_row.refresh_token_encrypted = None
-      oauth_row.access_expires_at = None
-      oauth_row.scopes_granted = []
-      connector = (
-        db.query(models.Connector)
-        .filter(models.Connector.id == connector_id)
-        .first()
+      outcome = "revoked"
+    except core.ConnectorError:
+      outcome = "transient"
+
+    # The endpoint call is a grant-identity gap. Reopen once, prove the same
+    # connector generation and sealed credential pair still own the result,
+    # then mutate (or return the current token) in that one short transaction.
+    final = SessionLocal()
+    try:
+      connector, oauth_row = load_grant(final, expected_generation)
+      live_credential_fingerprint = (
+        (oauth_row.access_token_encrypted, oauth_row.refresh_token_encrypted)
+        if oauth_row is not None else (None, None)
       )
-      if connector is not None:
+      if (
+        oauth_row is None
+        or live_credential_fingerprint != credential_fingerprint
+      ):
+        return None
+      if outcome == "transient":
+        # Keep the last token for this turn; the provider decides whether its
+        # remaining validity is enough.
+        if not oauth_row.access_token_encrypted:
+          return None
+        return core.decrypt_oauth(oauth_row.access_token_encrypted)
+      if outcome == "revoked":
+        oauth_row.access_token_encrypted = None
+        oauth_row.refresh_token_encrypted = None
+        oauth_row.access_expires_at = None
+        oauth_row.scopes_granted = []
         connector.status = "oauth_required"
         connector.status_detail = "Sign in again to reconnect."
-      db.commit()
-      return None
-    except core.ConnectorError:
-      # Transient (server unreachable): keep the current token for this turn.
+        final.commit()
+        return None
+      assert tokens is not None
+      _store_tokens(oauth_row, tokens)
+      final.commit()
       return core.decrypt_oauth(oauth_row.access_token_encrypted)
-
-    _store_tokens(oauth_row, tokens)
-    db.commit()
-    return core.decrypt_oauth(oauth_row.access_token_encrypted)
+    finally:
+      final.close()
 
 
 async def refresh_tokens(
@@ -564,7 +711,7 @@ async def refresh_tokens(
   }
   if client_secret:
     form["client_secret"] = client_secret
-  status, body, _ = await core.pinned_json_request(
+  status, body, _ = await oauth_json_request(
     "POST", discovery.token_endpoint, form=form, timeout_seconds=30.0,
   )
   if status == 200 and body.get("access_token"):
@@ -575,3 +722,226 @@ async def refresh_tokens(
   raise core.ConnectorError(
     "Could not reach the authorization server.", transient=True,
   )
+
+
+# ── Google-account sign-in (Cloud SDK installed-app client) ────────────────
+#
+# Google supports neither dynamic client registration nor client-metadata
+# documents, so the standard one-click path (``ensure_client``) raises
+# ClientSetupRequired for its endpoints — leaving the owner to hand-build an
+# OAuth app in the Cloud console. This path sidesteps that entirely for Google
+# CLOUD services (BigQuery MCP and siblings): it reuses the Cloud SDK's own
+# PUBLISHED installed-app client and Google's hosted "copy this code" redirect
+# page, exactly as ``gcloud auth login --no-launch-browser`` does. The owner
+# opens a link, approves, and pastes back a code — no owner-created OAuth
+# project/app, consent configuration, client, or per-instance redirect URI.
+#
+# Once the code is exchanged, the sealed access/refresh tokens flow through the
+# very same storage (`_store_tokens`), refresh (`refresh_tokens`), and broker
+# attach as every other connection; only the initial handshake differs.
+
+_GCLOUD_ISSUER = "https://accounts.google.com"
+_GCLOUD_AUTH_ENDPOINT = "https://accounts.google.com/o/oauth2/auth"
+_GCLOUD_TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token"
+_GCLOUD_REVOKE_ENDPOINT = "https://oauth2.googleapis.com/revoke"
+# Google-hosted page that DISPLAYS the authorization code for the owner to copy
+# (selected by token_usage=remote). Pre-registered on the SDK client, so no
+# per-instance redirect URI ever needs registering — the whole point.
+_GCLOUD_REDIRECT = "https://sdk.cloud.google.com/authcode.html"
+# What gcloud itself requests: identity + full Cloud platform access (a
+# superset of the per-service scope such as .../auth/bigquery), so one sign-in
+# serves every Google Cloud MCP endpoint and the project-selection lookup.
+_GCLOUD_SCOPES = (
+  "openid "
+  "https://www.googleapis.com/auth/userinfo.email "
+  "https://www.googleapis.com/auth/cloud-platform"
+)
+# Published Cloud SDK installed-app client ("not so secret" in Google's own
+# source). Read from the installed SDK when present so a Google rotation in a
+# later SDK update is picked up automatically; these constants are the
+# authoritative fallback when the SDK is absent.
+_GCLOUD_CLIENT_ID = "32555940559.apps.googleusercontent.com"
+_GCLOUD_CLIENT_SECRET = "ZmssLNjJy2998hD4CTg2ejr2"
+_GOOGLE_CLOUD_MCP_HOSTS = frozenset({
+  "bigquery.googleapis.com",
+  "firestore.googleapis.com",
+  "logging.googleapis.com",
+  "pubsub.googleapis.com",
+  "run.googleapis.com",
+  "storage.googleapis.com",
+})
+
+
+def is_google_cloud_mcp_url(url: str) -> bool:
+  """True for one of the supported Google Cloud MCP endpoint hosts.
+
+  These are the resources whose authorization server is accounts.google.com
+  and that accept a Cloud user access token as Bearer auth — i.e. the ones the
+  gcloud sign-in path can serve. An exact host allowlist prevents an unrelated
+  or future ``googleapis.com`` service from receiving this broad Cloud token
+  merely because it shares Google's parent domain.
+  """
+  try:
+    host = (urlparse(url).hostname or "").lower()
+  except ValueError:
+    return False
+  return host in _GOOGLE_CLOUD_MCP_HOSTS
+
+
+def gcloud_client_identity() -> tuple[str, str]:
+  """Return (client_id, client_secret) for the Cloud SDK installed-app client.
+
+  Prefers the value in an installed SDK (env ``MOBIUS_GCLOUD_SDK_ROOT`` or the
+  default tools location) so an SDK update that rotates the client is honored;
+  falls back to the published constants when no SDK is on disk.
+  """
+  import os
+  import re
+
+  roots = [
+    os.environ.get("MOBIUS_GCLOUD_SDK_ROOT", ""),
+    "/data/shared/tools/google-cloud-sdk",
+  ]
+  for root in roots:
+    if not root:
+      continue
+    config_py = os.path.join(root, "lib/googlecloudsdk/core/config.py")
+    try:
+      with open(config_py, "r", encoding="utf-8") as handle:
+        text = handle.read()
+    except OSError:
+      continue
+    cid = re.search(r"CLOUDSDK_CLIENT_ID\s*=\s*'([^']+)'", text)
+    sec = re.search(r"CLOUDSDK_CLIENT_NOTSOSECRET\s*=\s*'([^']+)'", text)
+    if cid and sec:
+      return cid.group(1), sec.group(1)
+  return _GCLOUD_CLIENT_ID, _GCLOUD_CLIENT_SECRET
+
+
+def gcloud_discovery(resource_url: str) -> Discovery:
+  """A fixed Discovery for the Google-account path — no network walk.
+
+  The endpoints are Google's stable, published values; the resource is the
+  connector's own canonical MCP URL so the sealed row round-trips through the
+  ordinary refresh path.
+  """
+  return Discovery(
+    resource=canonical_resource(resource_url),
+    issuer=_GCLOUD_ISSUER,
+    authorization_endpoint=_GCLOUD_AUTH_ENDPOINT,
+    token_endpoint=_GCLOUD_TOKEN_ENDPOINT,
+    revocation_endpoint=_GCLOUD_REVOKE_ENDPOINT,
+    scopes=_GCLOUD_SCOPES.split(),
+  )
+
+
+def gcloud_authorization_url(client_id: str, challenge: str, state: str) -> str:
+  """Build the gcloud "remote" consent URL (code shown on Google's page).
+
+  Mirrors ``gcloud auth login --no-launch-browser``: token_usage=remote makes
+  the redirect page display the code, access_type=offline+prompt=consent force
+  a durable refresh token. No ``resource`` is sent (the minted Cloud token is
+  audience-less, exactly like gcloud's), and the redirect is Google's own page.
+  """
+  params = {
+    "response_type": "code",
+    "client_id": client_id,
+    "redirect_uri": _GCLOUD_REDIRECT,
+    "scope": _GCLOUD_SCOPES,
+    "state": state,
+    "code_challenge": challenge,
+    "code_challenge_method": "S256",
+    "access_type": "offline",
+    "prompt": "consent",
+    "token_usage": "remote",
+  }
+  return _GCLOUD_AUTH_ENDPOINT + "?" + urlencode(params)
+
+
+async def gcloud_exchange_code(
+  client_id: str,
+  client_secret: str,
+  code: str,
+  verifier: str,
+) -> dict:
+  """Exchange a pasted gcloud authorization code for tokens.
+
+  Distinct from ``exchange_code`` only in the redirect_uri (Google's hosted
+  code page, which must match the authorize request) and the omission of the
+  RFC 8707 resource param. Returns the raw token response dict.
+  """
+  form = {
+    "grant_type": "authorization_code",
+    "code": code.strip(),
+    "redirect_uri": _GCLOUD_REDIRECT,
+    "client_id": client_id,
+    "client_secret": client_secret,
+    "code_verifier": verifier,
+  }
+  status, body, _ = await oauth_json_request(
+    "POST", _GCLOUD_TOKEN_ENDPOINT, form=form, timeout_seconds=15.0,
+  )
+  if status != 200 or not body.get("access_token"):
+    raise OAuthError("The sign-in could not be completed.")
+  return body
+
+
+_PROJECT_ID_RE = re.compile(r"^[a-z][-a-z0-9]{4,28}[a-z0-9]$")
+
+
+def valid_gcloud_project_id(value: str) -> bool:
+  """True for a syntactically valid Google Cloud project id.
+
+  6–30 chars, lowercase letter first, letters/digits/hyphens, not ending in a
+  hyphen. Used to gate the ``x-goog-user-project`` header independently of the
+  live project list, so a control-character or junk value can never be sealed
+  and later emitted as a header (which would wedge the connection at send).
+  """
+  return bool(_PROJECT_ID_RE.match(value or ""))
+
+
+async def list_google_projects(access_token: str) -> list[dict]:
+  """Best-effort list of the owner's active Cloud projects (id + name).
+
+  Uses Cloud Resource Manager v1, which a cloud-platform token can call
+  without per-project API enablement. Follows pageToken up to the 500-project
+  safety cap so later-page projects within that bound are not falsely rejected
+  as "not yours". Returns [] on any failure — project selection is a
+  convenience, not a gate on completing sign-in.
+  """
+  projects: list[dict] = []
+  page_token = ""
+  for _ in range(20):  # defensive request bound; the result cap below is 500
+    params = {"pageSize": "500"}
+    if page_token:
+      params["pageToken"] = page_token
+    url = (
+      "https://cloudresourcemanager.googleapis.com/v1/projects?"
+      + urlencode(params)
+    )
+    try:
+      status, body, _ = await oauth_json_request(
+        "GET", url,
+        headers={"Authorization": f"Bearer {access_token}"},
+        timeout_seconds=15.0,
+      )
+    except core.ConnectorError:
+      break
+    if status != 200 or not isinstance(body.get("projects"), list):
+      break
+    for p in body["projects"]:
+      if (
+        isinstance(p, dict)
+        and p.get("lifecycleState", "ACTIVE") == "ACTIVE"
+        and p.get("projectId")
+      ):
+        projects.append({
+          "project_id": p["projectId"],
+          "name": p.get("name") or p["projectId"],
+        })
+        if len(projects) >= 500:
+          break
+    page_token = body.get("nextPageToken") or ""
+    if not page_token or len(projects) >= 500:
+      break
+  return projects

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1479,6 +1479,38 @@ def orm_schema_gaps(eng) -> list[str]:
   return gaps
 
 
+def _add_connector_oauth_gcloud_fields(eng) -> None:
+  """Add the Google-account (gcloud) sign-in fields to ``connector_oauth``.
+
+  Additive and idempotent: each column is inspector-gated so a re-run no-ops,
+  and existing browser-flow grants keep working unchanged (auth_mode defaults
+  to ``browser``). ``connector_oauth`` may not exist yet on an install that has
+  never added an OAuth connection; ``create_all`` builds it with these columns
+  already present, so skip the ALTERs entirely in that case.
+  """
+  from sqlalchemy import inspect as sa_inspect, text
+
+  inspector = sa_inspect(eng)
+  if "connector_oauth" not in inspector.get_table_names():
+    return
+  columns = {c["name"] for c in inspector.get_columns("connector_oauth")}
+  additions = (
+    ("auth_mode",
+     "ALTER TABLE connector_oauth ADD COLUMN auth_mode VARCHAR(16) "
+     "NOT NULL DEFAULT 'browser'"),
+    ("client_id",
+     "ALTER TABLE connector_oauth ADD COLUMN client_id VARCHAR(512) NULL"),
+    ("client_secret_encrypted",
+     "ALTER TABLE connector_oauth ADD COLUMN client_secret_encrypted TEXT NULL"),
+    ("user_project",
+     "ALTER TABLE connector_oauth ADD COLUMN user_project VARCHAR(256) NULL"),
+  )
+  with eng.begin() as conn:
+    for name, ddl in additions:
+      if name not in columns:
+        conn.execute(text(ddl))
+
+
 def _add_app_connections_manage(eng) -> None:
   """Grant column for the Connections mini-app's registry access.
 
@@ -1609,6 +1641,7 @@ _SCHEMA_MIGRATIONS = (
   ("0009_app_connections_manage", _add_app_connections_manage),
   ("0010_chat_pending_question_id", _add_chat_pending_question_id),
   ("0011_delegation_parent_wake", _add_delegation_parent_wake),
+  ("0012_connector_oauth_gcloud", _add_connector_oauth_gcloud_fields),
 )
 
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -961,6 +961,25 @@ class ConnectorOAuth(Base):
   access_expires_at = Column(DateTime, nullable=True)
   scopes_granted = Column(JSON, nullable=False, default=list)
   connected_at = Column(DateTime, nullable=True)
+  # How this grant was obtained. ``browser`` is the standard spec flow (an
+  # authorization-server redirect back to this instance's callback). ``gcloud``
+  # is the Google-account path: the redirect is Google's own hosted code-display
+  # page and the client identity is the Cloud SDK's published installed-app
+  # client, so the owner needs no Google Cloud console app. The flavor steers
+  # sign-in only; refresh is identical once tokens are sealed.
+  auth_mode = Column(
+    String(16), nullable=False, default="browser", server_default="browser",
+  )
+  # Per-connection client identity, used only when the client is NOT the
+  # issuer-shared registration — currently the gcloud installed-app client.
+  # Preferred over ``OAuthClientRegistration`` at refresh time when present, so
+  # a later bring-your-own Google client on the same issuer cannot collide.
+  client_id = Column(String(512), nullable=True)
+  client_secret_encrypted = Column(Text, nullable=True)
+  # Google Cloud requires the caller to name a billing/quota project on every
+  # request via the ``x-goog-user-project`` header; stored plainly (a project
+  # id is not a secret) and attached by the broker for gcloud-mode grants.
+  user_project = Column(String(256), nullable=True)
 
 
 class OAuthClientRegistration(Base):

--- a/backend/app/routes/connectors.py
+++ b/backend/app/routes/connectors.py
@@ -19,6 +19,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app import connectors as core
+from app import connector_oauth as connector_oauth_mod
 from app import models
 from app.database import get_db
 from app.deps import (
@@ -68,6 +69,15 @@ class _BrokerSnapshot:
   url: str
   auth_header: str | None
   secret: str | None
+  # Connector identity authenticated by the broker capability. Passing it to
+  # token refresh prevents a deleted/recreated numeric id from refreshing a
+  # replacement connection's grant.
+  generation: str | None = None
+  # Non-secret static headers the provider requires alongside auth — currently
+  # only Google Cloud's ``x-goog-user-project`` billing/quota project. A tuple
+  # of (name, value) pairs keeps the frozen snapshot cleanly copyable through
+  # ``dataclasses.replace`` when the OAuth token is attached.
+  extra_headers: tuple[tuple[str, str], ...] = ()
 
 
 class ConnectorCreate(BaseModel):
@@ -125,6 +135,18 @@ def _public(
     ),
     "signed_in": bool(oauth is not None and oauth.access_token_encrypted),
     "scopes": list(oauth.scopes_granted or []) if oauth is not None else [],
+    # Which sign-in the card should offer: "gcloud" for a Google Cloud endpoint
+    # (link-and-code, no console app), else "browser" (the standard popup).
+    # Only meaningful when auth_kind == "oauth".
+    "oauth_flavor": (
+      ("gcloud" if connector_oauth_mod.is_google_cloud_mcp_url(str(row.url))
+       else "browser")
+      if oauth is not None else None
+    ),
+    # For a gcloud grant, the quota project it will bill to (None until chosen).
+    "user_project": (
+      oauth.user_project if oauth is not None else None
+    ),
   }
 
 
@@ -134,6 +156,39 @@ def _oauth_row(db: Session, connector_id: int) -> "models.ConnectorOAuth | None"
     .filter(models.ConnectorOAuth.connector_id == connector_id)
     .first()
   )
+
+
+def _oauth_state_fingerprint(oauth: models.ConnectorOAuth) -> tuple:
+  """Stable snapshot of every mutable field on one OAuth grant row.
+
+  Used only around remote-call gaps where a same-generation sign-in can replace
+  the grant. Ciphertexts are safe identity markers here (never returned):
+  Fernet produces a new value on every authorization even when the provider
+  happens to reissue the same plaintext credential.
+  """
+  return (
+    oauth.resource,
+    oauth.issuer,
+    oauth.authorization_endpoint,
+    oauth.token_endpoint,
+    oauth.registration_endpoint,
+    oauth.revocation_endpoint,
+    tuple(oauth.scopes_advertised or []),
+    oauth.access_token_encrypted,
+    oauth.refresh_token_encrypted,
+    oauth.access_expires_at,
+    tuple(oauth.scopes_granted or []),
+    oauth.connected_at,
+    oauth.auth_mode,
+    oauth.client_id,
+    oauth.client_secret_encrypted,
+    oauth.user_project,
+  )
+
+
+def _oauth_credential_fingerprint(oauth: models.ConnectorOAuth) -> tuple:
+  """Identity of the access/refresh pair used for one remote operation."""
+  return (oauth.access_token_encrypted, oauth.refresh_token_encrypted)
 
 
 def _unique_slug(db: Session, base: str) -> str:
@@ -231,10 +286,33 @@ def _snapshot_broker_row(
       raise HTTPException(
         status_code=502, detail="The connection key could not be loaded.",
       ) from exc
+  # Google Cloud grants must name a quota/billing project on every call. The
+  # value is a project id (not a secret), stored on the grant row; attach it as
+  # a static header so it rides alongside the OAuth token resolved in the
+  # broker. Absent for every other connection.
+  extra_headers: tuple[tuple[str, str], ...] = ()
+  oauth = (
+    db.query(models.ConnectorOAuth)
+    .filter(models.ConnectorOAuth.connector_id == connector_id)
+    .first()
+  )
+  if oauth is not None and oauth.auth_mode == "gcloud" and not oauth.user_project:
+    # Invariant: a Google Cloud grant with no billing project cannot satisfy a
+    # tool call (the quota header is mandatory). Never broker it — status
+    # already withholds it from turns; this is the authoritative backstop.
+    raise HTTPException(status_code=404, detail="MCP connection unavailable.")
+  if (
+    oauth is not None
+    and oauth.auth_mode == "gcloud"
+    and oauth.user_project
+  ):
+    extra_headers = (("x-goog-user-project", str(oauth.user_project)),)
   return _BrokerSnapshot(
     url=str(row.url),
     auth_header=auth_header,
     secret=secret,
+    generation=str(row.capability_id),
+    extra_headers=extra_headers,
   )
 
 
@@ -250,6 +328,10 @@ def _broker_request_headers(
     )
   }
   headers.update(core.auth_headers(snapshot.auth_header, snapshot.secret))
+  # Provider-required static headers last, so an incoming request (which cannot
+  # name these — they are not in the forwarded allowlist) can never displace or
+  # forge them, and they sit beside, not over, the Authorization header.
+  headers.update(dict(snapshot.extra_headers))
   return headers
 
 
@@ -416,7 +498,9 @@ async def broker_connector(
       from app import connector_oauth
       oauth = _oauth_row(db, connector_id)
       if oauth is not None:
-        token = await connector_oauth.usable_access_token(db, connector_id)
+        token = await connector_oauth.usable_access_token(
+          db, connector_id, generation=snapshot.generation,
+        )
         if token is None:
           raise HTTPException(
             status_code=404, detail="MCP connection unavailable.",
@@ -493,6 +577,21 @@ async def add_connector(
     db.close()
     probe = await core.handshake(url, normalized_header, normalized_secret)
     discovery = None
+    if normalized_secret is None:
+      # A server may answer the whole anonymous handshake yet gate the actual
+      # tool calls behind sign-in — Google's MCP servers list tools openly and
+      # 401 only at call time. The published protected-resource metadata is
+      # the authoritative declaration of that gate, so consult it once here
+      # at add time; a service with no such document stays a plain keyless
+      # add, and rechecks never repeat this walk.
+      from app import connector_oauth
+      try:
+        anon_gate = await connector_oauth.discover(url, "")
+      except connector_oauth.OAuthError:
+        pass
+      else:
+        probe = None
+        discovery = anon_gate.as_row_fields()
   except core.OAuthSignInRequired as needs_oauth:
     # An OAuth-gated MCP server. This is a successful add of a signed-out
     # connection, not a failure: save the discovery so the owner can sign in.
@@ -621,6 +720,34 @@ def _record_check(connector_id: int, generation: str, values: dict) -> None:
     session.close()
 
 
+def _gcloud_refresh_shared(
+  db: Session, connector_id: int, refresh_plaintext: str,
+) -> bool:
+  """True if another Google connection still holds this exact refresh token.
+
+  Reuse copies a credential, so several connections can share one refresh
+  token. Fernet ciphertext is non-deterministic, so equality is decided on the
+  decrypted value. Used so sign-out revokes upstream only when it is safe —
+  i.e. no sibling would be signed out by Google killing the shared token.
+  """
+  rows = (
+    db.query(models.ConnectorOAuth)
+    .filter(
+      models.ConnectorOAuth.auth_mode == "gcloud",
+      models.ConnectorOAuth.connector_id != connector_id,
+      models.ConnectorOAuth.refresh_token_encrypted.isnot(None),
+    )
+    .all()
+  )
+  for other in rows:
+    try:
+      if core.decrypt_oauth(other.refresh_token_encrypted) == refresh_plaintext:
+        return True
+    except core.ConnectorError:
+      continue
+  return False
+
+
 async def _probe_signed_in(
   url: str, connector_id: int, generation: str, token: str, prior_status: str,
 ) -> None:
@@ -632,6 +759,29 @@ async def _probe_signed_in(
   their token, and an auth rejection latches to signed-out — a recoverable
   state whose fix (sign in) is one tap — never to "error".
   """
+  # Bind the remote result to the exact grant that supplied ``token``. OAuth
+  # re-authorization does not rotate the connector capability, so generation
+  # alone cannot stop an older in-flight probe from overwriting a newer sign-in.
+  snapshot = _reopen()
+  try:
+    current = snapshot.query(models.Connector).filter(
+      models.Connector.id == connector_id,
+      models.Connector.capability_id == generation,
+    ).first()
+    oauth = _oauth_row(snapshot, connector_id) if current is not None else None
+    if (
+      oauth is None
+      or not oauth.access_token_encrypted
+      or core.decrypt_oauth(oauth.access_token_encrypted) != token
+    ):
+      return
+    grant_state = _oauth_state_fingerprint(oauth)
+    needs_project = bool(
+      oauth.auth_mode == "gcloud" and not oauth.user_project
+    )
+  finally:
+    snapshot.close()
+
   clear_grant = False
   try:
     probe = await core.handshake(url, "Authorization", token)
@@ -641,6 +791,13 @@ async def _probe_signed_in(
       "status": "ok",
       "status_detail": None,
     }
+    # Single enforcement point for "a project-less Google grant is not ready":
+    # the handshake succeeds without a project, so without this any Recheck
+    # would flip it to "ok" and turns would advertise a tool that 404s on
+    # every call. Sign-in and reuse rely on this instead of a separate patch.
+    if needs_project:
+      values["status"] = "oauth_required"
+      values["status_detail"] = "Choose a billing project to run queries."
   except core.ConnectorError as exc:
     if exc.auth_rejected:
       # The grant no longer works. Latch signed-out AND clear the dead tokens
@@ -655,26 +812,29 @@ async def _probe_signed_in(
       values = {"status_detail": str(exc)} if prior_status == "ok" else {}
     else:
       values = {"status": "error", "status_detail": str(exc)}
-  _record_check(connector_id, generation, values)
-  if clear_grant:
-    session = _reopen()
-    try:
-      # Generation-guard the wipe exactly like _record_check: if a concurrent
-      # disconnect/delete rotated capability_id, this stale probe must not
-      # clear a newer, valid grant.
-      current = session.query(models.Connector).filter(
-        models.Connector.id == connector_id,
-        models.Connector.capability_id == generation,
-      ).first()
-      oauth = _oauth_row(session, connector_id) if current is not None else None
-      if oauth is not None:
-        oauth.access_token_encrypted = None
-        oauth.refresh_token_encrypted = None
-        oauth.access_expires_at = None
-        oauth.scopes_granted = []
-        session.commit()
-    finally:
-      session.close()
+  # Reopen after the handshake and apply health + any definitive token clear in
+  # one transaction only if the full OAuth row is still the captured grant.
+  session = _reopen()
+  try:
+    current = session.query(models.Connector).filter(
+      models.Connector.id == connector_id,
+      models.Connector.capability_id == generation,
+    ).first()
+    oauth = _oauth_row(session, connector_id) if current is not None else None
+    if oauth is None or _oauth_state_fingerprint(oauth) != grant_state:
+      return
+    for field_name, value in {
+      **values, "last_checked_at": now_naive_utc(),
+    }.items():
+      setattr(current, field_name, value)
+    if clear_grant:
+      oauth.access_token_encrypted = None
+      oauth.refresh_token_encrypted = None
+      oauth.access_expires_at = None
+      oauth.scopes_granted = []
+    session.commit()
+  finally:
+    session.close()
 
 
 @router.post("/{connector_id}/refresh")
@@ -691,14 +851,36 @@ async def refresh_connector(
 
     url = str(stored.url)
     prior_status = str(stored.status)
-    # May refresh the token (commits internally); needs the live session.
-    token = await connector_oauth.usable_access_token(db, connector_id)
+    grant_state = _oauth_state_fingerprint(oauth)
+    # May refresh the token. The helper releases this request Session before
+    # waiting on its single-flight lock or the provider.
+    token = await connector_oauth.usable_access_token(
+      db, connector_id, generation=generation,
+    )
     db.close()
     if token is None:
-      _record_check(connector_id, generation, {
-        "status": "oauth_required",
-        "status_detail": "Sign in to finish connecting.",
-      })
+      # ``None`` can also mean a newer same-generation sign-in superseded an
+      # in-flight refresh. Only latch signed-out when the original grant is
+      # still current; otherwise preserve the replacement's tokens and health.
+      check = _reopen()
+      try:
+        current = check.query(models.Connector).filter(
+          models.Connector.id == connector_id,
+          models.Connector.capability_id == generation,
+        ).first()
+        current_oauth = (
+          _oauth_row(check, connector_id) if current is not None else None
+        )
+        if (
+          current_oauth is not None
+          and _oauth_state_fingerprint(current_oauth) == grant_state
+        ):
+          current.status = "oauth_required"
+          current.status_detail = "Sign in to finish connecting."
+          current.last_checked_at = now_naive_utc()
+          check.commit()
+      finally:
+        check.close()
     else:
       await _probe_signed_in(url, connector_id, generation, token, prior_status)
     session = _reopen()
@@ -866,9 +1048,637 @@ async def oauth_start(
     authorize_url = connector_oauth.authorization_url(
       discovery, client_id, challenge, state,
     )
+  except connector_oauth.ClientSetupRequired as needs:
+    # The provider can't self-register and the owner hasn't supplied a client
+    # yet. Not an error — tell the app to collect credentials. The redirect
+    # URI comes from the server's authoritative value so the owner pastes the
+    # exact string the callback validates.
+    return {
+      "needs_client_setup": True,
+      "issuer": needs.issuer,
+      "redirect_uri": connector_oauth.redirect_uri(),
+    }
   except core.ConnectorError as exc:
     raise HTTPException(status_code=422, detail=str(exc)) from exc
   return {"authorize_url": authorize_url}
+
+
+# ── Google-account sign-in (link + pasted code, no console app) ─────────────
+
+
+def _require_gcloud_oauth(
+  db: Session, connector_id: int, generation: str,
+) -> tuple[models.Connector, models.ConnectorOAuth]:
+  """Load a Google Cloud connector and its grant row, or raise 4xx.
+
+  Shared precondition for the gcloud routes: the connection must exist at this
+  generation, carry a sign-in (OAuth) row, and point at a Google Cloud MCP
+  endpoint — the only place the link-and-code path applies.
+  """
+  stored = _get_row(db, connector_id, generation)
+  oauth = _oauth_row(db, connector_id)
+  if oauth is None:
+    raise HTTPException(
+      status_code=409, detail="This connection does not use sign-in.",
+    )
+  if not connector_oauth_mod.is_google_cloud_mcp_url(str(stored.url)):
+    raise HTTPException(
+      status_code=409,
+      detail="Google sign-in applies only to Google Cloud connections.",
+    )
+  return stored, oauth
+
+
+async def _resolve_gcloud_project(
+  access_token: str, requested: str,
+) -> tuple[str, list[dict]]:
+  """Validate/auto-select a billing project against the owner's live list.
+
+  Returns (chosen_or_empty, projects). A malformed id is a 400; a well-formed
+  id that isn't in the account is a 422 (skipped when the list is unavailable,
+  where the shape check is the only guard). Auto-selects the sole project when
+  the caller named none. Shared by the sign-in and reuse paths so both behave
+  identically.
+  """
+  chosen = (requested or "").strip()
+  if chosen and not connector_oauth_mod.valid_gcloud_project_id(chosen):
+    raise HTTPException(status_code=400, detail="That is not a valid project id.")
+  projects = await connector_oauth_mod.list_google_projects(access_token)
+  project_ids = [p["project_id"] for p in projects]
+  if chosen and project_ids and chosen not in project_ids:
+    raise HTTPException(
+      status_code=422, detail="That project isn't in your Google account.",
+    )
+  if not chosen and len(project_ids) == 1:
+    chosen = project_ids[0]
+  return chosen, projects
+
+
+@router.post("/{connector_id}/oauth/gcloud/start")
+async def oauth_gcloud_start(
+  connector_id: int,
+  generation: str = Depends(_require_generation),
+  _owner: models.Owner = Depends(get_owner_or_app_with_connections_manage),
+  db: Session = Depends(get_db),
+):
+  """Begin Google-account sign-in: return the consent link and sealed state.
+
+  Unlike the browser flow there is no redirect back to this instance — Google
+  shows the owner a code to copy. The PKCE verifier and connection binding
+  travel in the sealed ``state`` the app hands back to ``complete``, so nothing
+  is held server-side between the two calls (restart-safe).
+  """
+  _require_gcloud_oauth(db, connector_id, generation)
+  client_id, _secret = connector_oauth_mod.gcloud_client_identity()
+  verifier, challenge = connector_oauth_mod.generate_pkce()
+  state = connector_oauth_mod.seal_flow({
+    "connector_id": connector_id,
+    "generation": generation,
+    "verifier": verifier,
+    "client_id": client_id,
+    "mode": "gcloud",
+  })
+  authorize_url = connector_oauth_mod.gcloud_authorization_url(
+    client_id, challenge, state,
+  )
+  return {"authorize_url": authorize_url, "state": state}
+
+
+class GcloudCompleteBody(BaseModel):
+  state: str = Field(min_length=1, max_length=8192)
+  # Write-only like other credential inputs: typed object, validated in-route
+  # so a pydantic 422 can never echo the authorization code back.
+  code: object = ""
+  project_id: str = Field(default="", max_length=256)
+
+
+@router.post("/{connector_id}/oauth/gcloud/complete")
+async def oauth_gcloud_complete(
+  connector_id: int,
+  body: GcloudCompleteBody,
+  generation: str = Depends(_require_generation),
+  _owner: models.Owner = Depends(get_owner_or_app_with_connections_manage),
+  db: Session = Depends(get_db),
+):
+  """Finish Google-account sign-in from the pasted code.
+
+  Exchanges the code with the Cloud SDK client, seals the tokens onto the grant
+  through the same storage every connection uses, records the per-connection
+  client so refresh needs no console app, and selects the billing project when
+  it is unambiguous (or the caller named one). Returns the updated card plus
+  the project list so the app can prompt when a choice is needed.
+  """
+  stored, oauth = _require_gcloud_oauth(db, connector_id, generation)
+  flow = connector_oauth_mod.open_flow(body.state)
+  if (
+    flow is None
+    or flow.get("mode") != "gcloud"
+    or int(flow.get("connector_id") or 0) != connector_id
+    or str(flow.get("generation") or "") != generation
+  ):
+    raise HTTPException(
+      status_code=400, detail="This sign-in expired. Start it again.",
+    )
+  code = body.code
+  if not isinstance(code, str) or not code.strip():
+    raise HTTPException(status_code=400, detail="Paste the code from Google.")
+
+  client_id = str(flow["client_id"])
+  _cid, client_secret = connector_oauth_mod.gcloud_client_identity()
+  url = str(stored.url)
+  db.close()
+  try:
+    tokens = await connector_oauth_mod.gcloud_exchange_code(
+      client_id, client_secret, code, str(flow["verifier"]),
+    )
+  except core.ConnectorError as exc:
+    raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+  access_token = str(tokens["access_token"])
+  # Resolve the billing project: an explicit choice wins; otherwise pick the
+  # sole active project automatically, else leave it for the app to ask.
+  chosen, projects = await _resolve_gcloud_project(access_token, body.project_id)
+
+  discovery = connector_oauth_mod.gcloud_discovery(url)
+  db = _reopen()
+  try:
+    row = db.query(models.Connector).filter(
+      models.Connector.id == connector_id,
+      models.Connector.capability_id == generation,
+    ).first()
+    oauth = _oauth_row(db, connector_id)
+    if row is None or oauth is None:
+      raise HTTPException(
+        status_code=404,
+        detail="The connection changed during sign-in.",
+      )
+    # Stamp the Google endpoints so refresh runs against them, then seal the
+    # per-connection client and tokens through the shared writer.
+    for field_name, value in discovery.as_row_fields().items():
+      setattr(oauth, field_name, value)
+    oauth.auth_mode = "gcloud"
+    oauth.client_id = client_id
+    oauth.client_secret_encrypted = core.encrypt_oauth(client_secret)
+    # `or None` clears any project a prior sign-in left, so re-signing this
+    # connection into a DIFFERENT account can never keep the old project (which
+    # would bypass the project-less withholding and mis-bill the new account).
+    oauth.user_project = chosen or None
+    connector_oauth_mod._store_authorization_tokens(oauth, tokens)
+    oauth.connected_at = now_naive_utc()
+    row.status = "ok"
+    row.status_detail = None
+    row_generation = str(row.capability_id)
+    db.commit()
+  finally:
+    db.close()
+
+  # Populate tools + cost with the fresh grant, and let the probe decide the
+  # final status: a project-less gcloud grant is withheld there (a single
+  # enforcement point that also survives a later Recheck).
+  await _probe_signed_in(url, connector_id, row_generation, access_token, "ok")
+
+  session = _reopen()
+  try:
+    row = session.query(models.Connector).filter(
+      models.Connector.id == connector_id,
+      models.Connector.capability_id == row_generation,
+    ).first()
+    public = _public(row, _oauth_row(session, connector_id)) if row else None
+  finally:
+    session.close()
+  if public is None:
+    raise HTTPException(status_code=404, detail="Connection not found.")
+  return {
+    "connection": public,
+    "projects": projects,
+    "needs_project": not chosen,
+  }
+
+
+@router.get("/{connector_id}/oauth/gcloud/projects")
+async def oauth_gcloud_list_projects(
+  connector_id: int,
+  generation: str = Depends(_require_generation),
+  _owner: models.Owner = Depends(get_owner_or_app_with_connections_manage),
+  db: Session = Depends(get_db),
+):
+  """List the owner's Google Cloud projects for a signed-in connection.
+
+  Read-only: uses the stored token (refreshing if needed) to fetch the live
+  project list so the app can offer a picker when changing the billing project,
+  instead of asking the owner to type an id. Returns {projects, current}; an
+  empty list means the lookup was unavailable and the app falls back to entry.
+  """
+  _stored, oauth = _require_gcloud_oauth(db, connector_id, generation)
+  if not oauth.access_token_encrypted:
+    raise HTTPException(status_code=409, detail="Sign in with Google first.")
+  current = oauth.user_project
+  token = await connector_oauth_mod.usable_access_token(
+    db, connector_id, generation=generation,
+  )
+  if token is None:
+    raise HTTPException(status_code=409, detail="Sign in with Google again.")
+  # Project lookup is a remote call. Release the request's checked-out DB
+  # connection first; no database state is needed to build this read-only
+  # response, and the generation was already authenticated above.
+  db.close()
+  projects = await connector_oauth_mod.list_google_projects(token)
+  return {"projects": projects, "current": current}
+
+
+class GcloudProjectBody(BaseModel):
+  project_id: str = Field(min_length=1, max_length=256)
+
+
+@router.post("/{connector_id}/oauth/gcloud/project")
+async def oauth_gcloud_set_project(
+  connector_id: int,
+  body: GcloudProjectBody,
+  generation: str = Depends(_require_generation),
+  _owner: models.Owner = Depends(get_owner_or_app_with_connections_manage),
+  db: Session = Depends(get_db),
+):
+  """Set (or change) the billing project for a signed-in Google connection.
+
+  Validated against the owner's live project list using the stored token, so a
+  typo can't silently break every later query. Usable before first use (when
+  sign-in found several projects) or to move an existing connection later.
+  """
+  _stored, oauth = _require_gcloud_oauth(db, connector_id, generation)
+  if not oauth.access_token_encrypted:
+    raise HTTPException(status_code=409, detail="Sign in with Google first.")
+  chosen = body.project_id.strip()
+  if not connector_oauth_mod.valid_gcloud_project_id(chosen):
+    raise HTTPException(status_code=400, detail="That is not a valid project id.")
+  token = await connector_oauth_mod.usable_access_token(
+    db, connector_id, generation=generation,
+  )
+  if token is None:
+    raise HTTPException(status_code=409, detail="Sign in with Google again.")
+  # Tie the returned plaintext to the currently stored grant before releasing
+  # the Session. A same-generation re-sign between token resolution and this
+  # snapshot must not let account A's project list update account B.
+  db.expire_all()
+  row = db.query(models.Connector).filter(
+    models.Connector.id == connector_id,
+    models.Connector.capability_id == generation,
+  ).first()
+  oauth = _oauth_row(db, connector_id) if row is not None else None
+  if (
+    oauth is None
+    or not oauth.access_token_encrypted
+    or core.decrypt_oauth(oauth.access_token_encrypted) != token
+  ):
+    raise HTTPException(
+      status_code=409,
+      detail="The Google sign-in changed before the project could be set.",
+    )
+  credential_fingerprint = _oauth_credential_fingerprint(oauth)
+  # Do not hold the request Session across Cloud Resource Manager, then open a
+  # second Session for the write. That pattern can exhaust Postgres's bounded
+  # pool with concurrent requests. The fresh session below generation-guards
+  # the only mutation after the network result is in hand.
+  db.close()
+  projects = await connector_oauth_mod.list_google_projects(token)
+  project_ids = [p["project_id"] for p in projects]
+  if project_ids and chosen not in project_ids:
+    raise HTTPException(
+      status_code=422, detail="That project isn't in your Google account.",
+    )
+  session = _reopen()
+  try:
+    row = session.query(models.Connector).filter(
+      models.Connector.id == connector_id,
+      models.Connector.capability_id == generation,
+    ).first()
+    oauth = _oauth_row(session, connector_id) if row is not None else None
+    if oauth is None or row is None:
+      raise HTTPException(status_code=404, detail="Connection not found.")
+    if _oauth_credential_fingerprint(oauth) != credential_fingerprint:
+      raise HTTPException(
+        status_code=409,
+        detail="The Google sign-in changed before the project could be set.",
+      )
+    oauth.user_project = chosen
+    # A verified token plus a valid project makes the connection usable again:
+    # clear the "choose a project" withholding so it rejoins turns. (The token
+    # was just confirmed live via usable_access_token above.)
+    if row.status == "oauth_required":
+      row.status = "ok"
+    row.status_detail = None
+    session.commit()
+    public = _public(row, _oauth_row(session, connector_id))
+  finally:
+    session.close()
+  return {"connection": public, "projects": projects}
+
+
+@router.get("/{connector_id}/oauth/gcloud/reusable")
+async def oauth_gcloud_reusable(
+  connector_id: int,
+  generation: str = Depends(_require_generation),
+  _owner: models.Owner = Depends(get_owner_or_app_with_connections_manage),
+  db: Session = Depends(get_db),
+):
+  """List the owner's other signed-in Google connections this one can reuse.
+
+  One Google sign-in already grants cloud-platform access to every Google Cloud
+  service, so a second Google Cloud connection needs no fresh consent — only a
+  source to adopt the credential from. The source generation is part of the
+  choice so a stale tab cannot silently target a deleted/reused SQLite id.
+  """
+  _require_gcloud_oauth(db, connector_id, generation)
+  rows = (
+    db.query(models.ConnectorOAuth)
+    .filter(
+      models.ConnectorOAuth.auth_mode == "gcloud",
+      models.ConnectorOAuth.connector_id != connector_id,
+      models.ConnectorOAuth.access_token_encrypted.isnot(None),
+    )
+    .all()
+  )
+  sources = []
+  for source_oauth in rows:
+    source = (
+      db.query(models.Connector)
+      .filter(models.Connector.id == source_oauth.connector_id)
+      .first()
+    )
+    if source is not None:
+      sources.append({
+        "connector_id": source.id,
+        "generation": source.capability_id,
+        "name": source.name,
+      })
+  return {"sources": sources}
+
+
+class GcloudReuseBody(BaseModel):
+  source_connector_id: int
+  source_generation: str = Field(min_length=1, max_length=128)
+  project_id: str = Field(default="", max_length=256)
+
+
+@router.post("/{connector_id}/oauth/gcloud/reuse")
+async def oauth_gcloud_reuse(
+  connector_id: int,
+  body: GcloudReuseBody,
+  generation: str = Depends(_require_generation),
+  _owner: models.Owner = Depends(get_owner_or_app_with_connections_manage),
+  db: Session = Depends(get_db),
+):
+  """Adopt an existing Google sign-in for this connection — no re-approval.
+
+  Copies the sealed Google credential from another of the owner's signed-in
+  Google Cloud connections (same account, same cloud-platform scope) onto this
+  one, then resolves the billing project. Google does not rotate installed-app
+  refresh tokens on use, so the shared credential keeps working for both
+  connections independently; each refreshes its own access token. The billing
+  project stays per-connection.
+  """
+  stored, target_oauth = _require_gcloud_oauth(db, connector_id, generation)
+  target_state = _oauth_state_fingerprint(target_oauth)
+  if body.source_connector_id == connector_id:
+    raise HTTPException(status_code=400, detail="Pick a different connection.")
+  source_row = db.query(models.Connector).filter(
+    models.Connector.id == body.source_connector_id,
+    models.Connector.capability_id == body.source_generation,
+  ).first()
+  source = (
+    _oauth_row(db, body.source_connector_id)
+    if source_row is not None else None
+  )
+  if (
+    source is None
+    or source.auth_mode != "gcloud"
+    or not source.access_token_encrypted
+  ):
+    raise HTTPException(
+      status_code=409, detail="That Google sign-in isn't available to reuse.",
+    )
+  # Freshen the source token (if near expiry) so the adopted access token is
+  # live, then snapshot the credential fields as plain values before releasing
+  # the session for the network calls.
+  fresh = await connector_oauth_mod.usable_access_token(
+    db,
+    body.source_connector_id,
+    generation=body.source_generation,
+  )
+  # Re-query BOTH identities after token resolution. The helper may await a
+  # refresh; during that gap the source can be disconnected/recreated or the
+  # target can complete a fresh same-generation sign-in.
+  db.expire_all()
+  source_row = db.query(models.Connector).filter(
+    models.Connector.id == body.source_connector_id,
+    models.Connector.capability_id == body.source_generation,
+  ).first()
+  source = (
+    _oauth_row(db, body.source_connector_id)
+    if source_row is not None else None
+  )
+  target_row = db.query(models.Connector).filter(
+    models.Connector.id == connector_id,
+    models.Connector.capability_id == generation,
+  ).first()
+  live_target = _oauth_row(db, connector_id) if target_row is not None else None
+  if (
+    live_target is None
+    or _oauth_state_fingerprint(live_target) != target_state
+  ):
+    raise HTTPException(
+      status_code=409,
+      detail="This connection changed before the sign-in could be reused.",
+    )
+  if (
+    fresh is None
+    or source is None
+    or not source.access_token_encrypted
+    or core.decrypt_oauth(source.access_token_encrypted) != fresh
+  ):
+    raise HTTPException(
+      status_code=409, detail="That Google sign-in isn't available to reuse.",
+    )
+  cred = {
+    "client_id": source.client_id,
+    "client_secret_encrypted": source.client_secret_encrypted,
+    "access_token_encrypted": source.access_token_encrypted,
+    "refresh_token_encrypted": source.refresh_token_encrypted,
+    "access_expires_at": source.access_expires_at,
+    "scopes_granted": list(source.scopes_granted or []),
+  }
+  # Compare both sealed credentials byte-for-byte after the network gap. A
+  # disconnect, re-sign, or concurrent refresh replaces at least one of them;
+  # copying only the exact pair used for project lookup keeps the snapshot
+  # internally consistent.
+  credential_fingerprint = _oauth_credential_fingerprint(source)
+  access_token = fresh
+  url = str(stored.url)
+  db.close()
+
+  chosen, projects = await _resolve_gcloud_project(access_token, body.project_id)
+  discovery = connector_oauth_mod.gcloud_discovery(url)
+
+  session = _reopen()
+  try:
+    # Revalidate the SOURCE after the project-list network gap as well as the
+    # target. Without this, a concurrent source disconnect can revoke the sole
+    # token and reuse will still copy its stale snapshot; a deleted/reused id can
+    # likewise resolve to a different Google account in a stale tab.
+    live_source_row = session.query(models.Connector).filter(
+      models.Connector.id == body.source_connector_id,
+      models.Connector.capability_id == body.source_generation,
+    ).first()
+    live_source = (
+      _oauth_row(session, body.source_connector_id)
+      if live_source_row is not None else None
+    )
+    if (
+      live_source is None
+      or live_source.auth_mode != "gcloud"
+      or not live_source.access_token_encrypted
+      or _oauth_credential_fingerprint(live_source) != credential_fingerprint
+    ):
+      raise HTTPException(
+        status_code=409,
+        detail="That Google sign-in changed before it could be reused.",
+      )
+    row = session.query(models.Connector).filter(
+      models.Connector.id == connector_id,
+      models.Connector.capability_id == generation,
+    ).first()
+    target = _oauth_row(session, connector_id) if row is not None else None
+    if row is None or target is None:
+      raise HTTPException(status_code=404, detail="Connection not found.")
+    if _oauth_state_fingerprint(target) != target_state:
+      raise HTTPException(
+        status_code=409,
+        detail="This connection changed before the sign-in could be reused.",
+      )
+    for field_name, value in discovery.as_row_fields().items():
+      setattr(target, field_name, value)
+    target.auth_mode = "gcloud"
+    target.client_id = cred["client_id"]
+    target.client_secret_encrypted = cred["client_secret_encrypted"]
+    target.access_token_encrypted = cred["access_token_encrypted"]
+    target.refresh_token_encrypted = cred["refresh_token_encrypted"]
+    target.access_expires_at = cred["access_expires_at"]
+    target.scopes_granted = cred["scopes_granted"]
+    # `or None` clears a project left by a prior sign-in, so adopting a
+    # different account can't keep the old project and bypass the withhold.
+    target.user_project = chosen or None
+    target.connected_at = now_naive_utc()
+    row.status = "ok"
+    row.status_detail = None
+    row_generation = str(row.capability_id)
+    session.commit()
+  finally:
+    session.close()
+
+  # The probe decides the final status; a project-less grant is withheld there.
+  await _probe_signed_in(url, connector_id, row_generation, access_token, "ok")
+
+  final = _reopen()
+  try:
+    row = final.query(models.Connector).filter(
+      models.Connector.id == connector_id,
+      models.Connector.capability_id == row_generation,
+    ).first()
+    public = _public(row, _oauth_row(final, connector_id)) if row else None
+  finally:
+    final.close()
+  if public is None:
+    raise HTTPException(status_code=404, detail="Connection not found.")
+  return {"connection": public, "projects": projects, "needs_project": not chosen}
+
+
+class OAuthClientBody(BaseModel):
+  client_id: str = Field(min_length=1, max_length=512)
+  # Write-only, like ConnectorCreate.auth_value: typed `object` and validated
+  # in-route so a pydantic 422 can never echo the secret in its error body.
+  client_secret: object = ""
+
+
+@router.post("/{connector_id}/oauth/client")
+async def oauth_set_client(
+  connector_id: int,
+  body: OAuthClientBody,
+  generation: str = Depends(_require_generation),
+  _owner: models.Owner = Depends(get_owner_or_app_with_connections_manage),
+  db: Session = Depends(get_db),
+):
+  """Store the owner's own OAuth client for this connection's issuer.
+
+  The issuer is taken from the connection's discovered row, never from the
+  request, so one connector cannot name an issuer to borrow another's
+  credentials. Keyed by issuer (shared across connections on the same
+  provider) via an upsert, so re-saving a rotated secret updates rather than
+  conflicts. The secret is sealed and never returned or logged.
+  """
+  _get_row(db, connector_id, generation)
+  oauth = _oauth_row(db, connector_id)
+  if oauth is None:
+    raise HTTPException(
+      status_code=409, detail="This connection does not use sign-in.",
+    )
+  client_id = body.client_id.strip()
+  if not client_id:
+    raise HTTPException(status_code=400, detail="Enter the client ID.")
+  secret = body.client_secret
+  if not isinstance(secret, str):
+    raise HTTPException(status_code=400, detail="The client secret must be text.")
+  secret = secret.strip()
+  if len(secret) > 4096:
+    raise HTTPException(status_code=400, detail="The client secret is too long.")
+
+  issuer = str(oauth.issuer)
+  reg = (
+    db.query(models.OAuthClientRegistration)
+    .filter(models.OAuthClientRegistration.issuer == issuer)
+    .first()
+  )
+  if reg is None:
+    reg = models.OAuthClientRegistration(issuer=issuer, mode="byo", client_id=client_id)
+    db.add(reg)
+  reg.mode = "byo"
+  reg.client_id = client_id
+  reg.client_secret_encrypted = core.encrypt_oauth(secret) if secret else None
+  db.commit()
+  log.info(
+    "OAuth client set (issuer=%s) for connection %s", issuer, oauth.connector_id,
+  )
+  return _public(_get_row(db, connector_id, generation), _oauth_row(db, connector_id))
+
+
+@router.delete("/{connector_id}/oauth/client")
+async def oauth_clear_client(
+  connector_id: int,
+  generation: str = Depends(_require_generation),
+  _owner: models.Owner = Depends(get_owner_or_app_with_connections_manage),
+  db: Session = Depends(get_db),
+):
+  """Remove the owner-supplied client for this connection's issuer.
+
+  Issuer-scoped: this removes the shared client setup for every connection on
+  the same provider. Existing grants keep working until expiry or sign-out;
+  the next refresh then needs a re-setup. Automatically registered clients are
+  not owner-supplied and cannot be removed here.
+  """
+  _get_row(db, connector_id, generation)
+  oauth = _oauth_row(db, connector_id)
+  if oauth is None:
+    raise HTTPException(
+      status_code=409, detail="This connection does not use sign-in.",
+    )
+  removed = (
+    db.query(models.OAuthClientRegistration)
+    .filter(
+      models.OAuthClientRegistration.issuer == str(oauth.issuer),
+      models.OAuthClientRegistration.mode == "byo",
+    )
+    .delete(synchronize_session=False)
+  )
+  db.commit()
+  return {"ok": True, "removed": bool(removed)}
 
 
 @public_router.get("/oauth/callback")
@@ -926,7 +1736,7 @@ async def oauth_callback(
     ).first()
     if oauth is None or row is None:
       return _oauth_result_page(ok=False)
-    connector_oauth._store_tokens(oauth, tokens)
+    connector_oauth._store_authorization_tokens(oauth, tokens)
     oauth.connected_at = now_naive_utc()
     row.status = "ok"
     row.status_detail = None
@@ -963,6 +1773,19 @@ async def oauth_disconnect(
     )
   refresh_encrypted = oauth.refresh_token_encrypted
   revocation_endpoint = oauth.revocation_endpoint
+  # A gcloud credential may be SHARED with sibling connections that adopted it
+  # (reuse), and Google keeps a revoked refresh token dead for every holder — so
+  # revoking a shared token would silently sign the siblings out too. Skip the
+  # upstream revoke ONLY when a sibling still holds this exact token; an unshared
+  # grant revokes normally, so a lone connection's sign-out truly ends access.
+  if (
+    oauth.auth_mode == "gcloud"
+    and refresh_encrypted
+    and _gcloud_refresh_shared(
+      db, connector_id, core.decrypt_oauth(refresh_encrypted),
+    )
+  ):
+    revocation_endpoint = None
   issuer = oauth.issuer
   # Clear + latch signed-out + rotate the capability (a revocation boundary,
   # exactly like disable) so any minted broker capability cannot revive.
@@ -985,7 +1808,7 @@ async def oauth_disconnect(
   if revocation_endpoint and refresh_encrypted:
     try:
       token = core.decrypt_oauth(refresh_encrypted)
-      await core.pinned_json_request(
+      await connector_oauth.oauth_json_request(
         "POST", revocation_endpoint,
         form={"token": token, "token_type_hint": "refresh_token"},
         timeout_seconds=8.0,

--- a/backend/tests/test_connector_gcloud.py
+++ b/backend/tests/test_connector_gcloud.py
@@ -1,0 +1,1227 @@
+"""Google-account (gcloud) sign-in for Google Cloud MCP connections.
+
+Google supports neither dynamic client registration nor client-metadata
+documents, so the one-click path can't serve its endpoints. This flow reuses
+the Cloud SDK's published installed-app client and Google's hosted code page:
+the owner opens a link, pastes a code, and the tokens flow through the same
+sealed storage, refresh, and broker attach as every other connection — plus
+the one Google-specific ``x-goog-user-project`` header.
+
+A host-routed mock stands in for Google's token endpoint, Cloud Resource
+Manager, and the BigQuery MCP server, driven through the real routes.
+"""
+
+import json
+from datetime import datetime
+from urllib.parse import parse_qs, urlparse
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from app import connector_oauth as cox
+from app import connectors as core
+from app import models
+
+GCLOUD_MCP_URL = "https://bigquery.googleapis.com/mcp"
+_REAL_ASYNC_CLIENT = httpx.AsyncClient
+
+
+class GcloudMock:
+  """Token endpoint + Resource Manager + BigQuery MCP for one owner."""
+
+  def __init__(self, *, project_count=2, project_page_size=None):
+    self.project_count = project_count
+    self.project_page_size = project_page_size
+    self.issued = 0
+    self.access_tokens = {}
+    self.refresh_tokens = {}
+    self.token_client_ids = []
+    self.token_secrets = []
+    self.revoked = set()  # refresh tokens sent to the revoke endpoint
+    self.broker_headers = []  # headers seen on MCP calls carrying a bearer
+    self.project_queries = []  # exact CRM query parameters per page
+    self.fail_projects = False
+    self.fail_revoke = False
+    self.omit_code_refresh = False
+    self.omit_code_expiry = False
+
+  def handler(self, request: httpx.Request) -> httpx.Response:
+    host = request.url.host
+    path = request.url.path
+    form = {}
+    if request.headers.get("content-type", "").startswith(
+      "application/x-www-form-urlencoded"
+    ):
+      form = {k: v[0] for k, v in parse_qs(request.content.decode()).items()}
+    body = {}
+    if request.content and request.headers.get(
+      "content-type", ""
+    ).startswith("application/json"):
+      try:
+        body = json.loads(request.content)
+      except ValueError:
+        body = {}
+
+    # ── Google token endpoint ──
+    if host == "oauth2.googleapis.com" and path == "/token":
+      self.token_client_ids.append(form.get("client_id"))
+      self.token_secrets.append(form.get("client_secret"))
+      grant = form.get("grant_type")
+      if grant == "authorization_code":
+        return self._issue(
+          include_refresh=not self.omit_code_refresh,
+          include_expiry=not self.omit_code_expiry,
+        )
+      if grant == "refresh_token":
+        rt = form.get("refresh_token")
+        if rt not in self.refresh_tokens:
+          return httpx.Response(400, json={"error": "invalid_grant"})
+        return self._issue(rotate_from=rt)
+      return httpx.Response(400, json={"error": "unsupported_grant_type"})
+
+    # ── Google token revocation (RFC 7009) — should stay untouched for gcloud ──
+    if host == "oauth2.googleapis.com" and path == "/revoke":
+      if self.fail_revoke:
+        raise httpx.ConnectError("revoke unavailable", request=request)
+      self.revoked.add(form.get("token"))
+      return httpx.Response(200)
+
+    # ── Cloud Resource Manager: list the owner's projects (paginated) ──
+    if host == "cloudresourcemanager.googleapis.com" and path == "/v1/projects":
+      query = dict(request.url.params)
+      self.project_queries.append(query)
+      if self.fail_projects:
+        raise httpx.ConnectError("projects unavailable", request=request)
+      requested_page_size = int(query.get("pageSize", "50"))
+      page_size = min(
+        requested_page_size,
+        self.project_page_size or requested_page_size,
+      )
+      start = int(query.get("pageToken", "0"))
+      allp = [
+        {"projectId": f"proj-{i}", "name": f"Project {i}",
+         "lifecycleState": "ACTIVE"}
+        for i in range(1, self.project_count + 1)
+      ]
+      page = allp[start:start + page_size]
+      out = {"projects": page}
+      if start + page_size < len(allp):
+        out["nextPageToken"] = str(start + page_size)
+      return httpx.Response(200, json=out)
+
+    # ── Google Cloud MCP servers (BigQuery, Storage, …) — handshake open ──
+    if host.endswith("googleapis.com") and path.endswith("/mcp"):
+      auth = request.headers.get("authorization", "")
+      if auth.lower().startswith("bearer "):
+        self.broker_headers.append(dict(request.headers))
+      method = body.get("method")
+      if method == "initialize":
+        return httpx.Response(200, headers={"content-type": "application/json"},
+          json={"jsonrpc": "2.0", "id": body.get("id", 1),
+                "result": {"protocolVersion": "2025-11-25",
+                           "serverInfo": {"name": "BigQuery MCP"}}})
+      if method == "notifications/initialized":
+        return httpx.Response(202)
+      if method == "tools/list":
+        return httpx.Response(200, headers={"content-type": "application/json"},
+          json={"jsonrpc": "2.0", "id": body.get("id", 2),
+                "result": {"tools": [{"name": "list_dataset_ids"}]}})
+      return httpx.Response(200, headers={"content-type": "application/json"},
+        json={"jsonrpc": "2.0", "id": body.get("id"), "result": {}})
+
+    return httpx.Response(404, json={"error": "not_found", "host": host})
+
+  def _issue(
+    self, rotate_from=None, *, include_refresh=True, include_expiry=True,
+  ):
+    self.issued += 1
+    access, refresh = f"ya29.access-{self.issued}", f"refresh-{self.issued}"
+    self.access_tokens[access] = True
+    payload = {
+      "access_token": access,
+      "token_type": "Bearer",
+      "scope": "openid https://www.googleapis.com/auth/cloud-platform",
+    }
+    if include_expiry:
+      payload["expires_in"] = 3600
+    if include_refresh:
+      self.refresh_tokens[refresh] = self.issued
+      payload["refresh_token"] = refresh
+      if rotate_from:
+        self.refresh_tokens.pop(rotate_from, None)
+    return httpx.Response(200, json=payload)
+
+
+def _wire(monkeypatch, mock):
+  monkeypatch.setattr(
+    core, "_safe_endpoint",
+    lambda url: (url, httpx.URL(url).host, httpx.URL(url).host),
+  )
+  monkeypatch.setattr(
+    core.httpx, "AsyncClient",
+    lambda **kwargs: _REAL_ASYNC_CLIENT(
+      transport=httpx.MockTransport(mock.handler),
+      timeout=kwargs.get("timeout"),
+      follow_redirects=False,
+    ),
+  )
+  return mock
+
+
+def _headers(auth, generation):
+  return {**auth, "X-Mobius-Connector-Generation": generation}
+
+
+GCS_MCP_URL = "https://storage.googleapis.com/storage/mcp"
+
+
+def _seed_google_connector(db, *, slug="google_bigquery_test",
+                           name="Google BigQuery", url=GCLOUD_MCP_URL):
+  """Insert a signed-out Google Cloud connector as add_connector would."""
+  row = models.Connector(
+    slug=slug,
+    name=name,
+    url=url,
+    enabled=True,
+    tools_json=[],
+    est_tokens=0,
+    status="oauth_required",
+    status_detail="Sign in to finish connecting.",
+  )
+  db.add(row)
+  db.flush()
+  db.add(models.ConnectorOAuth(
+    connector_id=row.id,
+    resource=url,
+    issuer="https://accounts.google.com",
+    authorization_endpoint="https://accounts.google.com/o/oauth2/v2/auth",
+    token_endpoint="https://oauth2.googleapis.com/token",
+    scopes_advertised=["https://www.googleapis.com/auth/cloud-platform"],
+  ))
+  db.commit()
+  return row.id, row.capability_id
+
+
+def _complete_signin(client, auth, cid, gen, project_id=""):
+  started = client.post(
+    f"/api/connectors/{cid}/oauth/gcloud/start", headers=_headers(auth, gen),
+  ).json()
+  return client.post(
+    f"/api/connectors/{cid}/oauth/gcloud/complete",
+    headers=_headers(auth, gen),
+    json={"state": started["state"], "code": "4/x", "project_id": project_id},
+  ).json()
+
+
+# ── unit ────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("host", [
+  "bigquery.googleapis.com",
+  "firestore.googleapis.com",
+  "logging.googleapis.com",
+  "pubsub.googleapis.com",
+  "run.googleapis.com",
+  "storage.googleapis.com",
+])
+def test_is_google_cloud_mcp_url_exact_allowlist(host):
+  assert cox.is_google_cloud_mcp_url(f"https://{host}/any/mcp/path")
+
+
+@pytest.mark.parametrize("url", [
+  "https://googleapis.com/mcp",
+  "https://drivemcp.googleapis.com/mcp/v1",
+  "https://drive.googleapis.com/mcp",
+  "https://mapstools.googleapis.com/mcp",
+  "https://googleapis.com.evil.test/mcp",
+  "https://mcp.notion.com/mcp",
+])
+def test_is_google_cloud_mcp_url_rejects_other_hosts(url):
+  assert not cox.is_google_cloud_mcp_url(url)
+
+
+def test_gcloud_client_identity_reads_sdk():
+  cid, secret = cox.gcloud_client_identity()
+  assert cid.endswith(".apps.googleusercontent.com")
+  assert secret and len(secret) > 8
+
+
+def test_gcloud_authorization_url_shape():
+  url = cox.gcloud_authorization_url("client-x", "chal", "state-y")
+  parsed = urlparse(url)
+  q = {k: v[0] for k, v in parse_qs(parsed.query).items()}
+  assert parsed.netloc == "accounts.google.com"
+  assert q["redirect_uri"] == "https://sdk.cloud.google.com/authcode.html"
+  assert q["token_usage"] == "remote"
+  assert q["access_type"] == "offline"
+  assert q["code_challenge_method"] == "S256"
+  assert q["client_id"] == "client-x"
+  # The minted Cloud token is audience-less, like gcloud's — no resource param.
+  assert "resource" not in q
+
+
+# ── flow ──────────────────────────────────────────────────────────────────
+
+
+def test_gcloud_start_returns_link_and_state(client, auth, db, monkeypatch):
+  _wire(monkeypatch, GcloudMock())
+  cid, gen = _seed_google_connector(db)
+  started = client.post(
+    f"/api/connectors/{cid}/oauth/gcloud/start", headers=_headers(auth, gen),
+  )
+  assert started.status_code == 200
+  data = started.json()
+  assert "token_usage=remote" in data["authorize_url"]
+  assert data["state"]
+
+
+def test_gcloud_start_rejected_for_non_google(client, auth, db, monkeypatch):
+  _wire(monkeypatch, GcloudMock())
+  row = models.Connector(
+    slug="notion_test", name="Notion", url="https://mcp.notion.com/mcp",
+    enabled=True, tools_json=[], est_tokens=0, status="oauth_required",
+  )
+  db.add(row)
+  db.flush()
+  db.add(models.ConnectorOAuth(
+    connector_id=row.id, resource="https://mcp.notion.com/mcp",
+    issuer="https://mcp.notion.com",
+    authorization_endpoint="https://mcp.notion.com/authorize",
+    token_endpoint="https://mcp.notion.com/token", scopes_advertised=[],
+  ))
+  db.commit()
+  resp = client.post(
+    f"/api/connectors/{row.id}/oauth/gcloud/start",
+    headers=_headers(auth, row.capability_id),
+  )
+  assert resp.status_code == 409
+
+
+def test_gcloud_complete_multi_project_then_set_and_broker(
+  client, auth, db, monkeypatch,
+):
+  mock = _wire(monkeypatch, GcloudMock(project_count=2))
+  cid, gen = _seed_google_connector(db)
+  started = client.post(
+    f"/api/connectors/{cid}/oauth/gcloud/start", headers=_headers(auth, gen),
+  ).json()
+
+  done = client.post(
+    f"/api/connectors/{cid}/oauth/gcloud/complete",
+    headers=_headers(auth, gen),
+    json={"state": started["state"], "code": "4/pasted-code"},
+  )
+  assert done.status_code == 200
+  out = done.json()
+  # Two projects → the owner must choose; tokens are sealed regardless.
+  assert out["needs_project"] is True
+  assert {p["project_id"] for p in out["projects"]} == {"proj-1", "proj-2"}
+  assert out["connection"]["signed_in"] is True
+  assert out["connection"]["oauth_flavor"] == "gcloud"
+  # Withheld from turns until a project is chosen (can't call tools without it).
+  assert out["connection"]["status"] == "oauth_required"
+
+  # A project-less gcloud grant must NOT be brokered even if reached directly.
+  db.expire_all()
+  cap0 = core.mint_broker_capability(
+    cid, db.query(models.Connector).get(cid).capability_id,
+  )
+  with TestClient(client.app, client=("127.0.0.1", 43110)) as loopback:
+    refused = loopback.post(
+      f"/api/connectors/{cid}/broker",
+      headers={"Authorization": f"Bearer {cap0}",
+               "content-type": "application/json"},
+      content=json.dumps({"jsonrpc": "2.0", "id": 1,
+                          "method": "initialize", "params": {}}),
+    )
+  assert refused.status_code == 404
+
+  # The exchange used the Cloud SDK client (confidential) — not our CIMD URL.
+  gcloud_id, gcloud_secret = cox.gcloud_client_identity()
+  assert mock.token_client_ids[0] == gcloud_id
+  assert mock.token_secrets[0] == gcloud_secret
+
+  db.expire_all()
+  row = db.query(models.ConnectorOAuth).filter_by(connector_id=cid).one()
+  assert row.auth_mode == "gcloud"
+  assert row.client_id == gcloud_id
+  assert row.client_secret_encrypted  # sealed
+  assert row.access_token_encrypted and row.refresh_token_encrypted
+  assert row.user_project is None  # not chosen yet
+  # Tokens never cross the API boundary.
+  assert "ya29" not in json.dumps(out)
+
+  # Choose a project.
+  gen2 = db.query(models.Connector).get(cid).capability_id
+  chosen = client.post(
+    f"/api/connectors/{cid}/oauth/gcloud/project",
+    headers=_headers(auth, gen2), json={"project_id": "proj-2"},
+  )
+  assert chosen.status_code == 200
+  assert chosen.json()["connection"]["user_project"] == "proj-2"
+  db.expire_all()
+  assert db.query(models.ConnectorOAuth).filter_by(
+    connector_id=cid).one().user_project == "proj-2"
+
+  # Broker attaches BOTH the bearer token and the quota-project header.
+  cap = core.mint_broker_capability(
+    cid, db.query(models.Connector).get(cid).capability_id,
+  )
+  with TestClient(client.app, client=("127.0.0.1", 43110)) as loopback:
+    brokered = loopback.post(
+      f"/api/connectors/{cid}/broker",
+      headers={"Authorization": f"Bearer {cap}",
+               "content-type": "application/json"},
+      content=json.dumps({"jsonrpc": "2.0", "id": 1,
+                          "method": "initialize", "params": {}}),
+    )
+  assert brokered.status_code == 200
+  assert "BigQuery MCP" in brokered.text
+  seen = mock.broker_headers[-1]
+  assert seen.get("x-goog-user-project") == "proj-2"
+  assert seen.get("authorization", "").startswith("Bearer ya29.")
+
+
+def test_gcloud_reauthorization_clears_a_prior_refresh_token(
+  client, auth, db, monkeypatch,
+):
+  """An auth-code response for account B may omit a refresh token. It must
+  never retain account A's old refresh token and silently switch back later."""
+  mock = _wire(monkeypatch, GcloudMock(project_count=1))
+  cid, gen = _seed_google_connector(db)
+  _complete_signin(client, auth, cid, gen)
+  db.expire_all()
+  first = db.query(models.ConnectorOAuth).filter_by(connector_id=cid).one()
+  assert core.decrypt_oauth(first.refresh_token_encrypted) == "refresh-1"
+  prior_expiry = datetime(2099, 1, 1)
+  first.access_expires_at = prior_expiry
+  db.commit()
+
+  mock.omit_code_refresh = True
+  mock.omit_code_expiry = True
+  second = _complete_signin(client, auth, cid, gen, project_id="proj-1")
+  assert second["connection"]["signed_in"] is True
+  db.expire_all()
+  current = db.query(models.ConnectorOAuth).filter_by(connector_id=cid).one()
+  assert core.decrypt_oauth(current.access_token_encrypted) == "ya29.access-2"
+  assert current.refresh_token_encrypted is None
+  assert current.access_expires_at != prior_expiry
+
+
+def test_gcloud_complete_survives_project_transport_failure(
+  client, auth, db, monkeypatch,
+):
+  """Project listing is best-effort: a network failure after code exchange
+  must not lose the consumed one-shot code or the freshly issued grant."""
+  mock = _wire(monkeypatch, GcloudMock(project_count=1))
+  cid, gen = _seed_google_connector(db)
+  started = client.post(
+    f"/api/connectors/{cid}/oauth/gcloud/start", headers=_headers(auth, gen),
+  ).json()
+  mock.fail_projects = True
+  done = client.post(
+    f"/api/connectors/{cid}/oauth/gcloud/complete",
+    headers=_headers(auth, gen),
+    json={"state": started["state"], "code": "4/pasted-code"},
+  )
+  assert done.status_code == 200, done.text
+  assert done.json()["projects"] == []
+  assert done.json()["needs_project"] is True
+  db.expire_all()
+  oauth = db.query(models.ConnectorOAuth).filter_by(connector_id=cid).one()
+  assert oauth.access_token_encrypted and oauth.refresh_token_encrypted
+
+
+@pytest.mark.asyncio
+async def test_oauth_transport_errors_are_normalized(monkeypatch):
+  request = httpx.Request("GET", "https://oauth2.googleapis.com/token")
+  failures = (
+    TimeoutError("timed out"),
+    httpx.ConnectError("connect failed", request=request),
+  )
+  for failure in failures:
+    async def fail(*_args, _failure=failure, **_kwargs):
+      raise _failure
+
+    monkeypatch.setattr(core, "pinned_json_request", fail)
+    with pytest.raises(core.ConnectorError) as raised:
+      await cox.oauth_json_request(
+        "GET", "https://oauth2.googleapis.com/token",
+      )
+    assert raised.value.transient is True
+
+
+def test_gcloud_list_projects_for_signed_in_connection(
+  client, auth, db, monkeypatch,
+):
+  # After signing in (single project auto-selected), the picker endpoint
+  # returns the full live list plus the currently-selected project.
+  _wire(monkeypatch, GcloudMock(project_count=3))
+  cid, gen = _seed_google_connector(db)
+  started = client.post(
+    f"/api/connectors/{cid}/oauth/gcloud/start", headers=_headers(auth, gen),
+  ).json()
+  client.post(
+    f"/api/connectors/{cid}/oauth/gcloud/complete",
+    headers=_headers(auth, gen),
+    json={"state": started["state"], "code": "4/x", "project_id": "proj-2"},
+  )
+  db.expire_all()
+  gen2 = db.query(models.Connector).get(cid).capability_id
+  listed = client.get(
+    f"/api/connectors/{cid}/oauth/gcloud/projects", headers=_headers(auth, gen2),
+  )
+  assert listed.status_code == 200
+  body = listed.json()
+  assert {p["project_id"] for p in body["projects"]} == {"proj-1", "proj-2", "proj-3"}
+  assert body["current"] == "proj-2"
+
+
+def test_gcloud_list_projects_requires_signin(client, auth, db, monkeypatch):
+  _wire(monkeypatch, GcloudMock())
+  cid, gen = _seed_google_connector(db)  # signed out
+  resp = client.get(
+    f"/api/connectors/{cid}/oauth/gcloud/projects", headers=_headers(auth, gen),
+  )
+  assert resp.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_gcloud_set_project_releases_request_session_before_crm(
+  client, auth, db, monkeypatch,
+):
+  """The request Session must not remain checked out across CRM and then sit
+  beside the fresh generation-guarded write Session."""
+  from app.database import SessionLocal
+  from app.routes import connectors as connector_routes
+
+  _wire(monkeypatch, GcloudMock(project_count=1))
+  cid, gen = _seed_google_connector(db)
+  _complete_signin(client, auth, cid, gen)
+  db.close()
+
+  request_session = SessionLocal()
+
+  async def assert_released(_token):
+    assert not request_session.in_transaction()
+    return [{"project_id": "proj-1", "name": "Project 1"}]
+
+  monkeypatch.setattr(cox, "list_google_projects", assert_released)
+  try:
+    result = await connector_routes.oauth_gcloud_set_project(
+      cid,
+      connector_routes.GcloudProjectBody(project_id="proj-1"),
+      generation=gen,
+      _owner=None,
+      db=request_session,
+    )
+  finally:
+    request_session.close()
+  assert result["connection"]["user_project"] == "proj-1"
+
+
+def test_gcloud_set_project_aborts_when_signin_changes_during_lookup(
+  client, auth, db, monkeypatch,
+):
+  """A project verified with account A must not be written onto account B
+  when a fresh sign-in completes under the same connector generation."""
+  from app.database import SessionLocal
+
+  _wire(monkeypatch, GcloudMock(project_count=2))
+  cid, gen = _seed_google_connector(db)
+  _complete_signin(client, auth, cid, gen, project_id="proj-1")
+
+  async def resign_during_lookup(_token):
+    with SessionLocal() as concurrent:
+      oauth = concurrent.query(models.ConnectorOAuth).filter_by(
+        connector_id=cid,
+      ).one()
+      oauth.access_token_encrypted = core.encrypt_oauth("account-b-access")
+      oauth.refresh_token_encrypted = core.encrypt_oauth("account-b-refresh")
+      oauth.user_project = None
+      concurrent.commit()
+    return [{"project_id": "proj-2", "name": "Project 2"}]
+
+  monkeypatch.setattr(cox, "list_google_projects", resign_during_lookup)
+  changed = client.post(
+    f"/api/connectors/{cid}/oauth/gcloud/project",
+    headers=_headers(auth, gen),
+    json={"project_id": "proj-2"},
+  )
+  assert changed.status_code == 409, changed.text
+  db.expire_all()
+  oauth = db.query(models.ConnectorOAuth).filter_by(connector_id=cid).one()
+  assert core.decrypt_oauth(oauth.access_token_encrypted) == "account-b-access"
+  assert oauth.user_project is None
+
+
+def test_gcloud_reuse_signin_across_connections(client, auth, db, monkeypatch):
+  # Sign in one Google connection, then a second Google Cloud connection adopts
+  # that sign-in with no re-approval — only a project pick.
+  mock = _wire(monkeypatch, GcloudMock(project_count=1))
+  a_id, a_gen = _seed_google_connector(db)
+  _complete_signin(client, auth, a_id, a_gen)  # single project auto-selected
+
+  b_id, b_gen = _seed_google_connector(
+    db, slug="google_storage_test", name="Google Cloud Storage", url=GCS_MCP_URL,
+  )
+  # The second connection can see the first as a reusable source.
+  reusable = client.get(
+    f"/api/connectors/{b_id}/oauth/gcloud/reusable", headers=_headers(auth, b_gen),
+  ).json()
+  assert [s["connector_id"] for s in reusable["sources"]] == [a_id]
+  assert reusable["sources"][0]["generation"] == a_gen
+
+  reused = client.post(
+    f"/api/connectors/{b_id}/oauth/gcloud/reuse",
+    headers=_headers(auth, b_gen),
+    json={"source_connector_id": a_id, "source_generation": a_gen},
+  )
+  assert reused.status_code == 200
+  out = reused.json()
+  assert out["connection"]["signed_in"] is True
+  assert out["connection"]["oauth_flavor"] == "gcloud"
+  assert out["connection"]["user_project"] == "proj-1"  # single → auto
+  assert out["needs_project"] is False
+  # No fresh Google consent happened: reuse does not mint a new grant via the
+  # authorization-code exchange (issued count only moves for token refreshes).
+  assert "ya29" not in json.dumps(out)
+
+  # The adopted credential is the same one (copied), and B now brokers calls
+  # with its own project header + the shared bearer token.
+  db.expire_all()
+  a = db.query(models.ConnectorOAuth).filter_by(connector_id=a_id).one()
+  b = db.query(models.ConnectorOAuth).filter_by(connector_id=b_id).one()
+  assert b.refresh_token_encrypted and b.client_id == a.client_id
+  cap = core.mint_broker_capability(
+    b_id, db.query(models.Connector).get(b_id).capability_id,
+  )
+  with TestClient(client.app, client=("127.0.0.1", 43110)) as loopback:
+    brokered = loopback.post(
+      f"/api/connectors/{b_id}/broker",
+      headers={"Authorization": f"Bearer {cap}", "content-type": "application/json"},
+      content=json.dumps({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}}),
+    )
+  assert brokered.status_code == 200
+  seen = mock.broker_headers[-1]
+  assert seen.get("x-goog-user-project") == "proj-1"
+  assert seen.get("authorization", "").startswith("Bearer ya29.")
+
+
+def test_gcloud_reuse_rejects_unavailable_source(client, auth, db, monkeypatch):
+  _wire(monkeypatch, GcloudMock())
+  a_id, a_gen = _seed_google_connector(db)  # signed OUT
+  b_id, b_gen = _seed_google_connector(
+    db, slug="google_storage_test", name="Cloud Storage", url=GCS_MCP_URL,
+  )
+  # Source is not signed in → nothing to reuse.
+  resp = client.post(
+    f"/api/connectors/{b_id}/oauth/gcloud/reuse",
+    headers=_headers(auth, b_gen),
+    json={"source_connector_id": a_id, "source_generation": a_gen},
+  )
+  assert resp.status_code == 409
+  # And it cannot reuse itself.
+  self_resp = client.post(
+    f"/api/connectors/{b_id}/oauth/gcloud/reuse",
+    headers=_headers(auth, b_gen),
+    json={"source_connector_id": b_id, "source_generation": b_gen},
+  )
+  assert self_resp.status_code == 400
+
+
+def test_gcloud_reuse_rejects_a_stale_source_generation(
+  client, auth, db, monkeypatch,
+):
+  """A stale reusable choice must not follow a SQLite id into a newer grant."""
+  _wire(monkeypatch, GcloudMock(project_count=1))
+  source_id, old_source_gen = _seed_google_connector(db)
+  _complete_signin(client, auth, source_id, old_source_gen)
+  target_id, target_gen = _seed_google_connector(
+    db, slug="google_storage_test", name="Cloud Storage", url=GCS_MCP_URL,
+  )
+
+  disconnected = client.post(
+    f"/api/connectors/{source_id}/oauth/disconnect",
+    headers=_headers(auth, old_source_gen),
+  )
+  assert disconnected.status_code == 200
+  new_source_gen = disconnected.json()["generation"]
+  _complete_signin(client, auth, source_id, new_source_gen)
+
+  stale = client.post(
+    f"/api/connectors/{target_id}/oauth/gcloud/reuse",
+    headers=_headers(auth, target_gen),
+    json={
+      "source_connector_id": source_id,
+      "source_generation": old_source_gen,
+    },
+  )
+  assert stale.status_code == 409
+  db.expire_all()
+  target = db.query(models.ConnectorOAuth).filter_by(
+    connector_id=target_id,
+  ).one()
+  assert target.access_token_encrypted is None
+  assert target.refresh_token_encrypted is None
+
+
+def test_gcloud_reuse_aborts_when_source_changes_during_project_lookup(
+  client, auth, db, monkeypatch,
+):
+  """Deterministically exercise the snapshot→network→commit gap: a source
+  disconnect/replacement during CRM lookup must abort, never copy stale tokens."""
+  from app.database import SessionLocal
+  from app.routes import connectors as connector_routes
+
+  _wire(monkeypatch, GcloudMock(project_count=1))
+  source_id, source_gen = _seed_google_connector(db)
+  _complete_signin(client, auth, source_id, source_gen)
+  target_id, target_gen = _seed_google_connector(
+    db, slug="google_storage_test", name="Cloud Storage", url=GCS_MCP_URL,
+  )
+  real_resolve = connector_routes._resolve_gcloud_project
+
+  async def mutate_source(access_token, requested):
+    result = await real_resolve(access_token, requested)
+    with SessionLocal() as concurrent:
+      source_row = concurrent.query(models.Connector).filter_by(
+        id=source_id,
+      ).one()
+      source_oauth = concurrent.query(models.ConnectorOAuth).filter_by(
+        connector_id=source_id,
+      ).one()
+      source_row.capability_id = "f" * 64
+      source_row.status = "oauth_required"
+      source_oauth.access_token_encrypted = None
+      source_oauth.refresh_token_encrypted = None
+      concurrent.commit()
+    return result
+
+  monkeypatch.setattr(
+    connector_routes, "_resolve_gcloud_project", mutate_source,
+  )
+  reused = client.post(
+    f"/api/connectors/{target_id}/oauth/gcloud/reuse",
+    headers=_headers(auth, target_gen),
+    json={
+      "source_connector_id": source_id,
+      "source_generation": source_gen,
+    },
+  )
+  assert reused.status_code == 409, reused.text
+  db.expire_all()
+  target = db.query(models.ConnectorOAuth).filter_by(
+    connector_id=target_id,
+  ).one()
+  assert target.access_token_encrypted is None
+  assert target.refresh_token_encrypted is None
+
+
+def test_gcloud_reuse_aborts_when_target_signs_in_during_project_lookup(
+  client, auth, db, monkeypatch,
+):
+  """A stale reuse must not overwrite a same-generation target completion."""
+  from app.database import SessionLocal
+  from app.routes import connectors as connector_routes
+
+  _wire(monkeypatch, GcloudMock(project_count=1))
+  source_id, source_gen = _seed_google_connector(db)
+  _complete_signin(client, auth, source_id, source_gen)
+  target_id, target_gen = _seed_google_connector(
+    db, slug="google_storage_test", name="Cloud Storage", url=GCS_MCP_URL,
+  )
+  real_resolve = connector_routes._resolve_gcloud_project
+
+  async def complete_target(access_token, requested):
+    result = await real_resolve(access_token, requested)
+    with SessionLocal() as concurrent:
+      target = concurrent.query(models.ConnectorOAuth).filter_by(
+        connector_id=target_id,
+      ).one()
+      target.auth_mode = "gcloud"
+      target.client_id = "account-b-client"
+      target.access_token_encrypted = core.encrypt_oauth("account-b-access")
+      target.refresh_token_encrypted = core.encrypt_oauth("account-b-refresh")
+      target.user_project = "proj-2"
+      concurrent.commit()
+    return result
+
+  monkeypatch.setattr(connector_routes, "_resolve_gcloud_project", complete_target)
+  reused = client.post(
+    f"/api/connectors/{target_id}/oauth/gcloud/reuse",
+    headers=_headers(auth, target_gen),
+    json={
+      "source_connector_id": source_id,
+      "source_generation": source_gen,
+    },
+  )
+  assert reused.status_code == 409, reused.text
+  db.expire_all()
+  target = db.query(models.ConnectorOAuth).filter_by(
+    connector_id=target_id,
+  ).one()
+  assert core.decrypt_oauth(target.access_token_encrypted) == "account-b-access"
+  assert target.client_id == "account-b-client"
+  assert target.user_project == "proj-2"
+
+
+def test_gcloud_disconnect_does_not_revoke_shared_credential(
+  client, auth, db, monkeypatch,
+):
+  # Signing out one connection must NOT revoke the Google credential a sibling
+  # adopted — Google would kill it for every holder.
+  mock = _wire(monkeypatch, GcloudMock(project_count=1))
+  a_id, a_gen = _seed_google_connector(db)
+  _complete_signin(client, auth, a_id, a_gen)
+  b_id, b_gen = _seed_google_connector(
+    db, slug="google_storage_test", name="Cloud Storage", url=GCS_MCP_URL,
+  )
+  client.post(
+    f"/api/connectors/{b_id}/oauth/gcloud/reuse",
+    headers=_headers(auth, b_gen),
+    json={"source_connector_id": a_id, "source_generation": a_gen},
+  )
+  db.expire_all()
+  a_gen_now = db.query(models.Connector).get(a_id).capability_id
+  out = client.post(
+    f"/api/connectors/{a_id}/oauth/disconnect", headers=_headers(auth, a_gen_now),
+  )
+  assert out.status_code == 200
+  assert out.json()["signed_in"] is False
+  # Crucially: no upstream revocation, because the sibling still holds the token.
+  assert len(mock.revoked) == 0
+  # The sibling that adopted the credential is still signed in and usable.
+  db.expire_all()
+  b = db.query(models.ConnectorOAuth).filter_by(connector_id=b_id).one()
+  assert b.access_token_encrypted is not None
+
+
+def test_gcloud_disconnect_revokes_when_unshared(client, auth, db, monkeypatch):
+  # A lone gcloud connection whose token nobody else holds SHOULD revoke
+  # upstream on sign-out, so the grant truly ends.
+  mock = _wire(monkeypatch, GcloudMock(project_count=1))
+  cid, gen = _seed_google_connector(db)
+  _complete_signin(client, auth, cid, gen)
+  db.expire_all()
+  refresh = core.decrypt_oauth(
+    db.query(models.ConnectorOAuth).filter_by(connector_id=cid).one()
+    .refresh_token_encrypted
+  )
+  gen_now = db.query(models.Connector).get(cid).capability_id
+  client.post(
+    f"/api/connectors/{cid}/oauth/disconnect", headers=_headers(auth, gen_now),
+  )
+  assert refresh in mock.revoked
+
+
+def test_gcloud_disconnect_is_locally_successful_when_revoke_transport_fails(
+  client, auth, db, monkeypatch,
+):
+  mock = _wire(monkeypatch, GcloudMock(project_count=1))
+  cid, gen = _seed_google_connector(db)
+  _complete_signin(client, auth, cid, gen)
+  mock.fail_revoke = True
+  signed_out = client.post(
+    f"/api/connectors/{cid}/oauth/disconnect", headers=_headers(auth, gen),
+  )
+  assert signed_out.status_code == 200, signed_out.text
+  assert signed_out.json()["signed_in"] is False
+  db.expire_all()
+  oauth = db.query(models.ConnectorOAuth).filter_by(connector_id=cid).one()
+  assert oauth.access_token_encrypted is None
+  assert oauth.refresh_token_encrypted is None
+
+
+def test_gcloud_projectless_stays_withheld_after_recheck(
+  client, auth, db, monkeypatch,
+):
+  # Two projects, none chosen → withheld. A later Recheck must NOT flip it to
+  # "ok" (the handshake succeeds without a project, but tool calls can't).
+  _wire(monkeypatch, GcloudMock(project_count=2))
+  cid, gen = _seed_google_connector(db)
+  out = _complete_signin(client, auth, cid, gen)
+  assert out["needs_project"] is True
+  assert out["connection"]["status"] == "oauth_required"
+  db.expire_all()
+  gen_now = db.query(models.Connector).get(cid).capability_id
+  rechecked = client.post(
+    f"/api/connectors/{cid}/refresh", headers=_headers(auth, gen_now),
+  )
+  assert rechecked.status_code == 200
+  assert rechecked.json()["status"] == "oauth_required"  # still withheld
+
+
+def test_gcloud_reuse_clears_stale_project(client, auth, db, monkeypatch):
+  # A connection that once had a project, signed out, then reuses a multi-project
+  # account with none named must not keep the stale project.
+  _wire(monkeypatch, GcloudMock(project_count=1))
+  a_id, a_gen = _seed_google_connector(db)
+  _complete_signin(client, auth, a_id, a_gen)  # A: single project auto
+  b_id, b_gen = _seed_google_connector(
+    db, slug="google_storage_test", name="Cloud Storage", url=GCS_MCP_URL,
+  )
+  # Give B a stale project directly, as a prior sign-in would have.
+  b_oauth = db.query(models.ConnectorOAuth).filter_by(connector_id=b_id).one()
+  b_oauth.user_project = "old-stale-proj"
+  db.commit()
+  # Source A has one project; reuse WITHOUT naming one auto-selects A's sole
+  # project, so to exercise the clear path we point B at a 2-project account.
+  # Re-wire the mock to 2 projects for the reuse call.
+  _wire(monkeypatch, GcloudMock(project_count=2))
+  # A must look signed-in to the 2-project mock too; re-sign A so its token is
+  # valid against the new mock.
+  _complete_signin(client, auth, a_id,
+                   db.query(models.Connector).get(a_id).capability_id,
+                   project_id="proj-1")
+  db.expire_all()
+  reused = client.post(
+    f"/api/connectors/{b_id}/oauth/gcloud/reuse",
+    headers=_headers(auth, db.query(models.Connector).get(b_id).capability_id),
+    json={
+      "source_connector_id": a_id,
+      "source_generation": db.query(models.Connector).get(a_id).capability_id,
+    },  # no project_id → none auto-selected
+  )
+  assert reused.status_code == 200
+  assert reused.json()["needs_project"] is True
+  db.expire_all()
+  assert db.query(models.ConnectorOAuth).filter_by(
+    connector_id=b_id).one().user_project is None  # stale value cleared
+
+
+def test_gcloud_complete_single_project_auto_selects(
+  client, auth, db, monkeypatch,
+):
+  _wire(monkeypatch, GcloudMock(project_count=1))
+  cid, gen = _seed_google_connector(db)
+  started = client.post(
+    f"/api/connectors/{cid}/oauth/gcloud/start", headers=_headers(auth, gen),
+  ).json()
+  out = client.post(
+    f"/api/connectors/{cid}/oauth/gcloud/complete",
+    headers=_headers(auth, gen),
+    json={"state": started["state"], "code": "4/pasted-code"},
+  ).json()
+  assert out["needs_project"] is False
+  assert out["connection"]["user_project"] == "proj-1"
+
+
+def test_valid_gcloud_project_id():
+  assert cox.valid_gcloud_project_id("my-proj-123")
+  assert not cox.valid_gcloud_project_id("Bad_Upper")
+  assert not cox.valid_gcloud_project_id("ab")           # too short
+  assert not cox.valid_gcloud_project_id("ends-")        # trailing hyphen
+  assert not cox.valid_gcloud_project_id("p\r\nx: y")    # control chars
+
+
+def test_gcloud_complete_requests_max_project_page(
+  client, auth, db, monkeypatch,
+):
+  # Ask Resource Manager for its 500-item maximum so an owner with a large
+  # project list does not pay avoidable sequential page round-trips.
+  mock = _wire(monkeypatch, GcloudMock(project_count=120))
+  cid, gen = _seed_google_connector(db)
+  started = client.post(
+    f"/api/connectors/{cid}/oauth/gcloud/start", headers=_headers(auth, gen),
+  ).json()
+  out = client.post(
+    f"/api/connectors/{cid}/oauth/gcloud/complete",
+    headers=_headers(auth, gen),
+    json={"state": started["state"], "code": "4/x", "project_id": "proj-119"},
+  )
+  assert out.status_code == 200
+  assert len(out.json()["projects"]) == 120
+  assert out.json()["connection"]["user_project"] == "proj-119"
+  assert mock.project_queries == [{"pageSize": "500"}]
+
+
+def test_gcloud_project_list_honors_500_result_safety_cap(
+  client, auth, db, monkeypatch,
+):
+  # CRM may return fewer rows than requested and advertise a next page. Stop
+  # midway through that later page rather than exceeding the documented cap.
+  mock = _wire(
+    monkeypatch,
+    GcloudMock(project_count=800, project_page_size=400),
+  )
+  cid, gen = _seed_google_connector(db)
+  started = client.post(
+    f"/api/connectors/{cid}/oauth/gcloud/start", headers=_headers(auth, gen),
+  ).json()
+  out = client.post(
+    f"/api/connectors/{cid}/oauth/gcloud/complete",
+    headers=_headers(auth, gen),
+    json={"state": started["state"], "code": "4/x", "project_id": "proj-499"},
+  )
+  assert out.status_code == 200, out.text
+  assert len(out.json()["projects"]) == 500
+  assert out.json()["projects"][-1]["project_id"] == "proj-500"
+  assert mock.project_queries == [
+    {"pageSize": "500"},
+    {"pageSize": "500", "pageToken": "400"},
+  ]
+
+
+def test_gcloud_complete_rejects_malformed_project_id(client, auth, db, monkeypatch):
+  _wire(monkeypatch, GcloudMock(project_count=2))
+  cid, gen = _seed_google_connector(db)
+  started = client.post(
+    f"/api/connectors/{cid}/oauth/gcloud/start", headers=_headers(auth, gen),
+  ).json()
+  resp = client.post(
+    f"/api/connectors/{cid}/oauth/gcloud/complete",
+    headers=_headers(auth, gen),
+    json={"state": started["state"], "code": "4/x", "project_id": "Bad Id!"},
+  )
+  assert resp.status_code == 400
+
+
+def test_gcloud_complete_rejects_unknown_project(client, auth, db, monkeypatch):
+  _wire(monkeypatch, GcloudMock(project_count=2))
+  cid, gen = _seed_google_connector(db)
+  started = client.post(
+    f"/api/connectors/{cid}/oauth/gcloud/start", headers=_headers(auth, gen),
+  ).json()
+  resp = client.post(
+    f"/api/connectors/{cid}/oauth/gcloud/complete",
+    headers=_headers(auth, gen),
+    json={"state": started["state"], "code": "4/x",
+          "project_id": "not-my-project"},  # valid shape, not a member → 422
+  )
+  assert resp.status_code == 422
+
+
+def test_gcloud_complete_rejects_stale_state(client, auth, db, monkeypatch):
+  _wire(monkeypatch, GcloudMock())
+  cid, gen = _seed_google_connector(db)
+  # A sealed state for a different connector id must not be accepted here.
+  foreign = cox.seal_flow({
+    "connector_id": cid + 999, "generation": gen,
+    "verifier": "v", "client_id": "c", "mode": "gcloud",
+  })
+  resp = client.post(
+    f"/api/connectors/{cid}/oauth/gcloud/complete",
+    headers=_headers(auth, gen),
+    json={"state": foreign, "code": "4/x"},
+  )
+  assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_gcloud_refresh_uses_stored_client(client, auth, db, monkeypatch):
+  from app.database import SessionLocal
+  from app.timeutil import now_naive_utc
+
+  mock = _wire(monkeypatch, GcloudMock(project_count=1))
+  cid, gen = _seed_google_connector(db)
+  started = client.post(
+    f"/api/connectors/{cid}/oauth/gcloud/start", headers=_headers(auth, gen),
+  ).json()
+  client.post(
+    f"/api/connectors/{cid}/oauth/gcloud/complete",
+    headers=_headers(auth, gen),
+    json={"state": started["state"], "code": "4/pasted-code"},
+  )
+  db.expire_all()
+  oauth = db.query(models.ConnectorOAuth).filter_by(connector_id=cid).one()
+  first = core.decrypt_oauth(oauth.access_token_encrypted)
+  oauth.access_expires_at = now_naive_utc()  # force near-expiry
+  db.commit()
+
+  session = SessionLocal()
+  try:
+    fresh = await cox.usable_access_token(session, cid)
+  finally:
+    session.close()
+  assert fresh and fresh != first
+  # The refresh authenticated with the stored gcloud client, not CIMD.
+  gcloud_id, _ = cox.gcloud_client_identity()
+  assert mock.token_client_ids[-1] == gcloud_id
+
+
+@pytest.mark.asyncio
+async def test_gcloud_refresh_does_not_overwrite_a_replacement_generation(
+  client, auth, db, monkeypatch,
+):
+  """A refresh result in flight for a stale generation cannot land on a
+  disconnect/re-sign replacement that retained the same numeric id."""
+  from app.database import SessionLocal
+
+  _wire(monkeypatch, GcloudMock(project_count=1))
+  cid, gen = _seed_google_connector(db)
+  _complete_signin(client, auth, cid, gen)
+  db.expire_all()
+  oauth = db.query(models.ConnectorOAuth).filter_by(connector_id=cid).one()
+  oauth.access_expires_at = datetime(2000, 1, 1)
+  db.commit()
+
+  async def replace_during_refresh(*_args, **_kwargs):
+    with SessionLocal() as concurrent:
+      row = concurrent.query(models.Connector).filter_by(id=cid).one()
+      replacement = concurrent.query(models.ConnectorOAuth).filter_by(
+        connector_id=cid,
+      ).one()
+      row.capability_id = "f" * 64
+      replacement.access_token_encrypted = core.encrypt_oauth(
+        "replacement-access",
+      )
+      replacement.refresh_token_encrypted = core.encrypt_oauth(
+        "replacement-refresh",
+      )
+      replacement.access_expires_at = datetime(2099, 1, 1)
+      concurrent.commit()
+    return {
+      "access_token": "stale-refresh-access",
+      "refresh_token": "stale-refresh-token",
+      "expires_in": 3600,
+    }
+
+  monkeypatch.setattr(cox, "refresh_tokens", replace_during_refresh)
+  session = SessionLocal()
+  try:
+    fresh = await cox.usable_access_token(session, cid, generation=gen)
+  finally:
+    session.close()
+  assert fresh is None
+  db.expire_all()
+  replacement = db.query(models.ConnectorOAuth).filter_by(
+    connector_id=cid,
+  ).one()
+  assert core.decrypt_oauth(
+    replacement.access_token_encrypted,
+  ) == "replacement-access"
+  assert core.decrypt_oauth(
+    replacement.refresh_token_encrypted,
+  ) == "replacement-refresh"
+
+
+@pytest.mark.asyncio
+async def test_gcloud_refresh_releases_request_session_before_waits(
+  client, auth, db, monkeypatch,
+):
+  """Near-expiry refresh must release the request DB lease before both the
+  single-flight wait and the token-endpoint await."""
+  from app.database import SessionLocal
+
+  _wire(monkeypatch, GcloudMock(project_count=1))
+  cid, gen = _seed_google_connector(db)
+  _complete_signin(client, auth, cid, gen)
+  oauth = db.query(models.ConnectorOAuth).filter_by(connector_id=cid).one()
+  oauth.access_expires_at = datetime(2000, 1, 1)
+  db.commit()
+
+  request_session = SessionLocal()
+
+  class AssertReleasedLock:
+    async def __aenter__(self):
+      assert not request_session.in_transaction()
+
+    async def __aexit__(self, *_args):
+      return False
+
+  real_refresh = cox.refresh_tokens
+
+  async def assert_released_refresh(*args, **kwargs):
+    assert not request_session.in_transaction()
+    return await real_refresh(*args, **kwargs)
+
+  monkeypatch.setattr(cox, "_refresh_lock", lambda _cid: AssertReleasedLock())
+  monkeypatch.setattr(cox, "refresh_tokens", assert_released_refresh)
+  try:
+    fresh = await cox.usable_access_token(
+      request_session, cid, generation=gen,
+    )
+  finally:
+    request_session.close()
+  assert fresh and fresh.startswith("ya29.access-")
+
+
+def test_refresh_route_does_not_latch_a_replacement_signin(
+  client, auth, db, monkeypatch,
+):
+  """A superseded refresh returning None must not mark a newer grant signed
+  out merely because reauthorization kept the same connector generation."""
+  from app.database import SessionLocal
+
+  _wire(monkeypatch, GcloudMock(project_count=1))
+  cid, gen = _seed_google_connector(db)
+  _complete_signin(client, auth, cid, gen)
+
+  async def replace_then_return_none(*_args, **_kwargs):
+    with SessionLocal() as concurrent:
+      row = concurrent.query(models.Connector).filter_by(id=cid).one()
+      oauth = concurrent.query(models.ConnectorOAuth).filter_by(
+        connector_id=cid,
+      ).one()
+      oauth.access_token_encrypted = core.encrypt_oauth("replacement-access")
+      oauth.refresh_token_encrypted = core.encrypt_oauth("replacement-refresh")
+      row.status = "ok"
+      row.status_detail = "replacement sign-in"
+      row.tools_json = ["replacement_tool"]
+      concurrent.commit()
+    return None
+
+  monkeypatch.setattr(cox, "usable_access_token", replace_then_return_none)
+  refreshed = client.post(
+    f"/api/connectors/{cid}/refresh", headers=_headers(auth, gen),
+  )
+  assert refreshed.status_code == 200, refreshed.text
+  body = refreshed.json()
+  assert body["signed_in"] is True
+  assert body["status"] == "ok"
+  assert body["status_detail"] == "replacement sign-in"
+  assert body["tools"] == ["replacement_tool"]
+  db.expire_all()
+  oauth = db.query(models.ConnectorOAuth).filter_by(connector_id=cid).one()
+  assert core.decrypt_oauth(oauth.access_token_encrypted) == "replacement-access"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("auth_rejected", [False, True])
+async def test_signed_in_probe_cannot_overwrite_a_reauthorization(
+  client, auth, db, monkeypatch, auth_rejected,
+):
+  """Both stale success and stale 401 outcomes must lose to a newer grant."""
+  from app.database import SessionLocal
+  from app.routes import connectors as connector_routes
+
+  _wire(monkeypatch, GcloudMock(project_count=1))
+  cid, gen = _seed_google_connector(db)
+  _complete_signin(client, auth, cid, gen)
+  db.expire_all()
+  oauth = db.query(models.ConnectorOAuth).filter_by(connector_id=cid).one()
+  old_token = core.decrypt_oauth(oauth.access_token_encrypted)
+
+  async def reauthorize_during_probe(*_args, **_kwargs):
+    with SessionLocal() as concurrent:
+      row = concurrent.query(models.Connector).filter_by(id=cid).one()
+      current = concurrent.query(models.ConnectorOAuth).filter_by(
+        connector_id=cid,
+      ).one()
+      current.access_token_encrypted = core.encrypt_oauth("replacement-access")
+      current.refresh_token_encrypted = core.encrypt_oauth("replacement-refresh")
+      row.status = "ok"
+      row.status_detail = "replacement sign-in"
+      row.tools_json = ["replacement_tool"]
+      row.est_tokens = 777
+      concurrent.commit()
+    if auth_rejected:
+      raise core.ConnectorError("old grant rejected", auth_rejected=True)
+    return {"tools": ["stale_tool"], "est_tokens": 1}
+
+  monkeypatch.setattr(core, "handshake", reauthorize_during_probe)
+  await connector_routes._probe_signed_in(
+    GCLOUD_MCP_URL, cid, gen, old_token, "ok",
+  )
+
+  db.expire_all()
+  row = db.query(models.Connector).filter_by(id=cid).one()
+  oauth = db.query(models.ConnectorOAuth).filter_by(connector_id=cid).one()
+  assert core.decrypt_oauth(oauth.access_token_encrypted) == "replacement-access"
+  assert core.decrypt_oauth(oauth.refresh_token_encrypted) == "replacement-refresh"
+  assert row.status == "ok"
+  assert row.status_detail == "replacement sign-in"
+  assert row.tools_json == ["replacement_tool"]
+  assert row.est_tokens == 777

--- a/backend/tests/test_connector_oauth.py
+++ b/backend/tests/test_connector_oauth.py
@@ -26,7 +26,8 @@ _REAL_ASYNC_CLIENT = httpx.AsyncClient
 class MockProvider:
   """Resource server + authorization server for one MCP endpoint."""
 
-  def __init__(self, *, cimd=False, issue_secret=False):
+  def __init__(self, *, cimd=False, issue_secret=False, no_register=False,
+               anon_open=False, slash_issuer=False):
     self.registered = 0
     self.codes = {}          # code -> {"challenge": ..., "resource": ...}
     self.refresh_tokens = {}  # refresh_token -> generation counter
@@ -35,7 +36,11 @@ class MockProvider:
     self.revoked = set()
     self.cimd = cimd                  # advertise Client ID Metadata Documents
     self.issue_secret = issue_secret  # DCR returns a client_secret (confidential)
+    self.no_register = no_register    # pre-registered-camp: no DCR, no CIMD (BYO)
+    self.anon_open = anon_open        # Google shape: handshake open, calls gated
+    self.slash_issuer = slash_issuer  # Google shape: PRM issuer has trailing "/"
     self.secrets_seen = []            # client_secret values the token endpoint got
+    self.client_ids_seen = []         # client_id values the token endpoint got
 
   def handler(self, request: httpx.Request) -> httpx.Response:
     url = str(request.url)
@@ -56,15 +61,18 @@ class MockProvider:
       auth = request.headers.get("authorization", "")
       token = auth[7:] if auth.lower().startswith("bearer ") else ""
       if not token or token not in self.access_tokens or not self.access_tokens[token]:
-        return httpx.Response(
-          401,
-          headers={
-            "www-authenticate":
-              'Bearer resource_metadata='
-              '"https://mcp.test/.well-known/oauth-protected-resource/mcp"',
-          },
-          json={"error": "invalid_token"},
-        )
+        if not self.anon_open:
+          return httpx.Response(
+            401,
+            headers={
+              "www-authenticate":
+                'Bearer resource_metadata='
+                '"https://mcp.test/.well-known/oauth-protected-resource/mcp"',
+            },
+            json={"error": "invalid_token"},
+          )
+        # anon_open (Google shape): initialize and tools/list answer without
+        # auth; only actual tool calls are gated — fall through to serving.
       # Signed in: normal MCP handshake.
       if body.get("method") == "initialize":
         return httpx.Response(200, headers={"content-type": "application/json"}, json={
@@ -86,7 +94,9 @@ class MockProvider:
     if path == "/.well-known/oauth-protected-resource/mcp":
       return httpx.Response(200, json={
         "resource": "https://mcp.test/mcp",
-        "authorization_servers": [AS_ISSUER],
+        "authorization_servers": [
+          AS_ISSUER + "/" if self.slash_issuer else AS_ISSUER,
+        ],
         "scopes_supported": ["read", "write"],
       })
 
@@ -105,6 +115,10 @@ class MockProvider:
       }
       if self.cimd:
         meta["client_id_metadata_document_supported"] = True
+      if self.no_register:
+        # Pre-registered camp (Google/GitHub/…): discovery + PKCE, but no way
+        # to self-register — the owner must bring their own client.
+        meta.pop("registration_endpoint")
       return httpx.Response(200, json=meta)
 
     # ── dynamic client registration (RFC 7591) ──
@@ -118,6 +132,7 @@ class MockProvider:
     # ── token endpoint ──
     if path == "/token":
       self.secrets_seen.append(form.get("client_secret"))
+      self.client_ids_seen.append(form.get("client_id"))
       if form.get("grant_type") == "authorization_code":
         return self._issue(form.get("code"))
       if form.get("grant_type") == "refresh_token":
@@ -538,6 +553,222 @@ def test_registration_is_reused_across_connectors_on_one_issuer(
   assert a["id"] != b["id"]
   assert provider.registered == 1  # cached per issuer, not re-registered
   assert db.query(models.OAuthClientRegistration).count() == 1
+
+
+def test_clear_client_does_not_remove_automatic_registration(
+  client, auth, db, provider,
+):
+  created = client.post(
+    "/api/connectors", headers=auth, json={"url": MCP_URL},
+  ).json()
+  client.post(
+    f"/api/connectors/{created['id']}/oauth/start",
+    headers=_headers(auth, created["generation"]),
+  )
+  reg = db.query(models.OAuthClientRegistration).one()
+  assert reg.mode == "dcr"
+
+  cleared = client.request(
+    "DELETE", f"/api/connectors/{created['id']}/oauth/client",
+    headers=_headers(auth, created["generation"]),
+  )
+  assert cleared.status_code == 200
+  assert cleared.json() == {"ok": True, "removed": False}
+  db.expire_all()
+  assert db.query(models.OAuthClientRegistration).filter_by(
+    issuer=AS_ISSUER, mode="dcr",
+  ).count() == 1
+
+
+def test_byo_setup_signin_and_recovery(client, auth, db, monkeypatch):
+  """A pre-registered-camp provider: no DCR/CIMD. Sign-in first asks for the
+  owner's client, then works end to end; credentials are recoverable."""
+  mock = _wire(monkeypatch, MockProvider(no_register=True))
+  created = client.post("/api/connectors", headers=auth, json={"url": MCP_URL}).json()
+  cid, generation = created["id"], created["generation"]
+  assert created["status"] == "oauth_required"
+
+  # 1. Start sign-in → not a 422; a structured "needs setup" with the issuer
+  #    and the server's authoritative redirect URI.
+  started = client.post(
+    f"/api/connectors/{cid}/oauth/start", headers=_headers(auth, generation),
+  )
+  assert started.status_code == 200, started.text
+  body = started.json()
+  assert body["needs_client_setup"] is True
+  assert body["issuer"] == AS_ISSUER
+  assert body["redirect_uri"].endswith("/api/connectors/oauth/callback")
+  assert mock.registered == 0  # never tried to self-register
+
+  # 2. Save the owner's client. Issuer is server-derived — a body issuer is
+  #    ignored — and the secret never comes back.
+  saved = client.post(
+    f"/api/connectors/{cid}/oauth/client", headers=_headers(auth, generation),
+    json={"client_id": "owner-client-42", "client_secret": "owner-secret",
+          "issuer": "https://evil.test"},
+  )
+  assert saved.status_code == 200, saved.text
+  assert "owner-secret" not in saved.text
+  reg = db.query(models.OAuthClientRegistration).filter_by(issuer=AS_ISSUER).one()
+  assert reg.mode == "byo" and reg.client_id == "owner-client-42"
+  assert reg.client_secret_encrypted and "owner-secret" not in reg.client_secret_encrypted
+  assert core.decrypt_oauth(reg.client_secret_encrypted) == "owner-secret"
+
+  # 3. Now start returns a real authorize URL carrying the owner's client_id.
+  started2 = client.post(
+    f"/api/connectors/{cid}/oauth/start", headers=_headers(auth, generation),
+  ).json()
+  from urllib.parse import parse_qs, urlparse
+  q = parse_qs(urlparse(started2["authorize_url"]).query)
+  assert q["client_id"] == ["owner-client-42"]
+  state = q["state"][0]
+
+  # 4. Callback exchanges with the owner's client_id + secret and signs in.
+  cb = client.get("/api/connectors/oauth/callback",
+                  params={"code": "c1", "state": state, "iss": AS_ISSUER})
+  assert "connected" in cb.text
+  assert "owner-client-42" in mock.client_ids_seen
+  assert "owner-secret" in mock.secrets_seen
+  listed = client.get("/api/connectors", headers=auth).json()["connectors"]
+  assert next(c for c in listed if c["id"] == cid)["signed_in"] is True
+
+  # 5. Re-saving a rotated secret upserts (no IntegrityError), and delete
+  #    clears the shared credential.
+  rotate = client.post(
+    f"/api/connectors/{cid}/oauth/client", headers=_headers(auth, generation),
+    json={"client_id": "owner-client-42", "client_secret": "rotated-secret"},
+  )
+  assert rotate.status_code == 200
+  db.expire_all()
+  reg = db.query(models.OAuthClientRegistration).filter_by(issuer=AS_ISSUER).one()
+  assert core.decrypt_oauth(reg.client_secret_encrypted) == "rotated-secret"
+  cleared = client.request(
+    "DELETE", f"/api/connectors/{cid}/oauth/client",
+    headers=_headers(auth, generation),
+  )
+  assert cleared.status_code == 200 and cleared.json()["removed"] is True
+  assert db.query(models.OAuthClientRegistration).filter_by(issuer=AS_ISSUER).count() == 0
+
+
+def test_anon_open_gate_detected_and_slash_issuer_normalized(
+  client, auth, db, monkeypatch,
+):
+  """Google's exact shape: the whole anonymous handshake succeeds (initialize
+  and tools/list are open; only tool calls are gated) and the protected-
+  resource metadata names the issuer with a bare trailing slash. The add must
+  classify this as a signed-out OAuth connection — not a healthy keyless one
+  that would start failing mid-conversation — and store the issuer in its
+  canonical slash-free form so one credential row serves every connection to
+  that authority."""
+  _wire(monkeypatch, MockProvider(
+    anon_open=True, slash_issuer=True, no_register=True,
+  ))
+  created = client.post("/api/connectors", headers=auth, json={"url": MCP_URL})
+  assert created.status_code == 201, created.text
+  row = created.json()
+  assert row["status"] == "oauth_required"
+  assert row["auth_kind"] == "oauth"
+  assert row["signed_in"] is False
+  db.expire_all()
+  oauth = db.query(models.ConnectorOAuth).filter_by(connector_id=row["id"]).one()
+  assert oauth.issuer == AS_ISSUER  # "…/" in the metadata, normalized here
+
+
+def test_keyless_open_server_without_prm_stays_keyless(
+  client, auth, monkeypatch,
+):
+  """The add-time gate check must not reclassify a genuinely open server: no
+  protected-resource document → plain keyless add with its tool catalog."""
+  base = MockProvider(anon_open=True)
+  def no_prm(request):
+    if request.url.path.startswith("/.well-known/"):
+      return httpx.Response(404, json={})
+    return base.handler(request)
+  monkeypatch.setattr(
+    core, "_safe_endpoint",
+    lambda url: (url, httpx.URL(url).host, httpx.URL(url).host),
+  )
+  monkeypatch.setattr(
+    core.httpx, "AsyncClient",
+    lambda **kw: _REAL_ASYNC_CLIENT(
+      transport=httpx.MockTransport(no_prm),
+      timeout=kw.get("timeout"), follow_redirects=False),
+  )
+  created = client.post("/api/connectors", headers=auth, json={"url": MCP_URL})
+  assert created.status_code == 201, created.text
+  row = created.json()
+  assert row["status"] == "ok"
+  assert row["auth_kind"] != "oauth"
+  assert row["tools"] == ["search"]
+
+
+def test_keyless_open_server_survives_unavailable_prm(
+  client, auth, monkeypatch,
+):
+  """The opportunistic anonymous-gate discovery is not allowed to turn a
+  healthy keyless add into a 500 when its well-known route is unavailable."""
+  base = MockProvider(anon_open=True)
+
+  def unavailable_prm(request):
+    if request.url.path.startswith("/.well-known/"):
+      raise httpx.ConnectError("metadata unavailable", request=request)
+    return base.handler(request)
+
+  monkeypatch.setattr(
+    core, "_safe_endpoint",
+    lambda url: (url, httpx.URL(url).host, httpx.URL(url).host),
+  )
+  monkeypatch.setattr(
+    core.httpx, "AsyncClient",
+    lambda **kw: _REAL_ASYNC_CLIENT(
+      transport=httpx.MockTransport(unavailable_prm),
+      timeout=kw.get("timeout"), follow_redirects=False,
+    ),
+  )
+  created = client.post("/api/connectors", headers=auth, json={"url": MCP_URL})
+  assert created.status_code == 201, created.text
+  row = created.json()
+  assert row["status"] == "ok"
+  assert row["auth_kind"] != "oauth"
+
+
+def test_byo_client_secret_never_echoed_in_422(client, auth, db, monkeypatch):
+  """A non-string secret is rejected value-free — pydantic must not echo it."""
+  _wire(monkeypatch, MockProvider(no_register=True))
+  created = client.post("/api/connectors", headers=auth, json={"url": MCP_URL}).json()
+  cid, generation = created["id"], created["generation"]
+  bad = client.post(
+    f"/api/connectors/{cid}/oauth/client", headers=_headers(auth, generation),
+    json={"client_id": "x", "client_secret": {"leak": "never-echo-secret"}},
+  )
+  assert bad.status_code == 400
+  assert "never-echo-secret" not in bad.text
+
+
+def test_google_issuer_requests_offline_access():
+  """Google needs access_type=offline to return a refresh token; gated on the
+  issuer host and applied to no one else."""
+  from app import connector_oauth as cox
+  from urllib.parse import parse_qs, urlparse
+
+  google = cox.Discovery(
+    resource="https://bigquery.googleapis.com/mcp",
+    issuer="https://accounts.google.com",
+    authorization_endpoint="https://accounts.google.com/o/oauth2/v2/auth",
+    token_endpoint="https://oauth2.googleapis.com/token",
+    scopes=["https://www.googleapis.com/auth/bigquery"],
+  )
+  q = parse_qs(urlparse(cox.authorization_url(google, "cid", "chal", "st")).query)
+  assert q["access_type"] == ["offline"]
+  assert q["prompt"] == ["consent"]
+
+  other = cox.Discovery(
+    resource="https://mcp.test/mcp", issuer="https://as.test",
+    authorization_endpoint="https://as.test/authorize",
+    token_endpoint="https://as.test/token", scopes=["read"],
+  )
+  q2 = parse_qs(urlparse(cox.authorization_url(other, "cid", "chal", "st")).query)
+  assert "access_type" not in q2 and "prompt" not in q2
 
 
 def test_callback_rejects_forged_state(client, auth, db, provider):

--- a/backend/tests/test_connectors.py
+++ b/backend/tests/test_connectors.py
@@ -655,7 +655,7 @@ def test_connector_routes_keep_keys_out_of_responses(
   assert set(body) == {
     "id", "generation", "name", "url", "enabled", "has_auth",
     "tools", "tool_count", "est_tokens", "status", "status_detail",
-    "auth_kind", "signed_in", "scopes",
+    "auth_kind", "signed_in", "scopes", "oauth_flavor", "user_project",
   }
   assert body["tools"] == ["lookup"]
   assert body["est_tokens"] == 5150

--- a/backend/tests/test_db_migrations.py
+++ b/backend/tests/test_db_migrations.py
@@ -1015,6 +1015,7 @@ def test_run_migrations_records_an_inspectable_append_only_history(tmp_path):
     "0009_app_connections_manage",
     "0010_chat_pending_question_id",
     "0011_delegation_parent_wake",
+    "0012_connector_oauth_gcloud",
   ]
   assert second == first
 
@@ -1114,6 +1115,95 @@ def test_connections_manage_reaches_a_ledgered_database(tmp_path):
   # Idempotent over the hand-patched production shape too.
   run_migrations(eng)
   assert "0009_app_connections_manage" in {
+    entry["version"] for entry in schema_migration_history(eng)
+  }
+
+
+def test_connector_oauth_gcloud_migration_upgrades_legacy_rows_idempotently(
+  tmp_path,
+):
+  """An existing OAuth grant gains Google fields without losing its mode.
+
+  Deleting the ledger marker after the first run simulates a crash after the
+  ALTER statements committed but before the migration was recorded. The retry
+  must see the columns, preserve the legacy row, and complete normally.
+  """
+  eng = create_engine(f"sqlite:///{tmp_path / 'legacy-connector-oauth.db'}")
+  previous_versions = (
+    "0001_legacy_schema_convergence",
+    "0002_chat_run_goal_objective",
+    "0003_chat_run_root_identity",
+    "0004_app_identity_required",
+    "0005_connectors",
+    "0006_connector_capability_identity",
+    "0007_chat_has_messages",
+    "0008_chat_search_documents",
+    "0009_app_connections_manage",
+    "0010_chat_pending_question_id",
+    "0011_delegation_parent_wake",
+  )
+  with eng.begin() as conn:
+    conn.execute(text(
+      "CREATE TABLE apps (id INTEGER PRIMARY KEY, name VARCHAR(255))"
+    ))
+    conn.execute(text(
+      "CREATE TABLE connector_oauth ("
+      "connector_id INTEGER PRIMARY KEY, resource VARCHAR(2048) NOT NULL, "
+      "issuer VARCHAR(512) NOT NULL, "
+      "authorization_endpoint VARCHAR(2048) NOT NULL, "
+      "token_endpoint VARCHAR(2048) NOT NULL, "
+      "registration_endpoint VARCHAR(2048), "
+      "revocation_endpoint VARCHAR(2048), "
+      "scopes_advertised JSON NOT NULL, access_token_encrypted TEXT, "
+      "refresh_token_encrypted TEXT, access_expires_at DATETIME, "
+      "scopes_granted JSON NOT NULL, connected_at DATETIME)"
+    ))
+    conn.execute(text(
+      "INSERT INTO connector_oauth "
+      "(connector_id, resource, issuer, authorization_endpoint, "
+      "token_endpoint, scopes_advertised, access_token_encrypted, "
+      "refresh_token_encrypted, scopes_granted) VALUES "
+      "(7, 'https://mcp.example/mcp', 'https://issuer.example', "
+      "'https://issuer.example/auth', 'https://issuer.example/token', "
+      "'[]', 'sealed-access', 'sealed-refresh', '[]')"
+    ))
+    conn.execute(text(
+      "CREATE TABLE schema_migrations ("
+      "version VARCHAR(128) PRIMARY KEY, applied_at TIMESTAMP NOT NULL)"
+    ))
+    for version in previous_versions:
+      conn.execute(text(
+        "INSERT INTO schema_migrations (version, applied_at) "
+        "VALUES (:version, '2026-08-06 00:00:00')"
+      ), {"version": version})
+
+  run_migrations(eng)
+  with eng.begin() as conn:
+    conn.execute(text(
+      "DELETE FROM schema_migrations "
+      "WHERE version = '0012_connector_oauth_gcloud'"
+    ))
+  run_migrations(eng)
+
+  columns = {
+    column["name"]: column
+    for column in inspect(eng).get_columns("connector_oauth")
+  }
+  assert set((
+    "auth_mode", "client_id", "client_secret_encrypted", "user_project",
+  )).issubset(columns)
+  assert columns["auth_mode"]["nullable"] is False
+  assert columns["auth_mode"]["default"] is not None
+  with eng.connect() as conn:
+    row = conn.execute(text(
+      "SELECT auth_mode, client_id, client_secret_encrypted, user_project, "
+      "access_token_encrypted, refresh_token_encrypted "
+      "FROM connector_oauth WHERE connector_id = 7"
+    )).one()
+  assert tuple(row) == (
+    "browser", None, None, None, "sealed-access", "sealed-refresh",
+  )
+  assert "0012_connector_oauth_gcloud" in {
     entry["version"] for entry in schema_migration_history(eng)
   }
 


### PR DESCRIPTION
## Summary

- Lets OAuth providers without client metadata or dynamic registration use an owner-supplied client ID and optional secret, shared by issuer and kept write-only.
- Adds a dedicated Google Cloud link-and-code sign-in that uses the Cloud SDK's published installed-app identity, so owners do not need to create a Google OAuth app.
- Discovers and validates Google Cloud projects, attaches the required quota-project header, and withholds project-less connections from agent turns.
- Reuses one Google credential across Cloud connections while keeping each connection's project independent and avoiding upstream revocation while a sibling still shares the refresh token.
- Migrates existing OAuth grants additively; existing browser-based connections continue with `auth_mode=browser`.

## Context

This completes the guided bring-your-own-credentials follow-up identified in [#431](https://github.com/mobius-os/mobius/pull/431) and extends the generic OAuth foundation merged in [#666](https://github.com/mobius-os/mobius/pull/666).

The generic flow previously stopped when a provider supported neither client metadata nor dynamic registration. Google Cloud also has an unusual shape: its MCP endpoints can complete the anonymous handshake and defer authentication until a tool call. This change detects that gate during setup and gives Google Cloud connections a purpose-built account flow instead of treating them as healthy keyless services.

## Security and compatibility

- Owner-supplied client secrets, Google access tokens, refresh tokens, and the per-connection installed-app client secret are sealed at rest and never returned by the management API.
- The pasted Google authorization code uses a typed write-only request field; the sealed flow state binds the connector generation and PKCE verifier.
- Project IDs are syntax-checked and, when Google's project list is available, membership-checked before they can become an `x-goog-user-project` header.
- Shared Google refresh tokens are compared only after decryption and are revoked upstream only when no sibling connection still holds the same credential.
- The credential-looking fallback client constants are Google's published Cloud SDK installed-app identity, not an instance or owner secret. An installed SDK is consulted first, but it is not a runtime dependency.
- This removes Google OAuth-app setup only; it does not auto-enable product APIs or grant IAM roles in the selected Cloud project. The companion app states that requirement explicitly.
- Migration `0012_connector_oauth_gcloud` adds four nullable/defaulted fields without rewriting existing grants and is safe to retry after a partial migration.

## Verification

- 147 focused connector, OAuth, grant-policy, and migration tests pass on the current public base.
- The complete backend suite reports 3,935 passed and 1 skipped here; its six recovery-target filesystem failures reproduce unchanged on public main because this runner places temporary files outside `/tmp`, and those six pass when rerun with `TMPDIR=/tmp`.
- Coverage includes legacy-table upgrade and retry, forged/stale flow rejection, write-only secret handling, Google project validation and pagination, project-less withholding, broker headers, credential reuse, refresh, and shared-token sign-out behavior.
- `git diff --check` passes. The repository's hosted CI remains the full-suite gate.
- Manually exercised Google sign-in, project selection, sign-in reuse, a real BigQuery query, and a Cloud Storage connection through the running platform.

## Companion

The owner-facing Connections v0.4 app change is prepared independently in `mobius-os/app-connections` and should land after this platform change.