### PR TITLE
Sharpen the currency dollar-escaping guidance in the agent guide

### DIFF
--- a/skill/core.md
+++ b/skill/core.md
@@ -202,7 +202,7 @@ Partner-facing messages describe what the app does and how it feels, not how it'
 ### Chat rendering
 
 - **Math**: `$...$` (inline) and `$$...$$` (block) render KaTeX.
-- **Currency**: escape dollar signs used as currency (for example, `\$62.5k`) so they are not interpreted as math delimiters.
+- **Currency**: ALWAYS write a currency dollar sign as `\$` — for example `\$5`, `\$7–9/turn`, `\$62.5k`. A bare `$` opens KaTeX math and pairs with the next `$` on the line, silently swallowing every word between two amounts into a garbled formula. This is easiest to forget in a message with more than one amount (`$7 ... $5`), which is exactly the case that breaks — so escape every currency `$`, without exception.
 - **Images**: any `/api/` image URL in markdown renders inline. Two or more
   adjacent image-only Markdown blocks automatically render as a horizontally
   scrollable filmstrip; use that form for a related set and keep a lone image


### PR DESCRIPTION
## What

Strengthen the currency-escaping instruction in `skill/core.md` (the agent guide's **Chat rendering** section).

## Why

Chat messages render `$…$` as inline KaTeX math. A bare `$` used for currency therefore opens a math span that pairs with the *next* `$` on the same line — so a message containing two dollar amounts (e.g. `$7/turn` and `$5/turn`) renders everything between them as one garbled formula.

The prior wording ("escape dollar signs used as currency … so they are not interpreted as math delimiters") was easy to under-weight in practice: a single amount gets escaped while a second amount on the same line slips through, which is exactly the case that breaks.

## Change

Rewrites that one bullet to:

- state the rule unconditionally — always write a currency dollar sign as `\$`;
- name the actual failure mode (a bare `$` pairs with the next `$` and swallows the text between two amounts); and
- call out a message with more than one amount as the case that breaks.

Docs-only; no code or behavior change.