### PR TITLE
Keep drawer rename open when closing the action menu steals focus

### DIFF
--- a/frontend/src/components/Drawer/Drawer.jsx
+++ b/frontend/src/components/Drawer/Drawer.jsx
@@ -409,16 +409,6 @@ export default function Drawer({
     startRename(kind, id, surface = 'drawer') {
       rowActionInputsRef.current.setRenaming({ kind, id, surface })
     },
-    // Closing the menu consumes its Back-stack sentinel, and the traversal that
-    // follows drops focus to the document a few milliseconds later. The menu's
-    // post-close animation frame is the one place that focus is reclaimed, so
-    // its target has to be whatever the action left behind. Rename replaces the
-    // row trigger with an editor, and reasserting focus onto the now-unmounted
-    // trigger does nothing at all — the editor stays blurred, and its own blur
-    // handler then commits and unmounts it before the user can type.
-    claimMenuFocusReturn(element) {
-      rowActionInputsRef.current.menuRestoreFocusRef.current = element
-    },
     cancelRename() {
       rowActionInputsRef.current.setRenaming(null)
     },
@@ -1406,15 +1396,21 @@ const DrawerRow = memo(function DrawerRow({
     }
   }, [drawerRowGesturesRef, id, kind, variant])
 
-  // Autofocus + select-all on rename open so the user can either retype
-  // from scratch or tap into the existing name to edit it.
+  // Autofocus + select-all on rename open so the user can either retype from
+  // scratch or tap into the existing name to edit it. Defer one frame: opening
+  // rename tears down the action menu, and focusing synchronously here races
+  // the browser moving focus off the just-unmounted menu item, which overrides
+  // the editor focus. A frame later the teardown has settled and focus sticks.
   useEffect(() => {
-    if (renaming && inputRef.current) {
-      actions.claimMenuFocusReturn(inputRef.current)
-      inputRef.current.focus()
-      inputRef.current.select()
-    }
-  }, [actions, renaming])
+    if (!renaming) return undefined
+    const frame = requestAnimationFrame(() => {
+      const input = inputRef.current
+      if (!input) return
+      input.focus()
+      input.select()
+    })
+    return () => cancelAnimationFrame(frame)
+  }, [renaming])
 
   function commitRename() {
     if (cancelingRef.current) {
@@ -1428,7 +1424,22 @@ const DrawerRow = memo(function DrawerRow({
   function onRenameBlur() {
     const input = inputRef.current
     requestAnimationFrame(() => {
-      if (document.activeElement !== input) commitRename()
+      const active = document.activeElement
+      if (active === input) return
+      // Closing the action menu calls history.back() to release its Back-stack
+      // entry; that popstate drops focus to <body> a frame later. That is the
+      // app moving focus, not the user leaving the field, so reclaim it instead
+      // of committing — otherwise the just-opened editor blur-commits and
+      // vanishes. A real exit tabs to another control; outside-pointer and
+      // Escape cancel through their own paths (cancelingRef).
+      const focusDropped = !active
+        || active === document.body
+        || active === document.documentElement
+      if (focusDropped && input?.isConnected && !cancelingRef.current) {
+        input.focus()
+        return
+      }
+      commitRename()
     })
   }
 

--- a/frontend/src/components/Drawer/DrawerItemActionMenu.jsx
+++ b/frontend/src/components/Drawer/DrawerItemActionMenu.jsx
@@ -288,7 +288,9 @@ export default function DrawerItemActionMenu({
                 type="button"
                 role="menuitem"
                 className="drawer__item-action-item"
-                onClick={() => run(onRename)}
+                // Rename opens an inline editor that focuses itself, so the menu
+                // must not restore focus to the (now-unmounted) row trigger.
+                onClick={() => run(onRename, { restoreFocus: false })}
               >
                 Rename
               </button>


### PR DESCRIPTION
## What

Renaming a chat or app from the drawer's right-click action menu opened the inline rename field and then closed it a frame later, before you could type — every time.

## Why

Choosing **Rename** closes the row action menu, which releases its Back-stack sentinel via `history.back()`. That traversal's asynchronous `popstate` fires a frame later and pulls keyboard focus off the just-opened rename `<input>` onto `<body>`. `onRenameBlur` couldn't distinguish that app-initiated focus move from the user leaving the field, so it blur-committed and unmounted the editor immediately.

## Fix

Give the rename editor a single, self-contained focus story:

- **Autofocus defers one frame** (like the drawer's focus-trap) so it lands after the menu teardown settles, instead of racing the browser moving focus off the just-unmounted menu item.
- **`onRenameBlur` reclaims focus** when focus is dropped to nothing (`body` / `documentElement` / null) while the input is still mounted and no cancel is in flight — the async `popstate` is the one disruptor no focus-restore choice can pre-empt. Genuine exits are unchanged: Tab commits, the outside-pointer path and Escape cancel, Enter commits.
- **Rename declares its handoff** with `run(onRename, { restoreFocus: false })` so the menu doesn't fight the editor for focus.

This lets the reclaim subsume the `claimMenuFocusReturn` hook added in #633 (which reached from a row action across to mutate the menu component's `menuRestoreFocusRef`), removing that cross-component coupling. #633 fixed the synchronous half of this handoff but not the asynchronous `popstate`, so the field still tore itself down.

## Testing

Reproduced in the running shell (right-click a chat → Rename): before, the input blurred to `<body>` and unmounted ~4ms after opening; after, it stays open, focused, with the name selected. Verified Enter commits a real rename, Escape cancels, and outside-click discards, across repeated runs. Frontend hook tests pass.
