### PR TITLE
Don't let a question-parked turn pin a pending shell update

### DIFF
--- a/backend/app/routes/chats.py
+++ b/backend/app/routes/chats.py
@@ -334,6 +334,11 @@ def _owner_chat_summary(chat, *, durable_running: bool = False) -> dict:
     "has_messages": bool(chat.has_messages),
     "created_by_app_id": chat.created_by_app_id,
     "running": durable_running or is_chat_running(chat.id),
+    # A turn parked on the owner's AskUserQuestion answer is `running` but is
+    # NOT streaming — nothing to interrupt, and the card is durable — so the
+    # shell excludes it from the reload-defer's active-turn test. The durable
+    # column is the source of truth (see `_open_question_id_for`).
+    "pending_question_id": chat.pending_question_id,
   }
 
 
@@ -558,6 +563,10 @@ def list_chats(
     # than pulling transcript/runtime JSON into the hot path.
     models.Chat.agent_settings_json,
     models.Chat.has_messages,
+    # Scalar "parked on the owner's AskUserQuestion answer" marker — lets the
+    # shell tell a parked turn from a live stream without decoding the messages
+    # JSON. Consumed by _owner_chat_summary below.
+    models.Chat.pending_question_id,
   ).filter(models.Chat.deleted_at.is_(None))
   chats = (
     q.order_by(

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -1410,6 +1410,22 @@ export default function Shell() {
   }, [localStreamingChatIds, chats])
   const streamingChatIdsRef = useRef(streamingChatIds)
   useEffect(() => { streamingChatIdsRef.current = streamingChatIds }, [streamingChatIds])
+  // Whether the chat the owner is looking at is parked on an AskUserQuestion
+  // answer. Such a turn is `running` (so it stays in streamingChatIds above,
+  // keeping its drawer dot) but is NOT streaming tokens: the card is durably
+  // persisted and a reload re-renders it from server state without touching the
+  // server-owned turn. The reload policy treats this as idle, so an unanswered
+  // question can no longer pin a pending shell update. Only the active chat can
+  // defer a reload, so a single boolean is all the policy needs.
+  const activeChatWaitingOnQuestion = useMemo(() => {
+    if (activeChatId == null) return false
+    const active = chats.find(chat => String(chat.id) === String(activeChatId))
+    return active?.pending_question_id != null
+  }, [chats, activeChatId])
+  const activeChatWaitingOnQuestionRef = useRef(activeChatWaitingOnQuestion)
+  useEffect(() => {
+    activeChatWaitingOnQuestionRef.current = activeChatWaitingOnQuestion
+  }, [activeChatWaitingOnQuestion])
   // The reload check runs inside a setTimeout (scheduleShellReloadCheck), which
   // reads render-time state through a ref, so the boolean still needs a ref
   // mirror even though it is no longer a Set.
@@ -1431,6 +1447,7 @@ export default function Shell() {
     drawerOpenRef,
     multiPaneBuilderVisibleRef,
     streamingChatIdsRef,
+    activeChatWaitingOnQuestionRef,
     voiceDictationActiveRef,
     activeView,
     activeChatId,

--- a/frontend/src/components/Shell/__tests__/shellReloadPolicy.test.js
+++ b/frontend/src/components/Shell/__tests__/shellReloadPolicy.test.js
@@ -41,6 +41,22 @@ test('only the actively viewed chat turn defers shell reloads', () => {
   }), false)
 })
 
