### PR TITLE
Budget crash-loop recovery by volume capacity

### DIFF
--- a/backend/app/browser_profiles.py
+++ b/backend/app/browser_profiles.py
@@ -246,6 +246,7 @@ def enforce_browser_profile_quota(
   low_water_bytes: int | None = None,
   inactive_days: int | None = None,
   active_profile_names: set[str] | None = None,
+  cache_only: bool = False,
 ) -> dict:
   """Prune caches, then inactive chat profiles to honor the byte budget.
 
@@ -255,6 +256,10 @@ def enforce_browser_profile_quota(
   mark, the oldest remaining inactive chat profiles yield too. Live sessions
   never do, and deliberately named sessions retain their full inactivity grace.
   Any protected overage is reported rather than mislabelled as reclaimed.
+
+  ``cache_only`` applies the same active-profile protection for a volume
+  admission check, but never removes a whole profile even if durable session
+  state keeps the root above the requested low-water mark.
   """
   root = Path(data_dir) / "agent-browser-profiles"
   now = now or datetime.now(UTC).replace(tzinfo=None)
@@ -363,7 +368,7 @@ def enforce_browser_profile_quota(
       if total <= low_water_bytes:
         break
 
-    if total > low_water_bytes:
+    if total > low_water_bytes and not cache_only:
       for profile in profile_candidates:
         if not profile["path"].exists():
           continue

--- a/backend/app/data_volume.py
+++ b/backend/app/data_volume.py
@@ -1,0 +1,494 @@
+"""Capacity-aware observation and crash-loop retention for ``/data``.
+
+The live platform tree and its newest crash-loop quarantine are durable owner
+state.  This module keeps those invariants at the point where a second platform
+tree would be admitted, while treating browser caches and older redundant
+quarantines as reclaimable in that order.
+
+Normal health reads consume a cached, bounded top-level scan.  The only exact
+recursive scans are on the crash-loop path, where underestimating a clone would
+be unsafe and the work happens before the live tree is moved.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import sys
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Callable
+
+
+MIB = 1024 * 1024
+GIB = 1024 * MIB
+_STATUS_RELATIVE = Path("run/data-volume-status.json")
+_RECOVERY_PREFIX = "platform.crashloop-prev."
+_DEFAULT_BREAKDOWN_SECONDS = 2.0
+_DEFAULT_BREAKDOWN_ENTRIES = 200_000
+_DEFAULT_TOP_LEVEL_ENTRIES = 256
+
+
+def _allocated_bytes(stat_result: os.stat_result) -> int:
+  blocks = getattr(stat_result, "st_blocks", None)
+  if blocks is not None:
+    return int(blocks) * 512
+  return int(stat_result.st_size)
+
+
+def _raise_walk_error(error: OSError) -> None:
+  raise error
+
+
+def _tree_allocated_bytes(
+  path: Path,
+  *,
+  deadline: float | None = None,
+  remaining_entries: list[int] | None = None,
+) -> tuple[int, bool]:
+  """Count allocated bytes exactly, or return a bounded lower estimate."""
+  def exhausted() -> bool:
+    return (
+      (deadline is not None and time.monotonic() >= deadline)
+      or (remaining_entries is not None and remaining_entries[0] <= 0)
+    )
+
+  total = _allocated_bytes(path.lstat())
+  if remaining_entries is not None:
+    remaining_entries[0] -= 1
+  if path.is_symlink() or not path.is_dir():
+    return total, True
+  for current, dirnames, filenames in os.walk(
+    path, followlinks=False, onerror=_raise_walk_error,
+  ):
+    if exhausted():
+      return total, False
+    current_path = Path(current)
+    kept_dirs = []
+    for name in dirnames:
+      if exhausted():
+        return total, False
+      child = current_path / name
+      total += _allocated_bytes(child.lstat())
+      if remaining_entries is not None:
+        remaining_entries[0] -= 1
+      if not child.is_symlink():
+        kept_dirs.append(name)
+    dirnames[:] = kept_dirs
+    for name in filenames:
+      if exhausted():
+        return total, False
+      total += _allocated_bytes((current_path / name).lstat())
+      if remaining_entries is not None:
+        remaining_entries[0] -= 1
+  return total, True
+
+
+def exact_tree_allocated_bytes(path: str | Path) -> int:
+  """Return allocated bytes without following symlinks; fail on unreadable data."""
+  total, _complete = _tree_allocated_bytes(Path(path))
+  return total
+
+
+def _disk_dict(data_dir: Path, disk_usage: Callable = shutil.disk_usage) -> dict:
+  usage = disk_usage(data_dir)
+  return {
+    "path": str(data_dir),
+    "total_bytes": int(usage.total),
+    "used_bytes": int(usage.used),
+    "free_bytes": int(usage.free),
+  }
+
+
+def data_volume_snapshot(
+  data_dir: str | Path,
+  *,
+  disk_usage: Callable = shutil.disk_usage,
+  time_budget_seconds: float = _DEFAULT_BREAKDOWN_SECONDS,
+  entry_budget: int = _DEFAULT_BREAKDOWN_ENTRIES,
+  top_level_budget: int = _DEFAULT_TOP_LEVEL_ENTRIES,
+) -> dict[str, Any]:
+  """Capture capacity plus a bounded top-level allocated-byte breakdown."""
+  root = Path(data_dir)
+  deadline = time.monotonic() + max(0.01, time_budget_seconds)
+  remaining_entries = max(1, entry_budget)
+  entries = []
+  complete = True
+  try:
+    children = sorted(root.iterdir(), key=lambda child: child.name)
+  except OSError:
+    children = []
+    complete = False
+  omitted_top_level = max(0, len(children) - top_level_budget)
+  children = children[:top_level_budget]
+  complete = complete and omitted_top_level == 0
+  for index, child in enumerate(children):
+    now = time.monotonic()
+    if now >= deadline or remaining_entries <= 0:
+      complete = False
+      entries.extend({
+        "name": pending.name,
+        "bytes": None,
+        "complete": False,
+      } for pending in children[index:])
+      break
+    remaining_children = len(children) - index
+    child_entry_budget = max(1, remaining_entries // remaining_children)
+    child_entries = [child_entry_budget]
+    child_deadline = min(
+      deadline,
+      now + max(0.005, (deadline - now) / remaining_children),
+    )
+    try:
+      size, child_complete = _tree_allocated_bytes(
+        child,
+        deadline=child_deadline,
+        remaining_entries=child_entries,
+      )
+    except OSError:
+      size, child_complete = None, False
+    remaining_entries -= child_entry_budget - max(0, child_entries[0])
+    entries.append({
+      "name": child.name,
+      "bytes": size,
+      "complete": child_complete,
+    })
+    complete = complete and child_complete
+  entries.sort(key=lambda entry: (
+    entry["bytes"] is None,
+    -(entry["bytes"] or 0),
+    entry["name"],
+  ))
+  return {
+    "captured_at": datetime.now(UTC).isoformat(),
+    "capacity": _disk_dict(root, disk_usage),
+    "top_level": {
+      "entries": entries,
+      "complete": complete,
+      "entry_budget": entry_budget,
+      "top_level_budget": top_level_budget,
+      "omitted_top_level": omitted_top_level,
+      "time_budget_seconds": time_budget_seconds,
+    },
+  }
+
+
+def _write_json_atomic(path: Path, value: dict[str, Any]) -> None:
+  temp = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+  temp.write_text(json.dumps(value, sort_keys=True) + "\n", encoding="utf-8")
+  os.replace(temp, path)
+
+
+def _status_path(data_dir: str | Path) -> Path:
+  return Path(data_dir) / _STATUS_RELATIVE
+
+
+def refresh_data_volume_status(data_dir: str | Path) -> dict[str, Any]:
+  snapshot = data_volume_snapshot(data_dir)
+  previous = read_data_volume_status(data_dir)
+  if previous is not None:
+    for key in ("last_crashloop_admission", "last_crashloop_retention"):
+      if key in previous:
+        snapshot[key] = previous[key]
+  _write_json_atomic(_status_path(data_dir), snapshot)
+  return snapshot
+
+
+def read_data_volume_status(data_dir: str | Path) -> dict[str, Any] | None:
+  try:
+    value = json.loads(
+      _status_path(data_dir).read_text(encoding="utf-8"),
+    )
+  except (OSError, json.JSONDecodeError):
+    return None
+  if not isinstance(value, dict) or not isinstance(value.get("top_level"), dict):
+    return None
+  return value
+
+
+def _record_status(data_dir: str | Path, key: str, value: dict[str, Any]) -> None:
+  status = refresh_data_volume_status(data_dir)
+  status[key] = value
+  _write_json_atomic(_status_path(data_dir), status)
+
+
+def _env_bytes(name: str, default: int) -> int:
+  try:
+    value = int(os.environ.get(name, str(default)))
+  except ValueError:
+    return default
+  return value if value >= 0 else default
+
+
+def _reserve_bytes(total_bytes: int) -> int:
+  default = min(total_bytes, max(32 * MIB, int(total_bytes * 0.05)), GIB)
+  return _env_bytes("MOBIUS_DATA_VOLUME_RESERVE_BYTES", default)
+
+
+def _recovery_budget_bytes(total_bytes: int) -> int:
+  default = min(2 * GIB, total_bytes // 4)
+  return _env_bytes("MOBIUS_CRASHLOOP_RECOVERY_MAX_BYTES", default)
+
+
+def _clone_estimate_bytes(
+  primary_bytes: int,
+  clone_source_dir: str | Path | None,
+  tree_size: Callable[[Path], int],
+) -> int:
+  estimate = primary_bytes
+  if clone_source_dir is not None:
+    source = Path(clone_source_dir)
+    if source.is_dir():
+      estimate = max(estimate, tree_size(source))
+  # An override may reserve more for unusual remotes, never less than either
+  # concrete tree available at admission time.
+  return max(
+    estimate,
+    _env_bytes("MOBIUS_PLATFORM_CLONE_ESTIMATE_BYTES", estimate),
+  )
+
+
+def _recovery_points(data_dir: Path) -> list[Path]:
+  points = [
+    path for path in data_dir.glob(f"{_RECOVERY_PREFIX}*")
+    if path.is_dir() and not path.is_symlink()
+  ]
+  # The UTC timestamp in the quarantine name is immutable creation identity;
+  # directory mtimes change when an owner inspects or repairs preserved files.
+  return sorted(points, key=lambda path: path.name, reverse=True)
+
+
+def _prune_recovery_history(
+  data_dir: Path,
+  *,
+  required_free_bytes: int,
+  budget_bytes: int,
+  disk_usage: Callable = shutil.disk_usage,
+  tree_size: Callable[[Path], int] = exact_tree_allocated_bytes,
+  remove_tree: Callable[[Path], None] = shutil.rmtree,
+) -> dict[str, Any]:
+  points = _recovery_points(data_dir)
+  sizes: dict[Path, int] = {}
+  errors = []
+  for path in points:
+    try:
+      sizes[path] = tree_size(path)
+    except OSError as exc:
+      errors.append(f"could not size {path.name}: {exc}")
+  retained_bytes = sum(sizes.values())
+  pruned = []
+  # The newest point is never a candidate. Older points yield oldest-first so
+  # the most recent redundant history survives when capacity permits.
+  for path in reversed(points[1:]):
+    free_bytes = int(disk_usage(data_dir).free)
+    if free_bytes >= required_free_bytes and retained_bytes <= budget_bytes:
+      break
+    if path not in sizes:
+      continue
+    try:
+      remove_tree(path)
+    except OSError as exc:
+      errors.append(f"could not prune {path.name}: {exc}")
+      continue
+    retained_bytes = max(0, retained_bytes - sizes[path])
+    pruned.append({"name": path.name, "bytes": sizes[path]})
+  return {
+    "newest_preserved": points[0].name if points else None,
+    "pruned": pruned,
+    "retained_bytes": retained_bytes,
+    "budget_bytes": budget_bytes,
+    "errors": errors,
+    "free_bytes": int(disk_usage(data_dir).free),
+  }
+
+
+def admit_crashloop_reclone(
+  data_dir: str | Path,
+  platform_dir: str | Path,
+  *,
+  disk_usage: Callable = shutil.disk_usage,
+  tree_size: Callable[[Path], int] = exact_tree_allocated_bytes,
+  cache_reclaimer: Callable[[Path], dict[str, Any]] | None = None,
+  remove_tree: Callable[[Path], None] = shutil.rmtree,
+  clone_source_dir: str | Path | None = None,
+) -> dict[str, Any]:
+  """Reclaim safe bytes and decide before the live platform tree is moved."""
+  root = Path(data_dir)
+  platform = Path(platform_dir)
+  usage = disk_usage(root)
+  total_bytes = int(usage.total)
+  reserve_bytes = _reserve_bytes(total_bytes)
+  try:
+    platform_bytes = tree_size(platform)
+  except OSError as exc:
+    return {
+      "admitted": False,
+      "reason": f"live platform tree could not be sized: {exc}",
+      "free_bytes": int(usage.free),
+    }
+  try:
+    clone_estimate = _clone_estimate_bytes(
+      platform_bytes, clone_source_dir, tree_size,
+    )
+  except OSError as exc:
+    return {
+      "admitted": False,
+      "reason": f"baked clone source could not be sized: {exc}",
+      "free_bytes": int(usage.free),
+    }
+  required_free = clone_estimate + reserve_bytes
+  cache_result: dict[str, Any] = {"reclaimed_bytes": 0}
+  if int(usage.free) < required_free:
+    try:
+      if cache_reclaimer is None:
+        from app.browser_profiles import enforce_browser_profile_quota
+        cache_result = enforce_browser_profile_quota(
+          root,
+          {},
+          set(),
+          max_bytes=0,
+          low_water_bytes=0,
+          cache_only=True,
+        )
+      else:
+        cache_result = cache_reclaimer(root)
+    except Exception as exc:  # Admission continues to older redundant history.
+      cache_result = {"reclaimed_bytes": 0, "error": str(exc)}
+
+  recovery = _prune_recovery_history(
+    root,
+    required_free_bytes=required_free,
+    budget_bytes=_recovery_budget_bytes(total_bytes),
+    disk_usage=disk_usage,
+    tree_size=tree_size,
+    remove_tree=remove_tree,
+  )
+  free_bytes = int(disk_usage(root).free)
+  # Every currently retained point becomes older history after the atomic move
+  # installs the current live tree as the new newest recovery. Admission may
+  # therefore rely on those bytes, but does not delete them early; the post-move
+  # check below must actually reclaim them before bootstrap can clone.
+  post_move_free_bytes = free_bytes + int(recovery["retained_bytes"])
+  admitted = free_bytes >= required_free or post_move_free_bytes >= required_free
+  return {
+    "admitted": admitted,
+    "reason": None if admitted else "insufficient free space for a second platform tree",
+    "volume_total_bytes": total_bytes,
+    "free_bytes": free_bytes,
+    "platform_bytes": platform_bytes,
+    "clone_estimate_bytes": clone_estimate,
+    "reserve_bytes": reserve_bytes,
+    "required_free_bytes": required_free,
+    "post_move_free_bytes": post_move_free_bytes,
+    "post_move_prune_required": free_bytes < required_free,
+    "browser_cache": cache_result,
+    "recovery": recovery,
+  }
+
+
+def record_crashloop_quarantine(
+  data_dir: str | Path,
+  *,
+  disk_usage: Callable = shutil.disk_usage,
+  tree_size: Callable[[Path], int] = exact_tree_allocated_bytes,
+  remove_tree: Callable[[Path], None] = shutil.rmtree,
+  clone_source_dir: str | Path | None = None,
+) -> dict[str, Any]:
+  """Apply the byte budget after a new quarantine becomes the newest point."""
+  root = Path(data_dir)
+  usage = disk_usage(root)
+  points = _recovery_points(root)
+  if not points:
+    return {
+      "newest_preserved": None,
+      "pruned": [],
+      "retained_bytes": 0,
+      "budget_bytes": _recovery_budget_bytes(int(usage.total)),
+      "free_bytes": int(usage.free),
+      "required_free_bytes": None,
+      # No recovery means a bootstrap would create the only platform tree; the
+      # second-tree admission policy has nothing to protect or budget here.
+      "ready_for_clone": True,
+      "errors": [],
+    }
+  try:
+    newest_bytes = tree_size(points[0])
+    clone_estimate = _clone_estimate_bytes(
+      newest_bytes, clone_source_dir, tree_size,
+    )
+  except OSError as exc:
+    return {
+      "newest_preserved": points[0].name,
+      "pruned": [],
+      "retained_bytes": 0,
+      "budget_bytes": _recovery_budget_bytes(int(usage.total)),
+      "free_bytes": int(usage.free),
+      "required_free_bytes": None,
+      "ready_for_clone": False,
+      "errors": [f"could not size clone inputs: {exc}"],
+    }
+  required_free = clone_estimate + _reserve_bytes(int(usage.total))
+  result = _prune_recovery_history(
+    root,
+    required_free_bytes=required_free,
+    budget_bytes=_recovery_budget_bytes(int(usage.total)),
+    disk_usage=disk_usage,
+    tree_size=tree_size,
+    remove_tree=remove_tree,
+  )
+  result["required_free_bytes"] = required_free
+  result["ready_for_clone"] = (
+    result["free_bytes"] >= required_free and not result["errors"]
+  )
+  return result
+
+
+def _parser() -> argparse.ArgumentParser:
+  parser = argparse.ArgumentParser(description=__doc__)
+  subparsers = parser.add_subparsers(dest="command", required=True)
+  for command in ("admit-crashloop", "record-crashloop", "snapshot"):
+    child = subparsers.add_parser(command)
+    child.add_argument("--data-dir", default="/data")
+    if command in ("admit-crashloop", "record-crashloop"):
+      child.add_argument("--clone-source-dir", default="/app/platform-baked")
+    if command == "admit-crashloop":
+      child.add_argument("--platform-dir", default="/data/platform")
+  return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+  args = _parser().parse_args(argv)
+  if args.command == "admit-crashloop":
+    result = admit_crashloop_reclone(
+      args.data_dir,
+      args.platform_dir,
+      clone_source_dir=args.clone_source_dir,
+    )
+    try:
+      _record_status(args.data_dir, "last_crashloop_admission", result)
+    except OSError as exc:
+      result["status_error"] = str(exc)
+    print(json.dumps(result, sort_keys=True), file=sys.stderr)
+    return 0 if result["admitted"] else 75
+  if args.command == "record-crashloop":
+    result = record_crashloop_quarantine(
+      args.data_dir,
+      clone_source_dir=args.clone_source_dir,
+    )
+    try:
+      _record_status(args.data_dir, "last_crashloop_retention", result)
+    except OSError as exc:
+      result["status_error"] = str(exc)
+  else:
+    result = refresh_data_volume_status(args.data_dir)
+  print(json.dumps(result, sort_keys=True), file=sys.stderr)
+  if args.command == "record-crashloop":
+    return 0 if result.get("ready_for_clone") else 75
+  return 1 if result.get("errors") else 0
+
+
+if __name__ == "__main__":
+  raise SystemExit(main())

--- a/backend/app/resource_pressure.py
+++ b/backend/app/resource_pressure.py
@@ -332,6 +332,16 @@ def resource_status(
     disk_usage=disk_usage,
     memory=memory,
   )
+  from app.data_volume import read_data_volume_status
+  volume_status = read_data_volume_status(data_dir)
+  if volume_status is not None:
+    facts["disk"]["top_level_breakdown"] = {
+      "captured_at": volume_status.get("captured_at"),
+      **volume_status["top_level"],
+    }
+    for key in ("last_crashloop_admission", "last_crashloop_retention"):
+      if key in volume_status:
+        facts["disk"][key] = volume_status[key]
   return {
     "facts": facts,
     "pressure": assess_resource_pressure(facts),

--- a/backend/app/runtime_supervisors.py
+++ b/backend/app/runtime_supervisors.py
@@ -185,6 +185,15 @@ class RuntimeSupervisors:
           )
 
     async def browser_profile_loop():
+      from app.data_volume import refresh_data_volume_status
+      try:
+        await asyncio.to_thread(
+          refresh_data_volume_status, self.settings.data_dir,
+        )
+      except Exception as exc:
+        self.log.error(
+          "initial data-volume scan failed: %s", exc, exc_info=True,
+        )
       await asyncio.sleep(300)
       while True:
         sweep_seconds = 60 * 60
@@ -209,11 +218,14 @@ class RuntimeSupervisors:
               "agent-browser profile quota reclaimed %d bytes",
               result["reclaimed_bytes"],
             )
+          await asyncio.to_thread(
+            refresh_data_volume_status, self.settings.data_dir,
+          )
         except asyncio.CancelledError:
           raise
         except Exception as exc:
           self.log.error(
-            "agent-browser profile quota failed: %s", exc, exc_info=True,
+            "browser-profile and volume sweep failed: %s", exc, exc_info=True,
           )
         await asyncio.sleep(sweep_seconds)
 

--- a/backend/scripts/entrypoint.sh
+++ b/backend/scripts/entrypoint.sh
@@ -236,10 +236,12 @@ fi
 # loop. Threshold = 3 because a transient OOM or SIGKILL can cause 1-2
 # false failures; three consecutive failures without a health success
 # strongly implies the platform code itself is broken.
+_crashloop_force_baked=0
+_crashloop_clone_ready=0
 if [ "$_boot_counter_enabled" -eq 1 ] &&
    [ "$_boot_counter" -ge 3 ] &&
    [ -f /data/.last-successful-boot ]; then
-  echo "PLATFORM-RESTORE: boot-attempt counter = $_boot_counter, re-cloning platform..." >&2
+  echo "PLATFORM-RESTORE: boot-attempt counter = $_boot_counter, evaluating re-clone capacity..." >&2
   # Crash-loop escape hatch: the platform imported OK (else the probe would
   # have already fallen back to baked) but keeps crashing at runtime. Move the
   # broken tree ASIDE so the next boot re-clones a fresh canonical
@@ -247,22 +249,39 @@ if [ "$_boot_counter_enabled" -eq 1 ] &&
   # TIMESTAMPED /data/platform.crashloop-prev.<ts> for inspection/recovery, not
   # deleted. A one-slot .crashloop-prev would let a SECOND crash-loop delete the
   # first preserved tree before the owner could inspect it, so we timestamp each
-  # quarantine and keep only the newest few. (slice B's deploy=merge
-  # reconciliation will refine this.)
+  # quarantine. Capacity policy always preserves the newest point and keeps
+  # older redundant history only while its byte budget permits.
   _cl_ts=$(date -u +%Y%m%dT%H%M%SZ)
+  _cl_admitted=0
   if [ -e /data/platform ] && [ -n "$(ls -A /data/platform 2>/dev/null)" ] &&
+     PYTHONPATH=/app python3 -P -m app.data_volume \
+       admit-crashloop --data-dir /data --platform-dir /data/platform; then
+    _cl_admitted=1
+  fi
+  if [ "$_cl_admitted" -eq 1 ] &&
      mv /data/platform "/data/platform.crashloop-prev.$_cl_ts" 2>/dev/null; then
     echo "PLATFORM-RESTORE: broken tree moved to /data/platform.crashloop-prev.$_cl_ts; next boot re-clones." >&2
     echo "crashloop-reclone /data/platform.crashloop-prev.$_cl_ts $(date -u +%Y-%m-%dT%H:%M:%SZ)" > /data/.platform-restore-active
     chown mobius:mobius /data/.platform-restore-active 2>/dev/null || true
-    # Retention cap: keep the newest 3 crashloop quarantines, prune older ones.
-    # Pruning runs AFTER the move so the tree just preserved this boot is always
-    # among the kept copies — we never delete the only/newest copy.
-    ls -1dt /data/platform.crashloop-prev.* 2>/dev/null | tail -n +4 | while IFS= read -r _old; do
-      rm -rf "$_old" 2>/dev/null || true
-    done
+    # Re-apply the byte budget after the just-moved tree becomes the newest
+    # recovery point. The helper never prunes that newest point.
+    if ! PYTHONPATH=/app python3 -P -m app.data_volume \
+      record-crashloop --data-dir /data; then
+      echo "WARNING: crash-loop recovery could not create safe clone headroom; serving baked floor." >&2
+      _crashloop_force_baked=1
+    else
+      _crashloop_clone_ready=1
+    fi
   else
-    echo "PLATFORM-RESTORE: no /data/platform to move aside (or mv failed); serving baked floor." >&2
+    if [ "$_cl_admitted" -eq 1 ]; then
+      echo "PLATFORM-RESTORE: platform move failed; live tree left in place and baked floor will serve." >&2
+      _crashloop_force_baked=1
+    else
+      echo "PLATFORM-RESTORE: re-clone not admitted; live tree left in place and baked floor will serve." >&2
+      if [ -e /data/platform ] && [ -n "$(ls -A /data/platform 2>/dev/null)" ]; then
+        _crashloop_force_baked=1
+      fi
+    fi
   fi
   # Reset counter after the restore attempt regardless of success, so
   # the next boot gets a clean slate. If the restore fixed things, the
@@ -780,8 +799,19 @@ fi
 
 chown -R mobius:mobius /data/platform 2>/dev/null || true
 
-if [ ! -d "$_platform_app" ]; then
-  if _platform_bootstrap && _platform_git_valid && _platform_import_probe; then
+if [ "$_crashloop_force_baked" -eq 1 ]; then
+  _platform_use_baked
+elif [ ! -d "$_platform_app" ]; then
+  _restore_capacity_ready=1
+  if [ "$_crashloop_clone_ready" -ne 1 ] &&
+     [ -f /data/.platform-restore-active ] &&
+     ! PYTHONPATH=/app python3 -P -m app.data_volume \
+       record-crashloop --data-dir /data; then
+    _restore_capacity_ready=0
+    echo "PLATFORM LAYER WARNING: crash-loop restore still lacks safe clone headroom." >&2
+  fi
+  if [ "$_restore_capacity_ready" -eq 1 ] &&
+     _platform_bootstrap && _platform_git_valid && _platform_import_probe; then
     _platform_use_direct
   else
     echo "PLATFORM LAYER WARNING: bootstrap did not produce an importable repo." >&2

--- a/backend/tests/test_browser_profiles.py
+++ b/backend/tests/test_browser_profiles.py
@@ -394,6 +394,28 @@ def test_quota_prunes_regenerable_cache_before_profile(tmp_path):
   assert result["profiles_pruned"] == 0
 
 
+def test_cache_only_admission_never_removes_durable_profile_state(tmp_path):
+  closed = "10101010-1010-1010-1010-101010101010"
+  active = "20202020-2020-2020-2020-202020202020"
+  closed_profile = _profile(tmp_path, closed, cache_bytes=80, durable_bytes=20)
+  active_profile = _profile(tmp_path, active, cache_bytes=80, durable_bytes=20)
+
+  result = enforce_browser_profile_quota(
+    tmp_path,
+    {},
+    {active},
+    max_bytes=0,
+    low_water_bytes=0,
+    cache_only=True,
+  )
+
+  assert closed_profile.exists()
+  assert not (closed_profile / "Default" / "Cache").exists()
+  assert (closed_profile / "Default" / "IndexedDB" / "state.bin").exists()
+  assert (active_profile / "Default" / "Cache" / "cache.bin").exists()
+  assert result["profiles_pruned"] == 0
+
+
 def test_quota_never_prunes_a_live_chat_profile(tmp_path):
   live = "22222222-2222-2222-2222-222222222222"
   profile = _profile(tmp_path, live, cache_bytes=100, durable_bytes=20)

--- a/backend/tests/test_data_volume.py
+++ b/backend/tests/test_data_volume.py
@@ -1,0 +1,237 @@
+"""Volume-capacity policy stays non-destructive under Trial-sized pressure."""
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+from app.data_volume import (
+  MIB,
+  admit_crashloop_reclone,
+  data_volume_snapshot,
+  read_data_volume_status,
+  record_crashloop_quarantine,
+  refresh_data_volume_status,
+)
+
+
+def _point(root: Path, name: str, *, mtime: int) -> Path:
+  point = root / name
+  point.mkdir()
+  (point / "owner-edit.txt").write_text(name)
+  os.utime(point, (mtime, mtime))
+  return point
+
+
+def test_trial_volume_reclaims_cache_then_old_redundant_recovery(
+  tmp_path,
+):
+  total = 512 * MIB
+  platform = tmp_path / "platform"
+  platform.mkdir()
+  recovery = _point(
+    tmp_path, "platform.crashloop-prev.20260809T020000Z", mtime=2,
+  )
+  cache_reclaimed = False
+  actions = []
+
+  def disk_usage(_path):
+    free = 33 * MIB
+    if cache_reclaimed:
+      free += 95 * MIB
+    if not recovery.exists():
+      free += 95 * MIB
+    return SimpleNamespace(total=total, used=total - free, free=free)
+
+  sizes = {
+    "platform": 133 * MIB,
+    recovery.name: 95 * MIB,
+  }
+
+  def reclaim(_root):
+    nonlocal cache_reclaimed
+    cache_reclaimed = True
+    actions.append("browser-cache")
+    return {"reclaimed_bytes": 95 * MIB}
+
+  def remove(path):
+    actions.append(path.name)
+    shutil.rmtree(path)
+
+  result = admit_crashloop_reclone(
+    tmp_path,
+    platform,
+    disk_usage=disk_usage,
+    tree_size=lambda path: sizes[path.name],
+    cache_reclaimer=reclaim,
+    remove_tree=remove,
+  )
+
+  assert result["admitted"] is True
+  assert result["required_free_bytes"] == 165 * MIB
+  assert result["post_move_prune_required"] is True
+  assert actions == ["browser-cache"]
+  assert recovery.exists()
+  assert platform.exists(), "admission must not move the live tree"
+
+  newest = tmp_path / "platform.crashloop-prev.20260809T030000Z"
+  platform.rename(newest)
+  sizes[newest.name] = 133 * MIB
+  retention = record_crashloop_quarantine(
+    tmp_path,
+    disk_usage=disk_usage,
+    tree_size=lambda path: sizes[path.name],
+    remove_tree=remove,
+  )
+
+  assert retention["ready_for_clone"] is True
+  assert actions == ["browser-cache", recovery.name]
+  assert newest.exists()
+  assert not recovery.exists()
+
+
+def test_admission_fails_before_touching_live_or_only_recovery(tmp_path):
+  total = 512 * MIB
+  platform = tmp_path / "platform"
+  platform.mkdir()
+  newest = _point(
+    tmp_path, "platform.crashloop-prev.20260809T020000Z", mtime=2,
+  )
+  cache_reclaimed = False
+
+  def disk_usage(_path):
+    free = 20 * MIB + (10 * MIB if cache_reclaimed else 0)
+    return SimpleNamespace(total=total, used=total - free, free=free)
+
+  def reclaim(_root):
+    nonlocal cache_reclaimed
+    cache_reclaimed = True
+    return {"reclaimed_bytes": 10 * MIB}
+
+  result = admit_crashloop_reclone(
+    tmp_path,
+    platform,
+    disk_usage=disk_usage,
+    tree_size=lambda path: 133 * MIB if path == platform else 95 * MIB,
+    cache_reclaimer=reclaim,
+  )
+
+  assert result["admitted"] is False
+  assert platform.exists()
+  assert newest.exists()
+  assert result["recovery"]["pruned"] == []
+
+
+def test_admission_sizes_the_larger_baked_clone_source(monkeypatch, tmp_path):
+  platform = tmp_path / "platform"
+  platform.mkdir()
+  baked = tmp_path / "platform-baked"
+  baked.mkdir()
+  monkeypatch.setenv("MOBIUS_PLATFORM_CLONE_ESTIMATE_BYTES", "1")
+
+  result = admit_crashloop_reclone(
+    tmp_path,
+    platform,
+    clone_source_dir=baked,
+    disk_usage=lambda _path: SimpleNamespace(
+      total=512 * MIB, used=352 * MIB, free=160 * MIB,
+    ),
+    tree_size=lambda path: 100 * MIB if path == platform else 140 * MIB,
+    cache_reclaimer=lambda _root: {"reclaimed_bytes": 0},
+  )
+
+  assert result["clone_estimate_bytes"] == 140 * MIB
+  assert result["required_free_bytes"] == 172 * MIB
+  assert result["admitted"] is False
+
+
+def test_newest_recovery_preserves_files_modes_and_symlinks(
+  monkeypatch, tmp_path,
+):
+  older = _point(
+    tmp_path, "platform.crashloop-prev.20260809T010000Z", mtime=3,
+  )
+  platform = tmp_path / "platform"
+  platform.mkdir()
+  owner_edit = platform / "owner-edit.txt"
+  owner_edit.write_text("committed")
+  subprocess.run(["git", "-C", str(platform), "init", "-q"], check=True)
+  subprocess.run(
+    ["git", "-C", str(platform), "config", "user.name", "Test Owner"],
+    check=True,
+  )
+  subprocess.run(
+    ["git", "-C", str(platform), "config", "user.email", "owner@example.test"],
+    check=True,
+  )
+  subprocess.run(["git", "-C", str(platform), "add", "."], check=True)
+  subprocess.run(
+    ["git", "-C", str(platform), "commit", "-qm", "owner commit"],
+    check=True,
+  )
+  owner_edit.write_text("dirty tracked edit")
+  (platform / "untracked.txt").write_text("untracked owner work")
+  executable = platform / "local-tool"
+  executable.write_text("#!/bin/sh\nexit 0\n")
+  executable.chmod(0o755)
+  (platform / "local-link").symlink_to("owner-edit.txt")
+  newest = tmp_path / "platform.crashloop-prev.20260809T020000Z"
+  platform.rename(newest)
+  monkeypatch.setenv("MOBIUS_CRASHLOOP_RECOVERY_MAX_BYTES", "0")
+
+  result = record_crashloop_quarantine(tmp_path)
+
+  assert result["newest_preserved"] == newest.name
+  assert not older.exists()
+  assert (newest / "owner-edit.txt").read_text() == "dirty tracked edit"
+  assert (newest / "untracked.txt").read_text() == "untracked owner work"
+  assert (newest / "local-link").is_symlink()
+  assert os.access(newest / executable.name, os.X_OK)
+  assert subprocess.check_output(
+    ["git", "-C", str(newest), "rev-list", "--count", "HEAD"], text=True,
+  ).strip() == "1"
+  status = subprocess.check_output(
+    ["git", "-C", str(newest), "status", "--porcelain"], text=True,
+  )
+  assert " M owner-edit.txt" in status
+  assert "?? untracked.txt" in status
+
+
+def test_status_scan_is_bounded_and_round_trips(tmp_path):
+  (tmp_path / "run").mkdir()
+  (tmp_path / "platform").mkdir()
+  (tmp_path / "platform" / "a").write_bytes(b"a" * 4096)
+  (tmp_path / "db").mkdir()
+  snapshot = data_volume_snapshot(tmp_path, entry_budget=1)
+
+  assert snapshot["capacity"]["total_bytes"] > 0
+  assert snapshot["top_level"]["complete"] is False
+  assert any(entry["complete"] is False for entry in snapshot["top_level"]["entries"])
+
+  written = refresh_data_volume_status(tmp_path)
+  assert read_data_volume_status(tmp_path) == written
+  status_path = tmp_path / "run/data-volume-status.json"
+  status = json.loads(status_path.read_text())
+  status["last_crashloop_admission"] = {"admitted": False}
+  status_path.write_text(json.dumps(status))
+  assert refresh_data_volume_status(tmp_path)["last_crashloop_admission"] == {
+    "admitted": False,
+  }
+
+
+def test_entrypoint_admits_before_move_and_falls_back_without_capacity():
+  entrypoint = (
+    Path(__file__).resolve().parents[1] / "scripts" / "entrypoint.sh"
+  ).read_text(encoding="utf-8")
+  admission = entrypoint.index("admit-crashloop --data-dir /data")
+  move = entrypoint.index(
+    'mv /data/platform "/data/platform.crashloop-prev.$_cl_ts"', admission,
+  )
+  selection = entrypoint.index('if [ "$_crashloop_force_baked" -eq 1 ]')
+
+  assert admission < move < selection
+  assert "tail -n +4" not in entrypoint
+  assert "record-crashloop --data-dir /data" in entrypoint
+  assert "_restore_capacity_ready" in entrypoint

--- a/backend/tests/test_resource_pressure.py
+++ b/backend/tests/test_resource_pressure.py
@@ -1,5 +1,6 @@
 """Focused coverage for resource facts and pressure interpretation."""
 
+import json
 from types import SimpleNamespace
 
 from app.resource_pressure import (
@@ -193,3 +194,32 @@ def test_resource_status_keeps_facts_and_pressure_separate():
 
   assert set(status) == {"facts", "pressure"}
   assert status["pressure"]["state"] == "normal"
+
+
+def test_resource_status_surfaces_cached_volume_breakdown(tmp_path):
+  (tmp_path / "run").mkdir()
+  (tmp_path / "run/data-volume-status.json").write_text(json.dumps({
+    "captured_at": "2026-08-09T12:00:00+00:00",
+    "top_level": {
+      "entries": [{"name": "platform", "bytes": 123, "complete": True}],
+      "complete": True,
+      "entry_budget": 10,
+      "time_budget_seconds": 1,
+    },
+    "last_crashloop_admission": {"admitted": False},
+  }))
+
+  status = resource_status(
+    tmp_path,
+    disk_usage=lambda _path: SimpleNamespace(total=1000, used=700, free=300),
+    memory={
+      "available": True,
+      "working_set_bytes": 400,
+      "limit_bytes": 1000,
+      "pressure": {},
+    },
+  )
+
+  disk = status["facts"]["disk"]
+  assert disk["top_level_breakdown"]["entries"][0]["name"] == "platform"
+  assert disk["last_crashloop_admission"] == {"admitted": False}


### PR DESCRIPTION
## Summary

- admit a crash-loop re-clone only when the volume can hold the larger of the live and baked platform trees plus a capacity-relative reserve
- reclaim closed Chromium caches first, then prune only older redundant crash-loop recoveries; the newest recovery point is never a deletion candidate
- replace the three-tree count limit with a byte budget and recheck real free space after the atomic quarantine move before bootstrap may clone
- expose current volume capacity with a bounded, cached top-level `/data` breakdown and the last crash-loop admission/retention result

## Safety boundaries

| Situation | Behavior |
| --- | --- |
| enough free space | quarantine the live tree, preserve it as the newest recovery, then bootstrap |
| headroom depends on an existing recovery | keep it until the live tree becomes the new recovery, then prune the now-older copy and recheck free space |
| cache and older recoveries cannot create headroom | leave the live tree in place and serve the baked floor |
| post-move pruning or sizing fails | preserve the new recovery, serve the baked floor, and retry the capacity check on the next boot |
| normal operation | refresh the bounded breakdown after readiness and with the existing hourly browser-profile sweep; health reads never walk `/data` |

The default clone reserve matches the small-volume critical floor (5% with a 32 MiB minimum), and older crash-loop history is capped at one quarter of volume capacity up to 2 GiB. Operators can raise the clone estimate or tune both byte budgets without introducing a provider-specific mode.

This builds on the active-profile and hard-quota guarantees from #226 and the capacity-derived browser budget from #635. It completes the remaining persistent-volume admission, recovery-retention, and operator-diagnostics work in #160 without adding recovery archive formats or another daemon.

## Verification

- simulated a 512 MiB volume with 33 MiB free, a 133 MiB live platform, a 95 MiB recovery, and 95 MiB of reclaimable browser cache
- proved the order is cache first, then only the recovery that becomes redundant after the atomic move
- proved an unsafe restore fails before moving the live tree or deleting the only recovery
- proved the newest recovery keeps a local commit, dirty tracked work, untracked files, executable modes, and symlinks even when it exceeds the history budget
- proved the larger baked tree controls admission and an operator estimate cannot lower that measured requirement
- 45 focused volume, browser-profile, resource-pressure, and supervisor tests passed
- 79 fast platform contract tests passed; shell syntax, Python compilation, and canonical diff checks passed

Closes #160