### PR TITLE
Surface the baked-platform fallback instead of running silently

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,10 +3,11 @@ import { PersistQueryClientProvider } from '@tanstack/react-query-persist-client
 import { QueryClientProvider, useIsRestoring } from '@tanstack/react-query'
 import ErrorBoundary from './components/ErrorBoundary/ErrorBoundary.jsx'
 import RecoveryLink from './components/ErrorBoundary/RecoveryLink.jsx'
+import PlatformDegradedNotice from './components/ErrorBoundary/PlatformDegradedNotice.jsx'
 import './components/ErrorBoundary/RecoveryPanel.css'
 import { api, beginEphemeralAuth, getToken, setToken, BASE } from './api/client.js'
 import * as setupSession from './lib/setupSession.js'
-import { setupQueries } from './hooks/queries.js'
+import { setupQueries, versionQueries } from './hooks/queries.js'
 import { queryClient, persistOptions } from './queryClient.js'
 import { shellReload } from './lib/shellReloadState.js'
 import { beginEmbedBootstrap } from './lib/chatEmbedBootstrap.js'
@@ -118,8 +119,19 @@ function AppRoot() {
                 ? 'sso'
                 : (ssoSignal === 'error' ? 'sso-error' : 'loading'))))
   const [status, setStatus] = useState(initialStatus)
+  // "Continue to the built-in version" hides the notice for THIS mount so the
+  // owner can use the working fallback. Deliberately not persisted: any reload
+  // re-surfaces it while the platform is still degraded, so it never hides.
+  const [degradedDismissed, setDegradedDismissed] = useState(false)
   const setupStatusQuery = setupQueries.status.useQuery({
     enabled: !hasToken && !ssoSignal && status !== 'install-pass',
+  })
+  // `/api/version` already owns the identity of the tree actually being served
+  // (`platform` vs the image-baked floor). Read it once the authenticated shell
+  // is selected instead of repurposing the setup-status request: managed SSO
+  // handoff deliberately skips that separate account-setup path.
+  const servedVersionQuery = versionQueries.current.useQuery({
+    enabled: hasToken && status === 'shell' && !STANDALONE_APP,
   })
   useEffect(() => {
     if (installPass && hasToken) clearInstallPassFromUrl()
@@ -298,6 +310,18 @@ function AppRoot() {
       }} />
     </Suspense>
   )
