### PR TITLE
Fetch speech models from the public release, not mobius.local

### DIFF
--- a/frontend/src/lib/speech/speechModelAssets.js
+++ b/frontend/src/lib/speech/speechModelAssets.js
@@ -1,6 +1,10 @@
 // Generated from the locally quantized Pocket TTS v2 assets.
 // The shell verifies every chunk before retaining it in the device cache.
-const LOCAL_SPEECH_ROOT = 'https://mobius.local/speech-models/pocket-tts-v2'
+// Voice models are published as a public GitHub Release on the Voice app repo
+// and fetched through the reviewed device-asset relay (which follows the
+// release redirect and verifies each chunk's SHA-256). This works on any
+// deployment, unlike the former mobius.local local-only host.
+const LOCAL_SPEECH_ROOT = 'https://github.com/mobius-os/app-voice/releases/download/models-v2'
 
 export const POCKET_TTS_V2_ASSETS = Object.freeze({
   "english-alba.safetensors": Object.freeze({


### PR DESCRIPTION
**Fixes on-device speech on fresh deployments** ("The device asset source returned 400").

The merged speech feature shipped `speechModelAssets.js` pointing model URLs at `https://mobius.local/…`, but the `mobius.local` local-serving path never landed upstream — so on any deployment without locally-built models the device-asset relay can't resolve it (reserved, non-public host) and returns 400.

This points the model root at the public Pocket-TTS release on `mobius-os/app-voice` (`models-v2`). The reviewed device-asset relay proxies it (following the release redirect, range-streamed) and verifies each chunk's SHA-256 before caching — so models download and cache on any instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)