### PR TITLE
Drain in-flight background subagents before reaping a settled Claude turn

### DIFF
--- a/backend/app/claude_events.py
+++ b/backend/app/claude_events.py
@@ -37,6 +37,20 @@ except ImportError:
   TERMINAL_TASK_STATUSES = frozenset()
   TaskUpdatedMessage = None
 
+# Only *delegated agent* tasks reliably reach a terminal status, so only these
+# are safe to wait on before the turn-end reap. The SDK gates its own
+# task-lifecycle tracker on this exact set (claude_agent_sdk/_internal/query.py)
+# and warns that tracking anything else "will hang the query": a background shell
+# or Monitor is a long-running watch that by design never emits a terminal frame,
+# so adding it to the in-flight set would make the drain block to its full
+# timeout instead of returning. The constant lives in the SDK's private
+# internals (not exported from types), so mirror it with a best-effort import and
+# a hardcoded fallback that matches the current SDK value.
+try:
+  from claude_agent_sdk._internal.query import DEFERRING_TASK_TYPES
+except ImportError:
+  DEFERRING_TASK_TYPES = frozenset({"local_agent", "local_workflow"})
+
 from app import activity
 from app.sdk_emit import emit_unknown_enabled, unknown_event
 from app.tool_summaries import summarize_tool_input
@@ -209,6 +223,39 @@ def _claude_text_item_id(message_id: str | None, index: object) -> str | None:
   if message_id is None or index is None:
     return None
   return f"{message_id}:{index}"
