### PR TITLE
platform-update: apply Python dependency changes in place instead of forcing a rebuild

### DIFF
--- a/backend/app/platform_activation.py
+++ b/backend/app/platform_activation.py
@@ -20,6 +20,9 @@ class ActivationLevel(str, Enum):
 
   LIVE = "live"
   SERVER_RESTART = "server_restart"
+  # In-place dependency install (pip) plus a server restart to load them. More
+  # than a bare restart, but still completable in-product — no image rebuild.
+  DEPENDENCY_SYNC = "dependency_sync"
   PROXY_RELOAD = "proxy_reload"
   CONTAINER_RECREATE = "container_recreate"
   IMAGE_REBUILD = "image_rebuild"
@@ -95,8 +98,8 @@ _RULES = (
   ),
   _Rule(
     "python_dependencies",
-    ActivationLevel.IMAGE_REBUILD,
-    "Python dependencies changed and must be installed into a new image.",
+    ActivationLevel.DEPENDENCY_SYNC,
+    "Python dependencies changed; Apply installs them in place, then restart.",
     exact=("backend/requirements.txt", "backend/requirements.lock"),
     dependency_fingerprint=True,
   ),
@@ -194,7 +197,10 @@ def backend_import_probe_required(paths: Iterable[str]) -> bool:
     rule = _rule_for_path(normalized)
     if (
       rule
-      and rule.level is ActivationLevel.SERVER_RESTART
+      and rule.level in (
+        ActivationLevel.SERVER_RESTART,
+        ActivationLevel.DEPENDENCY_SYNC,
+      )
       and normalized != "skill/core.md"
     ):
       return True
@@ -210,6 +216,11 @@ def _guidance(level: ActivationLevel, deployment: DeploymentKind) -> str:
     return "No deployment action is required; live source is rebuilt or read on demand."
   if level is ActivationLevel.SERVER_RESTART:
     return "Restart Möbius after Apply so the running server loads the new source."
+  if level is ActivationLevel.DEPENDENCY_SYNC:
+    return (
+      "Apply installs the new Python dependencies in place, then restart to load "
+      "them — no image rebuild needed."
+    )
   if deployment == "railway":
     if level is ActivationLevel.CONTAINER_RECREATE:
       return (

--- a/backend/app/platform_update.py
+++ b/backend/app/platform_update.py
@@ -1020,6 +1020,11 @@ def _complete_boot_activation(repo: Path) -> None:
     if level in {
       platform_activation.ActivationLevel.LIVE.value,
       platform_activation.ActivationLevel.SERVER_RESTART.value,
+      # Owner Apply installed the locked deps in place before writing this
+      # marker, so a fresh boot that loads the target already has them — retire
+      # like a restart. A rebuild that bakes them instead retires via
+      # build_contains_target below.
+      platform_activation.ActivationLevel.DEPENDENCY_SYNC.value,
     }:
       continue
     if build_contains_target and level in completed_by_image:
@@ -1054,6 +1059,49 @@ def _touched_frontend(repo: Path, before: str | None, after: str | None) -> bool
     path == "frontend" or path.startswith("frontend/")
     for path in (_changed_paths(repo, before, after) or [])
   )
+
+
+# pip can be slow on a small self-hosted box fetching wheels; keep the bound
+# generous but finite so a wedged install still fails closed.
+_DEP_SYNC_TIMEOUT = 900
+
+
+def _requirements_changed(
+  repo: Path, before: str | None, after: str | None
+) -> bool:
+  """Whether the locked Python dependency inputs changed between two commits."""
+  return any(
+    path in ("backend/requirements.lock", "backend/requirements.txt")
+    for path in (_changed_paths(repo, before, after) or [])
+  )
+
+
+def _sync_python_dependencies(repo: Path) -> tuple[bool, str]:
+  """Install the locked Python deps in place — the SAME command the image build
+  runs — so an owner Apply lands a dependency bump without a container rebuild.
+
+  Returns ``(ok, error_tail)`` and never raises for an operational failure.
+  """
+  lock = repo / "backend" / "requirements.lock"
+  if not lock.is_file():
+    return True, ""
+  try:
+    proc = subprocess.run(
+      [
+        sys.executable, "-m", "pip", "install", "--no-cache-dir",
+        "--require-hashes", "-r", "requirements.lock",
+      ],
+      cwd=str(repo / "backend"),
+      capture_output=True,
+      text=True,
+      timeout=_DEP_SYNC_TIMEOUT,
+    )
+  except (subprocess.TimeoutExpired, OSError) as exc:
+    return False, repr(exc)[-500:]
+  if proc.returncode != 0:
+    detail = (proc.stderr or proc.stdout or "pip install failed").strip()
+    return False, detail[-500:]
+  return True, ""
 
 
 def _hook_git(repo: Path, *args: str) -> subprocess.CompletedProcess:
