### PR TITLE
Soften single-pane Builder tab entry

### DIFF
--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -3256,6 +3256,7 @@ export default function Shell() {
           // a tab out with ≥2 tabs present splits the pane.
           data-pane-strip={workspace.focusedPaneId}
           data-mode-pane-vt={navViewStyle ? navPaneId : undefined}
+          data-mode-strip-soft-entry=""
           style={navViewStyle || undefined}
           onKeyDown={(e) => stripKeyDown(e, openTabs, (tab) => closeTab(tab))}
         >

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -641,6 +641,10 @@ test('pane surfaces and strips are captured individually; dividers remain outsid
   // Exit snapshots must also paint during the browser's pre-ready interval.
   assert.match(css, /html\[data-mode-view-transition="exit"\]::view-transition-new\(\*\)\s*,[\s\S]*?html\[data-mode-view-transition="exit"\]::view-transition-old\(\*\)\s*\{\s*opacity: 1;/)
   assert.match(css, /html\[data-mode-view-transition="exit"\]::view-transition-old\(mode-workspace\),[\s\S]*?mode-navigation-drawer\)\s*\{\s*opacity: 0;/)
+  assert.match(shell, /data-mode-strip-soft-entry=""/)
+  assert.match(modeViewTransitionSrc, /softEntry: element\.hasAttribute\('data-mode-strip-soft-entry'\)/)
+  assert.match(modeViewTransitionSrc, /const softStripEntering = direction === 'enter' && softEntry/)
+  assert.match(modeViewTransitionSrc, /softStripEntering[\s\S]*?opacity: 0, transform: 'translate3d\(0, 12px, 0\)'[\s\S]*?offset: 0\.55/)
 })
 
 test('navigation is a stationary foreground capture above travelling panes', () => {

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -641,10 +641,6 @@ test('pane surfaces and strips are captured individually; dividers remain outsid
   // Exit snapshots must also paint during the browser's pre-ready interval.
   assert.match(css, /html\[data-mode-view-transition="exit"\]::view-transition-new\(\*\)\s*,[\s\S]*?html\[data-mode-view-transition="exit"\]::view-transition-old\(\*\)\s*\{\s*opacity: 1;/)
   assert.match(css, /html\[data-mode-view-transition="exit"\]::view-transition-old\(mode-workspace\),[\s\S]*?mode-navigation-drawer\)\s*\{\s*opacity: 0;/)
-  assert.match(shell, /data-mode-strip-soft-entry=""/)
-  assert.match(modeViewTransitionSrc, /softEntry: element\.hasAttribute\('data-mode-strip-soft-entry'\)/)
-  assert.match(modeViewTransitionSrc, /const softStripEntering = direction === 'enter' && softEntry/)
-  assert.match(modeViewTransitionSrc, /softStripEntering[\s\S]*?opacity: 0, transform: 'translate3d\(0, 12px, 0\)'[\s\S]*?offset: 0\.55/)
 })
 
 test('navigation is a stationary foreground capture above travelling panes', () => {

--- a/frontend/src/components/Shell/useModeViewTransition.js
+++ b/frontend/src/components/Shell/useModeViewTransition.js
@@ -36,7 +36,12 @@ function participantSnapshots(root, offsets) {
     if (!offset) continue
     const name = getComputedStyle(element).viewTransitionName
     if (!name || name === 'none') continue
-    out.push({ name, offset })
+    out.push({
+      name,
+      offset,
+      // Tiled strips stay attached to pane travel; only the single strip opts in.
+      softEntry: element.hasAttribute('data-mode-strip-soft-entry'),
+    })
   }
   return out
 }
@@ -167,14 +172,31 @@ export default function useModeViewTransition({ rootRef, durationMs }) {
         ))
       }
       const paneSide = direction === 'enter' ? 'new' : 'old'
-      for (const { name, offset } of snapshots) {
+      for (const { name, offset, softEntry } of snapshots) {
         const away = `translate3d(${offset.x}px, ${offset.y}px, 0)`
+        const softStripEntering = direction === 'enter' && softEntry
+        let keyframes
+        if (softStripEntering) {
+          keyframes = [
+            { opacity: 0, transform: 'translate3d(0, 12px, 0)', offset: 0 },
+            { opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 0.55 },
+            { opacity: 1, transform: 'translate3d(0, 0, 0)', offset: 1 },
+          ]
+        } else if (direction === 'enter') {
+          keyframes = [
+            { opacity: 1, transform: away },
+            { opacity: 1, transform: 'translate3d(0, 0, 0)' },
+          ]
+        } else {
+          keyframes = [
+            { opacity: 1, transform: 'translate3d(0, 0, 0)' },
+            { opacity: 1, transform: away },
+          ]
+        }
         animations.push(animatePseudo(
           html,
           `::view-transition-${paneSide}(${name})`,
-          direction === 'enter'
-            ? [{ opacity: 1, transform: away }, { opacity: 1, transform: 'translate3d(0, 0, 0)' }]
-            : [{ opacity: 1, transform: 'translate3d(0, 0, 0)' }, { opacity: 1, transform: away }],
+          keyframes,
           timing,
           startTime,
         ))


### PR DESCRIPTION
## Summary
- Give the one-pane Builder tab strip a gentle fade-and-rise entrance.
- Keep multi-pane strips tied to their existing pane motion.

## Testing
- Ran the focused workspace transition test suite.