### PR TITLE
fix(e2e): cache sw.js in the idle-apply spec to stop CI timeouts

### DIFF
--- a/tests/shell-update-idle.spec.mjs
+++ b/tests/shell-update-idle.spec.mjs
@@ -403,15 +403,23 @@ test.describe('shell update — apply on idle, SW on a leash', () => {
     // left waiting. That is generation identity: it landed on the new generation,
     // not back on the outgoing one.
     let swMarker = ''
+    // Serve /sw.js from a single cached fetch. updateViaCache:'none' plus the
+    // reg.update() calls below make the browser re-request it many times, and a
+    // live route.fetch() per hit is a real round-trip to the shared test backend
+    // the parallel workers already contend on — that contention, not any SW
+    // race, is what timed this case out. Served bytes are unchanged.
+    let swBase = null
     await page.route('**/sw.js', async (route) => {
-      const res = await route.fetch()
-      let body = await res.text()
+      if (!swBase) {
+        const res = await route.fetch()
+        swBase = { status: res.status(), headers: res.headers(), body: await res.text() }
+      }
       // A STABLE byte-append once armed → the browser installs ONE genuinely new,
       // leashed worker; later re-fetches stay byte-identical so it does not
       // reinstall. The bundle is unchanged — the new WORKER's identity is the
       // generation the page must land on.
-      if (swMarker) body += `\n//${swMarker}\n`
-      await route.fulfill({ status: res.status(), headers: res.headers(), body })
+      const body = swMarker ? `${swBase.body}\n//${swMarker}\n` : swBase.body
+      await route.fulfill({ status: swBase.status, headers: swBase.headers, body })
     })
     await setup(page, {
       streamRoute: route => route.fulfill(fulfillStream(sse([{ type: 'done' }]))),


### PR DESCRIPTION
## Problem
The e2e case *"an idle apply lands the page on the new SW generation"* in `tests/shell-update-idle.spec.mjs` intermittently times out on CI — failing **both** attempts against its extended (`test.slow()`) budget, burning ~6 minutes and turning the whole `e2e` job red.

## Root cause
The test's `page.route('**/sw.js')` handler did a live `route.fetch()` to the shared test backend on **every** interception. With `updateViaCache:'none'` and several real `reg.update()` cycles, the browser re-requests `sw.js` many times, and each was a real round-trip to the single uvicorn + SQLite backend that the parallel Playwright workers already contend on. Under load that unbounded contention — not any service-worker race — is what pushes the case past even its slow budget. `retries: 1` then reruns under the same saturation, so the second attempt never recovers and just doubles the waste.

## Fix
Fetch the built `sw.js` **once**, then serve every later interception from that cached copy. The served bytes are identical to before (the real bundle, with the gen-B marker appended once armed), so the SW generation behaviour under test is unchanged — only the repeated contended round-trips are removed.

No product code changes; test-only.