### PR TITLE
ci: warm the shared build cache daily so PR e2e builds stay fast

### DIFF
--- a/.github/workflows/warm-build-cache.yml
+++ b/.github/workflows/warm-build-cache.yml
@@ -1,0 +1,52 @@
+name: Warm build cache
+
+# The e2e job restores the test image's large browser/CLI layers from the GHA
+# build cache but deliberately never writes it back — exporting from a
+# short-lived PR merge ref would duplicate those layers under GHA's ~10GB cap
+# and evict the shared entry other PRs rely on. So the cache is only refreshed
+# by release-candidate image builds; between releases its layers drift from main
+# (and can evict during quiet periods), and PRs fall back to a slow cold build.
+#
+# Keep main's cache current by rebuilding and exporting it daily from the
+# default branch, where PRs (whose base is main) can restore it.
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  # The downloadable Buildx record duplicates the build summary already in the
+  # job log and is not used here.
+  DOCKER_BUILD_RECORD_UPLOAD: 'false'
+
+concurrency:
+  group: warm-build-cache
+  cancel-in-progress: true
+
+jobs:
+  warm:
+    runs-on: ubuntu-latest
+    # A full cold build can approach the same duration as the e2e build it feeds.
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build and export the test image cache
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          # No load or push: this run exists only to refresh the shared cache.
+          push: false
+          load: false
+          # Match the e2e build so the exported layers are the ones it restores.
+          build-args: |
+            BUILD_SHA=${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max,ignore-error=true


### PR DESCRIPTION
## Problem
The `e2e` job restores the test image's large browser/CLI layers from the GHA build cache (`cache-from: type=gha`) but deliberately never writes it back — exporting from a short-lived PR merge ref would duplicate those layers under GHA's ~10 GB repository cap and evict the shared entry other PRs rely on. As a result the cache is only populated by release-candidate image builds, so between releases it ages out (GHA evicts entries untouched for 7 days) and the next PR pays a full **cold build (~20 min)** before Playwright even starts.

## Fix
Add a scheduled daily (and manually dispatchable) job on the default branch that rebuilds the image and exports the cache with `mode=max`. It runs only on `main`, writing the cache under main's scope where pull requests (whose base is `main`) can restore it — keeping the cache warm inside the 7-day eviction window so PR e2e builds stay on the ~3-min warm path. It doesn't `load` or `push`; it exists only to refresh the shared cache.

Leaves the deliberate "PRs don't export cache" design untouched.