@@ -1515,6 +1563,25 @@ def reconcile_clone(
             ),
           )
 
+    # Dependency sync (owner Apply only): install the newly locked Python deps
+    # in place — the same command the image build runs — so the merged code can
+    # import them and this update lands with no container rebuild. Boot never
+    # does this: a fresh image already has them, boot must stay fast/offline, and
+    # a boot that merged a dep bump instead fails the probe below and rolls back
+    # (correct — the deps are not installed until an owner Apply). A pip failure
+    # is fail-closed exactly like a failed probe: reset to PRE and serve the old
+    # tree.
+    if not at_boot and _requirements_changed(repo, pre, _rev(repo, local)):
+      if progress:
+        progress(PlatformUpdatePhase.BUILDING)
+      deps_ok, deps_err = _sync_python_dependencies(repo)
+      if not deps_ok:
+        _reset_hard_to(repo, local, pre)
+        _write_rolled_back_flag(target, f"dependency_install_failed: {deps_err}")
+        CONFLICT_FLAG.unlink(missing_ok=True)
+        _clear_reconcile_pre()
+        return ReconcileResult("rolled_back", pre, pre, target, error=deps_err)
+
     # Post-reconcile import probe: a text-clean ff/merge can still produce a
     # tree that fails to import (upstream dropped a module a local edit imports;
     # a bad deploy). Roll back to the previous served commit rather than serve it
@@ -1710,7 +1777,11 @@ def _state_for_activation(
   impact: PlatformActivationImpact,
 ) -> PlatformUpdateState:
   level = impact["level"]
-  if level == platform_activation.ActivationLevel.SERVER_RESTART.value:
+  if level in {
+    platform_activation.ActivationLevel.SERVER_RESTART.value,
+    # Deps were installed in place during Apply; only the restart remains.
+    platform_activation.ActivationLevel.DEPENDENCY_SYNC.value,
+  }:
     return PlatformUpdateState.RESTART_NEEDED
   if level == platform_activation.ActivationLevel.LIVE.value:
     return PlatformUpdateState.UP_TO_DATE
@@ -1742,10 +1813,10 @@ def platform_status(repo: Path = PLATFORM_REPO) -> PlatformStatus:
   rolled_back = ROLLED_BACK_FLAG.exists()
   activation = _platform_activation_impact(repo)
   activation_state = _state_for_activation(activation)
-  restart_needed = (
-    activation["level"]
-    == platform_activation.ActivationLevel.SERVER_RESTART.value
-  )
+  restart_needed = activation["level"] in {
+    platform_activation.ActivationLevel.SERVER_RESTART.value,
+    platform_activation.ActivationLevel.DEPENDENCY_SYNC.value,
+  }
   local = _local_branch(repo)
   target = _rev(repo, DEFAULT_TARGET_REF)
   target_contained = bool(target) and _is_ancestor(repo, target, local)

--- a/backend/tests/test_platform_activation.py
+++ b/backend/tests/test_platform_activation.py
@@ -31,17 +31,23 @@ def test_deployment_specific_inputs_share_contract_without_fake_commands():
   assert railway_on_self_hosted["reasons"] == []
 
 
