### PR TITLE
Cap concurrent agent turns with a global admission control

### DIFF
--- a/backend/app/agent_admission.py
+++ b/backend/app/agent_admission.py
@@ -1,0 +1,74 @@
+"""Global admission control for agent turns.
+
+Turn dispatch is otherwise unbounded — every turn spawns a heavy provider
+subprocess, so a fan-out of many concurrent chats + delegated subagents can
+exhaust the container's memory. This module caps the number of *concurrent*
+turns with two in-process semaphores; excess turns park at ``acquire`` holding
+no subprocess (and no registry handle) until a slot frees.
+
+Two buckets, keyed on whether the turn is a delegation CHILD: a parent turn that
+blocks in-turn on a delegated child must not compete with that child for the
+SAME slot, or a saturated pool would deadlock (parent holds a slot, child can't
+get one). Children are depth-1 (they cannot spawn further children), so two
+buckets are sufficient — there is no deeper nesting to account for.
+
+Single-process design: the whole backend runs one event loop, so plain
+``asyncio.Semaphore`` (not a cross-process lock) is the right primitive. The
+per-turn subprocess is a child of this process; the semaphore gates how many
+``run_chat`` coroutines may proceed to spawn one.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+
+_main_sem: asyncio.Semaphore | None = None
+_child_sem: asyncio.Semaphore | None = None
+
+
+def _semaphores() -> tuple[asyncio.Semaphore, asyncio.Semaphore]:
+  """Lazily build the two semaphores from settings on first use.
+
+  Built lazily (inside a running turn, hence inside the event loop) rather than
+  at import so construction can't race module import order, and so tests that
+  reconfigure the ceilings via ``reset_for_tests`` take effect.
+  """
+  global _main_sem, _child_sem
+  if _main_sem is None or _child_sem is None:
+    from app.config import get_settings
+
+    settings = get_settings()
+    _main_sem = asyncio.Semaphore(max(1, settings.max_concurrent_agent_turns))
+    _child_sem = asyncio.Semaphore(
+      max(1, settings.max_concurrent_delegated_turns)
+    )
+  return _main_sem, _child_sem
+
+
+@contextlib.asynccontextmanager
+async def turn_slot(*, delegated: bool):
+  """Hold one admission slot for the duration of a turn.
+
+  ``delegated`` selects the bucket: delegation children draw from the child
+  pool, everything else from the main pool. A queued turn awaits here holding
+  no subprocess; the slot is released on every exit (return, error, cancel).
+  """
+  main, child = _semaphores()
+  sem = child if delegated else main
+  await sem.acquire()
+  try:
+    yield
+  finally:
+    sem.release()
+
+
+def reset_for_tests() -> None:
+  """Drop the cached semaphores so the next turn rebuilds them from settings.
+
+  Tests set small ceilings via the settings override then call this so the new
+  values take effect.
+  """
+  global _main_sem, _child_sem
+  _main_sem = None
+  _child_sem = None

--- a/backend/app/chat.py
+++ b/backend/app/chat.py
@@ -3345,13 +3345,31 @@ async def run_chat(
   disposition = chat_queue.TerminalDisposition.FAILED_LEAVE_MARKER
   runtime_settled = False
   try:
-    disposition = await _run_chat_impl(
-      messages, chat_id=chat_id, session_id=session_id,
-      provider_id=provider_id, run_gen=run_gen,
-      attachments=attachments, timezone=timezone, viewport=viewport,
-      run_token=run_token,
-    )
-    runtime_settled = True
+    from app import agent_admission
+    from app.delegations import is_delegation_child
+
+    # Bound peak concurrent agent subprocesses. A queued turn parks in
+    # `turn_slot` holding NO subprocess and no registry handle; delegation
+    # children draw from a separate bucket so a parent that blocks in-turn on a
+    # child never deadlocks against it. The bucket is decided before acquiring.
+    delegated = is_delegation_child(chat_id)
+    async with agent_admission.turn_slot(delegated=delegated):
+      # A Stop (or supersede) can bump the generation while this turn was queued
+      # for a slot. stop_chat_for on a not-yet-started turn finds no handle to
+      # cancel (it takes the handleless finalize path), so recheck here and bow
+      # out WITHOUT spawning rather than burn a full agent run. STALE_NO_ACTION
+      # leaves the newer owner's already-finalized run + broadcast untouched.
+      if _run_generation_superseded(chat_id, run_gen):
+        disposition = chat_queue.TerminalDisposition.STALE_NO_ACTION
+        runtime_settled = True
+      else:
+        disposition = await _run_chat_impl(
+          messages, chat_id=chat_id, session_id=session_id,
+          provider_id=provider_id, run_gen=run_gen,
+          attachments=attachments, timezone=timezone, viewport=viewport,
+          run_token=run_token,
+        )
+        runtime_settled = True
   except asyncio.CancelledError:
     raise
   except Exception as exc:

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -74,6 +74,17 @@ class Settings(BaseSettings):
   # is sent, so it adds no user-facing latency. No chat agent writes these files.
   ensure_chat_note: bool = True
 
+  # Peak concurrent agent turns (each spawns a heavy provider subprocess).
+  # Turn dispatch is otherwise unbounded, so a fan-out of many chats/subagents
+  # can exhaust the container's memory. These ceilings queue excess turns
+  # (holding no subprocess while waiting) instead of spawning without limit.
+  # Two buckets so a parent turn that BLOCKS on a delegated child never
+  # deadlocks against it (they draw from different pools; children are depth-1).
+  # Sized for the default ~6 GB cgroup; owners self-host, so raise on bigger
+  # hosts / lower on smaller ones via env (MAX_CONCURRENT_AGENT_TURNS, etc).
+  max_concurrent_agent_turns: int = 6
+  max_concurrent_delegated_turns: int = 3
+
   # Managed deployments receive this complete triplet from their provisioning
   # layer. When absent, Möbius is an ordinary self-hosted installation and
   # keeps the local username/password setup flow. Partial configuration is a

--- a/backend/app/delegations.py
+++ b/backend/app/delegations.py
@@ -130,6 +130,25 @@ def policy_for_chat(db: Session, chat_id: str) -> RunPolicy | None:
   )
 
 
+def is_delegation_child(chat_id: str) -> bool:
+  """True if this chat is a delegation's durable child, via one indexed lookup.
+
+  Used by the admission layer to pick the child vs top-level concurrency bucket.
+  Opens its own short-lived session so callers on the hot turn path (run_chat)
+  need no db handle. `child_chat_id` is unique+indexed, so this is a point read.
+  """
+  if not chat_id:
+    return False
+  from app.database import SessionLocal
+
+  with SessionLocal() as db:
+    return db.query(
+      db.query(models.Delegation)
+      .filter(models.Delegation.child_chat_id == chat_id)
+      .exists()
+    ).scalar() or False
+
+
 def latest_run(db: Session, chat_id: str) -> models.ChatRun | None:
   return (
     db.query(models.ChatRun)

--- a/backend/tests/test_agent_admission.py
+++ b/backend/tests/test_agent_admission.py
@@ -1,0 +1,155 @@
+"""Contracts for the global agent-turn admission cap."""
+
+import asyncio
+
+import pytest
+
+import app.agent_admission as adm
+
+
+def _set_ceilings(main: int, child: int) -> None:
+  adm._main_sem = asyncio.Semaphore(main)
+  adm._child_sem = asyncio.Semaphore(child)
+
+
+def test_main_bucket_bounds_concurrent_turns():
+  async def _run():
+    _set_ceilings(2, 1)
+    active = 0
+    peak = 0
+    release = asyncio.Event()
+
+    async def turn():
+      nonlocal active, peak
+      async with adm.turn_slot(delegated=False):
+        active += 1
+        peak = max(peak, active)
+        await release.wait()
+        active -= 1
+
+    tasks = [asyncio.create_task(turn()) for _ in range(5)]
+    await asyncio.sleep(0.05)  # let all five contend for the two slots
+    assert active == 2  # only two admitted; the rest are parked on acquire
+    release.set()
+    await asyncio.gather(*tasks)
+    assert peak == 2
+
+  try:
+    asyncio.run(_run())
+  finally:
+    adm.reset_for_tests()
+
+
+def test_child_bucket_is_separate_so_parent_blocking_on_child_cannot_deadlock():
+  async def _run():
+    # Main pool has a single slot. A parent holds it and then blocks in-turn on
+    # a delegated child. The child draws from the SEPARATE child bucket, so it
+    # can start even though main is saturated. One shared bucket would deadlock.
+    _set_ceilings(1, 1)
+    child_ran = asyncio.Event()
+
+    async def child():
+      async with adm.turn_slot(delegated=True):
+        child_ran.set()
+
+    async def parent():
+      async with adm.turn_slot(delegated=False):
+        await child()
+
+    await asyncio.wait_for(parent(), timeout=2.0)
+    assert child_ran.is_set()
+
+  try:
+    asyncio.run(_run())
+  finally:
+    adm.reset_for_tests()
+
+
+def test_slot_is_released_on_exception():
+  async def _run():
+    _set_ceilings(1, 1)
+    with pytest.raises(ValueError):
+      async with adm.turn_slot(delegated=False):
+        raise ValueError("boom")
+    # The single slot must be free again — a fresh acquire returns at once.
+    async with asyncio.timeout(1.0):
+      async with adm.turn_slot(delegated=False):
+        pass
+
+  try:
+    asyncio.run(_run())
+  finally:
+    adm.reset_for_tests()
+
+
+def test_cancelling_a_parked_waiter_does_not_leak_a_slot():
+  async def _run():
+    _set_ceilings(1, 1)
+    holder_in = asyncio.Event()
+    holder_release = asyncio.Event()
+
+    async def holder():
+      async with adm.turn_slot(delegated=False):
+        holder_in.set()
+        await holder_release.wait()
+
+    async def waiter():
+      async with adm.turn_slot(delegated=False):
+        pass
+
+    h = asyncio.create_task(holder())
+    await holder_in.wait()
+    w = asyncio.create_task(waiter())
+    await asyncio.sleep(0.05)  # waiter parks on acquire (slot held by holder)
+    w.cancel()
+    with pytest.raises(asyncio.CancelledError):
+      await w
+    # A cancelled acquire must not have taken (or leaked) the slot.
+    holder_release.set()
+    await h
+    async with asyncio.timeout(1.0):
+      async with adm.turn_slot(delegated=False):
+        pass
+
+  try:
+    asyncio.run(_run())
+  finally:
+    adm.reset_for_tests()
+
+
+def test_reset_rebuilds_from_settings(monkeypatch):
+  async def _run():
+    adm.reset_for_tests()
+
+    class _Stub:
+      max_concurrent_agent_turns = 1
+      max_concurrent_delegated_turns = 1
+
+    monkeypatch.setattr("app.config.get_settings", lambda: _Stub())
+    # First acquire builds the semaphores from the stubbed ceiling (1).
+    held = asyncio.Event()
+    release = asyncio.Event()
+
+    async def first():
+      async with adm.turn_slot(delegated=False):
+        held.set()
+        await release.wait()
+
+    t = asyncio.create_task(first())
+    await held.wait()
+    second_started = asyncio.Event()
+
+    async def second():
+      async with adm.turn_slot(delegated=False):
+        second_started.set()
+
+    s = asyncio.create_task(second())
+    await asyncio.sleep(0.05)
+    assert not second_started.is_set()  # ceiling of 1 blocks the second
+    release.set()
+    await asyncio.gather(t, s)
+
+  try:
+    asyncio.run(_run())
+  finally:
+    adm.reset_for_tests()

--- a/backend/tests/test_delegations.py
+++ b/backend/tests/test_delegations.py
@@ -534,6 +534,16 @@ def test_reconcile_wakes_parent_for_completed_while_away(db, monkeypatch):
   assert len(starts) == 1
 
 
+def test_is_delegation_child_detects_child_and_ignores_others(db):
+  from app.delegations import is_delegation_child
+
+  _, child_id, _ = _seed_delegation(db, suffix="isc")
+  assert is_delegation_child(child_id) is True
+  assert is_delegation_child("parent-isc") is False
+  assert is_delegation_child("no-such-chat") is False
+  assert is_delegation_child("") is False
+
+
 def test_wake_disposition_gate_excludes_non_durable_terminals():
   import app.chat_queue as chat_queue
   from app.chat import _DELEGATION_WAKE_DISPOSITIONS


### PR DESCRIPTION
## Problem

Turn dispatch is unbounded: every turn spawns a heavy provider subprocess via a bare `asyncio.create_task(run_chat)`. A fan-out of many concurrent chats plus delegated subagents can spawn unlimited subprocesses and exhaust the container's memory.

## Change

A global admission control caps the number of *concurrent* turns with two in-process `asyncio.Semaphore`s. The backend runs a single event loop, so an in-process semaphore — not a cross-process lock — is the right primitive; the per-turn subprocess is a child of this process.

- `max_concurrent_agent_turns` (default 6) and `max_concurrent_delegated_turns` (default 3) in `Settings`, env-tunable and sized for the default ~6 GB cgroup.
- `agent_admission.turn_slot(delegated=...)` parks excess turns at `acquire` holding **no** subprocess and no registry handle; the slot is released on every exit, including cancellation.
- Two buckets, keyed on whether the turn is a delegation child, so a parent turn that blocks in-turn on a delegated child cannot deadlock against it for the same slot (children are depth-1). `run_chat` selects the bucket via `delegations.is_delegation_child`, one indexed point read.
- After acquiring a slot, `run_chat` rechecks the run generation: a Stop that arrived while the turn was queued (it finalizes via the handleless path and cannot cancel the parked task) makes the turn bow out with `STALE_NO_ACTION` instead of burning a full run.

Native in-process agents are structurally excluded — they never call `run_chat`.

## Tests

- `test_agent_admission.py`: semaphore bounds, deadlock-freedom across the two buckets, release-on-error, and no-leak-on-cancel.
- `test_delegations.py`: the delegation-child classification.