### PR TITLE
Fold turn-end drain task tracking into dispatch_sdk_message

### DIFF
--- a/backend/app/claude_events.py
+++ b/backend/app/claude_events.py
@@ -225,43 +225,11 @@ def _claude_text_item_id(message_id: str | None, index: object) -> str | None:
   return f"{message_id}:{index}"
 
 
-def update_inflight_tasks(sdk_msg: Any, inflight: set) -> None:
-  """Maintain the set of *drainable* background task_ids still running, keyed on
-  the SAME message types ``dispatch_sdk_message`` translates. A task_id is added
-  when a TaskStartedMessage for a DEFERRING_TASK_TYPES agent (``local_agent`` /
-  ``local_workflow`` — Task-tool subagents and Workflows) arrives, and removed on
-  its terminal signal — a TaskNotificationMessage (dispatch's ``task_done``), or a
-  TaskUpdatedMessage patch carrying a TERMINAL_TASK_STATUSES status (the path a
-  TaskStop-killed task reports through). The runner uses this set to decide
-  whether background work is still live at the turn's terminal result, so it can
-  drain it before reaping instead of killing it.
-
-  Only delegated-agent tasks are tracked: background shells and Monitors run
-  indefinitely by design and never emit a terminal frame, so adding one would
-  make the drain block until its bounded timeout rather than returning promptly.
-  The SDK gates its own tracker on the same set for exactly this reason. Purely
-  observational — never raises on shape drift.
-  """
-  if isinstance(sdk_msg, TaskStartedMessage):
-    if getattr(sdk_msg, "task_type", None) not in DEFERRING_TASK_TYPES:
-      return
-    task_id = getattr(sdk_msg, "task_id", None)
-    if task_id is not None:
-      inflight.add(task_id)
-  elif isinstance(sdk_msg, TaskNotificationMessage):
-    inflight.discard(getattr(sdk_msg, "task_id", None))
-  elif (
-    TaskUpdatedMessage is not None
-    and isinstance(sdk_msg, TaskUpdatedMessage)
-    and getattr(sdk_msg, "status", None) in TERMINAL_TASK_STATUSES
-  ):
-    inflight.discard(getattr(sdk_msg, "task_id", None))
-
-
 def dispatch_sdk_message(
   sdk_msg: Any,
   bc,
   current_session_id: str | None,
+  inflight: set | None = None,
 ) -> tuple[str | None, dict | None]:
   """Translates one SDK message into broadcast events.
 
@@ -270,6 +238,13 @@ def dispatch_sdk_message(
   dict and stops draining the SDK stream. For every other message
   type the caller updates ``current_session_id`` from the first
   return value and keeps reading.
+
+  When ``inflight`` is passed, this also maintains it as the set of
+  *drainable* background task_ids still running — added when a
+  DEFERRING_TASK_TYPES agent starts, discarded on its terminal frame —
+  from the very branches that already classify those task messages. The
+  runner keeps a live client draining until that set empties so
+  parallel subagents finish instead of being reaped at turn end.
 
   Extracted from the runner loop so unit tests can exercise the
   full dispatch matrix (named events, unknown fallthrough, usage
@@ -301,6 +276,12 @@ def dispatch_sdk_message(
           "source_event_id": getattr(sdk_msg, "uuid", None),
         })
       bc.publish(public_event)
+      if (
+        inflight is not None
+        and getattr(sdk_msg, "task_type", None) in DEFERRING_TASK_TYPES
+        and sdk_msg.task_id is not None
+      ):
+        inflight.add(sdk_msg.task_id)
       return current_session_id, None
     if isinstance(sdk_msg, TaskProgressMessage):
       bc.publish({
@@ -328,6 +309,8 @@ def dispatch_sdk_message(
           "source_event_id": getattr(sdk_msg, "uuid", None),
         })
       bc.publish(public_event)
+      if inflight is not None:
+        inflight.discard(sdk_msg.task_id)
       return current_session_id, None
     if TaskUpdatedMessage is not None and isinstance(sdk_msg, TaskUpdatedMessage):
       # A background task's terminal state can arrive ONLY as a task_updated
@@ -360,6 +343,8 @@ def dispatch_sdk_message(
           recorder(private_event)
         bc.publish({key: private_event.get(key) for key in (
           "type", "task_id", "status", "summary", "tool_use_id")})
+        if inflight is not None:
+          inflight.discard(sdk_msg.task_id)
       return current_session_id, None
     if sdk_msg.subtype == "init":
       # Setup metadata only — no Möbius-side render.

--- a/backend/app/claude_sdk_runner.py
+++ b/backend/app/claude_sdk_runner.py
@@ -84,11 +84,7 @@ from claude_agent_sdk.types import (
 )
 
 from app import activity
-from app.claude_events import (
-  _clip_task_text,
-  dispatch_sdk_message,
-  update_inflight_tasks,
-)
+from app.claude_events import _clip_task_text, dispatch_sdk_message
 from app.claude_sdk_contract import transport_exit_error, transport_process_pid
 from app.process_groups import (
   isolated_process_group_id,
@@ -132,16 +128,15 @@ async def _drain_background_tasks(client, bc, inflight, session_id, chat_id):
   task finishes; then the caller returns into the normal reap.
 
   Wait for the real work, not an arbitrary clock. Only drainable delegated-agent
-  tasks are tracked (see ``update_inflight_tasks``), and those reliably reach a
-  terminal status, so this returns as soon as the subagents actually settle —
-  there is deliberately no time cap. Fail-safe: on ANY stream error it returns so
-  the reap proceeds; a real Stop raises CancelledError (BaseException), which
-  propagates untouched and aborts the wait at once.
+  tasks are tracked (``dispatch_sdk_message`` maintains ``inflight``), and those
+  reliably reach a terminal status, so this returns as soon as the subagents
+  actually settle — there is deliberately no time cap. Fail-safe: on ANY stream
+  error it returns so the reap proceeds; a real Stop raises CancelledError
+  (BaseException), which propagates untouched and aborts the wait at once.
   """
   try:
     async for sdk_msg in client.receive_messages():
