### PR TITLE
Give hold-to-move room before opening tab actions

### DIFF
--- a/frontend/src/components/Shell/__tests__/dragController.test.js
+++ b/frontend/src/components/Shell/__tests__/dragController.test.js
@@ -103,7 +103,7 @@ test('releasedInPlace is true only within the release radius', () => {
 
 test('a press exposes drag before a stationary hold opens actions', () => {
   assert.equal(PRESS_DRAG_HOLD_MS, 180)
-  assert.equal(PRESS_MENU_HOLD_MS, 400)
+  assert.equal(PRESS_MENU_HOLD_MS, 600)
   // The drag stage must precede the menu stage, so a short hold moves and only a
   // longer stationary hold opens actions — the single contract drawer rows,
   // launcher cards, and workspace tabs all share.

--- a/frontend/src/components/Shell/dragController.js
+++ b/frontend/src/components/Shell/dragController.js
@@ -41,11 +41,14 @@ export const POINTER_SLOP = 5
 // a long hold opens actions, identically everywhere. (Tabs previously diverged
 // with one longer hold whose RELEASE opened the menu; they now share this.)
 export const PRESS_DRAG_HOLD_MS = 180
-// Stay ahead of the platform's own long-press takeover. Some touch browsers
-// cancel the pointer around their native context-menu threshold; opening first
-// keeps the menu on our single Pointer Events path instead of a release-time
-// native contextmenu fallback.
-export const PRESS_MENU_HOLD_MS = 400
+// The menu wants a deliberate long hold, clearly separated from the short drag
+// grab above, so a hold-to-MOVE gesture has room to begin moving after the grab
+// haptic before this would fire — at 400ms the ~220ms window after the grab was
+// too tight and the menu kept stealing move attempts. The native long-press is
+// held off for the whole window by active suppression (the capture-phase
+// `contextmenu` preventDefault plus callout/selection disable in the binding),
+// not by staying under the browser's own threshold, so this can sit past it.
+export const PRESS_MENU_HOLD_MS = 600
 // Movement past this before a hold resolves yields to the source scroller.
 export const PRE_HOLD_MOVE_PX = 8
 // After a touch lift, a release that never moved past this is not a drop; the

--- a/tests/workspace-panes.spec.mjs
+++ b/tests/workspace-panes.spec.mjs
@@ -22,6 +22,7 @@ import { test, expect } from '@playwright/test'
 import { createTaggedChat, attachCleanup } from './_chatTracker.mjs'
 import { mockAcceptedMessages } from './_mockAcceptedMessages.mjs'
 import * as paneModel from '../frontend/src/components/Shell/paneModel.js'
+import { PRESS_MENU_HOLD_MS } from '../frontend/src/components/Shell/dragController.js'
 
 const BASE = process.env.MOBIUS_URL || 'http://localhost:8001'
 const DESKTOP_SIDEBAR_STORAGE_KEY = 'mobius:desktop-sidebar-open:v1'
@@ -659,7 +660,7 @@ test.describe('Workspace panes (PR2 gate)', () => {
       clientX: touchPoint.x,
       clientY: touchPoint.y,
     })
-    await page.waitForTimeout(450)
+    await page.waitForTimeout(PRESS_MENU_HOLD_MS + 50)
     await activeTab.dispatchEvent('pointerup', {
       pointerId: 41,
       pointerType: 'touch',


### PR DESCRIPTION
## What changed
- raise the shared actions-menu hold from 400ms to 600ms
- keep the drag grab at 180ms, leaving a deliberate window to start moving
- pin the two-stage timing contract in the drag-controller test

## Why
On touch, a tab becomes draggable at 180ms but the actions menu previously opened only 220ms later. That made a deliberate hold-to-move frequently open the menu before movement began. The longer stationary hold keeps actions deliberate without changing the shared gesture model.

## Verification
- targeted drag-controller suite: 44/44 passed
