### PR TITLE
Fix microphone capture readiness for voice cloning

### DIFF
--- a/frontend/src/lib/__tests__/capabilityProviders.test.js
+++ b/frontend/src/lib/__tests__/capabilityProviders.test.js
@@ -6,6 +6,7 @@ import {
   createSpeechModelsProvider,
   createSpeechProvider,
 } from '../capabilityProviders.js'
+import { createCapabilityHost } from '../capabilityHost.js'
 
 test('microphone provider clamps app input to the reviewed manifest ceiling', async () => {
   let receivedSeconds
@@ -13,6 +14,7 @@ test('microphone provider clamps app input to the reviewed manifest ceiling', as
   const done = new Promise((resolve) => { resolveDone = resolve })
   const capture = {
     sampleRate: 48000,
+    ready: Promise.resolve(),
     done,
     stop() { resolveDone({ samples: new Float32Array(0), sampleRate: 48000 }) },
     cancel() {},
@@ -38,8 +40,67 @@ test('microphone provider clamps app input to the reviewed manifest ceiling', as
   assert.deepEqual(messages, [['ready', { sampleRate: 48000 }]])
   control.control('finish')
   await done
-  await Promise.resolve()
+  await new Promise((resolve) => setImmediate(resolve))
   assert.equal(messages.at(-1)[0], 'result')
+})
+
+test('microphone capture can be cancelled while waiting for its first audio frame', async () => {
+  let rejectReady
+  let rejectDone
+  let cancelCalls = 0
+  const ready = new Promise((resolve, reject) => { rejectReady = reject })
+  const done = new Promise((resolve, reject) => { rejectDone = reject })
+  ready.catch(() => {})
+  done.catch(() => {})
+  const capture = {
+    sampleRate: 48000,
+    ready,
+    done,
+    stop() {},
+    cancel() {
+      cancelCalls += 1
+      const error = new Error('Recording cancelled.')
+      error.name = 'AbortError'
+      rejectReady(error)
+      rejectDone(error)
+    },
+  }
+  const sent = []
+  const source = {}
+  const host = createCapabilityHost({
+    providers: {
+      'media.microphone.capture': createMicrophoneProvider({
+        startCapture: async () => capture,
+      }),
+    },
+    getDeclaration() {
+      return { version: 1, limits: { max_duration_ms: 8000 } }
+    },
+    isActive: () => true,
+    send(_source, message) { sent.push(message) },
+  })
+
+  host.handle(source, {
+    type: 'moebius:capability-open',
+    requestId: 'microphone-startup',
+    capability: 'media.microphone.capture',
+    version: 1,
+    input: { maxDurationMs: 8000 },
+  })
+  await new Promise((resolve) => setImmediate(resolve))
+  assert.equal(sent.some((message) => message.type === 'moebius:capability-ready'), false)
+  host.handle(source, {
+    type: 'moebius:capability-control',
+    requestId: 'microphone-startup',
+    capability: 'media.microphone.capture',
+    action: 'cancel',
+  })
+  await new Promise((resolve) => setImmediate(resolve))
+
+  assert.equal(cancelCalls, 1)
+  assert.ok(sent.some((message) => (
+    message.type === 'moebius:capability-error' && message.name === 'AbortError'
+  )))
 })
 
 test('speech providers lazy-load the runtime and preserve the invoking app identity', async () => {

--- a/frontend/src/lib/__tests__/microphoneCapture.test.js
+++ b/frontend/src/lib/__tests__/microphoneCapture.test.js
@@ -174,6 +174,62 @@ test('capture reports startup failure when no microphone frame arrives', async (
   assert.equal(processor.onaudioprocess, null)
 })
 
+test('an immediate first frame cannot leave the startup timeout armed', async (t) => {
+  t.mock.timers.enable({ apis: ['setTimeout'] })
+  let processor
+  let sourceConnected = false
+  const node = () => ({ connect() {}, disconnect() {} })
+  const frame = {
+    inputBuffer: { getChannelData: () => new Float32Array([0.25, -0.5, 0.125]) },
+  }
+  class FakeAudioContext {
+    constructor() {
+      this.sampleRate = 48_000
+      this.state = 'running'
+      this.destination = node()
+    }
+    createMediaStreamSource() {
+      return {
+        ...node(),
+        connect() {
+          sourceConnected = true
+          processor.onaudioprocess?.(frame)
+        },
+      }
+    }
+    createScriptProcessor() {
+      let handler = null
+      processor = { ...node() }
+      Object.defineProperty(processor, 'onaudioprocess', {
+        get: () => handler,
+        set(value) {
+          handler = value
+          if (sourceConnected) handler?.(frame)
+        },
+      })
+      return processor
+    }
+    createGain() { return { ...node(), gain: { value: 1 } } }
+    close() {}
+  }
+
+  const control = await startMicrophoneCapture({
+    mediaDevices: {
+      async getUserMedia() { return { getTracks: () => [{ stop() {} }] } },
+    },
+    AudioContextCtor: FakeAudioContext,
+    maxSeconds: 60,
+  })
+  await control.ready
+  let done = false
+  control.done.then(() => { done = true })
+  t.mock.timers.tick(5_000)
+  await Promise.resolve()
+
+  assert.equal(done, false)
+  await control.stop()
+})
+
 test('cancelling shell capture rejects and releases every resource', async () => {
   let processor
   let trackStops = 0

--- a/frontend/src/lib/__tests__/microphoneCapture.test.js
+++ b/frontend/src/lib/__tests__/microphoneCapture.test.js
@@ -45,15 +45,130 @@ test('shell microphone capture returns mono PCM and releases every resource', as
     onLevel: (level) => levels.push(level),
   })
 
+  const ready = control.ready
   processor.onaudioprocess({
     inputBuffer: { getChannelData: () => new Float32Array([0.25, -0.75, 0.5]) },
   })
+  await ready
   const resultPromise = control.stop()
   const result = await resultPromise
 
   assert.equal(result.sampleRate, 100)
   assert.deepEqual([...result.samples], [0.25, -0.75, 0.5])
   assert.deepEqual(levels, [0.75])
+  assert.equal(trackStopped, true)
+  assert.equal(contextClosed, true)
+  assert.equal(processor.onaudioprocess, null)
+})
+
+test('audio context activation is requested before the microphone permission promise', async () => {
+  const order = []
+  let resolveStream
+  let processor
+  const stream = { getTracks: () => [{ stop() {} }] }
+  const node = () => ({ connect() {}, disconnect() {} })
+  class FakeAudioContext {
+    constructor() {
+      order.push('context')
+      this.sampleRate = 48_000
+      this.state = 'suspended'
+      this.destination = node()
+    }
+    resume() {
+      order.push('resume')
+      this.state = 'running'
+      return Promise.resolve()
+    }
+    createMediaStreamSource() { return node() }
+    createScriptProcessor() {
+      processor = { ...node(), onaudioprocess: null }
+      return processor
+    }
+    createGain() { return { ...node(), gain: { value: 1 } } }
+    close() {}
+  }
+
+  const start = startMicrophoneCapture({
+    mediaDevices: {
+      getUserMedia() {
+        order.push('getUserMedia')
+        return new Promise((resolve) => { resolveStream = resolve })
+      },
+    },
+    AudioContextCtor: FakeAudioContext,
+  })
+  await Promise.resolve()
+  assert.deepEqual(order, ['context', 'resume', 'getUserMedia'])
+
+  resolveStream(stream)
+  const control = await start
+  await assert.rejects(control.cancel(), { name: 'AbortError' })
+  assert.equal(processor.onaudioprocess, null)
+})
+
+test('finishing before any microphone frame rejects instead of returning silence', async () => {
+  let processor
+  const node = () => ({ connect() {}, disconnect() {} })
+  class FakeAudioContext {
+    constructor() {
+      this.sampleRate = 48_000
+      this.state = 'running'
+      this.destination = node()
+    }
+    createMediaStreamSource() { return node() }
+    createScriptProcessor() {
+      processor = { ...node(), onaudioprocess: null }
+      return processor
+    }
+    createGain() { return { ...node(), gain: { value: 1 } } }
+    close() {}
+  }
+
+  const control = await startMicrophoneCapture({
+    mediaDevices: {
+      async getUserMedia() { return { getTracks: () => [{ stop() {} }] } },
+    },
+    AudioContextCtor: FakeAudioContext,
+  })
+  const ready = control.ready
+  await assert.rejects(control.stop(), { name: 'NotReadableError' })
+  await assert.rejects(ready, { name: 'NotReadableError' })
+  assert.equal(processor.onaudioprocess, null)
+})
+
+test('capture reports startup failure when no microphone frame arrives', async (t) => {
+  t.mock.timers.enable({ apis: ['setTimeout'] })
+  let processor
+  let trackStopped = false
+  let contextClosed = false
+  const node = () => ({ connect() {}, disconnect() {} })
+  class FakeAudioContext {
+    constructor() {
+      this.sampleRate = 48_000
+      this.state = 'running'
+      this.destination = node()
+    }
+    createMediaStreamSource() { return node() }
+    createScriptProcessor() {
+      processor = { ...node(), onaudioprocess: null }
+      return processor
+    }
+    createGain() { return { ...node(), gain: { value: 1 } } }
+    close() { contextClosed = true }
+  }
+
+  const control = await startMicrophoneCapture({
+    mediaDevices: {
+      async getUserMedia() { return { getTracks: () => [{ stop: () => { trackStopped = true } }] } },
+    },
+    AudioContextCtor: FakeAudioContext,
+  })
+  const ready = control.ready
+  const done = control.done
+  t.mock.timers.tick(5_000)
+
+  await assert.rejects(ready, { name: 'NotReadableError' })
+  await assert.rejects(done, { name: 'NotReadableError' })
   assert.equal(trackStopped, true)
   assert.equal(contextClosed, true)
   assert.equal(processor.onaudioprocess, null)
@@ -89,7 +204,9 @@ test('cancelling shell capture rejects and releases every resource', async () =>
     AudioContextCtor: FakeAudioContext,
   })
 
+  const ready = control.ready
   await assert.rejects(control.cancel(), { name: 'AbortError' })
+  await assert.rejects(ready, { name: 'AbortError' })
   assert.equal(trackStops, 1)
   assert.equal(contextCloses, 1)
   assert.equal(processor.onaudioprocess, null)

--- a/frontend/src/lib/__tests__/speechRuntime.test.js
+++ b/frontend/src/lib/__tests__/speechRuntime.test.js
@@ -51,6 +51,23 @@ function memoryStorage(initial = {}) {
   }
 }
 
+function voiceSamples(length = 24_000 * 3, amplitude = 0.25) {
+  const samples = new Float32Array(length)
+  for (let index = 0; index < samples.length; index += 1) {
+    samples[index] = Math.sin((index + 1) / 20) * amplitude
+  }
+  return samples
+}
+
+function silentPcm16Base64(length = 24_000 * 3) {
+  const bytes = new Uint8Array(new Int16Array(length).buffer)
+  let binary = ''
+  for (let offset = 0; offset < bytes.length; offset += 32_768) {
+    binary += String.fromCharCode(...bytes.subarray(offset, offset + 32_768))
+  }
+  return globalThis.btoa(binary)
+}
+
 function missingSpeechAssets() {
   return {
     cacheStorage: {
@@ -183,8 +200,7 @@ test('speech models download from the public versioned Voice release', () => {
 
 test('a recorded clone is resampled, persisted privately, and becomes a catalog model', () => {
   const storage = memoryStorage()
-  const source = new Float32Array(48_000 * 3)
-  for (let index = 0; index < source.length; index += 1) source[index] = Math.sin(index / 20) * 0.25
+  const source = voiceSamples(48_000 * 3)
   const saved = saveSpeechClone({
     language: 'German', name: 'My voice', samples: source, sampleRate: 48_000,
   }, { storage })
@@ -198,7 +214,7 @@ test('a recorded clone is resampled, persisted privately, and becomes a catalog 
 })
 
 test('clone load identity is deterministic for its recording content', () => {
-  const samples = new Float32Array(24_000 * 3).fill(0.25)
+  const samples = voiceSamples()
   const firstStorage = memoryStorage()
   const secondStorage = memoryStorage()
   const first = saveSpeechClone({
@@ -224,7 +240,7 @@ test('clone load identity is deterministic for its recording content', () => {
 
 test('invalid legacy clone revision metadata cannot wedge the voice library', () => {
   const storage = memoryStorage()
-  const samples = new Float32Array(24_000 * 3).fill(0.25)
+  const samples = voiceSamples()
   const saved = saveSpeechClone({
     language: 'English', name: 'Original', samples, sampleRate: 24_000,
   }, { storage })
@@ -242,8 +258,8 @@ test('invalid legacy clone revision metadata cannot wedge the voice library', ()
 
 test('replacing a same-language clone changes its content identity and reloads the engine', async (t) => {
   const storage = memoryStorage()
-  const firstSamples = new Float32Array(24_000 * 3).fill(0.1)
-  const secondSamples = new Float32Array(24_000 * 3).fill(0.5)
+  const firstSamples = voiceSamples(24_000 * 3, 0.1)
+  const secondSamples = voiceSamples(24_000 * 3, 0.5)
   const first = saveSpeechClone({
     language: 'English', name: 'First', samples: firstSamples, sampleRate: 24_000,
   }, { storage })
@@ -282,8 +298,7 @@ test('replacing a same-language clone changes its content identity and reloads t
 
 test('clone persistence trims oversized input to eight seconds before resampling', () => {
   const storage = memoryStorage()
-  const source = new Float32Array(48_000 * 9)
-  source.fill(0.25, 0, 48_000 * 8)
+  const source = voiceSamples(48_000 * 9)
   source.fill(0.75, 48_000 * 8)
   const saved = saveSpeechClone({
     language: 'English', name: 'Trimmed', samples: source, sampleRate: 48_000,
@@ -291,7 +306,49 @@ test('clone persistence trims oversized input to eight seconds before resampling
 
   const restored = speechModelLoadSnapshot(saved.id, storage).clonedVoiceSamples
   assert.equal(restored.length, 24_000 * 8)
-  assert.ok(Math.abs(restored.at(-1) - 0.25) < 0.001)
+  assert.ok(Math.abs(restored.at(-1) - source[48_000 * 8 - 2]) < 0.001)
+})
+
+test('silent or malformed clone recordings are rejected before storage changes', () => {
+  const storage = memoryStorage()
+  assert.throws(
+    () => saveSpeechClone({
+      language: 'English', name: 'Silent', samples: new Float32Array(24_000 * 3), sampleRate: 24_000,
+    }, { storage }),
+    (error) => error.code === 'invalid_request' && error.name === 'TypeError',
+  )
+  assert.throws(
+    () => saveSpeechClone({
+      language: 'English', name: 'Flat signal',
+      samples: new Float32Array(24_000 * 3).fill(0.25), sampleRate: 24_000,
+    }, { storage }),
+    (error) => error.code === 'invalid_request' && error.name === 'TypeError',
+  )
+  const malformed = voiceSamples()
+  malformed[0] = Number.NaN
+  assert.throws(
+    () => saveSpeechClone({
+      language: 'English', name: 'Malformed', samples: malformed, sampleRate: 24_000,
+    }, { storage }),
+    (error) => error.code === 'invalid_request' && error.name === 'TypeError',
+  )
+  assert.equal(storage.getItem('mobius:speech:cloned-profiles:v1'), null)
+})
+
+test('a legacy silent clone cannot reach the speech worker', () => {
+  const storage = memoryStorage()
+  const saved = saveSpeechClone({
+    language: 'English', name: 'Old clone', samples: voiceSamples(), sampleRate: 24_000,
+  }, { storage })
+  const library = JSON.parse(storage.getItem('mobius:speech:cloned-profiles:v1'))
+  library[0].pcm16Base64 = silentPcm16Base64()
+  storage.setItem('mobius:speech:cloned-profiles:v1', JSON.stringify(library))
+
+  assert.ok(speechModel(saved.id, storage))
+  assert.throws(
+    () => speechModelLoadSnapshot(saved.id, storage),
+    (error) => error.code === 'silent_recording',
+  )
 })
 
 test('clone saves do not re-read storage after the write succeeds', () => {
@@ -311,7 +368,7 @@ test('clone saves do not re-read storage after the write succeeds', () => {
 
   saveSpeechClone({
     language: 'English', name: 'Saved once',
-    samples: new Float32Array(24_000 * 3), sampleRate: 24_000,
+    samples: voiceSamples(), sampleRate: 24_000,
   }, { storage })
 
   assert.equal(libraryReads, 1)
@@ -324,7 +381,7 @@ test('clone persistence preserves a damaged library instead of overwriting it', 
   assert.throws(
     () => saveSpeechClone({
       language: 'English', name: 'Replacement',
-      samples: new Float32Array(24_000 * 3), sampleRate: 24_000,
+      samples: voiceSamples(), sampleRate: 24_000,
     }, { storage }),
     (error) => error.code === 'storage_corrupt',
   )
@@ -436,7 +493,7 @@ test('clone removal uses the same injected storage that supplied the model', asy
   const storage = memoryStorage()
   const saved = saveSpeechClone({
     language: 'Italian', name: 'Temporary',
-    samples: new Float32Array(24_000 * 3), sampleRate: 24_000,
+    samples: voiceSamples(), sampleRate: 24_000,
   }, { storage })
 
   await removeSpeechModel(saved.id, { storage })
@@ -449,7 +506,7 @@ test('clone removal does not verify after storage has already mutated', async ()
   const seed = memoryStorage()
   const saved = saveSpeechClone({
     language: 'Italian', name: 'Temporary',
-    samples: new Float32Array(24_000 * 3), sampleRate: 24_000,
+    samples: voiceSamples(), sampleRate: 24_000,
   }, { storage: seed })
   let library = seed.getItem('mobius:speech:cloned-profiles:v1')
   let mutated = false
@@ -477,11 +534,11 @@ test('engine load resolves one coherent clone storage snapshot', async (t) => {
   const secondStorage = memoryStorage()
   const first = saveSpeechClone({
     language: 'English', name: 'First',
-    samples: new Float32Array(24_000 * 3).fill(0.1), sampleRate: 24_000,
+    samples: voiceSamples(24_000 * 3, 0.1), sampleRate: 24_000,
   }, { storage: firstStorage })
   saveSpeechClone({
     language: 'English', name: 'Second',
-    samples: new Float32Array(24_000 * 3).fill(0.7), sampleRate: 24_000,
+    samples: voiceSamples(24_000 * 3, 0.7), sampleRate: 24_000,
   }, { storage: secondStorage })
   const libraries = [
     firstStorage.getItem('mobius:speech:cloned-profiles:v1'),

--- a/frontend/src/lib/capabilityProviders.js
+++ b/frontend/src/lib/capabilityProviders.js
@@ -55,8 +55,13 @@ export function createMicrophoneProvider({ startCapture = startMicrophoneCapture
         maxSeconds: maxDurationMs / 1000,
         onLevel(level) { channel.event('level', level) },
       })
-      channel.ready({ sampleRate: capture.sampleRate })
-      capture.done.then((result) => {
+      // Return the control surface before waiting for the first PCM frame, so
+      // the app or lifecycle host can still cancel a stalled startup. The
+      // capability itself is not ready until the recorder has received audio.
+      capture.ready.then(() => {
+        channel.ready({ sampleRate: capture.sampleRate })
+        return capture.done
+      }).then((result) => {
         const samples = result.samples
         channel.result(
           { samples, sampleRate: result.sampleRate },

--- a/frontend/src/lib/microphoneCapture.js
+++ b/frontend/src/lib/microphoneCapture.js
@@ -1,5 +1,6 @@
 const DEFAULT_MAX_SECONDS = 30
 const MAX_SECONDS = 60
+const START_TIMEOUT_MS = 5_000
 
 export function normalizeMicrophoneSeconds(value) {
   const seconds = Number(value)
@@ -32,22 +33,19 @@ export async function startMicrophoneCapture({
     throw new Error('Audio recording is unavailable in this browser.')
   }
 
-  const stream = await mediaDevices.getUserMedia({
-    audio: {
-      echoCancellation: false,
-      noiseSuppression: false,
-      autoGainControl: false,
-    },
-  })
-
+  let stream
   let context
   let source
   let processor
   let silent
-  let timer
+  let recordingTimer
+  let startTimer
   let settled = false
   let resolveDone
   let rejectDone
+  let resolveReady
+  let rejectReady
+  let readySettled = false
   const chunks = []
   let sampleCount = 0
 
@@ -55,14 +53,32 @@ export async function startMicrophoneCapture({
     resolveDone = resolve
     rejectDone = reject
   })
+  // A capture may be cancelled or fail before the first audio callback. Keep
+  // the promise observable to callers without producing a global unhandled
+  // rejection in that setup window.
+  done.catch(() => {})
+  const ready = new Promise((resolve, reject) => {
+    resolveReady = resolve
+    rejectReady = reject
+  })
+  ready.catch(() => {})
+
+  function settleReady(error = null) {
+    if (readySettled) return
+    readySettled = true
+    clearTimeout(startTimer)
+    if (error) rejectReady(error)
+    else resolveReady({ sampleRate: context.sampleRate })
+  }
 
   function cleanup() {
-    clearTimeout(timer)
+    clearTimeout(recordingTimer)
+    clearTimeout(startTimer)
     if (processor) processor.onaudioprocess = null
     cleanupNode(processor)
     cleanupNode(silent)
     cleanupNode(source)
-    stream.getTracks().forEach((track) => track.stop())
+    stream?.getTracks?.().forEach((track) => track.stop())
     try { context?.close?.() } catch {}
   }
 
@@ -73,6 +89,15 @@ export async function startMicrophoneCapture({
     if (cancelled) {
       const error = new Error('Recording cancelled.')
       error.name = 'AbortError'
+      settleReady(error)
+      rejectDone(error)
+      return done
+    }
+
+    if (!readySettled) {
+      const error = new Error('The microphone did not start delivering audio. Check your microphone permissions and input, then try again.')
+      error.name = 'NotReadableError'
+      settleReady(error)
       rejectDone(error)
       return done
     }
@@ -88,8 +113,19 @@ export async function startMicrophoneCapture({
   }
 
   try {
+    // Construct and resume this while the originating click can still carry
+    // user activation. A microphone permission prompt may consume that
+    // activation; creating the context after it returns can leave the graph
+    // permanently suspended and therefore unable to deliver PCM callbacks.
     context = new AudioContextCtor()
-    if (context.state === 'suspended') await context.resume?.()
+    if (context.state === 'suspended') Promise.resolve(context.resume?.()).catch(() => {})
+    stream = await mediaDevices.getUserMedia({
+      audio: {
+        echoCancellation: false,
+        noiseSuppression: false,
+        autoGainControl: false,
+      },
+    })
     source = context.createMediaStreamSource(stream)
     processor = context.createScriptProcessor(4096, 1, 1)
     silent = context.createGain()
@@ -103,6 +139,10 @@ export async function startMicrophoneCapture({
     processor.onaudioprocess = (event) => {
       if (settled) return
       const input = event.inputBuffer.getChannelData(0)
+      if (!readySettled) {
+        settleReady()
+        recordingTimer = setTimeout(() => finish(false), seconds * 1000 + 100)
+      }
       const remaining = maxFrames - sampleCount
       if (remaining <= 0) {
         finish(false)
@@ -119,19 +159,18 @@ export async function startMicrophoneCapture({
       }
       if (sampleCount >= maxFrames) finish(false)
     }
-    timer = setTimeout(() => finish(false), seconds * 1000 + 100)
+    startTimer = setTimeout(() => finish(false), START_TIMEOUT_MS)
   } catch (error) {
     cleanup()
     settled = true
+    settleReady(error)
     rejectDone(error)
-    // Avoid an unhandled rejection when setup itself fails before a caller can
-    // receive the returned control object.
-    done.catch(() => {})
     throw error
   }
 
   return {
     sampleRate: context.sampleRate,
+    ready,
     done,
     stop: () => finish(false),
     cancel: () => finish(true),

--- a/frontend/src/lib/microphoneCapture.js
+++ b/frontend/src/lib/microphoneCapture.js
@@ -130,9 +130,6 @@ export async function startMicrophoneCapture({
     processor = context.createScriptProcessor(4096, 1, 1)
     silent = context.createGain()
     silent.gain.value = 0
-    source.connect(processor)
-    processor.connect(silent)
-    silent.connect(context.destination)
 
     const seconds = normalizeMicrophoneSeconds(maxSeconds)
     const maxFrames = Math.max(1, Math.round(context.sampleRate * seconds))
@@ -160,6 +157,9 @@ export async function startMicrophoneCapture({
       if (sampleCount >= maxFrames) finish(false)
     }
     startTimer = setTimeout(() => finish(false), START_TIMEOUT_MS)
+    source.connect(processor)
+    processor.connect(silent)
+    silent.connect(context.destination)
   } catch (error) {
     cleanup()
     settled = true

--- a/frontend/src/lib/speech/speechModelStore.js
+++ b/frontend/src/lib/speech/speechModelStore.js
@@ -3,6 +3,7 @@ import {
   clonedSpeechLibraryStatus,
   DEFAULT_SPEECH_ENGINE_ID,
   DEFAULT_SPEECH_MODEL_ID,
+  hasUsableCloneSignal,
   isClonedSpeechModelId,
   publicSpeechEngine,
   publicSpeechModel,
@@ -423,6 +424,13 @@ export function saveSpeechClone({ language, name, samples, sampleRate }, { stora
   const resampled = resampleMono(boundedSamples, sampleRate)
   if (resampled.length < 24_000 * 3) {
     throw speechError('invalid_request', 'Record at least three seconds of clear speech.', 'TypeError')
+  }
+  if (!hasUsableCloneSignal(resampled)) {
+    throw speechError(
+      'invalid_request',
+      'We could not hear clear speech in that recording. Check your microphone and record again.',
+      'TypeError',
+    )
   }
   const targetStorage = storage || globalThis.localStorage
   let model

--- a/frontend/src/lib/speech/speechModels.js
+++ b/frontend/src/lib/speech/speechModels.js
@@ -15,6 +15,8 @@ const ENGLISH_VOICES = Object.freeze([
 const CLONED_PROFILES_KEY = 'mobius:speech:cloned-profiles:v1'
 const MIN_CLONE_PCM_BYTES = 24_000 * 3 * 2
 const MAX_CLONE_PCM_BYTES = 24_000 * 8 * 2
+const MIN_CLONE_SIGNAL_RMS = 0.001
+const MIN_CLONE_SIGNAL_RANGE = 0.005
 
 function asset(file, id) {
   const value = POCKET_TTS_V2_ASSETS[file]
@@ -250,10 +252,31 @@ function bytesFromBase64(value) {
   return bytes
 }
 
-function modelCloneSamples(model) {
-  if (!model?.cloned) return null
+export function hasUsableCloneSignal(samples) {
+  if (!(samples instanceof Float32Array) || samples.length === 0) return false
+  let total = 0
+  let min = Infinity
+  let max = -Infinity
+  for (let index = 0; index < samples.length; index += 1) {
+    const sample = samples[index]
+    if (!Number.isFinite(sample) || Math.abs(sample) > 1) return false
+    total += sample
+    min = Math.min(min, sample)
+    max = Math.max(max, sample)
+  }
+  if (max - min < MIN_CLONE_SIGNAL_RANGE) return false
+  const mean = total / samples.length
+  let variance = 0
+  for (let index = 0; index < samples.length; index += 1) {
+    const difference = samples[index] - mean
+    variance += difference * difference
+  }
+  return Math.sqrt(variance / samples.length) >= MIN_CLONE_SIGNAL_RMS
+}
+
+function clonePcmSamples(pcm16Base64) {
   let bytes
-  try { bytes = bytesFromBase64(model.clonePcm16Base64) } catch (error) {
+  try { bytes = bytesFromBase64(pcm16Base64) } catch (error) {
     throw profileStorageError('The saved voice recording is damaged.', error)
   }
   if (bytes.byteLength < MIN_CLONE_PCM_BYTES
@@ -264,6 +287,19 @@ function modelCloneSamples(model) {
   const pcm16 = new Int16Array(bytes.buffer, bytes.byteOffset, Math.floor(bytes.byteLength / 2))
   const samples = new Float32Array(pcm16.length)
   for (let index = 0; index < pcm16.length; index += 1) samples[index] = pcm16[index] / 32_768
+  return samples
+}
+
+function modelCloneSamples(model) {
+  if (!model?.cloned) return null
+  const samples = clonePcmSamples(model.clonePcm16Base64)
+  if (!hasUsableCloneSignal(samples)) {
+    throw profileStorageError(
+      'The saved voice recording contains no audible speech. Record it again.',
+      undefined,
+      'silent_recording',
+    )
+  }
   return samples
 }
 
@@ -305,6 +341,11 @@ export function saveClonedSpeechProfile(profile, storage = globalThis.localStora
   if (current.error) throw current.error
   const saved = normalizeClonedProfile(profile)
   if (!saved) throw new TypeError('The cloned voice profile is invalid.')
+  if (!hasUsableCloneSignal(clonePcmSamples(saved.pcm16Base64))) {
+    const error = new TypeError('The cloned voice profile contains no audible speech.')
+    error.code = 'silent_recording'
+    throw error
+  }
   const next = [...current.profiles.filter((item) => item.languageId !== saved.languageId), saved]
   storage?.setItem?.(CLONED_PROFILES_KEY, JSON.stringify(next))
   return clonedModel(saved)


### PR DESCRIPTION
## Summary
- initialize and resume Web Audio before the microphone permission await
- treat the first PCM frame as capture readiness and expose cancellation during startup
- reject silent, flat, malformed, and legacy silent clone recordings before they reach Pocket TTS

## Verification
- npm run runtime:build
- npm run runtime:check
- npm run test (2,447 library tests and 79 hook tests)
- focused Chromium execution of the microphone capture lifecycle
- isolated Node container validation of Voice clone storage