### PR TITLE
Fix empty model selection in chat picker

### DIFF
--- a/frontend/src/components/ChatView/ChatSettingsPanel.css
+++ b/frontend/src/components/ChatView/ChatSettingsPanel.css
@@ -97,6 +97,17 @@
   }
 }
 
+/* The selected provider-default row is state, not another choice. */
+.csp-row--static {
+  cursor: default;
+}
+@media (hover: hover) and (pointer: fine) {
+  .csp-row--static:hover,
+  .csp-row--selected.csp-row--static:hover {
+    background: color-mix(in srgb, var(--accent) 9%, var(--surface));
+  }
+}
+
 .csp-row--locked {
   opacity: 0.4;
   cursor: not-allowed;

--- a/frontend/src/components/ChatView/ChatSettingsPanel.jsx
+++ b/frontend/src/components/ChatView/ChatSettingsPanel.jsx
@@ -630,7 +630,12 @@ export default function ChatSettingsPanel({
   }, [registry, hiddenIds, selectedModel, selectedProvider, draftModel, draftProvider])
 
   const currentProviderConfigured = availability.configuredProviders.has(draftProvider)
-  const currentProviderLabel = PROVIDER_INFO[draftProvider]?.label || draftProvider
+  const currentProviderInfo = PROVIDER_INFO[draftProvider]
+  const currentProviderLabel = currentProviderInfo?.label || draftProvider
+  // A chat can deliberately have no model override: the provider then chooses
+  // its own default. Keep that real state selected in the picker instead of
+  // making every explicit model row look inactive.
+  const usesProviderDefault = !selectedModel
 
   return (
     <div className="csp">
@@ -689,6 +694,33 @@ export default function ChatSettingsPanel({
                 : `${currentProviderLabel} isn’t connected. Connect a provider in Settings.`}
             </span>
           </div>
+      )}
+      {dataReady && usesProviderDefault && currentProviderInfo && (
+        <div className="csp__default-model">
+          <div
+            className="csp-row csp-row--selected csp-row--static"
+            aria-label={`Using ${currentProviderLabel}'s default model`}
+          >
+            <span className="csp-row__icon"><currentProviderInfo.Logo /></span>
+            <span className="csp-row__main">
+              <span className="csp-row__title">
+                <span>{currentProviderLabel} default model</span>
+              </span>
+              <span className="csp-row__sub">
+                No specific model is pinned for this chat
+              </span>
+            </span>
+            <span className="csp-row__dot" aria-hidden="true" />
+          </div>
+          <div className="csp-effort-indent">
+            <EffortStepper
+              efforts={currentProviderInfo.efforts}
+              value={draftEffort}
+              onChange={handleEffortChange}
+              disabled={switchBusy || !currentProviderConfigured}
+            />
+          </div>
+        </div>
       )}
       {dataReady && PROVIDER_ORDER.map(pid => {
         const info = PROVIDER_INFO[pid]


### PR DESCRIPTION
## Summary
- Show a selected provider-default state when a chat has no model pinned.
- Explain that state without claiming a specific model is running.

## Testing
- `npm run lint -- --quiet`
- `npm run build`