### PR TITLE
Show a server-created chat in recents as soon as its run starts

### DIFF
--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -2255,9 +2255,24 @@ export default function Shell() {
       })
     } else if (ev.type === 'chat_run_started') {
       if (ev.chatId) {
+        // Capture drawer membership BEFORE the mark* projections below: those
+        // only patch an existing row, never insert one, so this stays a true
+        // read of whether the drawer already knows this chat.
+        const knownInDrawer = chatsRef.current.some(
+          c => String(c.id) === String(ev.chatId),
+        )
         markChatRunActivity(ev.chatId)
         markStreamingStart(ev.chatId)
         markChatRunState(ev.chatId, true)
+        // A run can be the drawer's FIRST evidence of a chat created entirely
+        // server-side — the platform/app conflict resolver, a background or
+        // morning agent, autopilot. selectChat only navigates; it never
+        // inserts a row, so such a chat is invisible in recents until some
+        // unrelated refresh happens to run. When the started chat isn't in the
+        // cached list yet, pull server truth so it appears immediately.
+        if (!knownInDrawer) {
+          void invalidateShellListCache('chats').then(refreshChats)
+        }
       }
     } else if (ev.type === 'chat_run_finished') {
       const chatId = ev.chatId


### PR DESCRIPTION
## Problem

A chat created entirely server-side — the platform/app update-conflict resolver, a background or morning agent, autopilot — is opened by navigation only. `selectChat` never inserts a drawer row, and no lifecycle event refreshes the chat list for a brand-new chat, so the chat is missing from recents until some unrelated action (for example creating another chat) happens to refetch the list.

## Fix

When a `chat_run_started` event arrives for a chat the drawer's cached list has never seen, refresh the chat list so the new chat appears in recents immediately. Drawer membership is captured before the existing `mark*` projections (which only patch an existing row, never insert one), so the check is a true read of whether the drawer already knows the chat; chats already listed take no extra refetch.

This mirrors the drawer's existing lifecycle handling — `chat_recovered` already refetches on its event — and covers every server-created chat at one chokepoint rather than adding a per-producer signal.