+test('a question-parked active chat no longer defers the shell reload', () => {
+  const base = {
+    activeElement: el('body'),
+    activeView: 'chat',
+    activeChatId: 'c1',
+    streamingChatIds: new Set(['c1']),
+    lastUserInteractionAt: 0,
+    now: 10000,
+  }
+  assert.equal(shouldDeferShellReload(base), true, 'a streaming turn still holds')
+  assert.equal(shouldDeferShellReload({
+    ...base,
+    activeChatWaitingOnQuestion: true,
+  }), false, 'parked on the owner\'s answer is a safe apply boundary')
+})
+
 test('recent interaction defers visible shell reloads', () => {
   assert.equal(shouldDeferShellReload({
     activeElement: el('body'),

--- a/frontend/src/components/Shell/shellReloadPolicy.js
+++ b/frontend/src/components/Shell/shellReloadPolicy.js
@@ -73,6 +73,7 @@ export function shouldDeferShellReload({
   activeChatId,
   multiPaneBuilderVisible = false,
   streamingChatIds,
+  activeChatWaitingOnQuestion = false,
   passiveRebuild = false,
   voiceDictationActive = false,
   lastUserInteractionAt = 0,
@@ -100,7 +101,16 @@ export function shouldDeferShellReload({
   // through the ordinary apply-on-idle policy below.
   if (passiveRebuild && activeView === 'chat' && activeChatId != null) return true
   if (hasProtectedEditingContent(activeElement)) return true
-  if (hasActiveChatTurn({ activeView, activeChatId, streamingChatIds })) return true
+  // A turn parked on the owner's AskUserQuestion answer is `running` (so the
+  // active chat is in streamingChatIds) but is NOT streaming tokens: the card is
+  // durably persisted and reloading re-renders it from server state without
+  // touching the server-owned turn. So it never counts as a live turn here —
+  // otherwise an unanswered question pins a pending shell update indefinitely
+  // while the owner reads the card.
+  if (
+    !activeChatWaitingOnQuestion
+    && hasActiveChatTurn({ activeView, activeChatId, streamingChatIds })
+  ) return true
   // A reload mid-dictation would drop the in-flight transcript, so hold it
   // while the mic is live.
   if (voiceDictationActive) return true

--- a/frontend/src/components/Shell/useShellReloadController.js
+++ b/frontend/src/components/Shell/useShellReloadController.js
@@ -73,6 +73,7 @@ export default function useShellReloadController(inputs) {
       activeChatIdRef,
       multiPaneBuilderVisibleRef,
       streamingChatIdsRef,
+      activeChatWaitingOnQuestionRef,
       voiceDictationActiveRef,
     } = inputsRef.current
     return shouldDeferShellReload({
@@ -81,6 +82,7 @@ export default function useShellReloadController(inputs) {
       activeChatId: activeChatIdRef.current,
       multiPaneBuilderVisible: multiPaneBuilderVisibleRef.current,
       streamingChatIds: streamingChatIdsRef.current,
+      activeChatWaitingOnQuestion: activeChatWaitingOnQuestionRef.current,
       passiveRebuild: passive,
       voiceDictationActive: voiceDictationActiveRef.current,
       lastUserInteractionAt: interactionGraceSpent()


### PR DESCRIPTION
## Problem

The shell holds back a pending update (a waiting service worker) while the chat the owner is viewing has an active turn. "Active turn" is derived from the chat's `running` flag — but `running` is also true when a turn is simply **parked waiting for the owner to answer an AskUserQuestion**. Those need opposite handling:

- **Actively streaming** → reloading would interrupt a live stream. Correctly deferred.
- **Parked on a question** → nothing is streaming; the card is durably persisted (`chats.pending_question_id`) and a reload re-renders it from server state without touching the server-owned turn.

Because a parked turn stays `running`, an unanswered question keeps the reload deferred for as long as the owner views that chat — pinning the installed PWA to a stale bundle indefinitely (a hard refresh cannot dislodge a controlling service worker).

## Fix

Treat a turn parked on an AskUserQuestion answer as idle for the apply-on-idle reload policy:

- Surface the existing durable `pending_question_id` marker in the drawer chat-list summary (previously only in the chat-detail payload). It is a scalar column, so the lightweight list projection stays cheap.
- In `shouldDeferShellReload`, when the active chat is waiting on a question, do not count it as a live turn — so a pending update applies at that safe boundary.

Only the active chat can defer a reload, so the shell passes a single boolean (`activeChatWaitingOnQuestion`) rather than building a set.

## Notes

- A genuinely streaming turn is still protected (unchanged).
- `hasActiveChatTurn` is unchanged; the parked exclusion is one guard in `shouldDeferShellReload`.
- Unit tests cover both directions: a streaming turn still defers; a question-parked active chat does not.