### PR TITLE
Highlight the focused app in the drawer instead of falling back to Apps

### DIFF
--- a/frontend/src/components/Drawer/Drawer.jsx
+++ b/frontend/src/components/Drawer/Drawer.jsx
@@ -127,6 +127,13 @@ export default function Drawer({
   const streamingSet = streamingChatIds || EMPTY_SET
   const attentionSet = attentionChatIds || EMPTY_SET
   const newAppSet = newAppIds || EMPTY_SET
+  // One source of truth for which row the focused pane is showing, so a chat
+  // and an app are selected by the same rule wherever the row is rendered.
+  const isRowActive = ({ kind, item }) => (
+    kind === 'chat'
+      ? activeView === 'chat' && activeChatId === item.id
+      : activeView === 'canvas' && Number(activeAppId) === Number(item.id)
+  )
   const resizeRef = useRef(null)
   const pinnedReorderGenerationRef = useRef(0)
   const [pinnedOrderHandoff, setPinnedOrderHandoff] = useState(null)
@@ -1054,8 +1061,8 @@ export default function Drawer({
               <button
                 ref={appsButtonRef}
                 type="button"
-                className={`drawer__item drawer__item--apps${appsActive ? ' drawer__item--active' : ''}`}
-                aria-current={appsActive ? 'page' : undefined}
+                className={`drawer__item drawer__item--apps${activeView === 'apps' ? ' drawer__item--active' : ''}`}
+                aria-current={activeView === 'apps' ? 'page' : undefined}
                 onClick={openApps}
               >
                 <span className="drawer__item-icon" aria-hidden="true">
@@ -1089,11 +1096,7 @@ export default function Drawer({
                       attention={kind === 'chat'
                         ? attentionSet.has(item.id)
                         : newAppSet.has(Number(item.id))}
-                      active={!appsActive && (
-                        kind === 'chat'
-                          ? activeView === 'chat' && activeChatId === item.id
-                          : activeView === 'canvas' && Number(activeAppId) === Number(item.id)
-                      )}
+                      active={isRowActive({ kind, item })}
                       renaming={!!(renaming
                         && renaming.surface === 'drawer'
                         && renaming.kind === kind
@@ -1133,11 +1136,7 @@ export default function Drawer({
                     attention={kind === 'chat'
                       ? attentionSet.has(item.id)
                       : newAppSet.has(Number(item.id))}
-                    active={!appsActive && (
-                      kind === 'chat'
-                        ? activeView === 'chat' && activeChatId === item.id
-                        : activeView === 'canvas' && Number(activeAppId) === Number(item.id)
-                    )}
+                    active={isRowActive({ kind, item })}
                     renaming={!!(renaming
                       && renaming.surface === 'drawer'
                       && renaming.kind === kind

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -827,7 +827,8 @@ test('the Apps tab never disables the mobile drawer layered above it', () => {
     'workspace content is inert while the drawer is open; the drawer must stay interactive')
   assert.doesNotMatch(drawer, /interactionLocked \|\| appsActive/,
     'Apps is a tab underneath navigation, not a modal owner of Escape')
-  assert.match(drawer, /appsActive \? ' drawer__item--active'/)
+  assert.match(drawer, /activeView === 'apps' \? ' drawer__item--active'/,
+    'the Apps entry highlights from the focused-pane route, matching how chats do')
   assert.match(shell, /appsActive=\{appsVisibleAsTab\}/)
 })
 


### PR DESCRIPTION
## Problem

When an app is opened in a side pane while the Apps directory is still visible in another pane, the drawer highlights the generic **Apps** entry as selected and never highlights the specific open app. Chats do not have this problem: a chat opened in a side pane is highlighted correctly.

## Cause

The drawer's selection highlight was driven by `appsActive` (passed in as `appsVisibleAsTab`) — a workspace-wide flag that is true whenever *any* visible pane shows the Apps directory. That single flag both lit the **Apps** entry and, through a `!appsActive` gate, suppressed the per-app row highlight in the Pinned/Recents lists. Because it is workspace-wide rather than focused-pane-scoped, opening an app beside a visible Apps directory kept **Apps** highlighted and hid the app row. Chats were unaffected because they already key their highlight off the focused-pane route.

## Fix

Drive the drawer selection highlight from the focused-pane route (`activeView === 'apps'`) — the same basis chats already use — instead of the workspace-wide flag. The `!appsActive` gate on the Pinned/Recents rows then becomes redundant (the focused pane's `activeView` is mutually exclusive across chat/canvas/apps) and is removed. `appsActive` is kept where it is still correct: gating the Apps directory portal render, which legitimately means "the grid is visible in any pane."

The `workspaceUi` source-match test that pinned the old `appsActive`-driven Apps highlight is updated to assert the corrected `activeView === 'apps'` basis.

Net effect: an app opened in any pane now highlights in the drawer exactly like a chat does.