+
+
+def update_inflight_tasks(sdk_msg: Any, inflight: set) -> None:
+  """Maintain the set of *drainable* background task_ids still running, keyed on
+  the SAME message types ``dispatch_sdk_message`` translates. A task_id is added
+  when a TaskStartedMessage for a DEFERRING_TASK_TYPES agent (``local_agent`` /
+  ``local_workflow`` — Task-tool subagents and Workflows) arrives, and removed on
+  its terminal signal — a TaskNotificationMessage (dispatch's ``task_done``), or a
+  TaskUpdatedMessage patch carrying a TERMINAL_TASK_STATUSES status (the path a
+  TaskStop-killed task reports through). The runner uses this set to decide
+  whether background work is still live at the turn's terminal result, so it can
+  drain it before reaping instead of killing it.
+
+  Only delegated-agent tasks are tracked: background shells and Monitors run
+  indefinitely by design and never emit a terminal frame, so adding one would
+  make the drain block until its bounded timeout rather than returning promptly.
+  The SDK gates its own tracker on the same set for exactly this reason. Purely
+  observational — never raises on shape drift.
+  """
+  if isinstance(sdk_msg, TaskStartedMessage):
+    if getattr(sdk_msg, "task_type", None) not in DEFERRING_TASK_TYPES:
+      return
+    task_id = getattr(sdk_msg, "task_id", None)
+    if task_id is not None:
+      inflight.add(task_id)
+  elif isinstance(sdk_msg, TaskNotificationMessage):
+    inflight.discard(getattr(sdk_msg, "task_id", None))
+  elif (
+    TaskUpdatedMessage is not None
+    and isinstance(sdk_msg, TaskUpdatedMessage)
+    and getattr(sdk_msg, "status", None) in TERMINAL_TASK_STATUSES
+  ):
+    inflight.discard(getattr(sdk_msg, "task_id", None))
 
 
 def dispatch_sdk_message(

--- a/backend/app/claude_sdk_runner.py
+++ b/backend/app/claude_sdk_runner.py
@@ -84,7 +84,11 @@ from claude_agent_sdk.types import (
 )
 
 from app import activity
-from app.claude_events import _clip_task_text, dispatch_sdk_message
+from app.claude_events import (
+  _clip_task_text,
+  dispatch_sdk_message,
+  update_inflight_tasks,
+)
 from app.claude_sdk_contract import transport_exit_error, transport_process_pid
 from app.process_groups import (
   isolated_process_group_id,
@@ -114,6 +118,37 @@ def _claude_cli_path() -> str:
   ):
     return _ISOLATED_CLAUDE_CLI
   return _CLAUDE_CLI
+
+
+async def _drain_background_tasks(client, bc, inflight, session_id, chat_id):
+  """Let still-running background subagents/tasks finish before the turn reaps.
+
+  The main agent's terminal ResultMessage ends the TURN, not the background
+  tasks it spawned — the SDK keeps the channel open past the result frame
+  ("result frame ends one turn, not necessarily the run"). The turn-end
+  process-group reap would kill any task still running and lose its work. So at a
+  genuine terminal we keep the connected client and keep reading its stream,
+  dispatching each event and clearing tasks as they settle, until every tracked
+  task finishes; then the caller returns into the normal reap.
+
+  Wait for the real work, not an arbitrary clock. Only drainable delegated-agent
+  tasks are tracked (see ``update_inflight_tasks``), and those reliably reach a
+  terminal status, so this returns as soon as the subagents actually settle —
+  there is deliberately no time cap. Fail-safe: on ANY stream error it returns so
+  the reap proceeds; a real Stop raises CancelledError (BaseException), which
+  propagates untouched and aborts the wait at once.
+  """
+  try:
+    async for sdk_msg in client.receive_messages():
+      dispatch_sdk_message(sdk_msg, bc, session_id)
+      update_inflight_tasks(sdk_msg, inflight)
+      if not inflight:
+        return
+  except Exception as exc:
+    log.warning(
+      "background-task drain ended early chat_id=%s inflight=%d: %s",
+      chat_id, len(inflight), exc,
+    )
 
 
 def _claude_process_group_id(client: ClaudeSDKClient) -> int | None:
@@ -1099,6 +1134,9 @@ async def run_claude_sdk_turn(
       # recovery in the terminal branch below), so a genuinely-empty resume
       # can never loop.
       did_auto_requery = False
+      # task_ids of background subagents/tasks still running, tracked across the
+      # requery loop so a terminal result knows whether to drain before reaping.
+      inflight_tasks: set = set()
       while True:
         async for sdk_msg in client.receive_response():
           # Persist the session id ONLY from real conversation messages.
@@ -1124,6 +1162,7 @@ async def run_claude_sdk_turn(
           current_session_id, terminal = dispatch_sdk_message(
             sdk_msg, bc, current_session_id,
           )
+          update_inflight_tasks(sdk_msg, inflight_tasks)
           if terminal is None:
             # A steer fires its interrupt synchronously in
             # ActiveClaudeClient.steer() (a soft interrupt on the same
@@ -1189,6 +1228,16 @@ async def run_claude_sdk_turn(
           cost_usd = terminal.get("cost_usd")
           if rate_limit_resets_at is not None:
             terminal.setdefault("rate_limit_resets_at", rate_limit_resets_at)
+          # Background subagents/tasks the agent launched but did not block on
+          # are still live at this terminal result. The turn-end reap would kill
+          # them mid-work; keep the connected client and drain until they finish,
+          # THEN return into the reap. Skipped on a Stop — the owner asked to
+          # stop, so honor it immediately. Fail-safe: on any stream error the
+          # drain returns and the reap proceeds exactly as before.
+          if inflight_tasks and not active_client.interrupt_requested:
+            await _drain_background_tasks(
+              client, bc, inflight_tasks, current_session_id, chat_id,
+            )
           return terminal
         else:
           # The stream ended without a terminal ResultMessage. Any buffered


### PR DESCRIPTION
## Problem

Background subagents and tasks an agent launches during a turn (the `Agent`/`Task` tools; background is the default for subagents since Claude Code 2.1.198) run as children of the CLI process. When the turn settles, the runner reaps the CLI's process group as a backstop for tool children — killing any background task still running and discarding its work.

The Claude Agent SDK keeps the message channel open past the main turn's result ("result frame ends one turn, not necessarily the run"), but the runner returns at the terminal `ResultMessage` and reaps immediately, so a background task that outlives the main reply is lost. On a later resume, a dangling background task can also drive the CLI into a reconcile that emits a synthetic "No response requested." close-out.

## Fix

Track in-flight background subagents from the `TaskStarted` / `TaskNotification` / terminal `TaskUpdated` messages the runner already dispatches, **gated to the SDK's own `DEFERRING_TASK_TYPES`** (`local_agent`, `local_workflow`) — the delegated-agent tasks that reliably reach a terminal status. Background shells and monitors are deliberately excluded (they never emit a terminal frame; the SDK gates its own tracker the same way, and tracking them would otherwise stall the drain).

At a genuine terminal result — and only when the turn was not stopped by the user — keep the connected client and drain its message stream until every tracked subagent settles, then proceed to the normal process-group reap.

Strictly additive and fail-safe:

- Empty in-flight set → no drain (identical to prior behavior).
- Any stream error → returns into the normal reap.
- A user Stop (`CancelledError` / `interrupt_requested`) is honored immediately and aborts the drain at once.

There is **no arbitrary time cap**: because only delegated-agent tasks are tracked — and those reach a terminal status when the real work is done — the drain returns as soon as the subagents actually settle.

## Scope

This is the targeted fix for background work being reaped at turn end. It intentionally keeps the runner's per-turn model: native subagents remain in-turn (this makes them reliable), and work that must survive a server restart uses the durable delegation path instead. Migrating to the SDK's streaming-input mode is explicitly not part of this change.

## Testing

- The in-flight tracking helper is unit-verified against real SDK message types (only `local_agent`/`local_workflow` tracked; shells/monitors ignored; both terminal paths clear).
- The drain loop is fail-safe by construction (defensive; Stop-aborting), so the worst case is a settled turn waiting for its own background subagents to finish before reaping.