-def test_baked_runtime_and_dependencies_never_degrade_to_restart_only():
-  for path in (
-    "backend/requirements.txt",
-    "frontend/package-lock.json",
-    "backend/scripts/entrypoint.sh",
-    "backend/runtime/restart_ledger.py",
-    "backend/recovery_target/targetd.py",
-    "protected-files.txt",
-  ):
+def test_dependency_and_baked_runtime_never_degrade_to_restart_only():
+  # Python deps now apply in place (a rebuild is no longer forced), but they are
+  # still MORE than a bare restart. Frontend deps and baked-runtime inputs still
+  # require a new image.
+  expected = {
+    "backend/requirements.txt": "dependency_sync",
+    "backend/requirements.lock": "dependency_sync",
+    "frontend/package-lock.json": "image_rebuild",
+    "backend/scripts/entrypoint.sh": "image_rebuild",
+    "backend/runtime/restart_ledger.py": "image_rebuild",
+    "backend/recovery_target/targetd.py": "image_rebuild",
+    "protected-files.txt": "image_rebuild",
+  }
+  for path, level in expected.items():
     impact = activation.classify_activation([path], deployment="self_hosted")
-    assert impact["level"] == "image_rebuild", path
+    assert impact["level"] == level, path
+    assert impact["level"] not in {"live", "server_restart"}, path
 
 
 def test_dependency_fingerprint_comes_from_the_image_rules():
@@ -57,3 +63,28 @@ def test_dependency_fingerprint_comes_from_the_image_rules():
     "frontend/package-lock.json",
     "frontend/package.json",
   })
+
+
+def test_python_dependencies_apply_in_place_not_via_rebuild():
+  impact = activation.classify_activation(
+    ["backend/requirements.lock"], deployment="self_hosted",
+  )
+  assert impact["level"] == "dependency_sync"
+  assert any("in place" in line for line in impact["guidance"])
+
+  # A backend code change alongside a dep bump resolves to the dep-sync boundary
+  # (which already includes a restart), not a rebuild.
+  mixed = activation.classify_activation(
+    ["backend/requirements.txt", "backend/app/main.py"], deployment="self_hosted",
+  )
+  assert mixed["level"] == "dependency_sync"
+
+  # But a Dockerfile change in the same update still forces a rebuild.
+  with_dockerfile = activation.classify_activation(
+    ["backend/requirements.txt", "Dockerfile"], deployment="self_hosted",
+  )
+  assert with_dockerfile["level"] == "image_rebuild"
+
+
+def test_dependency_sync_requires_an_import_probe():
+  assert activation.backend_import_probe_required(["backend/requirements.lock"])

--- a/backend/tests/test_platform_update.py
+++ b/backend/tests/test_platform_update.py
@@ -1258,7 +1258,7 @@ def test_platform_update_uses_explicit_activation_levels():
   assert classify(["skill/core.md"])["level"] == \
     "server_restart"
   assert classify(["backend/requirements.txt"])["level"] == \
-    "image_rebuild"
+    "dependency_sync"
   assert classify(["backend/scripts/entrypoint.sh"])["level"] == \
     "image_rebuild"
   assert classify(["Caddyfile"])["level"] == "proxy_reload"
@@ -1359,7 +1359,7 @@ def test_status_no_restart_when_only_tests_changed(clone_env):
   assert status["state"] == pu.PlatformUpdateState.UP_TO_DATE.value
 
 
