### PR TITLE
Stream full thinking live without bounded previews

### DIFF
--- a/backend/app/broadcast.py
+++ b/backend/app/broadcast.py
@@ -160,6 +160,26 @@ class ChatBroadcast:
       self.event_log[-1] = dict(
         prev, content=(prev.get("content") or "") + (event.get("content") or "")
       )
+    elif (
+      event_type == "thinking"
+      and self.event_log
+      and self.event_log[-1].get("type") == "thinking"
+      and self.event_log[-1].get("thinking_id") == event.get("thinking_id")
+      and self.event_log[-1].get("segment_id") == event.get("segment_id")
+      and len(self.event_log[-1].get("content") or "")
+        + len(event.get("content") or "") <= _TEXT_LOG_SEGMENT_MAX
+    ):
+      # Reasoning now streams as deltas like text (the sink no longer blanks it),
+      # so coalesce it in the replay log the same way: merge deltas of the same
+      # thinking segment in place, keeping distinct segments (and distinct
+      # thoughts) as separate entries so a reconnecting client replays the same
+      # paragraph structure. Live subscribers already received each raw delta
+      # below; this only bounds the log so a long thought is a handful of entries
+      # instead of thousands.
+      prev = self.event_log[-1]
+      self.event_log[-1] = dict(
+        prev, content=(prev.get("content") or "") + (event.get("content") or "")
+      )
     elif event_type == "task_progress" and self._coalesce_task_progress(event):
       # The invariant is that the coalescer already appended the newest tick.
       pass

--- a/backend/app/chat_event_sink.py
+++ b/backend/app/chat_event_sink.py
@@ -561,17 +561,14 @@ class ChatEventSink:
     # save is due (immediate for save-triggering types, throttled
     # otherwise).
     accumulated = process_event(event, self.assistant_blocks)
-    if event_type == "thinking" and self.assistant_blocks:
-      thought = self.assistant_blocks[-1]
-      content = str(thought.get("content") or "")
-      if len(content) > THINKING_INLINE_THRESHOLD:
-        # The reducer keeps the full run privately for persistence. The public
-        # event log/SSE gets only stable identity + version after the cutoff;
-        # this crossing event tells the client to discard its <=1KB prefix.
-        event["content"] = ""
-        event["thinking_deferred"] = True
-        event["thinking_revision"] = len(content)
-        event["duration_ms"] = thought.get("duration_ms", 0)
+    # Thinking streams live like answer text: the raw delta goes out on every
+    # event so a connected client appends it token-by-token (see
+    # streamReducers.appendThinkingChunk). We deliberately do NOT blank the delta
+    # past a size cutoff. The broadcaster coalesces thinking in its replay log
+    # the same way it coalesces text (see ChatBroadcast.publish), so the log
+    # stays bounded even as deltas flow; and persistence still stashes the full
+    # trace out-of-band as a deferred sidecar (see _deferred_snapshot), so the
+    # durable transcript stays lean and a reopened thought is fetched on demand.
     # `not self._steering`: a snapshot submitted mid-split would replace the
     # still-trailing pre-steer assistant message (A1) with continuation text
     # before A1 is sealed and the steered user row is appended. The split's

--- a/backend/tests/test_thinking_trace_lazy.py
+++ b/backend/tests/test_thinking_trace_lazy.py
@@ -33,7 +33,7 @@ def test_thinking_stash_is_revision_monotonic(db):
     assert row.complete is True
 
 
-def test_sink_bounds_wire_and_snapshot_after_cutoff(db):
+def test_sink_streams_thinking_live_and_defers_only_persistence(db):
     bus = _Bus()
     sink = _ChatEventSink(bus, "trace-chat", run_token="rt", recall_binding=EMPTY_RECALL_BINDING)
     # Keep this unit test off the periodic transcript path; exercise the
@@ -44,13 +44,18 @@ def test_sink_bounds_wire_and_snapshot_after_cutoff(db):
     sink.publish({"type": "thinking", "content": first, "ts": 1000})
     sink.publish({"type": "thinking", "content": second, "ts": 1100})
 
+    # The live wire streams the raw deltas token-by-token, even past the size
+    # cutoff — never blanked, never flagged deferred. The client appends them the
+    # same way it appends answer-text deltas (the typewriter).
     assert bus.events[0]["content"] == first
