### PR TITLE
Fix: a resumable park keeps its open AskUserQuestion

### DIFF
--- a/backend/app/chat_writer.py
+++ b/backend/app/chat_writer.py
@@ -1607,9 +1607,12 @@ class ChatWriterActor:
     chat = _active_chat(db, chat_id)
     if chat is None:
       return _WriteOutcome.NOOP
-    # Finalize is terminal; unlike ParkRun it cannot leave an open question.
-    # Stage the clear before the transcript helper commits so both facts become
-    # durable together. A failed/no-op transcript write rolls the clear back.
+    # Finalize persists the turn's terminal blocks and assumes the turn is
+    # ending, so it clears the open-question marker. A resumable pause is NOT
+    # Finalize's concern — ParkRun runs after this in the restart drain and
+    # re-derives the marker from the parked transcript. Staged before the
+    # transcript helper commits so both facts become durable together; a
+    # failed/no-op transcript write rolls the clear back.
     chat.pending_question_id = None
     if thinking_stashes:
       self._stage_thinking_stashes(db, thinking_stashes)
@@ -2905,6 +2908,14 @@ class ChatWriterActor:
       if changed and not _commit_or_rollback(db):
         raise _PersistFailed("ParkRun did not persist")
       return False
+    # A resumable pause preserves an open AskUserQuestion — the answer IS the
+    # continuation. Re-derive the durable marker from the transcript being
+    # parked so it holds even though the drain's preceding Finalize cleared it
+    # (and self-heals a restart that preempted QuestionCommit). Committed with
+    # the park so the run status and the marker land together.
+    chat = _active_chat(db, cmd.chat_id)
+    if chat is not None:
+      chat.pending_question_id = _tail_open_question_id(chat.messages)
     if changed and not _commit_or_rollback(db):
       raise _PersistFailed("ParkRun did not persist")
     if owner is None or owner == cmd.run_token:
@@ -3671,6 +3682,36 @@ class _WriteOutcome(enum.Enum):
   APPLIED = "applied"  # found a row + assistant slot, committed cleanly
   NOOP = "noop"  # no chat_id / missing row / no messages to write into
   DROPPED = "dropped"  # write attempted but the commit dropped (lock)
+
+
+def _tail_open_question_id(messages) -> str | None:
+  """question_id of the last assistant message's open AskUserQuestion, else None.
+
+  The durable `pending_question_id` marker is, by definition, "the transcript
+  tail is an unanswered question." Deriving it from the messages is the single
+  rule every writer that needs to (re)establish the marker can share, so the
+  marker cannot drift from the transcript. This mirrors the one-time boot
+  backfill in database._add_chat_pending_question_id and applies the same
+  1..64-char id validation the column accepts.
+  """
+  for message in reversed(messages or []):
+    if not isinstance(message, dict) or message.get("hidden"):
+      continue
+    if message.get("role") != "assistant":
+      break
+    for block in reversed(message.get("blocks") or []):
+      if not isinstance(block, dict):
+        continue
+      candidate = block.get("question_id")
+      if (
+        block.get("type") == "question"
+        and not block.get("answers")
+        and isinstance(candidate, str)
+        and 0 < len(candidate) <= 64
+      ):
+        return candidate
+    break
+  return None
 
 
 def _active_chat(db, chat_id: str):

--- a/backend/tests/test_limit_park.py
+++ b/backend/tests/test_limit_park.py
@@ -40,6 +40,7 @@ from app.chat_writer import (
   ResolvePark,
   RollbackAutoResume,
   StartTurn,
+  _tail_open_question_id,
   get_writer,
 )
 from app.database import SessionLocal
@@ -302,6 +303,97 @@ def test_park_run_parks_row_and_clears_marker():
   assert row["ended_at"] is not None
   # The per-chat marker is cleared: the turn is over, the chat is not busy.
   assert _chat_row(cid)["running_status"] is None