-      dispatch_sdk_message(sdk_msg, bc, session_id)
-      update_inflight_tasks(sdk_msg, inflight)
+      dispatch_sdk_message(sdk_msg, bc, session_id, inflight)
       if not inflight:
         return
   except Exception as exc:
@@ -1160,9 +1155,8 @@ async def run_claude_sdk_turn(
             if _resets is not None:
               rate_limit_resets_at = _resets
           current_session_id, terminal = dispatch_sdk_message(
-            sdk_msg, bc, current_session_id,
+            sdk_msg, bc, current_session_id, inflight_tasks,
           )
-          update_inflight_tasks(sdk_msg, inflight_tasks)
           if terminal is None:
             # A steer fires its interrupt synchronously in
             # ActiveClaudeClient.steer() (a soft interrupt on the same


### PR DESCRIPTION
## What

Follow-up cleanup on #710 (which added the turn-end background-task drain). That change introduced `update_inflight_tasks`, which re-ran the same `isinstance` ladder over `TaskStartedMessage` / `TaskNotificationMessage` / terminal `TaskUpdatedMessage` that `dispatch_sdk_message` already runs to translate those messages.

This folds the in-flight tracking directly into `dispatch_sdk_message` via an optional `inflight: set | None = None` parameter, updated from the exact branches that already classify those task messages, and removes the standalone `update_inflight_tasks` function.

## Why

One place now owns "interpret a task message": its broadcast-event translation and its lifecycle bookkeeping stay in sync by construction, instead of two functions duplicating the same type ladder that a future SDK task-type change would have to update in both.

## Behavior

Identical. The `DEFERRING_TASK_TYPES` gate (only track task types that reliably terminate) and the discard-on-terminal logic are preserved exactly; tracking now rides the dispatch pass the runner already makes. Verified against real SDK message types: parallel starts tracked, background shells excluded, both terminal paths (notification and terminal `task_updated`) clear, and `dispatch_sdk_message` called without the new argument is unchanged.

Net: 2 files, +26/-47.