-def test_status_requires_image_instead_of_offering_restart_for_dependencies(
+def test_status_offers_in_place_restart_for_dependency_changes(
   clone_env,
 ):
   _, platform = clone_env
@@ -1370,12 +1370,34 @@ def test_status_requires_image_instead_of_offering_restart_for_dependencies(
 
   status = pu.platform_status(platform)
 
-  assert status["state"] == pu.PlatformUpdateState.ACTIVATION_NEEDED.value
-  assert status["needs_restart"] is False
-  assert status["activation"]["level"] == "image_rebuild"
+  # A Python dependency change is installed in place by Apply and then loaded by
+  # a restart — no image rebuild — so it is offered as an in-product restart.
+  assert status["state"] == pu.PlatformUpdateState.RESTART_NEEDED.value
+  assert status["needs_restart"] is True
+  assert status["activation"]["level"] == "dependency_sync"
 
 
 def test_boot_clears_restart_but_preserves_unverified_image_work(clone_env):
+  _, platform = clone_env
+  target = _served_sha(platform)
+  pu.mark_activation_needed(
+    target,
+    ["backend/app/main.py", "frontend/package-lock.json"],
+  )
+
+  res = pu.reconcile_clone(platform, at_boot=True)
+
+  assert res.status == "up_to_date"
+  assert pu._read_activation_marker() == {
+    "target_sha": target,
+    "paths": ["frontend/package-lock.json"],
+  }
+
+
+def test_boot_retires_in_place_python_dependency_sync(clone_env):
+  # Owner Apply installs the locked Python deps in place BEFORE writing this
+  # marker, so a fresh boot that loads the target already has them — retire like
+  # a restart, not preserved as unverified image work.
   _, platform = clone_env
   target = _served_sha(platform)
   pu.mark_activation_needed(
@@ -1386,10 +1408,56 @@ def test_boot_clears_restart_but_preserves_unverified_image_work(clone_env):
   res = pu.reconcile_clone(platform, at_boot=True)
 
   assert res.status == "up_to_date"
-  assert pu._read_activation_marker() == {
-    "target_sha": target,
-    "paths": ["backend/requirements.lock"],
-  }
+  # Every path retired (deps like a restart, code by the restart) -> no pending
+  # activation work at all.
+  assert pu._read_activation_marker() is None
+
+
+def test_apply_installs_python_dependencies_in_place(clone_env, monkeypatch):
+  origin, platform = clone_env
+  target = _advance_origin(
+    origin,
+    edits={"backend/requirements.lock": "new-locked-deps\n"},
+    msg="bump python deps",
+  )
+  pu._fetch(platform)
+
+  synced = {}
+
+  def fake_sync(repo):
+    synced["ran"] = True
+    return True, ""
+
+  monkeypatch.setattr(pu, "_sync_python_dependencies", fake_sync)
+
+  res = pu.reconcile_clone(platform, target_ref=target, fetch_remote=False)
+
+  assert res.status == "updated"
+  assert synced.get("ran") is True  # the in-place install ran during Apply
+  assert _served_sha(platform) == target
+
+
+def test_apply_rolls_back_when_dependency_install_fails(clone_env, monkeypatch):
+  origin, platform = clone_env
+  pre = pu._rev(platform, pu._local_branch(platform))
+  target = _advance_origin(
+    origin,
+    edits={"backend/requirements.lock": "new-locked-deps\n"},
+    msg="bump python deps",
+  )
+  pu._fetch(platform)
+
+  monkeypatch.setattr(
+    pu, "_sync_python_dependencies", lambda repo: (False, "boom"),
+  )
+
+  res = pu.reconcile_clone(platform, target_ref=target, fetch_remote=False)
+
+  # A dependency install failure is fail-closed: reset to the pre-reconcile
+  # commit and serve the old tree, exactly like a failed import probe.
+  assert res.status == "rolled_back"
+  assert "boom" in (res.error or "")
+  assert pu._rev(platform, pu._local_branch(platform)) == pre
 
 
 # --- restart flag lifecycle -------------------------------------------------
@@ -1561,20 +1629,21 @@ def test_update_preview_clean_fast_forward(clone_env):
   assert preview["activation"]["level"] == "server_restart"
 
 
-def test_update_preview_warns_before_dependency_update_is_applied(clone_env):
+def test_update_preview_shows_dependency_change_applies_in_place(clone_env):
   origin, platform = clone_env
   _advance_origin(
     origin,
     edits={"backend/requirements.lock": "locked dependency bytes\n"},
-    msg="change image dependency",
+    msg="change dependency",
   )
   pu._fetch(platform)
 
   preview = pu.platform_update_preview(platform)
 
-  assert preview["activation"]["level"] == "image_rebuild"
-  assert "Restart cannot" not in " ".join(preview["activation"]["guidance"])
-  assert "rebuild the image" in " ".join(preview["activation"]["guidance"])
+  assert preview["activation"]["level"] == "dependency_sync"
+  guidance = " ".join(preview["activation"]["guidance"])
+  assert "in place" in guidance
+  assert "rebuild the image" not in guidance
 
 
 def test_update_preview_excludes_local_edits(clone_env):

--- a/frontend/src/lib/__tests__/platformUpdateState.test.js
+++ b/frontend/src/lib/__tests__/platformUpdateState.test.js
@@ -67,6 +67,32 @@ test('an image-required apply projects the external activation contract', () => 
   assert.equal(platformUpdateStatusLabel(projected), 'Image rebuild required')
 })
 
+test('a dependency apply projects an in-place restart, not a rebuild', () => {
+  const activation = {
+    level: 'dependency_sync',
+    guidance: [
+      'Apply installs the new Python dependencies in place, then restart.',
+    ],
+  }
+  const projected = platformStatusFromApply(
+    { state: 'available', available: true, needs_restart: false },
+    {
+      state: 'restart_needed',
+      needs_restart: true,
+      activation,
+      upstream_commit: 'applied',
+    },
+  )
+
+  assert.equal(projected.available, false)
+  assert.equal(projected.needs_restart, true)
+  assert.equal(projected.activation, activation)
+  assert.equal(
+    platformActivationLabel(projected.activation), 'Dependency update',
+  )
+  assert.equal(platformUpdateStatusLabel(projected), 'Ready to restart')
+})
+
 test('a failed newer release does not forget an earlier staged update', () => {
   const projected = platformStatusFromApply(
     {

--- a/frontend/src/lib/platformUpdateState.js
+++ b/frontend/src/lib/platformUpdateState.js
@@ -53,7 +53,10 @@ export function platformUpdateStatusLabel(platform) {
   if (state === 'conflict') return 'Update blocked'
   if (state === 'rolled_back') return 'Update needs repair'
   if (activationLevel !== 'live' && available) return 'More updates available'
-  if (activationLevel === 'server_restart') return 'Ready to restart'
+  if (
+    activationLevel === 'server_restart'
+    || activationLevel === 'dependency_sync'
+  ) return 'Ready to restart'
   if (activationLevel === 'proxy_reload') return 'Proxy reload required'
   if (activationLevel === 'container_recreate') return 'Deployment required'
   if (activationLevel === 'image_rebuild') return 'Image rebuild required'
@@ -85,6 +88,7 @@ export function platformActivationLabel(activation) {
   const labels = {
     live: 'Live refresh',
     server_restart: 'Server restart',
+    dependency_sync: 'Dependency update',
     proxy_reload: 'Proxy reload',
     container_recreate: 'Container recreation',
     image_rebuild: 'Image rebuild',


### PR DESCRIPTION
## Summary

A platform update that only bumps **Python dependencies** no longer forces a
container rebuild. `platform_activation.py` gains one ordered level,
`DEPENDENCY_SYNC`, between `SERVER_RESTART` and the external-plane levels;
`backend/requirements.{txt,lock}` classify to it instead of `IMAGE_REBUILD`.

Owner **Apply** then installs the locked deps in place — the *same*
`pip install --require-hashes -r requirements.lock` the image build runs — right
before the existing post-merge import probe, so the merged code imports its new
deps and the update lands with a restart and **no rebuild, no downtime**.

## Why

On a single-owner box the operator already has in-container root, so a dependency
bump doesn't need a fresh image to run — only to become *durable*. A rebuild is
still available (and still required for `Dockerfile`/base-image and, for now,
frontend dependency changes), but it's no longer the only way to run a new
Python dep.

## How it stays safe

- **Fail-closed:** a `pip` failure is treated exactly like a failed import
  probe — reset to the pre-reconcile commit and serve the old tree. No
  half-applied state.
- **Boot never installs:** boot must stay fast and offline-tolerant, and a fresh
  image already has the deps. A boot that merged a dep bump instead fails the
  probe and rolls back — deps are only installed by an interactive owner Apply.
- **Correct completion:** the install runs *before* the activation marker is
  written, so a fresh boot legitimately retires the work like a restart; a
  rebuild that bakes the deps retires it via the existing `build_contains_target`
  proof. A bare crash-restart cannot falsely clear it.
- **Reuses existing machinery:** no new apply path, no new marker system, no new
  progress phase (reuses `BUILDING`), no new rollback code.

## Scope

Python deps only. `Dockerfile` and frontend `package.json` changes still
classify as `IMAGE_REBUILD`. Frontend in-place apply (npm install + bundle
rebuild) is a clean follow-up; deferred here to keep the change small.

## Tests

- `test_platform_activation.py`: the new level, reclassification, guidance, and
  import-probe requirement.
- `test_platform_update.py`: Apply runs the in-place install; a failed install
  rolls back to the pre-reconcile commit; a fresh boot retires dep-sync work;
  status/preview surface `dependency_sync` as an in-product restart, not a
  rebuild.
- `platformUpdateState.test.js`: the Settings row shows "Ready to restart" /
  "Dependency update", not a rebuild prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
