### PR TITLE
Offer one combined review+resolve when platform updates stack behind a conflict

### DIFF
--- a/backend/app/platform_update.py
+++ b/backend/app/platform_update.py
@@ -248,6 +248,12 @@ class PlatformStatus(TypedDict):
   # the owner straight to it. None unless ``state == "conflict"`` AND the id was
   # recorded.
   conflict_chat_id: str | None
+  # True only while ``state == "conflict"`` and origin/main has advanced past the
+  # version this conflict is pinned to — i.e. more updates stacked up behind the
+  # one being resolved. Lets Settings offer "review all & resolve together" so a
+  # backlog is reviewed once and resolved once, instead of one resolve per
+  # release. Fetch-free like the rest of status: reflects the last fetch.
+  newer_updates_available: bool
 
 
 class PlatformApplyResult(TypedDict):
@@ -1754,6 +1760,14 @@ def platform_status(repo: Path = PLATFORM_REPO) -> PlatformStatus:
   if conflict:
     flag = _read_conflict_flag() or {}
     paths = flag.get("paths") or _unmerged_paths(repo)
+    # `target` is the last-fetched origin/main. If it strictly descends the
+    # version this conflict is pinned to, newer releases stacked up behind the
+    # one being resolved — Settings can then offer one combined review+resolve.
+    conflict_target = flag.get("upstream")
+    newer_available = bool(
+      target and conflict_target and target != conflict_target
+      and _is_ancestor(repo, conflict_target, target)
+    )
     return PlatformStatus(
       state=PlatformUpdateState.CONFLICT.value, available=False,
       needs_restart=restart_needed, activation=activation,
@@ -1762,6 +1776,7 @@ def platform_status(repo: Path = PLATFORM_REPO) -> PlatformStatus:
       contained_upstream_sha=contained_upstream_sha,
       seed_required=False,
       conflict_paths=paths, conflict_chat_id=flag.get("chat_id"),
+      newer_updates_available=newer_available,
     )
 
   available = bool(target) and not target_contained
@@ -1783,6 +1798,7 @@ def platform_status(repo: Path = PLATFORM_REPO) -> PlatformStatus:
     current_build_sha=image_sha, recorded_upstream_sha=upstream_sha,
     contained_upstream_sha=contained_upstream_sha,
     seed_required=False, conflict_paths=[], conflict_chat_id=None,
+    newer_updates_available=False,
   )
 
 

--- a/backend/app/routes/platform.py
+++ b/backend/app/routes/platform.py
@@ -69,7 +69,7 @@ async def get_platform_status(
       current_build_sha=None,
       recorded_upstream_sha=None, contained_upstream_sha=None,
       seed_required=False, conflict_paths=[],
-      conflict_chat_id=None,
+      conflict_chat_id=None, newer_updates_available=False,
     )
 
 

--- a/backend/tests/test_platform_update.py
+++ b/backend/tests/test_platform_update.py
@@ -298,6 +298,31 @@ def test_conflict_serves_old_and_flags(clone_env):
   status = pu.platform_status(platform)
   assert status["state"] == pu.PlatformUpdateState.CONFLICT.value
   assert any("main.py" in p for p in status["conflict_paths"])
+  # Freshly pinned: origin/main IS the conflicting target, nothing newer yet.
+  assert status["newer_updates_available"] is False
+
+
+def test_conflict_flags_newer_updates_when_origin_advances(clone_env):
+  """A pinned conflict reports ``newer_updates_available`` once origin/main moves
+  past the version it is pinned to, so Settings can offer one combined
+  review+resolve instead of forcing a resolve per stacked release."""
+  origin, platform = clone_env
+  _local_commit(platform, edits={"backend/app/main.py":
+    _MAIN_PY.replace("LINE_A = 1", "LINE_A = 'LOCAL'")})
+  _advance_origin(origin, edits={"backend/app/main.py":
+    _MAIN_PY.replace("LINE_A = 1", "LINE_A = 'UPSTREAM'")})
+
+  assert pu.reconcile_clone(platform, at_boot=True).status == "conflict"
+  assert pu.platform_status(platform)["newer_updates_available"] is False
+
+  # A later deploy lands upstream; the owner's fetch advances origin/main past
+  # the version the conflict is pinned to.
+  _advance_origin(origin, edits={"docs/RELEASE.md": "note\n"}, msg="later deploy")
+  _git(platform, "fetch", "-q", "origin")
+
+  status = pu.platform_status(platform)
+  assert status["state"] == pu.PlatformUpdateState.CONFLICT.value
+  assert status["newer_updates_available"] is True
 
 
 def test_contributed_squash_uses_provenance_for_both_histories(clone_env):

