### PR TITLE
Backpressure frame speech model streams

### DIFF
--- a/frontend/public/mobius-runtime.js
+++ b/frontend/public/mobius-runtime.js
@@ -3236,6 +3236,10 @@ function synthesizeInFrame({ input, channel, openModelStream, maxTextChars }) {
 			stream?.control?.("start");
 			return;
 		}
+		if (data.type === "chunk-accepted") {
+			stream?.control?.("chunk-accepted");
+			return;
+		}
 		if (data.type === "load-complete") {
 			channel.event("loading", {
 				stage: "preparing",

--- a/frontend/src/lib/__tests__/speechRuntime.test.js
+++ b/frontend/src/lib/__tests__/speechRuntime.test.js
@@ -110,6 +110,46 @@ function runSpeechModelsOperation(input, storage) {
   })
 }
 
+test('a frame reader receives one model chunk at a time', async () => {
+  const events = []
+  let firstChunk
+  let secondChunk
+  const receivedFirst = new Promise((resolve) => { firstChunk = resolve })
+  const receivedSecond = new Promise((resolve) => { secondChunk = resolve })
+  let control
+  const result = new Promise((resolve, reject) => {
+    control = openSpeechModelsCapability({
+      appId: 61,
+      input: { operation: 'read', engineId: DEFAULT_SPEECH_ENGINE_ID },
+      declaration: { limits: SPEECH_MODEL_STORAGE_LIMITS },
+      dependencies: readySpeechAssetsFor(DEFAULT_SPEECH_MODEL_ID),
+      channel: {
+        ready() {},
+        event(name, value) {
+          if (name === 'manifest') control.control('start')
+          if (name !== 'chunk') return
+          events.push(value)
+          if (events.length === 1) firstChunk()
+          if (events.length === 2) secondChunk()
+        },
+        result: resolve,
+        error: reject,
+      },
+    })
+  })
+
+  await receivedFirst
+  await new Promise((resolve) => setImmediate(resolve))
+  assert.equal(events.length, 1)
+
+  control.control('chunk-accepted')
+  await receivedSecond
+  assert.equal(events.length, 2)
+
+  control.control('cancel')
+  await assert.rejects(result, (error) => error.name === 'AbortError')
+})
+
 test('speech model selection exposes only the public catalog contract', () => {
   const selected = speechModel(DEFAULT_SPEECH_MODEL_ID)
   assert.equal(selected.id, 'pocket-tts-alba')

--- a/frontend/src/lib/speech/speechModelsProviderRuntime.js
+++ b/frontend/src/lib/speech/speechModelsProviderRuntime.js
@@ -34,16 +34,29 @@ export function openSpeechModelsCapability({
   declaration,
   channel,
   storage = globalThis.localStorage,
+  dependencies,
 }) {
   const operation = input?.operation || 'catalog'
   const controller = new AbortController()
   let allowStart = () => {}
   const started = new Promise((resolve) => { allowStart = resolve })
+  // A frame-owned worker copies each incoming model chunk into its Wasm
+  // allocation. Do not release the next chunk until that copy is acknowledged:
+  // otherwise the frame queue can briefly hold an entire model.
+  let acknowledgeChunk = null
+  const waitForChunkAcknowledgement = () => new Promise((resolve) => {
+    acknowledgeChunk = resolve
+  })
+  const releaseChunk = () => {
+    const acknowledge = acknowledgeChunk
+    acknowledgeChunk = null
+    acknowledge?.()
+  }
   const modelId = input?.modelId || DEFAULT_SPEECH_MODEL_ID
   const engineId = input?.engineId || DEFAULT_SPEECH_ENGINE_ID
   const progress = (value) => channel.event('progress', value)
   const options = {
-    appId, declaration, signal: controller.signal, onProgress: progress, storage,
+    appId, declaration, signal: controller.signal, onProgress: progress, storage, dependencies,
   }
   const task = Promise.resolve().then(async () => {
     if (operation === 'catalog') return speechModelCatalog(options)
@@ -80,11 +93,15 @@ export function openSpeechModelsCapability({
       // consumer's memory while its engine is still warming up.
       await started
       await streamSpeechModel(snapshot, {
+        ...options,
         signal: controller.signal,
         onProgress: (percent) => progress({ percent }),
         // Hand each chunk straight to the consumer; buffering the whole model
         // here would duplicate 148 MB before it ever reaches the engine.
-        onChunk: (value) => channel.event('chunk', value, [value.bytes]),
+        onChunk: async (value) => {
+          channel.event('chunk', value, [value.bytes])
+          await waitForChunkAcknowledgement()
+        },
       })
       return { modelId: snapshot.modelId, assetBytes: snapshot.assetBytes }
     }
@@ -120,11 +137,13 @@ export function openSpeechModelsCapability({
   channel.ready({ state: 'starting', operation })
   task.then(channel.result).catch(channel.error)
   return {
-    control(action) {
-      if (action === 'start') allowStart()
-      if (action === 'cancel' && !controller.signal.aborted) {
-        allowStart()
-        controller.abort(abortError())
+      control(action) {
+        if (action === 'start') allowStart()
+        if (action === 'chunk-accepted') releaseChunk()
+        if (action === 'cancel' && !controller.signal.aborted) {
+          releaseChunk()
+          allowStart()
+          controller.abort(abortError())
       }
     },
   }

--- a/frontend/src/lib/speech/speechProviderRuntime.js
+++ b/frontend/src/lib/speech/speechProviderRuntime.js
@@ -162,6 +162,15 @@ export function openSpeechCapability({
     const controller = new AbortController()
     let allowStart = () => {}
     const started = new Promise((resolve) => { allowStart = resolve })
+    let acknowledgeChunk = null
+    const waitForChunkAcknowledgement = () => new Promise((resolve) => {
+      acknowledgeChunk = resolve
+    })
+    const releaseChunk = () => {
+      const acknowledge = acknowledgeChunk
+      acknowledgeChunk = null
+      acknowledge?.()
+    }
     Promise.resolve().then(async () => {
       const snapshot = input?.engineId
         ? speechEngineLoadSnapshot(input.engineId)
@@ -184,7 +193,10 @@ export function openSpeechCapability({
       await streamSpeechModel(snapshot, {
         signal: controller.signal,
         onProgress: (percent) => channel.event('progress', { percent }),
-        onChunk: (value) => channel.event('chunk', value, [value.bytes]),
+        onChunk: async (value) => {
+          channel.event('chunk', value, [value.bytes])
+          await waitForChunkAcknowledgement()
+        },
       })
       return { modelId: snapshot.modelId }
     }).then(channel.result).catch(channel.error)
@@ -192,7 +204,9 @@ export function openSpeechCapability({
     return {
       control(action) {
         if (action === 'start') allowStart()
+        if (action === 'chunk-accepted') releaseChunk()
         if (action === 'cancel') {
+          releaseChunk()
           allowStart()
           if (!controller.signal.aborted) controller.abort(abortError())
         }

--- a/frontend/src/runtime/speech.js
+++ b/frontend/src/runtime/speech.js
@@ -108,6 +108,10 @@ export function synthesizeInFrame({ input, channel, openModelStream, maxTextChar
       stream?.control?.('start')
       return
     }
+    if (data.type === 'chunk-accepted') {
+      stream?.control?.('chunk-accepted')
+      return
+    }
     if (data.type === 'load-complete') {
       channel.event('loading', { stage: 'preparing', percent: 100 })
       generateNext()


### PR DESCRIPTION
## Summary
- let frame-owned speech readers opt in to one-chunk-at-a-time model streaming
- wait until the worker has copied a chunk before releasing the next one
- preserve current behavior for older mini-app versions

## Validation
- npm run test:lib

This bounds the model-transfer queue while a cloned voice initializes its encoder.