### PR TITLE
Let apps collapse shell chrome from their own header

### DIFF
--- a/frontend/public/mobius-runtime.js
+++ b/frontend/public/mobius-runtime.js
@@ -3577,6 +3577,166 @@ function makeCapabilities({ declarations = {}, hostWindow, selfWindow } = {}) {
 }
 
 //#endregion
+//#region src/runtime/immersive.js
+const HOLD_MS = 450;
+const MOVE_TOL_PX = 10;
+function makeImmersive({ appId } = {}) {
+	let hidden = false;
+	const listeners = /* @__PURE__ */ new Set();
+	const hasParent = typeof window !== "undefined" && window.parent && window.parent !== window;
+	function notify() {
+		for (const cb of [...listeners]) try {
+			cb(hidden);
+		} catch (e) {}
+	}
+	if (typeof window !== "undefined" && hasParent) window.addEventListener("message", (e) => {
+		if (e.source !== window.parent) return;
+		const msg = e.data;
+		if (!msg || msg.type !== "moebius:immersive-state") return;
+		const next = msg.value === true;
+		if (next === hidden) return;
+		hidden = next;
+		notify();
+	});
+	function post(value) {
+		try {
+			window.parent.postMessage({
+				type: "moebius:immersive",
+				value: !!value,
+				mode: "bar",
+				appId
+			}, "*");
+		} catch (e) {}
+	}
+	function set(nextHidden) {
+		const v = !!nextHidden;
+		if (v !== hidden) {
+			hidden = v;
+			notify();
+		}
+		if (hasParent) post(v);
+		return hidden;
+	}
+	function toggle() {
+		return set(!hidden);
+	}
+	function subscribe(cb) {
+		if (typeof cb !== "function") return () => {};
+		listeners.add(cb);
+		try {
+			cb(hidden);
+		} catch (e) {}
+		return () => {
+			listeners.delete(cb);
+		};
+	}
+	function holdToToggle(el, opts = {}) {
+		if (!el || typeof el.addEventListener !== "function") return () => {};
+		if (el.__mobiusHold) return el.__mobiusHold;
+		const holdMs = typeof opts.holdMs === "number" ? opts.holdMs : HOLD_MS;
+		let timer = null;
+		let startX = 0;
+		let startY = 0;
+		let fired = false;
+		let pointerId = null;
+		const prev = {
+			cursor: el.style.cursor,
+			touchAction: el.style.touchAction,
+			userSelect: el.style.userSelect,
+			webkitUserSelect: el.style.webkitUserSelect,
+			webkitTouchCallout: el.style.webkitTouchCallout
+		};
+		el.style.cursor = "pointer";
+		el.style.touchAction = "none";
+		el.style.userSelect = "none";
+		el.style.webkitUserSelect = "none";
+		el.style.webkitTouchCallout = "none";
+		function clearTimer() {
+			if (timer !== null) {
+				clearTimeout(timer);
+				timer = null;
+			}
+		}
+		function release() {
+			clearTimer();
+			if (pointerId !== null) {
+				try {
+					el.releasePointerCapture(pointerId);
+				} catch (e2) {}
+				pointerId = null;
+			}
+		}
+		function onPointerDown(e) {
+			if (e.pointerType === "mouse" && e.button !== 0) return;
+			fired = false;
+			startX = e.clientX;
+			startY = e.clientY;
+			pointerId = e.pointerId;
+			try {
+				el.setPointerCapture(e.pointerId);
+			} catch (e2) {}
+			clearTimer();
+			timer = setTimeout(() => {
+				timer = null;
+				fired = true;
+				try {
+					if (navigator.vibrate) navigator.vibrate(10);
+				} catch (e2) {}
+				toggle();
+			}, holdMs);
+		}
+		function onPointerMove(e) {
+			if (timer === null) return;
+			if (Math.abs(e.clientX - startX) > MOVE_TOL_PX || Math.abs(e.clientY - startY) > MOVE_TOL_PX) clearTimer();
+		}
+		function onPointerEnd() {
+			release();
+		}
+		function onClickCapture(e) {
+			if (!fired) return;
+			e.preventDefault();
+			e.stopPropagation();
+			fired = false;
+		}
+		function onContextMenu(e) {
+			e.preventDefault();
+		}
+		el.addEventListener("pointerdown", onPointerDown);
+		el.addEventListener("pointermove", onPointerMove);
+		el.addEventListener("pointerup", onPointerEnd);
+		el.addEventListener("pointercancel", onPointerEnd);
+		el.addEventListener("click", onClickCapture, true);
+		el.addEventListener("contextmenu", onContextMenu);
+		const cleanup = () => {
+			release();
+			delete el.__mobiusHold;
+			el.style.cursor = prev.cursor;
+			el.style.touchAction = prev.touchAction;
+			el.style.userSelect = prev.userSelect;
+			el.style.webkitUserSelect = prev.webkitUserSelect;
+			el.style.webkitTouchCallout = prev.webkitTouchCallout;
+			el.removeEventListener("pointerdown", onPointerDown);
+			el.removeEventListener("pointermove", onPointerMove);
+			el.removeEventListener("pointerup", onPointerEnd);
+			el.removeEventListener("pointercancel", onPointerEnd);
+			el.removeEventListener("click", onClickCapture, true);
+			el.removeEventListener("contextmenu", onContextMenu);
+		};
+		el.__mobiusHold = cleanup;
+		return cleanup;
+	}
+	return {
+		set,
+		toggle,
+		subscribe,
+		holdToToggle,
+		get hidden() {
+			return hidden;
+		}
+	};
+}
+
+//#endregion
 //#region src/runtime/index.js
 let _online = typeof navigator !== "undefined" ? navigator.onLine : true;
 const _onlineListeners = /* @__PURE__ */ new Set();