--- a/frontend/src/components/SettingsView/SettingsView.jsx
+++ b/frontend/src/components/SettingsView/SettingsView.jsx
@@ -1198,7 +1198,13 @@ export default function SettingsView({
   // so the owner sees the incoming changes first. Apply happens from inside the
   // sheet (which then advances the row to "Restart to finish").
   function openUpdateReview() {
-    if (platformPhase !== 'idle' || !platform?.available) return
+    // Also reachable from a conflict that has newer releases stacked behind it:
+    // the review sheet then previews the FULL combined diff to the latest tip,
+    // and its Apply re-targets the pinned conflict so one Resolve covers all.
+    if (
+      platformPhase !== 'idle'
+      || !(platform?.available || platform?.newer_updates_available)
+    ) return
     setPlatformError('')
     setReviewOpen(true)
   }
@@ -1679,19 +1685,41 @@ export default function SettingsView({
             </div>
             {platformConflict ? (
               onOpenChat ? (
-                <button
-                  ref={platformActionRef}
-                  className="settings__btn settings__btn--outline settings__btn--sm settings__btn--nowrap"
-                  type="button"
-                  onClick={resolvePlatformConflict}
-                  disabled={platformPhase === 'resolving'}
+                // A conflict is always resolvable in chat. When newer releases
+                // have stacked up behind it, prepend a primary "Review all" that
+                // previews the full combined diff and re-targets on Apply, so a
+                // single resolve covers the whole backlog.
+                <div
+                  className="settings__update-actions"
+                  role="group"
+                  aria-label="Resolve update conflict actions"
                 >
-                  {platformPhase === 'resolving'
-                    ? 'Opening…'
-                    : platform?.conflict_chat_id
-                      ? 'Open chat'
-                      : 'Resolve in chat'}
-                </button>
+                  {platform?.newer_updates_available && (
+                    <button
+                      className="settings__btn settings__btn--sm settings__btn--nowrap"
+                      type="button"
+                      onClick={openUpdateReview}
+                      disabled={mobiusUpdating || platformPhase !== 'idle'}
+                    >
+                      {mobiusUpdating ? 'Updating…' : 'Review all updates'}
+                    </button>
+                  )}
+                  <button
+                    ref={platformActionRef}
+                    className="settings__btn settings__btn--outline settings__btn--sm settings__btn--nowrap"
+                    type="button"
+                    onClick={resolvePlatformConflict}
+                    disabled={platformPhase === 'resolving'}
+                  >
+                    {platformPhase === 'resolving'
+                      ? 'Opening…'
+                      : platform?.conflict_chat_id
+                        ? 'Open chat'
+                        : platform?.newer_updates_available
+                          ? 'Resolve just this'
+                          : 'Resolve in chat'}
+                  </button>
+                </div>
               ) : null
             ) : platformExternalActivation ? (
               updateAvailable ? (
@@ -1794,6 +1822,13 @@ export default function SettingsView({
                 <span key={line}>{line}</span>
               ))}
               <span>A server restart alone will not complete this update.</span>
+            </div>
+          )}
+          {platformConflict && platform?.newer_updates_available && (
+            <div className="settings__notice" role="status">
+              More updates have arrived since the one that conflicted — review
+              them all together and resolve in one pass, or resolve just this one
+              now.
             </div>
           )}
           {platformError && (


### PR DESCRIPTION
## Problem

A platform update that conflicts with local edits is pinned to the exact release the owner reviewed. When newer releases land upstream before that conflict is resolved, resolving the pinned one leaves the newer ones still pending — so the owner has to return to Settings and review + resolve a second time. With several updates stacked up, this repeats.

## Change

Surface whether a conflict has newer releases stacked behind it, and let the owner fold them into one pass:

- **Backend:** add `newer_updates_available` to platform status. It is true only while `state == "conflict"` and the fetched `origin/main` strictly descends the version the conflict is pinned to. It stays fetch-free like the rest of status.
- **Settings:** when a conflict has newer updates available, show a short note and a primary **Review all updates** action alongside **Resolve just this**. "Review all" reuses the existing review sheet (which previews the full combined diff to the latest tip); its Apply re-targets the pinned conflict to that tip, so a single **Resolve in chat** covers the whole backlog — or it applies cleanly and needs no resolve at all. With nothing newer stacked, the row is unchanged.

No new resolve machinery is introduced: Apply already re-targets a pinned conflict when re-applied against a newer tip, and the preview already targets the latest `origin/main`. The change is one status field plus the Settings affordance that consumes it.

## Tests

Adds `test_conflict_flags_newer_updates_when_origin_advances`: a pinned conflict reports `newer_updates_available == False` when freshly pinned, and `True` after a later deploy advances `origin/main` past the pinned target.