+  // The platform failed to import and we are serving the built-in copy. Surface
+  // it before the shell instead of running silently; "Continue" dismisses to the
+  // working fallback. Shell only (a standalone mini-app is not the repair owner).
+  if (
+    hasToken &&
+    status === 'shell' &&
+    !STANDALONE_APP &&
+    servedVersionQuery.data?.serving_source === 'baked' &&
+    !degradedDismissed
+  ) {
+    return <PlatformDegradedNotice onContinue={() => setDegradedDismissed(true)} />
+  }
   return (
     <Suspense fallback={<RouteLoading />}>
       {STANDALONE_APP

--- a/frontend/src/components/ErrorBoundary/ErrorBoundary.css
+++ b/frontend/src/components/ErrorBoundary/ErrorBoundary.css
@@ -51,3 +51,40 @@
 .errbound__updating-text {
   outline: none;
 }
+
+/* Platform-degraded notice: stack the shared recovery card with a quiet
+   "continue" affordance. The built-in copy still works, so dismissing to keep
+   using it is a legitimate, low-emphasis choice. */
+.platform-degraded {
+  margin: auto;
+  width: 100%;
+  max-width: 28rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+}
+
+.platform-degraded .errbound__card {
+  margin: 0;
+}
+
+.platform-degraded__continue {
+  background: none;
+  border: none;
+  padding: 6px 8px;
+  color: var(--text-muted, rgba(236, 236, 236, 0.72));
+  font: inherit;
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.platform-degraded__continue:hover {
+  color: var(--text, #ececec);
+}
+
+.platform-degraded__continue:focus-visible {
+  outline: 2px solid var(--focus, #4a9eff);
+  outline-offset: 2px;
+  border-radius: 4px;
+}

--- a/frontend/src/components/ErrorBoundary/PlatformDegradedNotice.jsx
+++ b/frontend/src/components/ErrorBoundary/PlatformDegradedNotice.jsx
@@ -1,0 +1,103 @@
+import { useState } from 'react'
+import { api, BASE } from '../../api/client.js'
+import {
+  errorRecoveryFingerprint,
+  readErrorRecoveryAttempt,
+  runAgentRepair,
+  writeRefreshedRecoveryAttempt,
+} from '../../lib/errorRecovery.js'
+import RecoveryPanel from './RecoveryPanel.jsx'
+import './ErrorBoundary.css'
+
+// The backend reports `platform_degraded` when the entrypoint is serving the
+// image-baked floor because /data/platform failed to import. The app still
+// works (it is the built-in copy), so this is not a crash — but it must not run
+// silently. We surface the SAME refresh -> ask-agent recovery flow the error
+// boundary uses, driven by the shared errorRecovery ledger, rather than a
+// parallel popup. A fixed surface key gives the refresh->agent escalation a
+// stable identity across reloads without a component stack to fingerprint.
+const SURFACE_KEY = 'platform-degraded'
+const FINGERPRINT = errorRecoveryFingerprint(SURFACE_KEY, 'platform-degraded', '')
+const DIAGNOSTIC =
+  'Möbius is serving the built-in version because your latest changes to ' +
+  '/data/platform did not load. Your edits are preserved on disk but are not ' +
+  'running.'
+
+// Not a UI crash, so buildAgentRepairPrompt (which frames a React failure with a
+// component stack) does not fit. Tell the agent the real situation instead.
+const REPAIR_PROMPT = [
+  'Möbius is running the built-in fallback because /data/platform failed to ' +
+    'import at boot, so the latest edits are on disk but are not being served.',
+  '',
+  'Reproduce the import failure from the served backend, read the relevant ' +
+    'boot/container logs, find the root cause in /data/platform, and implement ' +
+    'a targeted fix so the normal platform serves again.',
+  '',
+  'Preserve the edits and all data. Do not reset or restore the platform unless ' +
+    'ordinary diagnosis and a targeted fix cannot make progress. The app must be ' +
+    'restarted to pick up the repaired tree.',
+].join('\n')
+
+export default function PlatformDegradedNotice({ onContinue }) {
+  const [attempt, setAttempt] = useState(() =>
+    readErrorRecoveryAttempt({ surfaceKey: SURFACE_KEY, fingerprint: FINGERPRINT }),
+  )
+  const [repairActive, setRepairActive] = useState(false)
+
+  const handleRefresh = () => {
+    // Record the refresh so a still-degraded reload escalates to "ask agent",
+    // exactly like the error boundary's manual refresh.
+    writeRefreshedRecoveryAttempt({ surfaceKey: SURFACE_KEY, fingerprint: FINGERPRINT })
+    try { sessionStorage.setItem('shell-reload', '1') } catch { /* ignore */ }
+    window.location.reload()
+  }
+
+  const handleAgentRepair = async () => {
+    if (repairActive) return
+    setRepairActive(true)
+    try {
+      const result = await runAgentRepair({
+        client: api,
+        base: BASE,
+        surfaceKey: SURFACE_KEY,
+        fingerprint: FINGERPRINT,
+        previousAttempt: attempt,
+        onAttempt: setAttempt,
+        prompt: REPAIR_PROMPT,
+      })
+      window.location.assign(result.path)
+    } catch (error) {
+      if (error?.name === 'AbortError') return
+    } finally {
+      setRepairActive(false)
+    }
+  }
+
+  return (
+    <div className="errbound">
+      <div className="platform-degraded">
+        <RecoveryPanel
+          variant="boundary"
+          className="errbound__card"
+          title="Your latest changes didn’t load"
+          subject="app"
+          diagnostic={DIAGNOSTIC}
+          attempt={attempt}
+          repairActive={repairActive}
+          refreshLabel="Refresh"
+          onRefresh={handleRefresh}
+          onAgentRepair={handleAgentRepair}
+        />
+        {onContinue && (
+          <button
+            type="button"
+            className="platform-degraded__continue"
+            onClick={onContinue}
+          >
+            Continue to the built-in version
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## What changed
- read the already-authoritative `/api/version` serving identity when the authenticated shell starts
- show the shared refresh → repair-chat recovery flow when the entrypoint is serving the image-baked floor
- let the owner continue into the working built-in version for the current mount
- resurface the notice on every reload while the live platform still fails
- preserve the managed-SSO fast path: it still skips the separate account-setup request

## Why
The entrypoint deliberately keeps Möbius reachable by falling back to the image-baked platform when `/data/platform` cannot import. That fallback was silent, so the owner could unknowingly run the older built-in tree while their edits sat unused. This makes the degraded state visible and sends repair through the existing recovery owner without creating a second backend identity mechanism.

## Verification
- frontend lint: 0 errors (existing warning budget unchanged)
- existing version tests already pin `serving_source=baked`
- `git diff --check`