-    assert bus.events[1]["content"] == ""
-    assert bus.events[1]["thinking_deferred"] is True
-    assert bus.events[1]["thinking_revision"] == len(first + second)
+    assert bus.events[1]["content"] == second
+    assert "thinking_deferred" not in bus.events[1]
     assert bus.events[0]["thinking_id"] == bus.events[1]["thinking_id"]
     assert sink.assistant_blocks[0]["content"] == first + second
 
+    # Persistence still defers past the cutoff: the durable transcript carries a
+    # bounded reference and the full trace is stashed out-of-band, so the
+    # transcript stays lean and a reopened thought is fetched on demand.
     snapshot, stashes = sink._deferred_snapshot(sink.assistant_blocks)
     block = snapshot["blocks"][0]
     assert "content" not in block
@@ -61,6 +66,24 @@ def test_sink_bounds_wire_and_snapshot_after_cutoff(db):
     get_writer().submit(Barrier()).result(timeout=5)
     row = db.query(models.ThinkingTrace).one()
     assert row.content == first + second
+
+
+def test_broadcast_coalesces_thinking_deltas_in_replay_log():
+    from app.broadcast import ChatBroadcast
+
+    bc = ChatBroadcast("coalesce-chat")
+    # Same thought + same segment: deltas merge into ONE bounded log entry, so a
+    # long thought is a handful of entries instead of thousands on reconnect.
+    bc.publish({"type": "thinking", "content": "aa", "thinking_id": "t1", "segment_id": "s1"})
+    bc.publish({"type": "thinking", "content": "bb", "thinking_id": "t1", "segment_id": "s1"})
+    # A new segment of the same thought stays a separate entry so replayed
+    # reasoning keeps its paragraph breaks.
+    bc.publish({"type": "thinking", "content": "cc", "thinking_id": "t1", "segment_id": "s2"})
+    # A different thought is its own entry.
+    bc.publish({"type": "thinking", "content": "dd", "thinking_id": "t2", "segment_id": "s1"})
+
+    thinking = [e["content"] for e in bc.event_log if e.get("type") == "thinking"]
+    assert thinking == ["aabb", "cc", "dd"]
 
 
 def test_thinking_trace_endpoint_serves_exact_full_text(client, auth, db):

--- a/frontend/src/components/ChatView/ActivityStretch.jsx
+++ b/frontend/src/components/ChatView/ActivityStretch.jsx
@@ -119,24 +119,6 @@ function TimelineThought({ label, thought, chatId, disclosureKey, direct = false
       )}
       <div ref={bodyRef} id={bodyId} className="chat__reasoning-body" hidden={!open}>
         {open && body}
-        {open && loadState === 'ready' && !trace.previewComplete && (
-          <div className="chat__lazy-status chat__reasoning-preview-status">
-            <span>
-              {trace.traceComplete
-                ? 'Showing a bounded preview to keep this chat responsive.'
-                : 'Showing a bounded preview while this thought is in progress.'}
-            </span>
-            {trace.traceComplete && (
-              <button
-                type="button"
-                className="chat__lazy-retry"
-                onClick={trace.loadFull}
-              >
-                Load full thought
-              </button>
-            )}
-          </div>
-        )}
       </div>
     </div>
   )

--- a/frontend/src/components/ChatView/__tests__/thinkingTraceRetry.test.js
+++ b/frontend/src/components/ChatView/__tests__/thinkingTraceRetry.test.js
@@ -27,13 +27,22 @@ test('missing Retry-After falls back to capped exponential backoff', () => {
   assert.equal(pendingTraceRetryDelay(undefined, 8), 5000)
 })
 
