### PR TITLE
fix(contribute): re-resolve a deleted fork instead of an opaque push failure

### DIFF
--- a/backend/app/github_contributions.py
+++ b/backend/app/github_contributions.py
@@ -1403,13 +1403,14 @@ def _github_remote_slug(remote_url: str) -> str | None:
 
 def _ensure_owner_fork_remote(repo: Path, upstream_repo: str, login: str) -> str:
   """Make local remote `fork` point at the approving owner's fork."""
-  existing = _git_ops._git(repo, "remote", "get-url", "fork", check=False)
-  if existing.returncode == 0:
-    actual_slug = _github_remote_slug(existing.stdout)
-    if actual_slug and actual_slug.split("/", 1)[0].lower() == login.lower():
-      return actual_slug
-    # The staged contribution checkout is disposable. Replacing a stale
-    # remote is safer than pushing reviewed code to an ambient `fork` URL.
+  # A cached `fork` remote is never trusted on its own: it can name a fork the
+  # owner has since deleted on GitHub, and pushing reviewed code at a missing
+  # repository fails with an opaque error. Drop any existing remote and always
+  # re-resolve through `gh repo fork`, which is idempotent — it reuses the
+  # owner's fork or creates one — so a stale, ambient, or deleted remote all
+  # heal the same way. The staged contribution checkout is disposable, so
+  # replacing the remote is safe.
+  if _git_ops._git(repo, "remote", "get-url", "fork", check=False).returncode == 0:
     _git_ops._git(repo, "remote", "remove", "fork", check=False)
 
   origin = _git_ops._git(repo, "remote", "get-url", "origin", check=False)

--- a/backend/tests/test_github_routes.py
+++ b/backend/tests/test_github_routes.py
@@ -2807,6 +2807,49 @@ def test_ensure_owner_fork_remote_runs_in_repo_after_pinning_origin(
   assert all("mobius-os/app-demo" not in call for call in gh_calls)
 
 
+def test_ensure_owner_fork_remote_never_trusts_a_cached_remote(
+  tmp_path, monkeypatch,
+):
+  from app.routes.github import _ensure_owner_fork_remote
+
+  repo = tmp_path / "repo"
+  repo.mkdir()
+  git_calls = []
+  gh_calls = []
+  reforked = False
+
+  def fake_git(repo_path, *args, check=True):
+    nonlocal reforked
+    git_calls.append(args)
+    if args == ("remote", "get-url", "fork"):
+      # A cached remote is present but names a fork the owner deleted; after
+      # re-resolving, the remote points at the live fork.
+      if reforked:
+        return _cp("https://github.com/octocat/mobius.git\n")
+      return _cp("https://github.com/octocat/stale-fork.git\n")
+    if args == ("remote", "get-url", "origin"):
+      return _cp("https://github.com/mobius-os/mobius.git\n")
+    return _cp("")
+
+  def fake_gh(repo_path, *args, check=True):
+    nonlocal reforked
+    gh_calls.append(args)
+    if args == ("repo", "fork", "--remote", "--remote-name", "fork"):
+      reforked = True
+    return _cp("")
+
+  monkeypatch.setattr("app.github_contribution_git._git", fake_git)
+  monkeypatch.setattr("app.github_contribution_git._gh", fake_gh)
+
+  fork_slug = _ensure_owner_fork_remote(repo, "mobius-os/mobius", "octocat")
+
+  assert fork_slug == "octocat/mobius"
+  # The cached remote is dropped and re-resolved through gh, never returned
+  # directly — so a deleted fork heals instead of failing the push.
+  assert ("remote", "remove", "fork") in git_calls
+  assert ("repo", "fork", "--remote", "--remote-name", "fork") in gh_calls
+
+
 def _commit_metadata(
   sha,
   *,


### PR DESCRIPTION
## Problem
When an owner deletes their personal GitHub fork and Contribute later submits a prepared PR, the push fails with an opaque error — "GitHub would not accept this branch, so nothing was published" — with nothing pointing at the real cause: a stale fork reference.

## Cause
`_ensure_owner_fork_remote` trusted the staged checkout's cached `fork` remote whenever its owner matched the connected login, returning it without checking the fork still exists. Once the owner deletes that fork, the remote still names it, so submission pushes the reviewed branch at a repository that no longer exists and GitHub rejects it.

## Fix
Remove the cached-remote fast path and always re-resolve through `gh repo fork`, which is idempotent: it reuses the owner's existing fork or creates one, then points the `fork` remote at it. A stale, ambient, or deleted remote now all heal the same way through a single path — rather than special-casing deletion with a validator on top of the fragile optimization. The fast path only ever saved one API call on an already network-bound submit. Fork-remote tests are updated to assert a cached remote is always re-resolved.

Backend-only; no API or schema change.
