### PR TITLE
fix(chat): don't blank an expanded live thought on each background re-fetch

### DIFF
--- a/frontend/src/components/ChatView/useThinkingTrace.js
+++ b/frontend/src/components/ChatView/useThinkingTrace.js
@@ -81,9 +81,16 @@ export function useThinkingTrace({ open, thought, chatId }) {
     }
   }, [open, deferred, chatId, thought.thinking_id, fullRequested, refreshNonce])
 
+  const content = deferred ? loadedContent : (thought.content || '')
   return {
-    content: deferred ? loadedContent : (thought.content || ''),
-    loadState,
+    content,
+    // A deferred thought re-fetches while it is still streaming (a debounced
+    // reload on every revision burst) and again on "Load full thought", and each
+    // reload flips the internal state back to 'loading' even though the text is
+    // still in hand. Surfacing that would blank an expanded, in-progress thought
+    // and flash "Loading…" on every token. The spinner and error only make sense
+    // on a COLD load, so once there is content the effective state is 'ready'.
+    loadState: content ? 'ready' : loadState,
     previewComplete: !deferred || previewComplete,
     // Persisted snapshots carry this flag, and final live-stream promotion
     // stamps it locally. This makes the explicit full-load action available


### PR DESCRIPTION
## Problem

Expanding a thinking/reasoning block **while the agent is still reasoning** makes the block blank out and flash "Loading…" repeatedly instead of showing the reasoning as it grows.

## Root cause

`useThinkingTrace` re-fetches a deferred thought's text on a debounce every time the reasoning advances (and again on "Load full thought"). Each re-fetch flips the hook's internal `loadState` back to `loading` even though the previously loaded text is still held in `loadedContent`. `TimelineThought` renders the "Loading thought…" placeholder whenever `loadState === 'loading'`, so every background re-fetch throws away the reasoning already on screen and replaces it with the spinner.

## Fix

Present an **honest** `loadState` from the hook: once there is content to show, the effective state is `ready`, so the spinner/error only appear on a *cold* load (nothing yet to show). The component is unchanged — the imprecise state is fixed at the layer that owns it, so no consumer has to re-derive it.

Bonus: "Load full thought" now keeps the preview visible while the fuller text loads, instead of also blanking to a spinner.

## Testing

`frontend` unit tests + lint pass. No new unit test: the fix is a two-line derivation documented inline, and a behavioral test of this hook would require standing up `fetch` + debounce-timer + `import.meta.env` scaffolding that the current hook harness (dependency-free hooks only) doesn't have — disproportionate for the change, and a source-text assertion is what `CONTRIBUTING.md` reserves against. Happy to add a hook-level test if a maintainer would prefer one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)