### PR TITLE
fix(shell): hide left rail backdrop in immersive mode

### DIFF
--- a/frontend/src/components/Shell/Shell.css
+++ b/frontend/src/components/Shell/Shell.css
@@ -814,4 +814,12 @@
   .shell--immersive > .shell__content {
     margin-left: 0;
   }
+
+  /* Immersive zeroes the content margin so the canvas spans full width, but the
+     desktop left-rail backdrop (.shell::before) sits above the content at
+     z-index 2 and would keep painting var(--bg) over the canvas — a black column
+     on a dark theme. Suppress it while immersive, as we do for .shell--immersive::after. */
+  .shell--immersive::before {
+    display: none;
+  }
 }


### PR DESCRIPTION
## What
In immersive mode (a mini-app requesting the full viewport, e.g. a game), the desktop shell shows a black column down the left edge where the rail/sidebar normally sits, while the rest of the canvas is full-screen.

## Why
On desktop, `.shell::before` paints the left rail/sidebar backdrop (`var(--bg)`, `z-index: 2`) — the collapsed-rail width, or the full `--desktop-sidebar-width` when the drawer is docked. Entering immersive zeroes the content's `margin-left` so the canvas spans the full viewport, and hides `.shell__bar` and `.shell--immersive::after` — but nothing suppresses `.shell::before`. That strip keeps painting `var(--bg)` over the canvas's left edge (it sits above the `z-index: 1` content), which reads as a black column on a dark theme.

## Fix
Suppress `.shell::before` while immersive, mirroring the existing `.shell--immersive::after { display: none }` rule. Desktop-only; no behaviour change outside immersive mode.