@@ -3653,7 +3813,8 @@ function init({ appId, appInstanceId = null, getToken, capabilityContract = null
 			storage
 		}),
 		nav: makeNav(),
-		split: makeSplit()
+		split: makeSplit(),
+		immersive: makeImmersive({ appId })
 	};
 	window.mobius = api;
 	_runtimeContext = {
@@ -3673,4 +3834,4 @@ function init({ appId, appInstanceId = null, getToken, capabilityContract = null
 }
 
 //#endregion
-export { CapabilityError, DurableWriteError, appChatMetadataBody, createUseDocument, init, makeCapabilities, makeChat, makeEmbedAuthorizationHandoff, makeEmbedFrameReveal, makeNav, makeSignal, makeSplit, makeStorage, overlayPending, purgeAppRuntimeData, runtimeFeatures, sanitizeEmbedGuidance };
+export { CapabilityError, DurableWriteError, appChatMetadataBody, createUseDocument, init, makeCapabilities, makeChat, makeEmbedAuthorizationHandoff, makeEmbedFrameReveal, makeImmersive, makeNav, makeSignal, makeSplit, makeStorage, overlayPending, purgeAppRuntimeData, runtimeFeatures, sanitizeEmbedGuidance };

--- a/frontend/src/components/AppCanvas/AppCanvas.jsx
+++ b/frontend/src/components/AppCanvas/AppCanvas.jsx
@@ -240,6 +240,12 @@ const AppCanvas = forwardRef(function AppCanvas({
   appId, version = 0, appName, appSlug, offlineCapable = false,
   capabilityContract = null,
   immersive = false,
+  // The lighter "look like a standalone app" collapse (mode:'bar'): the shell
+  // hides its toolbar but keeps the status-bar strip, so unlike `immersive`
+  // (full-bleed) the app is NOT painted under the notch and needs no safe-area
+  // insets. It still counts as "chrome hidden" for the app's immersive helper
+  // echo, so the app's toggle()/`.hidden` stay correct.
+  barCollapsed = false,
   // Whether this app is the currently-visible canvas (canvas view + active
   // app). One prop, two consumers:
   //   - `moebius:frame-visibility` — the shell keeps recently-used apps
@@ -724,9 +730,14 @@ const AppCanvas = forwardRef(function AppCanvas({
       // garbage reads as a release, the safe direction).
       if (msg.type === 'moebius:immersive') {
         const value = msg.value === true
+        // 'bar' is the general-app standalone-look collapse; anything else
+        // (including absent) is the game full-bleed default. Identity comes
+        // from the verified source, never the payload — but the mode is a
+        // harmless presentation hint the frame may choose.
+        const mode = msg.mode === 'bar' ? 'bar' : 'full'
         frameImmersiveRef.current.set(srcVersion, value)
         if (srcVersion === liveVersionRef.current && activeRef.current) {
-          onImmersive?.(appId, value)
+          onImmersive?.(appId, value, mode)
         }
         return
       }
@@ -1070,6 +1081,21 @@ const AppCanvas = forwardRef(function AppCanvas({
     postToFrame(v, { type: 'moebius:frame-insets', insets })
   }
 
+  // Echo the shell's APPLIED immersive verdict for this app so the runtime's
+  // window.mobius.immersive helper stays authoritative — toggle()/`.hidden`
+  // must reflect a release the shell made on its own (the floating exit button,
+  // or an app switch that dropped the lease), not just the app's last request.
+  // The `immersive` prop is exactly that applied verdict (active canvas AND this
+  // app holds the lease). Only the live frame is the immersive holder, so a
+  // hidden/incoming buffered frame always learns `false`.
+  function sendImmersiveState(v) {
+    postToFrame(v, {
+      type: 'moebius:immersive-state',
+      // Either flavor of hidden bar counts as "hidden" for the app helper.
+      value: v === liveVersionRef.current ? (immersive || barCollapsed) : false,
+    })
+  }
+
   // ── In-shell foreground/background signal ────────────────────────
   // Forward whether THIS app is the visible canvas. The shell keeps recently-
   // used apps mounted and hides the inactive ones with `visibility:hidden` on a
@@ -1126,6 +1152,15 @@ const AppCanvas = forwardRef(function AppCanvas({
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [immersive, swap.liveVersion])
+
+  // Keep the app's window.mobius.immersive helper in sync with the shell's
+  // applied verdict (see sendImmersiveState). Same triggers as the insets echo.
+  useEffect(() => {
+    for (const v of framesRef.current.keys()) {
+      if (loadedDocsRef.current.has(v)) sendImmersiveState(v)
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [immersive, barCollapsed, swap.liveVersion])
 
   // Re-forward insets on viewport geometry change WHILE immersive. Rotating the
   // device or a window resize moves the notch/home-indicator (landscape puts
@@ -1298,6 +1333,7 @@ const AppCanvas = forwardRef(function AppCanvas({
     sendInit(v)
     sendOnlineStatus(v)
     sendInsets(v)
+    sendImmersiveState(v)
     // A booting incoming frame is invisible by construction and must not
     // start audio/rAF work before promotion, so it learns `visible:false`
     // here; the live frame gets the real visible verdict. Promotion re-sends

--- a/frontend/src/components/Shell/Shell.css
+++ b/frontend/src/components/Shell/Shell.css
@@ -60,7 +60,10 @@
   transform: translateY(0);
 }
 
-.shell--immersive::after {
+/* Both hidden-bar modes span the full content area; suppress the bottom chrome
+   for either. `shell--barhidden` is applied whenever the top toolbar is hidden
+   (full immersive OR the lighter bar-collapse). */
+.shell--barhidden::after {
   display: none;
 }
 
@@ -180,6 +183,36 @@
   display: none;
 }
 
+/* ── Bar-collapse mode (general apps: "look like a standalone app") ──
+   Unlike full immersive, the Möbius toolbar is hidden but the top
+   status-bar/notch strip is KEPT: the bar shrinks to exactly the safe-area
+   inset (its themed background stays), so the app's own header sits just below
+   the status bar like an installed/standalone PWA — never under the notch. On
+   a device with no top inset (desktop) the strip collapses to 0, so the app
+   header simply reaches the top. */
+.shell--barcollapsed .shell__bar {
+  height: env(safe-area-inset-top, 0px);
+  min-height: 0;
+  padding-top: env(safe-area-inset-top, 0px);
+  padding-bottom: 0;
+  border-bottom: none;
+  overflow: hidden;
+}
+.shell--barcollapsed .shell__bar > * {
+  display: none;
+}
+/* The safety-net exit floats top-RIGHT in bar-collapse so it never sits over
+   the app's own top-left logo (which is itself the toggle-back handle). */
+.shell--barcollapsed .shell__immersive-exit {
+  left: auto;
+  right: calc(env(safe-area-inset-right, 0px) + 10px);
+}
+
+/* Full standalone look: hide the nav drawer/sidebar too while the bar is
+   hidden (either mode), so the app owns the entire viewport with no Möbius
+   chrome. The floating exit restores everything. */
+.shell--barhidden #navigation-drawer { display: none !important; }
+
 /* Floating exit affordance, provided by the SHELL (never the app) so
    immersive mode can't trap the user — with the bar hidden this is the
    only chrome on screen. Safe-area-inset so the notch/punch-hole can't
@@ -235,8 +268,8 @@
 
 /* Immersive apps own the full viewport without overwriting the saved sidebar
    preference; the reserved width returns when immersive mode exits. */
-.shell--immersive.shell--drawer-docked > .shell__tabstrip,
-.shell--immersive.shell--drawer-docked > .shell__content {
+.shell--barhidden.shell--drawer-docked > .shell__tabstrip,
+.shell--barhidden.shell--drawer-docked > .shell__content {
   margin-left: 0;
 }
 
@@ -731,6 +764,15 @@
     border-bottom: 0;
   }
 
+  /* Bar-collapse (full standalone look) removes the rail/header entirely on
+     desktop — there is no notch here, so no status strip is needed and the
+     app owns the whole viewport. (Mobile keeps its safe-area strip via the
+     base .shell--barcollapsed rule.) This must live inside the desktop media
+     query to beat the .shell--drawer-docked height:58px rule above. */
+  .shell--barcollapsed .shell__bar {
+    display: none;
+  }
+
   .shell--drawer-docked .shell__bar-actions {
     position: absolute;
     top: 7px;
@@ -810,16 +852,18 @@
     margin-left: var(--desktop-sidebar-width);
   }
 
-  .shell--immersive > .shell__tabstrip,
-  .shell--immersive > .shell__content {
+  .shell--barhidden > .shell__tabstrip,
+  .shell--barhidden > .shell__content {
     margin-left: 0;
   }
 
-  /* Immersive zeroes the content margin so the canvas spans full width, but the
-     desktop left-rail backdrop (.shell::before) sits above the content at
-     z-index 2 and would keep painting var(--bg) over the canvas — a black column
-     on a dark theme. Suppress it while immersive, as we do for .shell--immersive::after. */
-  .shell--immersive::before {
+  /* The left rail/sidebar backdrop (--desktop-rail-width, or the full
+     --desktop-sidebar-width when docked) is painted by .shell::before at
+     z-index 2, ABOVE the z-index:1 content. Immersive zeroes the content
+     margin so the canvas spans full width, but this strip would keep painting
+     var(--bg) over the game's left edge — a black column on a dark theme.
+     Suppress it whenever the bar is hidden, mirroring .shell--barhidden::after. */
+  .shell--barhidden::before {
     display: none;
   }
 }

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -329,6 +329,12 @@ export default function Shell() {
   // immersive can solo its pane over the whole workspace (§4/§9). Full contract:
   // lib/immersive.js.
   const [immersiveAppId, dispatchImmersive] = useReducer(immersiveReducer, null)
+  // Which flavor of hidden-bar the current holder asked for: 'full' (games —
+  // full-bleed under the notch) or 'bar' (general apps — hide the toolbar but
+  // keep the status-bar strip, so the app looks like a standalone PWA). Only a
+  // real-time request carries a mode; a lifecycle replay (in-place app update)
+  // omits it and leaves the last mode intact.
+  const [immersiveMode, setImmersiveMode] = useState('full')
   const [nowPlaying, setNowPlaying] = useState(null)
   const mediaSessionOwnerRef = useRef(null)
   if (!mediaSessionOwnerRef.current) {
@@ -341,8 +347,9 @@ export default function Shell() {
     mediaSessionOwnerRef.current.control(action)
   }, [])
   // Stable identity — AppCanvas's message-listener effect depends on it.
-  const handleImmersive = useCallback((appId, value) => {
+  const handleImmersive = useCallback((appId, value, mode) => {
     dispatchImmersive({ type: 'request', appId, value })
+    if (value && (mode === 'bar' || mode === 'full')) setImmersiveMode(mode)
   }, [])
   // Immersive is a temporary overlay lease, independent of the durable builder /
   // single worlds. A verified request from the focused app may therefore solo
@@ -3072,7 +3079,7 @@ export default function Shell() {
       data-mode-phase={modeView.active?.phase || modeState.transition?.phase || 'idle'}
       data-mode-epoch={modeView.active?.id || modeState.transition?.id || undefined}
       data-workspace-visual-state={workspaceVisualState}
-      className={`shell${immersiveActive ? ' shell--immersive' : ''}${desktopSidebarReserved ? ' shell--drawer-docked' : ''}`}>
+      className={`shell${immersiveActive ? ` shell--barhidden ${immersiveMode === 'bar' ? 'shell--barcollapsed' : 'shell--immersive'}` : ''}${desktopSidebarReserved ? ' shell--drawer-docked' : ''}`}>
       <a
         className="shell__skip-link"
         href="#main-content"
@@ -3358,7 +3365,8 @@ export default function Shell() {
               offlineCapable={!!app?.offline_capable}
               capabilityContract={app?.capability_contract || null}
               pendingIntent={appIntents[String(id)] || null}
-              immersive={immersiveActive && String(immersiveAppId) === String(id)}
+              immersive={immersiveActive && immersiveMode === 'full' && String(immersiveAppId) === String(id)}
+              barCollapsed={immersiveActive && immersiveMode === 'bar' && String(immersiveAppId) === String(id)}
               onNavPush={appNavPush}
               onNavPop={appNavPop}
               onNavReset={appNavReset}
@@ -3663,12 +3671,9 @@ export default function Shell() {
           />
         )}
       </main>
-      {/* SHELL-provided immersive exit. With the top bar gone the drawer
-          toggle is unreachable, so this floating button is the guaranteed
-          way back — an app can never trap the user in immersive mode.
-          Exit only clears the shell-side request; re-entry requires another
-          explicit app post, so the user remains in control. */}
-      {immersiveActive && (
+      {/* Full-bleed apps need the shell exit. Bar-collapse apps retain their own
+          header/logo, whose hold gesture is the way back. */}
+      {immersiveActive && immersiveMode !== 'bar' && (
         <button
           ref={immersiveExitRef}
           type="button"

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -380,8 +380,10 @@ test('the docked sidebar offsets only direct shell layout rows', () => {
   // from the pane rectangle that owns it.
   assert.match(shellCss, /\.shell--drawer-docked > \.shell__tabstrip,/)
   assert.match(shellCss, /\.shell--drawer-docked > \.shell__content/)
-  assert.match(shellCss, /\.shell--immersive\.shell--drawer-docked > \.shell__tabstrip,/)
-  assert.match(shellCss, /\.shell--immersive\.shell--drawer-docked > \.shell__content/)
+  // Both full-bleed games and app-owned bar collapse use the shared hidden-bar
+  // layout owner; either must release the docked drawer's reserved width.
+  assert.match(shellCss, /\.shell--barhidden\.shell--drawer-docked > \.shell__tabstrip,/)
+  assert.match(shellCss, /\.shell--barhidden\.shell--drawer-docked > \.shell__content/)
   assert.doesNotMatch(shellCss, /\.shell--drawer-docked \.shell__tabstrip/)
 })
 

--- a/frontend/src/lib/__tests__/immersiveRuntime.test.js
+++ b/frontend/src/lib/__tests__/immersiveRuntime.test.js
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import { makeImmersive } from '../../runtime/immersive.js'
+
+function target() {
+  const listeners = new Map()
+  return {
+    style: {
+      cursor: 'help',
+      touchAction: 'pan-y',
+      userSelect: 'text',
+      webkitUserSelect: 'text',
+      webkitTouchCallout: 'default',
+    },
+    listeners,
+    addEventListener(type, listener) {
+      const values = listeners.get(type) || []
+      values.push(listener)
+      listeners.set(type, values)
+    },
+    removeEventListener(type, listener) {
+      listeners.set(type, (listeners.get(type) || []).filter(value => value !== listener))
+    },
+  }
+}
+
+test('holdToToggle is idempotent and cleanup restores the target', () => {
+  const immersive = makeImmersive({ appId: 7 })
+  const element = target()
+  const before = { ...element.style }
+
+  const cleanup = immersive.holdToToggle(element)
+  const repeated = immersive.holdToToggle(element)
+
+  assert.equal(repeated, cleanup)
+  assert.equal(element.listeners.get('pointerdown').length, 1)
+  assert.deepEqual(element.style, {
+    cursor: 'pointer',
+    touchAction: 'none',
+    userSelect: 'none',
+    webkitUserSelect: 'none',
+    webkitTouchCallout: 'none',
+  })
+
+  cleanup()
+  assert.equal(element.__mobiusHold, undefined)
+  assert.deepEqual(element.style, before)
+  for (const listeners of element.listeners.values()) assert.equal(listeners.length, 0)
+})

--- a/frontend/src/runtime/immersive.js
+++ b/frontend/src/runtime/immersive.js
@@ -1,0 +1,196 @@
+// window.mobius.immersive — app-driven control of the Möbius shell top bar.
+//
+// Hiding the top bar lets an app that already has its OWN header take the whole
+// pane, so the owner never sees two stacked toolbars. This is the friendly
+// wrapper over the `moebius:immersive` postMessage protocol; the shell-side
+// state contract lives in src/lib/immersive.js and AppCanvas.jsx.
+//
+// The applied state is authoritative from the SHELL, not the app: AppCanvas
+// echoes `moebius:immersive-state` on every applied change — the app's own
+// request, the shell's floating exit button, and an app switch that releases
+// the lease (immersive is deliberately sessional). The helper mirrors that echo
+// so `toggle()` and `.hidden` stay correct even when the shell released the bar
+// on its own. Trust is the sender check `event.source === window.parent`
+// (matching navigation.js), because the opaque frame's origin string is not
+// reliable.
+//
+// Standalone `/apps/<slug>/` has no Möbius top bar, so the request is harmlessly
+// ignored there — the same app code is portable across both hosts.
+
+const HOLD_MS = 450
+const MOVE_TOL_PX = 10
+
+export function makeImmersive({ appId } = {}) {
+  let hidden = false
+  const listeners = new Set()
+  const hasParent = typeof window !== 'undefined'
+    && window.parent && window.parent !== window
+
+  function notify() {
+    for (const cb of [...listeners]) {
+      try { cb(hidden) } catch (e) {}
+    }
+  }
+
+  // Shell → app: the authoritative applied verdict for THIS app.
+  if (typeof window !== 'undefined' && hasParent) {
+    window.addEventListener('message', (e) => {
+      if (e.source !== window.parent) return
+      const msg = e.data
+      if (!msg || msg.type !== 'moebius:immersive-state') return
+      const next = msg.value === true
+      if (next === hidden) return
+      hidden = next
+      notify()
+    })
+  }
+
+  function post(value) {
+    // The documented immersive channel targets '*': the opaque frame cannot
+    // name the parent origin reliably (see building-apps.md).
+    // mode:'bar' asks the shell for the lighter "look like a standalone app"
+    // collapse — hide the Möbius toolbar but keep the status-bar/notch strip so
+    // the app's own header sits below it (NOT the full-bleed under-the-notch
+    // takeover a game gets with the default mode:'full').
+    try {
+      window.parent.postMessage(
+        { type: 'moebius:immersive', value: !!value, mode: 'bar', appId }, '*',
+      )
+    } catch (e) {}
+  }
+
+  // set(true) hides the Möbius top bar; set(false) restores it. Optimistic —
+  // the shell echo confirms or corrects. Returns the resulting hidden state.
+  function set(nextHidden) {
+    const v = !!nextHidden
+    if (v !== hidden) { hidden = v; notify() }
+    if (hasParent) post(v)
+    return hidden
+  }
+
+  function toggle() { return set(!hidden) }
+
+  // cb(hidden) fires immediately with the current value and again on change.
+  // Returns an unsubscribe function.
+  function subscribe(cb) {
+    if (typeof cb !== 'function') return () => {}
+    listeners.add(cb)
+    try { cb(hidden) } catch (e) {}
+    return () => { listeners.delete(cb) }
+  }
+
+  // Wire a press-AND-HOLD on an element (the app's own top-left logo) to toggle
+  // full-width. HOLD ONLY — a plain click never toggles, so an accidental tap on
+  // the logo can't collapse the app. Idempotent: safe to call on every React
+  // render via a callback ref — `ref={el => window.mobius.immersive.holdToToggle(el)}`
+  // — the second call returns the same cleanup instead of double-wiring. Returns
+  // a cleanup function.
+  function holdToToggle(el, opts = {}) {
+    if (!el || typeof el.addEventListener !== 'function') return () => {}
+    if (el.__mobiusHold) return el.__mobiusHold
+    const holdMs = typeof opts.holdMs === 'number' ? opts.holdMs : HOLD_MS
+    let timer = null
+    let startX = 0
+    let startY = 0
+    let fired = false
+    let pointerId = null
+
+    // Make the element a reliable long-press target on touch. Without
+    // `touch-action: none` the browser claims the touch for scrolling and fires
+    // pointercancel before the hold completes — the "holding does nothing on my
+    // phone" bug. We also suppress the iOS image/callout + text selection a
+    // long-press would otherwise raise, and show a pointer cursor so the logo
+    // reads as interactive. Saved/restored so cleanup is clean.
+    const prev = {
+      cursor: el.style.cursor,
+      touchAction: el.style.touchAction,
+      userSelect: el.style.userSelect,
+      webkitUserSelect: el.style.webkitUserSelect,
+      webkitTouchCallout: el.style.webkitTouchCallout,
+    }
+    el.style.cursor = 'pointer'
+    el.style.touchAction = 'none'
+    el.style.userSelect = 'none'
+    el.style.webkitUserSelect = 'none'
+    el.style.webkitTouchCallout = 'none'
+
+    function clearTimer() {
+      if (timer !== null) { clearTimeout(timer); timer = null }
+    }
+    function release() {
+      clearTimer()
+      if (pointerId !== null) {
+        try { el.releasePointerCapture(pointerId) } catch (e2) {}
+        pointerId = null
+      }
+    }
+    function onPointerDown(e) {
+      if (e.pointerType === 'mouse' && e.button !== 0) return
+      fired = false
+      startX = e.clientX
+      startY = e.clientY
+      pointerId = e.pointerId
+      // Capture so a slight finger drift keeps sending events here and the
+      // gesture can't be silently handed to an ancestor.
+      try { el.setPointerCapture(e.pointerId) } catch (e2) {}
+      clearTimer()
+      timer = setTimeout(() => {
+        timer = null
+        fired = true
+        try { if (navigator.vibrate) navigator.vibrate(10) } catch (e2) {}
+        toggle()
+      }, holdMs)
+    }
+    function onPointerMove(e) {
+      if (timer === null) return
+      if (Math.abs(e.clientX - startX) > MOVE_TOL_PX
+        || Math.abs(e.clientY - startY) > MOVE_TOL_PX) clearTimer()
+    }
+    function onPointerEnd() { release() }
+    function onClickCapture(e) {
+      if (!fired) return
+      // A hold just toggled; don't also fire the logo's own click.
+      e.preventDefault()
+      e.stopPropagation()
+      fired = false
+    }
+    function onContextMenu(e) {
+      // Touch long-press raises the native context menu — always suppress it on
+      // this element so the press reads as our gesture.
+      e.preventDefault()
+    }
+
+    el.addEventListener('pointerdown', onPointerDown)
+    el.addEventListener('pointermove', onPointerMove)
+    el.addEventListener('pointerup', onPointerEnd)
+    el.addEventListener('pointercancel', onPointerEnd)
+    el.addEventListener('click', onClickCapture, true)
+    el.addEventListener('contextmenu', onContextMenu)
+
+    const cleanup = () => {
+      release()
+      delete el.__mobiusHold
+      el.style.cursor = prev.cursor
+      el.style.touchAction = prev.touchAction
+      el.style.userSelect = prev.userSelect
+      el.style.webkitUserSelect = prev.webkitUserSelect
+      el.style.webkitTouchCallout = prev.webkitTouchCallout
+      el.removeEventListener('pointerdown', onPointerDown)
+      el.removeEventListener('pointermove', onPointerMove)
+      el.removeEventListener('pointerup', onPointerEnd)
+      el.removeEventListener('pointercancel', onPointerEnd)
+      el.removeEventListener('click', onClickCapture, true)
+      el.removeEventListener('contextmenu', onContextMenu)
+    }
+    el.__mobiusHold = cleanup
+    return cleanup
+  }
+
+  return {
+    set,
+    toggle,
+    subscribe,
+    holdToToggle,
+    get hidden() { return hidden },
+  }
+}

--- a/frontend/src/runtime/index.js
+++ b/frontend/src/runtime/index.js
@@ -46,6 +46,11 @@
 //   window.mobius.nav.open(label, onBack)        -> { ready, outcome, close }
 //     outcome distinguishes host ownership from request failures; see
 //     building-apps.md.
+//   window.mobius.immersive.toggle() / set(hidden) -> hides/shows the Möbius top
+//     bar so an app with its own header takes the full pane (no two toolbars).
+//     .hidden getter, .subscribe(cb), and .holdToToggle(el) (long-press an
+//     element — e.g. the app's own logo — to toggle). Sessional; standalone
+//     ignores it. See src/lib/immersive.js + AppCanvas.jsx.
 //   window.mobius.capabilities.available(name, version?)
 //   window.mobius.capabilities.open(name, input)  -> capability session
 //     session.ready, session.result, session.on(event, cb), finish(), cancel()
@@ -75,6 +80,7 @@ import { makeSignal } from './signal.js'
 import { makeChat } from './chat.js'
 import { makeNav, makeSplit } from './navigation.js'
 import { makeCapabilities } from './capabilities.js'
+import { makeImmersive } from './immersive.js'
 import { tokenMatchesRuntime } from './token.js'
 
 export * from './storage.js'
@@ -82,6 +88,7 @@ export * from './signal.js'
 export * from './chat.js'
 export * from './navigation.js'
 export * from './capabilities.js'
+export * from './immersive.js'
 
 
 // ── P1-A: probed-online reactive backing ─────────────────────────────────────
@@ -200,6 +207,7 @@ export function init({ appId, appInstanceId = null, getToken, capabilityContract
     chat: makeChat({ appId, getToken: scopedToken, storage }),
     nav: makeNav(),
     split: makeSplit(),
+    immersive: makeImmersive({ appId }),
   }
   window.mobius = api
   _runtimeContext = { identityKey, tokenRef, storage, signal, capabilities, api }

--- a/frontend/src/sw-cache-policy.js
+++ b/frontend/src/sw-cache-policy.js
@@ -43,7 +43,12 @@ export const SHELL_DATA_CACHE = 'mobius-shell-data'
 // changing the backend header leaves existing devices serving v5 indefinitely
 // on this cache-first route. Activation evicts that response before News (or
 // any other Wasm app) opens under the revised policy.
-export const OFFLINE_APPS_CACHE = 'mobius-offline-apps-v6'
+// Bumped -v6 → -v7 (2026-08-08): a cache-first app frame/module cached before a
+// runtime change keeps serving the OLD bundled runtime indefinitely — a device
+// holding it never sees a new window.mobius capability even after the app is
+// recompiled and the shell restarts. Activation evicts v6 so every client
+// refetches the current versioned module (with the current compiled runtime).
+export const OFFLINE_APPS_CACHE = 'mobius-offline-apps-v7'
 // Bumped -v2 → -v3 (2026-07-30): v2 standalone documents executed app-authored
 // modules directly at owner origin. The secure host now mounts the shared
 // opaque AppCanvas frame; activation must evict every cached v2 document so an


### PR DESCRIPTION
## What changed
- add `window.mobius.immersive` as the app-facing owner of shell bar collapse
- distinguish game-style full bleed from general-app bar collapse that preserves the phone safe-area strip
- keep the helper synchronized with the shell's applied state across app switches and frame promotion
- provide an idempotent hold-to-toggle binding suitable for React callback refs, with full style/listener cleanup
- evict the stale offline app cache so existing devices receive the new runtime

## Why
Apps with their own header otherwise show two stacked toolbars. This gives those apps one shared runtime primitive instead of each app inventing shell coordination, while preserving the existing full-bleed game behavior.

## Verification
- full frontend suite passed (779 structural/unit cases + 79 hook cases)
- runtime, speech runtime, and speech worker generated-output checks passed
- focused immersive/runtime suites passed (49/49)
