### PR TITLE
ci: run the expensive suite once per merge, not twice

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,6 +105,10 @@ jobs:
           caddy validate --config /etc/caddy/Caddyfile
       - name: Run pytest
         working-directory: backend
+        # Skip the full suite on pull_request — it is the expensive half of this
+        # job and the merge_group run (the authoritative gate) runs it in full.
+        # See the merge-queue rationale on the e2e job below.
+        if: github.event_name != 'pull_request'
         # -n auto parallelizes across the runner's CPUs — safe because the suite
         # is already process-isolated (each xdist worker imports conftest and
         # gets its own tempdir DATA_DIR + SQLite engine). pytest-cov combines
@@ -155,6 +159,13 @@ jobs:
 
   e2e:
     runs-on: ubuntu-latest
+    # Skip the browser suite on pull_request: it is the most expensive gate and
+    # the merge_group run (the authoritative pre-merge check) runs it in full, so
+    # a PR need not pay two full suite-lengths before it can land. This assumes
+    # branch protection treats a job skipped via `if:` as a satisfied required
+    # check on the PR; if it instead blocks on the skip, drop backend + e2e from
+    # the PR-required set and let the merge queue be the gate.
+    if: github.event_name != 'pull_request'
     # A cold hosted build can spend roughly 20 minutes populating the GHA cache
     # before Playwright starts. Leave enough room for the complete browser suite
     # and its diagnostic uploads instead of cancelling a healthy run mid-test.


### PR DESCRIPTION
## Problem
Every PR runs the full suite on the `pull_request` event and then the **identical** suite again in the merge queue (`merge_group`), so even a one-line fix pays two full suite-lengths back to back before it can land.

## Fix
Skip the two expensive gates — the full backend `pytest` run and the browser `e2e` job — on the `pull_request` event, leaving fast review-time feedback (`privacy`, `frontend-unit`, and backend static analysis). The `merge_group` run remains the authoritative gate and still runs everything; manual dispatch (used by pre-PR checks) also runs the full suite. This roughly **halves both time-to-merge and CI minutes** per change.

## Branch-protection note
This relies on GitHub treating a job skipped via `if:` as a **satisfied** required status check on the PR (its documented behavior), with the `merge_group` context enforcing all four checks before landing. If a repository's protection instead requires `backend`/`e2e` to actually run on the PR and blocks on a skip, move those two out of the PR-required set so the merge queue is the gate.

**Trade-off:** a PR that would fail the full suite is caught in the queue rather than on the PR, which can eject it and re-run the group behind it. With flakes addressed separately, ejections should track real failures.

---
*Second of a 2-PR stack on CI throughput; builds on the pytest-parallelization layer.*