### PR TITLE
Highlight the focused app in the drawer instead of falling back to Apps

### DIFF
--- a/frontend/src/components/Drawer/Drawer.jsx
+++ b/frontend/src/components/Drawer/Drawer.jsx
@@ -1054,8 +1054,8 @@ export default function Drawer({
               <button
                 ref={appsButtonRef}
                 type="button"
-                className={`drawer__item drawer__item--apps${appsActive ? ' drawer__item--active' : ''}`}
-                aria-current={appsActive ? 'page' : undefined}
+                className={`drawer__item drawer__item--apps${activeView === 'apps' ? ' drawer__item--active' : ''}`}
+                aria-current={activeView === 'apps' ? 'page' : undefined}
                 onClick={openApps}
               >
                 <span className="drawer__item-icon" aria-hidden="true">
@@ -1089,11 +1089,11 @@ export default function Drawer({
                       attention={kind === 'chat'
                         ? attentionSet.has(item.id)
                         : newAppSet.has(Number(item.id))}
-                      active={!appsActive && (
+                      active={
                         kind === 'chat'
                           ? activeView === 'chat' && activeChatId === item.id
                           : activeView === 'canvas' && Number(activeAppId) === Number(item.id)
-                      )}
+                      }
                       renaming={!!(renaming
                         && renaming.surface === 'drawer'
                         && renaming.kind === kind
@@ -1133,11 +1133,11 @@ export default function Drawer({
                     attention={kind === 'chat'
                       ? attentionSet.has(item.id)
                       : newAppSet.has(Number(item.id))}
-                    active={!appsActive && (
+                    active={
                       kind === 'chat'
                         ? activeView === 'chat' && activeChatId === item.id
                         : activeView === 'canvas' && Number(activeAppId) === Number(item.id)
-                    )}
+                    }
                     renaming={!!(renaming
                       && renaming.surface === 'drawer'
                       && renaming.kind === kind


### PR DESCRIPTION
## Problem

When an app is opened in a side pane while the Apps directory is still visible in another pane, the drawer highlights the generic **Apps** entry as selected and never highlights the specific open app. Chats do not have this problem: a chat opened in a side pane is highlighted correctly.

## Cause

The drawer's selection highlight was driven by `appsActive` (passed in as `appsVisibleAsTab`) — a workspace-wide flag that is true whenever *any* visible pane shows the Apps directory. That single flag both lit the **Apps** entry and, through a `!appsActive` gate, suppressed the per-app row highlight in the Pinned/Recents lists. Because it is workspace-wide rather than focused-pane-scoped, opening an app beside a visible Apps directory kept **Apps** highlighted and hid the app row. Chats were unaffected because they already key their highlight off the focused-pane route.

## Fix

Drive the drawer selection highlight from the focused-pane route (`activeView === 'apps'`) — the same basis chats already use — instead of the workspace-wide flag. The `!appsActive` gate on the Pinned/Recents rows then becomes redundant (the focused pane's `activeView` is mutually exclusive across chat/canvas/apps) and is removed. `appsActive` is kept where it is still correct: gating the Apps directory portal render, which legitimately means "the grid is visible in any pane."

Net effect: an app opened in any pane now highlights in the drawer exactly like a chat does.