+
+
+def _pending_question_id(chat_id: str):
+  db = SessionLocal()
+  try:
+    return db.query(models.Chat).filter(
+      models.Chat.id == chat_id
+    ).first().pending_question_id
+  finally:
+    db.close()
+
+
+def _open_question_transcript(qid: str):
+  return [
+    {"role": "user", "content": "help me choose", "ts": 1},
+    {"role": "assistant", "ts": 2, "blocks": [
+      {"type": "text", "content": "Here are the options."},
+      {"type": "question", "question_id": qid,
+       "questions": [{"question": "Which one?"}]},
+    ]},
+  ]
+
+
+def test_restart_park_restores_open_question_marker_from_transcript():
+  """A resumable park re-establishes the open-question marker from the parked
+  transcript.
+
+  Regression for the restart-resume-past-an-unanswered-question bug (chat
+  0f08c0c3): drain-for-restart calls Finalize (which clears the marker) and
+  THEN ParkRun. ParkRun owns the "resumable pause keeps the open question"
+  invariant, so it must re-derive the marker even though it enters with the
+  marker already None. Without it the resume gate saw None and continued past
+  the grayed-out card.
+  """
+  cid = "park-restore-open-q"
+  token = "rt-park-restore-open-q"
+  _seed_chat(cid, messages=_open_question_transcript("restart-q"))
+  _seed_run(cid, token)
+  assert _pending_question_id(cid) is None  # the post-Finalize state
+
+  get_writer().submit(ParkRun(
+    chat_id=cid, run_token=token,
+    parked_until=datetime(2026, 7, 11, 1, 40),
+    park_reason="restart", restart_nonce="nonce-restore-1234",
+  )).result(timeout=5)
+
+  assert _run_row(token)["status"] == "parked"
+  assert _pending_question_id(cid) == "restart-q"
+
+
+def test_park_run_leaves_marker_none_when_transcript_has_no_open_question():
+  """An ordinary park (tail is normal output) must not invent a marker."""
+  cid = "park-no-open-q"
+  token = "rt-park-no-open-q"
+  _seed_chat(cid, messages=[
+    {"role": "user", "content": "do work", "ts": 1},
+    {"role": "assistant", "ts": 2,
+     "blocks": [{"type": "text", "content": "All done."}]},
+  ])
+  _seed_run(cid, token)
+
+  get_writer().submit(ParkRun(
+    chat_id=cid, run_token=token,
+    parked_until=datetime(2026, 7, 11, 1, 40),
+    park_reason="restart", restart_nonce="nonce-noq-1234",
+  )).result(timeout=5)
+
+  assert _run_row(token)["status"] == "parked"
+  assert _pending_question_id(cid) is None
+
+
+def test_tail_open_question_id_derivation():
+  """The shared rule ParkRun and the boot backfill both use."""
+  qid = "q-tail"
+  assert _tail_open_question_id(_open_question_transcript(qid)) == qid
+  # Answered -> not open.
+  assert _tail_open_question_id([
+    {"role": "assistant", "blocks": [
+      {"type": "question", "question_id": qid, "answers": {"Which one?": "A"}}]},
+  ]) is None
+  # A trailing user message means the assistant is no longer the tail.
+  assert _tail_open_question_id(
+    _open_question_transcript(qid) + [{"role": "user", "content": "hi"}]
+  ) is None
+  # Oversized id rejected (the column is VARCHAR(64)).
+  assert _tail_open_question_id([
+    {"role": "assistant", "blocks": [
+      {"type": "question", "question_id": "x" * 65}]},
+  ]) is None
+  assert _tail_open_question_id([]) is None
+  assert _tail_open_question_id(None) is None
 
 
 def test_restart_park_carries_one_shot_intent_nonce():


### PR DESCRIPTION
drain_for_restart snapshots in-flight blocks via Finalize and then ParkRuns for
resume. Finalize is terminal and clears pending_question_id, so it wiped the
marker the park was meant to keep; on resume the auto-resume gate and send-block
(both read only the marker) saw None and continued past the unanswered card —
grayed-out but never answered (chat 0f08c0c3).

ParkRun already documents the invariant "a resumable pause deliberately leaves
the open question in place," but it only "left" it by not touching it, which a
preceding Finalize defeats. Make ParkRun own that invariant for real: it
re-derives pending_question_id from the transcript it is parking. Finalize stays
simple (terminal -> clear); the resumable-vs-terminal decision lives entirely in
the run-lifecycle commands (ParkRun keeps, FinishRun clears), not in the
block-write, so no writer has to guess. This also self-heals a restart that
preempts QuestionCommit — the marker is derived from the parked transcript
rather than depending on the live commit having landed.

_tail_open_question_id is the single derivation rule, matching the boot backfill
in database._add_chat_pending_question_id so runtime and migration agree.

Regression + unit coverage in test_limit_park.py.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