-test('thinking expansion is bounded until full content is explicitly requested', () => {
-  assert.match(source, /\+ \(fullRequested \? '' : '&preview=1'\)/)
-  assert.match(source, /loadFull: \(\) => \{\s*setFullRequested\(true\)/)
-  assert.match(source, /setFullRequested\(false\)[\s\S]*setRefreshNonce/,
-    'a growing live trace returns to previews instead of repeatedly loading full text')
+test('an open thought shows its full text and never blanks', () => {
+  // No bounded preview and no exact-revision pin: pull the whole trace the
+  // server has now, so there is never a "bounded preview" and a live thought
+  // cannot hang on "Loading…" waiting for a revision the server hasn't written.
+  assert.doesNotMatch(source, /preview=1/, 'no bounded-preview fetch')
+  assert.doesNotMatch(source, /[?&]revision=/, 'no exact-revision pin that could 202-hang')
+  assert.doesNotMatch(source, /loadFull/, 'full is the default; no explicit full-load step')
+  assert.match(source, /thinking-trace\/\$\{encodeURIComponent\(thought\.thinking_id\)\}/)
+  // Inline bridge + honest load state keep text on screen across the
+  // inline->deferred crossover and through background re-fetches / failures.
+  assert.match(source, /bridgeRef\.current = thought\.content/,
+    'captures the inline prefix before the server defers the thought')
+  assert.match(source, /loadedContent \|\| bridgeRef\.current/,
+    'shows the bridge until the first full fetch lands')
+  assert.match(source, /loadState: content \? 'ready' : loadState/,
+    'a re-fetch or transient failure never blanks text already on screen')
   assert.match(source, /if \(!open && deferred\) \{[\s\S]*setLoadedContent\(''\)/,
-    'closing the thought releases its loaded payload')
-  assert.match(source, /traceComplete \|\| !!thought\.thinking_complete/,
-    'final promotion unlocks explicit full loading without a background completion fetch')
+    'closing drops the fetched copy — no persistent local copy')
 })

--- a/frontend/src/components/ChatView/useThinkingTrace.js
+++ b/frontend/src/components/ChatView/useThinkingTrace.js
@@ -8,23 +8,34 @@ export {
   pendingSidecarRetryDelay as pendingTraceRetryDelay,
 } from './lazySidecar.js'
 
-/** Fetch a deferred thought only while its own nested disclosure is open.
- * Closing aborts in-flight work and releases the loaded string from memory. */
+/** Fetch a deferred thought's FULL text while its disclosure is open.
+ *
+ * The server keeps the whole thought; the browser only pulls it when you open
+ * the block, and drops it on close. There is deliberately no bounded preview
+ * and no persistent local copy: expanding shows the complete reasoning, and a
+ * thought that is still streaming re-fetches as it grows so you watch it fill
+ * in live. The text on screen never blanks — a thought that crosses the inline
+ * threshold while open keeps its last inline text as a bridge until the first
+ * fetch lands, and a failed/lagging fetch keeps whatever is already shown. */
 export function useThinkingTrace({ open, thought, chatId }) {
   const deferred = !!thought.thinking_deferred
   const [loadedContent, setLoadedContent] = useState('')
   const [loadState, setLoadState] = useState('idle')
-  const [previewComplete, setPreviewComplete] = useState(true)
-  const [traceComplete, setTraceComplete] = useState(false)
-  const [fullRequested, setFullRequested] = useState(false)
   const [refreshNonce, setRefreshNonce] = useState(0)
   const revisionRef = useRef(Number(thought.thinking_revision) || 0)
   revisionRef.current = Number(thought.thinking_revision) || 0
   const debouncedRevisionRef = useRef(revisionRef.current)
 
-  // Reasoning metadata can update once per token. Restarting a GET on every
-  // revision creates an abort/request storm, so only schedule a refresh after
-  // the stream has been quiet for a moment. Opening still fetches immediately.
+  // The last inline text seen before the server deferred this thought (it strips
+  // the inline copy at the ~1KB cutoff). Held so a thought that crosses that
+  // cutoff WHILE OPEN keeps its text on screen instead of blanking to a spinner
+  // until the first full fetch resolves.
+  const bridgeRef = useRef('')
+  if (!deferred && thought.content) bridgeRef.current = thought.content
+
+  // Reasoning metadata can bump once per token. A live thought re-fetches as it
+  // grows so you see it stream, but only after a short quiet window so a burst
+  // of tokens is one fetch, not dozens. Opening fetches immediately.
   useEffect(() => {
     if (!open || !deferred) {
       debouncedRevisionRef.current = revisionRef.current
@@ -32,13 +43,7 @@ export function useThinkingTrace({ open, thought, chatId }) {
     }
     if (debouncedRevisionRef.current === revisionRef.current) return
     debouncedRevisionRef.current = revisionRef.current
-    const timer = setTimeout(() => {
-      // A live trace that changes after an explicit full load returns to the
-      // bounded preview. Otherwise each token burst would redownload the full
-      // growing Markdown payload.
-      setFullRequested(false)
-      setRefreshNonce(value => value + 1)
-    }, 450)
+    const timer = setTimeout(() => setRefreshNonce(value => value + 1), 350)
     return () => clearTimeout(timer)
   }, [open, deferred, thought.thinking_revision])
 
@@ -47,61 +52,50 @@ export function useThinkingTrace({ open, thought, chatId }) {
       if (!open && deferred) {
         setLoadedContent('')
         setLoadState('idle')
-        setPreviewComplete(true)
-        setTraceComplete(false)
-        setFullRequested(false)
       }
       return
     }
     const controller = new AbortController()
     let cancelled = false
+    // Fetch the FULL current trace. No `preview` (never a bounded preview) and
+    // no `revision` pin: asking for an exact revision the server has not written
+    // yet returns 202 and makes a live thought hang on "Loading…", so instead
+    // take whatever is stored now — the next revision bump re-fetches to catch
+    // up.
     const url = `/chats/${chatId}/thinking-trace/${encodeURIComponent(thought.thinking_id)}`
-      + `?revision=${revisionRef.current}`
-      + (fullRequested ? '' : '&preview=1')
 
     setLoadState('loading')
     fetchLazyText(url, { signal: controller.signal })
-      .then(({ response, text }) => {
+      .then(({ text }) => {
         if (!cancelled) {
           setLoadedContent(text)
-          setPreviewComplete(
-            fullRequested
-            || response.headers.get('X-Thinking-Preview-Complete') !== '0',
-          )
-          setTraceComplete(response.headers.get('X-Thinking-Complete') === '1')
           setLoadState('ready')
         }
       })
       .catch(error => {
+        // Keep whatever is already on screen (the bridge or a prior fetch) and
+        // let the next revision re-fetch recover; a hard error only surfaces on
+        // a cold load with nothing to show (see the honest loadState below).
         if (!cancelled && error?.name !== 'AbortError') setLoadState('failed')
       })
     return () => {
       cancelled = true
       controller.abort()
     }
-  }, [open, deferred, chatId, thought.thinking_id, fullRequested, refreshNonce])
+  }, [open, deferred, chatId, thought.thinking_id, refreshNonce])
 
-  const content = deferred ? loadedContent : (thought.content || '')
+  const content = deferred
+    ? (loadedContent || bridgeRef.current || '')
+    : (thought.content || '')
+
   return {
     content,
-    // A deferred thought re-fetches while it is still streaming (a debounced
-    // reload on every revision burst) and again on "Load full thought", and each
-    // reload flips the internal state back to 'loading' even though the text is
-    // still in hand. Surfacing that would blank an expanded, in-progress thought
-    // and flash "Loading…" on every token. The spinner and error only make sense
-    // on a COLD load, so once there is content the effective state is 'ready'.
+    // Honest state: once there is any text to show (a fresh fetch OR the inline
+    // bridge), we are 'ready'. The spinner and the error/retry are only for a
+    // cold load with nothing on screen, so a background re-fetch (or a transient
+    // failure) never blanks a thought you are reading.
     loadState: content ? 'ready' : loadState,
-    previewComplete: !deferred || previewComplete,
-    // Persisted snapshots carry this flag, and final live-stream promotion
-    // stamps it locally. This makes the explicit full-load action available
-    // at completion without another request; the payload remains lazy.
-    traceComplete: !deferred || traceComplete || !!thought.thinking_complete,
-    loadFull: () => {
-      setFullRequested(true)
-      setLoadState('loading')
-    },
     retry: () => {
-      setLoadedContent('')
       setLoadState('loading')
       setRefreshNonce(value => value + 1)
     },

--- a/tests/activity-lazy.spec.mjs
+++ b/tests/activity-lazy.spec.mjs
@@ -384,8 +384,8 @@ test('activity stays nested and lazy, aborts on close, and copies exact tool out
   const toolUseId = 'tool-ui-contract'
   const excerpt = 'EXCERPT_SENTINEL: bounded output already on the transcript'
   const fullOutput = 'FULL_OUTPUT_SENTINEL: lazily fetched command output'
-  const thoughtPreview = 'THINKING_PREVIEW_SENTINEL: bounded reasoning preview'
-  const thoughtText = `${thoughtPreview}\nTHINKING_FULL_SENTINEL: explicit full trace`
+  const thoughtPreview = 'THINKING_PREFIX_SENTINEL: start of reasoning'
+  const thoughtText = `${thoughtPreview}\nTHINKING_FULL_SENTINEL: complete trace`
   const blocks = [
     {
       type: 'thinking',
@@ -431,13 +431,7 @@ test('activity stays nested and lazy, aborts on close, and copies exact tool out
     route.fulfill({ status: 204, body: '' }))
 
   let thinkingRequests = 0
-  let thinkingFullRequests = 0
   await page.route(new RegExp(`/api/chats/${chat.id}/thinking-trace/${thinkingId}`), route => {
-    const preview = new URL(route.request().url()).searchParams.get('preview') === '1'
-    if (!preview) {
-      thinkingFullRequests += 1
-      return route.fulfill({ status: 200, contentType: 'text/plain', body: thoughtText })
-    }
     thinkingRequests += 1
     if (thinkingRequests === 3) {
       return route.fulfill({ status: 503, contentType: 'text/plain', body: 'offline' })
@@ -445,11 +439,7 @@ test('activity stays nested and lazy, aborts on close, and copies exact tool out
     return route.fulfill({
       status: 200,
       contentType: 'text/plain',
-      headers: {
-        'X-Thinking-Complete': '1',
-        'X-Thinking-Preview-Complete': '0',
-      },
-      body: thoughtPreview,
+      body: thoughtText,
     })
   })
 
@@ -506,7 +496,6 @@ test('activity stays nested and lazy, aborts on close, and copies exact tool out
   await expect(activity.locator(`[id="${timelineId}"]`)).toHaveCount(1)
   await page.waitForTimeout(250)
   expect(thinkingRequests).toBe(0)
-  expect(thinkingFullRequests).toBe(0)
   expect(toolPreviewRequests).toBe(0)
   expect(toolCopyRequests).toBe(0)
 
@@ -520,7 +509,6 @@ test('activity stays nested and lazy, aborts on close, and copies exact tool out
   await expect(toolToggle).toHaveAttribute('aria-expanded', 'false')
   await expect(toolToggle).toHaveAttribute('aria-controls', /.+/)
   expect(thinkingRequests).toBe(0)
-  expect(thinkingFullRequests).toBe(0)
   expect(toolPreviewRequests).toBe(0)
   expect(toolCopyRequests).toBe(0)
   for (const toggle of [thoughtToggle, toolToggle]) {
@@ -550,12 +538,8 @@ test('activity stays nested and lazy, aborts on close, and copies exact tool out
   }
 
   await thoughtToggle.click()
-  await expect(page.locator('[data-chat-surface="painted"]').getByText(thoughtPreview)).toBeVisible()
-  expect(thinkingRequests).toBe(1)
-  await expect(page.locator('[data-chat-surface="painted"]').getByText('THINKING_FULL_SENTINEL', { exact: false })).toHaveCount(0)
-  await page.getByRole('button', { name: 'Load full thought' }).click()
   await expect(page.locator('[data-chat-surface="painted"]').getByText('THINKING_FULL_SENTINEL', { exact: false })).toBeVisible()
-  expect(thinkingFullRequests).toBe(1)
+  expect(thinkingRequests).toBe(1)
   await thoughtToggle.click()
   await expect(page.locator('[data-chat-surface="painted"]').getByText(thoughtPreview)).toHaveCount(0)
   await thoughtToggle.click()
@@ -632,7 +616,6 @@ test('activity stays nested and lazy, aborts on close, and copies exact tool out
   await expect(activity.locator('.chat__tool-header')).toHaveAttribute('aria-expanded', 'true')
   await expect(page.locator('[data-chat-surface="painted"]').getByText(fullOutput)).toBeVisible()
   expect(thinkingRequests).toBe(4)
-  expect(thinkingFullRequests).toBe(1)
   expect(toolPreviewRequests).toBe(6)
   expect(toolCopyRequests).toBe(0)
 })


### PR DESCRIPTION
## What changed
- stream live thinking deltas over the wire instead of blanking them past the persistence cutoff
- coalesce deltas by thought segment in the reconnect replay log
- keep durable transcripts lean by retaining the existing deferred sidecar persistence
- fetch the complete current trace whenever its disclosure is open
- remove bounded-preview, explicit-full-load, and exact-revision states
- preserve already-visible text across the inline-to-deferred crossover and transient refetch failures
- update the browser contract to require a full thought on first expansion and retain retry/abort coverage

## Verification
- thinking backend suite: 6/6 passed
- thinking browser unit suite: 3/3 passed
- end-to-end lazy-activity contract updated for full-first expansion
- full PR backend, frontend-unit, and browser checks passed before the clean rebase
- `git diff --check`
