### PR TITLE
Preserve Standard new-chat drafts across navigation

### DIFF
--- a/frontend/src/components/ChatView/__tests__/composerDraft.structure.test.js
+++ b/frontend/src/components/ChatView/__tests__/composerDraft.structure.test.js
@@ -1,0 +1,42 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+test('the composer state boundary saves before scheduling React state', () => {
+  const source = readFileSync(
+    new URL('../hooks/useComposerDraftState.js', import.meta.url),
+    'utf8',
+  )
+  const start = source.indexOf('const setComposerInput = useCallback((nextInput) =>')
+  const end = source.indexOf('\n  }, [chatId])', start)
+  const body = source.slice(start, end)
+
+  const save = body.indexOf('persistComposerDraft(chatId, nextInput, draftAttachmentsRef.current)')
+  const render = body.indexOf('setInputState(nextInput)')
+  assert.ok(save >= 0, 'all composer changes must be persisted directly')
+  assert.ok(render > save, 'draft persistence must happen before navigation can unmount React')
+})
+
+test('shell draft handoffs use the same owner instead of writing around its live mirror', () => {
+  const shellSource = readFileSync(
+    new URL('../../Shell/Shell.jsx', import.meta.url),
+    'utf8',
+  )
+  const chatSource = readFileSync(new URL('../ChatView.jsx', import.meta.url), 'utf8')
+  const directDraftWrite = /sessionStorage\.(?:setItem|removeItem)\(`draft:/
+  assert.doesNotMatch(shellSource, directDraftWrite,
+    'shell handoffs and deletion must not bypass the draft owner')
+  assert.doesNotMatch(chatSource, directDraftWrite,
+    'chat cleanup must clear memory, session, and durable copies together')
+  assert.match(shellSource, /stageComposerHandoff\(buildingChatId, report\)/)
+  assert.match(shellSource, /stageComposerHandoff\(request\.chatId, draftText\)/)
+  assert.match(shellSource,
+    /stageComposerHandoff\(chatId, handoff\.text, \{[\s\S]*?attachments: handoff\.attachments,[\s\S]*?autoSend: handoff\.autoSend/,
+    'new-chat handoffs must preserve the settled text, attachments, and autosend intent')
+  assert.match(shellSource, /consumeComposerHandoff\(prev\.chatId, prev\.draft\)/,
+    'an acknowledged direct handoff must retire its global fallback')
+  assert.match(shellSource, /requestComposer\(buildingChatId, \{ draft: report \}\)/,
+    'a crash report must update a retained destination composer too')
+  assert.match(shellSource, /clearComposerDraft\(id\)/)
+  assert.match(chatSource, /clearComposerDraft\(chatId\)/)
+})

--- a/frontend/src/components/ChatView/__tests__/composerDraft.test.js
+++ b/frontend/src/components/ChatView/__tests__/composerDraft.test.js
@@ -6,10 +6,8 @@ import {
   _clearComposerDraftMemoryForTests,
   clearComposerDraft,
   clearDurableComposerDrafts,
-  composerDraftSnapshots,
   consumeComposerHandoff,
   flushComposerDraftPersistence,
-  hydrateComposerDraftIndex,
   persistComposerDraft,
   readComposerHandoff,
   readComposerDraft,
@@ -44,41 +42,6 @@ test('persists and clears a chat draft synchronously', () => {
 
   assert.equal(persistComposerDraft('chat-a', '', [], storage), true)
   assert.equal(storage.getItem('draft:chat-a'), null)
-})
-
-test('hydrates a durable newest-first draft index after document memory resets', async () => {
-  await clearDurableComposerDrafts()
-  persistComposerDraft('older', 'first thought')
-  persistComposerDraft('newer', '', [{
-    name: 'reference.png', size: 12, mime_type: 'image/png', status: 'done',
-  }])
-  await flushComposerDraftPersistence()
-  _clearComposerDraftMemoryForTests()
-
-  const snapshots = await hydrateComposerDraftIndex()
-  assert.deepEqual(snapshots.map(snapshot => snapshot.chatId), ['newer', 'older'])
-  assert.deepEqual(snapshots[0].attachments, [{
-    name: 'reference.png', size: 12, mime_type: 'image/png', status: 'done',
-  }])
-  assert.deepEqual(composerDraftSnapshots(), snapshots)
-  await clearDurableComposerDrafts()
-})
-
-test('draft-index hydration includes legacy session drafts without resurrecting clears', async () => {
-  await clearDurableComposerDrafts()
-  const storage = storageStub({ 'draft:legacy-index': 'keep this too' })
-  assert.deepEqual((await hydrateComposerDraftIndex(storage)).map(d => d.chatId), [
-    'legacy-index',
-  ])
-
-  persistComposerDraft('clear-race', 'remove me')
-  await flushComposerDraftPersistence()
-  _clearComposerDraftMemoryForTests()
-  const hydration = hydrateComposerDraftIndex(storage)
-  clearComposerDraft('clear-race')
-  await hydration
-  assert.equal(composerDraftSnapshots().some(d => d.chatId === 'clear-race'), false)
-  await clearDurableComposerDrafts()
 })
 
 test('persists uploaded attachments with text and restores a sendable draft', () => {
@@ -316,7 +279,7 @@ test('quota recovery sacrifices only transient cache and keeps every owner draft
     _clearComposerDraftMemoryForTests()
     assert.equal(readComposerDraft('chat-d').input, 'old session copy')
     assert.equal(
-      (await hydrateComposerDraftIndex()).find(draft => draft.chatId === 'chat-d')?.input,
+      (await readComposerDraftAsync('chat-d')).input,
       'newest durable copy',
     )
     assert.equal(readComposerDraft('chat-d').input, 'newest durable copy')

--- a/frontend/src/components/ChatView/__tests__/composerDraft.test.js
+++ b/frontend/src/components/ChatView/__tests__/composerDraft.test.js
@@ -7,6 +7,7 @@ import {
   _clearComposerDraftMemoryForTests,
   clearComposerDraft,
   clearDurableComposerDrafts,
+  composerDraftHasContent,
   consumeComposerHandoff,
   flushComposerDraftPersistence,
   persistComposerDraft,
@@ -43,6 +44,22 @@ test('persists and clears a chat draft synchronously', () => {
 
   assert.equal(persistComposerDraft('chat-a', '', storage), true)
   assert.equal(storage.getItem('draft:chat-a'), null)
+})
+
+test('reports text and completed attachments as resumable draft content', () => {
+  const storage = storageStub()
+  assert.equal(composerDraftHasContent('draft', storage), false)
+
+  persistComposerDraft('draft', 'unfinished thought', storage)
+  assert.equal(composerDraftHasContent('draft', storage), true)
+
+  persistComposerDraft('draft', '', [{
+    name: 'reference.png', size: 12, mime_type: 'image/png', status: 'done',
+  }], storage)
+  assert.equal(composerDraftHasContent('draft', storage), true)
+
+  persistComposerDraft('draft', '', [], storage)
+  assert.equal(composerDraftHasContent('draft', storage), false)
 })
 
 test('persists uploaded attachments with text and restores a sendable draft', () => {

--- a/frontend/src/components/ChatView/__tests__/composerDraft.test.js
+++ b/frontend/src/components/ChatView/__tests__/composerDraft.test.js
@@ -1,15 +1,15 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
-import { readFileSync } from 'node:fs'
 import 'fake-indexeddb/auto'
 
 import {
   _clearComposerDraftMemoryForTests,
   clearComposerDraft,
   clearDurableComposerDrafts,
-  composerDraftHasContent,
+  composerDraftSnapshots,
   consumeComposerHandoff,
   flushComposerDraftPersistence,
+  hydrateComposerDraftIndex,
   persistComposerDraft,
   readComposerHandoff,
   readComposerDraft,
@@ -31,7 +31,7 @@ function storageStub(initial = {}) {
 
 test('persists and clears a chat draft synchronously', () => {
   const storage = storageStub()
-  assert.equal(persistComposerDraft('chat-a', 'unfinished thought', storage), true)
+  assert.equal(persistComposerDraft('chat-a', 'unfinished thought', [], storage), true)
   const stored = JSON.parse(storage.getItem('draft:chat-a'))
   assert.equal(stored.type, 'mobius-composer-draft')
   assert.equal(stored.version, 2)
@@ -42,24 +42,43 @@ test('persists and clears a chat draft synchronously', () => {
     attachments: [],
   })
 
-  assert.equal(persistComposerDraft('chat-a', '', storage), true)
+  assert.equal(persistComposerDraft('chat-a', '', [], storage), true)
   assert.equal(storage.getItem('draft:chat-a'), null)
 })
 
-test('reports text and completed attachments as resumable draft content', () => {
-  const storage = storageStub()
-  assert.equal(composerDraftHasContent('draft', storage), false)
-
-  persistComposerDraft('draft', 'unfinished thought', storage)
-  assert.equal(composerDraftHasContent('draft', storage), true)
-
-  persistComposerDraft('draft', '', [{
+test('hydrates a durable newest-first draft index after document memory resets', async () => {
+  await clearDurableComposerDrafts()
+  persistComposerDraft('older', 'first thought')
+  persistComposerDraft('newer', '', [{
     name: 'reference.png', size: 12, mime_type: 'image/png', status: 'done',
-  }], storage)
-  assert.equal(composerDraftHasContent('draft', storage), true)
+  }])
+  await flushComposerDraftPersistence()
+  _clearComposerDraftMemoryForTests()
 
-  persistComposerDraft('draft', '', [], storage)
-  assert.equal(composerDraftHasContent('draft', storage), false)
+  const snapshots = await hydrateComposerDraftIndex()
+  assert.deepEqual(snapshots.map(snapshot => snapshot.chatId), ['newer', 'older'])
+  assert.deepEqual(snapshots[0].attachments, [{
+    name: 'reference.png', size: 12, mime_type: 'image/png', status: 'done',
+  }])
+  assert.deepEqual(composerDraftSnapshots(), snapshots)
+  await clearDurableComposerDrafts()
+})
+
+test('draft-index hydration includes legacy session drafts without resurrecting clears', async () => {
+  await clearDurableComposerDrafts()
+  const storage = storageStub({ 'draft:legacy-index': 'keep this too' })
+  assert.deepEqual((await hydrateComposerDraftIndex(storage)).map(d => d.chatId), [
+    'legacy-index',
+  ])
+
+  persistComposerDraft('clear-race', 'remove me')
+  await flushComposerDraftPersistence()
+  _clearComposerDraftMemoryForTests()
+  const hydration = hydrateComposerDraftIndex(storage)
+  clearComposerDraft('clear-race')
+  await hydration
+  assert.equal(composerDraftSnapshots().some(d => d.chatId === 'clear-race'), false)
+  await clearDurableComposerDrafts()
 })
 
 test('persists uploaded attachments with text and restores a sendable draft', () => {
@@ -122,10 +141,18 @@ test('chat handoffs keep exact draft and autosend text under one owner', () => {
   })
 
   assert.equal(stageComposerHandoff('chat-a', 'Review this exactly', {
+    attachments: [{
+      name: 'review.txt', size: 9, mime_type: 'text/plain', status: 'done',
+    }],
     autoSend: true,
     storage,
   }), true)
-  assert.equal(readComposerDraft('chat-a', storage).input, 'Review this exactly')
+  assert.deepEqual(readComposerDraft('chat-a', storage), {
+    input: 'Review this exactly',
+    attachments: [{
+      name: 'review.txt', size: 9, mime_type: 'text/plain', status: 'done',
+    }],
+  })
   assert.equal(storage.getItem('pending-draft'), 'Review this exactly')
   assert.equal(storage.getItem('pending-draft-autosend'), 'Review this exactly')
   assert.equal(storage.getItem('draft-autosend:chat-a'), 'Review this exactly')
@@ -152,6 +179,30 @@ test('chat handoffs keep exact draft and autosend text under one owner', () => {
   assert.equal(storage.getItem('pending-draft'), 'Leave this for review')
   assert.equal(storage.getItem('pending-draft-autosend'), null)
   assert.equal(storage.getItem('draft-autosend:chat-a'), null)
+
+  assert.equal(stageComposerHandoff('attachment-only', '', {
+    attachments: [{
+      name: 'reference.png', size: 12, mime_type: 'image/png', status: 'done',
+    }],
+    storage,
+  }), true)
+  assert.deepEqual(readComposerDraft('attachment-only', storage), {
+    input: '',
+    attachments: [{
+      name: 'reference.png', size: 12, mime_type: 'image/png', status: 'done',
+    }],
+  })
+
+  persistComposerDraft('cleared-handoff', 'remove me', [], storage)
+  assert.equal(stageComposerHandoff('cleared-handoff', '', {
+    allowEmpty: true,
+    storage,
+  }), true)
+  assert.equal(storage.getItem('pending-draft'), null)
+  assert.equal(storage.getItem('draft-autosend:chat-a'), null)
+  assert.deepEqual(readComposerDraft('cleared-handoff', storage), {
+    input: '', attachments: [],
+  })
 })
 
 test('does not restore attachments that never finished uploading', () => {
@@ -264,7 +315,11 @@ test('quota recovery sacrifices only transient cache and keeps every owner draft
     await flushComposerDraftPersistence()
     _clearComposerDraftMemoryForTests()
     assert.equal(readComposerDraft('chat-d').input, 'old session copy')
-    assert.equal((await readComposerDraftAsync('chat-d')).input, 'newest durable copy')
+    assert.equal(
+      (await hydrateComposerDraftIndex()).find(draft => draft.chatId === 'chat-d')?.input,
+      'newest durable copy',
+    )
+    assert.equal(readComposerDraft('chat-d').input, 'newest durable copy')
 
     clearComposerDraft('chat-d')
     await flushComposerDraftPersistence()
@@ -285,43 +340,4 @@ test('quota recovery sacrifices only transient cache and keeps every owner draft
     if (previous) Object.defineProperty(globalThis, 'sessionStorage', previous)
     else delete globalThis.sessionStorage
   }
-})
-
-test('the composer state boundary saves before scheduling React state', () => {
-  const source = readFileSync(
-    new URL('../hooks/useComposerDraftState.js', import.meta.url),
-    'utf8',
-  )
-  const start = source.indexOf('const setComposerInput = useCallback((nextInput) =>')
-  const end = source.indexOf('\n  }, [chatId])', start)
-  const body = source.slice(start, end)
-
-  const save = body.indexOf('persistComposerDraft(chatId, nextInput, draftAttachmentsRef.current)')
-  const render = body.indexOf('setInputState(nextInput)')
-  assert.ok(save >= 0, 'all composer changes must be persisted directly')
-  assert.ok(render > save, 'draft persistence must happen before navigation can unmount React')
-})
-
-test('shell draft handoffs use the same owner instead of writing around its live mirror', () => {
-  const shellSource = readFileSync(
-    new URL('../../Shell/Shell.jsx', import.meta.url),
-    'utf8',
-  )
-  const chatSource = readFileSync(new URL('../ChatView.jsx', import.meta.url), 'utf8')
-  const directDraftWrite = /sessionStorage\.(?:setItem|removeItem)\(`draft:/
-  assert.doesNotMatch(shellSource, directDraftWrite,
-    'shell handoffs and deletion must not bypass the draft owner')
-  assert.doesNotMatch(chatSource, directDraftWrite,
-    'chat cleanup must clear memory, session, and durable copies together')
-  assert.match(shellSource, /stageComposerHandoff\(buildingChatId, report\)/)
-  assert.match(shellSource, /stageComposerHandoff\(request\.chatId, draftText\)/)
-  assert.match(shellSource,
-    /stageComposerHandoff\(chatId, draftText, \{\s*autoSend: suppliedDraft \? autoSend : false,\s*\}\)/,
-    'new-chat handoffs must preserve supplied autosend intent without sending early phone typing')
-  assert.match(shellSource, /consumeComposerHandoff\(prev\.chatId, prev\.draft\)/,
-    'an acknowledged direct handoff must retire its global fallback')
-  assert.match(shellSource, /requestComposer\(buildingChatId, \{ draft: report \}\)/,
-    'a crash report must update a retained destination composer too')
-  assert.match(shellSource, /clearComposerDraft\(id\)/)
-  assert.match(chatSource, /clearComposerDraft\(chatId\)/)
 })

--- a/frontend/src/components/ChatView/composerDraft.js
+++ b/frontend/src/components/ChatView/composerDraft.js
@@ -228,6 +228,12 @@ export function readComposerDraft(chatId, storage) {
   }
 }
 
+/** Whether this device owns unsent composer content for the chat. */
+export function composerDraftHasContent(chatId, storage) {
+  const draft = readComposerDraft(chatId, storage)
+  return draft.input.length > 0 || draft.attachments.length > 0
+}
+
 /**
  * Resolve the durable fallback after mount without overwriting a newer local
  * edit. Versioned session and IndexedDB values carry the same timestamp, so a

--- a/frontend/src/components/ChatView/composerDraft.js
+++ b/frontend/src/components/ChatView/composerDraft.js
@@ -2,6 +2,7 @@ import {
   clear as clearIdbStore,
   createStore,
   del as delIdbValue,
+  entries as idbEntries,
   get as getIdbValue,
   set as setIdbValue,
 } from 'idb-keyval'
@@ -228,10 +229,80 @@ export function readComposerDraft(chatId, storage) {
   }
 }
 
-/** Whether this device owns unsent composer content for the chat. */
-export function composerDraftHasContent(chatId, storage) {
-  const draft = readComposerDraft(chatId, storage)
-  return draft.input.length > 0 || draft.attachments.length > 0
+/** Return every known non-empty draft, newest edit first. */
+export function composerDraftSnapshots() {
+  const snapshots = []
+  for (const [chatId, entry] of liveDrafts) {
+    const decoded = decodeDraft(entry.raw)
+    if (!decoded.input && decoded.attachments.length === 0) continue
+    snapshots.push({
+      chatId,
+      input: decoded.input,
+      attachments: decoded.attachments,
+      updatedAt: decoded.updatedAt,
+    })
+  }
+  return snapshots.sort((left, right) => (
+    (right.updatedAt ?? 0) - (left.updatedAt ?? 0)
+    || left.chatId.localeCompare(right.chatId)
+  ))
+}
+
+/**
+ * Hydrate the synchronous draft index from both browser stores.
+ *
+ * New Chat needs a complete device-local view before choosing which compose
+ * surface to resume. The live mirror remains authoritative over hydration, so
+ * an edit or clear racing this read cannot be replaced by an older disk value.
+ */
+export async function hydrateComposerDraftIndex(storage) {
+  const target = availableStorage(storage)
+  if (target) {
+    try {
+      for (let index = 0; index < target.length; index += 1) {
+        const key = target.key(index)
+        if (!key?.startsWith('draft:')) continue
+        const chatId = key.slice('draft:'.length)
+        if (!chatId || liveDrafts.has(chatId)) continue
+        const raw = target.getItem(key)
+        if (raw) {
+          rememberLiveDraft(chatId, raw, 'session')
+        }
+      }
+    } catch { /* unavailable browser storage */ }
+  }
+
+  const generation = durableGeneration
+  let durableEntries = []
+  try { durableEntries = await idbEntries(durableDraftStore) } catch {}
+  if (generation !== durableGeneration) return composerDraftSnapshots()
+
+  const durableByChatId = new Map(durableEntries.map(([key, raw]) => [draftId(key), raw]))
+  for (const [chatId, current] of liveDrafts) {
+    if (current.source !== 'session' || !current.raw) continue
+    const durableRaw = durableByChatId.get(chatId)
+    const currentDecoded = decodeDraft(current.raw)
+    const durableDecoded = decodeDraft(durableRaw)
+    const currentIsLegacy = currentDecoded.updatedAt == null
+    const durableIsNewer = durableRaw && !currentIsLegacy && (
+      (durableDecoded.updatedAt ?? -1) > (currentDecoded.updatedAt ?? -1)
+    )
+    if (durableIsNewer) {
+      rememberLiveDraft(chatId, durableRaw, 'durable')
+      try { target?.setItem(`draft:${chatId}`, durableRaw) } catch {}
+    } else if (durableRaw !== current.raw) {
+      queueDurableDraftWrite(chatId, current.raw)
+    }
+    durableByChatId.delete(chatId)
+  }
+
+  for (const [chatId, raw] of durableByChatId) {
+    if (!raw) continue
+    const current = liveDrafts.get(chatId)
+    if (current?.source === 'live') continue
+    rememberLiveDraft(chatId, raw, 'durable')
+  }
+  return composerDraftSnapshots()
 }
 
 /**
@@ -302,24 +373,17 @@ export function clearComposerDraft(chatId, storage) {
  * a chance to remove the composer.
  */
 export function persistComposerDraft(chatId, input, attachments = [], storage) {
-  // Backward compatibility for callers of the former
-  // persistComposerDraft(chatId, input, storage) signature.
-  const legacyStorage = !Array.isArray(attachments) && storage === undefined
-    ? attachments
-    : undefined
-  const draftAttachments = Array.isArray(attachments) ? attachments : []
-  const storageOverride = storage ?? legacyStorage
-  const useDurableStore = storageOverride === undefined
+  const useDurableStore = storage === undefined
   if (chatId == null) return false
   const key = `draft:${chatId}`
-  const value = encodeDraft(input, draftAttachments)
+  const value = encodeDraft(input, attachments)
 
   if (useDurableStore) {
     rememberLiveDraft(chatId, value, 'live', { advance: true })
     queueDurableDraftWrite(chatId, value)
   }
 
-  const target = availableStorage(storageOverride)
+  const target = availableStorage(storage)
   // Dedicated memory + IndexedDB ownership does not depend on Web Storage
   // being exposed (private/opaque contexts can deny it altogether).
   if (!target) return useDurableStore
@@ -361,10 +425,12 @@ export function persistComposerDraft(chatId, input, attachments = [], storage) {
 export function stageComposerHandoff(
   chatId,
   input,
-  { autoSend = false, storage } = {},
+  { allowEmpty = false, attachments = [], autoSend = false, storage } = {},
 ) {
-  if (chatId == null || typeof input !== 'string' || input.length === 0) return false
-  const persisted = persistComposerDraft(chatId, input, [], storage)
+  if (chatId == null || typeof input !== 'string') return false
+  const hasAttachments = Array.isArray(attachments) && attachments.length > 0
+  if (input.length === 0 && !hasAttachments && !allowEmpty) return false
+  const persisted = persistComposerDraft(chatId, input, attachments, storage)
   const target = availableStorage(storage)
   if (!target) return persisted
 
@@ -372,7 +438,8 @@ export function stageComposerHandoff(
     // A session has one navigation handoff at a time. Retire abandoned keyed
     // autosends before staging the replacement so visiting an older chat later
     // cannot unexpectedly submit a stale approval.
-    const keepAutoSendKey = autoSend
+    const shouldAutoSend = !!input && autoSend
+    const keepAutoSendKey = shouldAutoSend
       ? `${HANDOFF_AUTOSEND_PREFIX}${chatId}`
       : null
     const staleAutoSendKeys = []
@@ -384,8 +451,9 @@ export function stageComposerHandoff(
     }
     for (const key of staleAutoSendKeys) target.removeItem(key)
 
-    target.setItem(PENDING_HANDOFF_KEY, input)
-    if (autoSend) {
+    if (input) target.setItem(PENDING_HANDOFF_KEY, input)
+    else target.removeItem(PENDING_HANDOFF_KEY)
+    if (shouldAutoSend) {
       target.setItem(PENDING_HANDOFF_AUTOSEND_KEY, input)
       target.setItem(`${HANDOFF_AUTOSEND_PREFIX}${chatId}`, input)
     } else {

--- a/frontend/src/components/ChatView/composerDraft.js
+++ b/frontend/src/components/ChatView/composerDraft.js
@@ -2,7 +2,6 @@ import {
   clear as clearIdbStore,
   createStore,
   del as delIdbValue,
-  entries as idbEntries,
   get as getIdbValue,
   set as setIdbValue,
 } from 'idb-keyval'
@@ -227,82 +226,6 @@ export function readComposerDraft(chatId, storage) {
   } catch {
     return { input: '', attachments: [] }
   }
-}
-
-/** Return every known non-empty draft, newest edit first. */
-export function composerDraftSnapshots() {
-  const snapshots = []
-  for (const [chatId, entry] of liveDrafts) {
-    const decoded = decodeDraft(entry.raw)
-    if (!decoded.input && decoded.attachments.length === 0) continue
-    snapshots.push({
-      chatId,
-      input: decoded.input,
-      attachments: decoded.attachments,
-      updatedAt: decoded.updatedAt,
-    })
-  }
-  return snapshots.sort((left, right) => (
-    (right.updatedAt ?? 0) - (left.updatedAt ?? 0)
-    || left.chatId.localeCompare(right.chatId)
-  ))
-}
-
-/**
- * Hydrate the synchronous draft index from both browser stores.
- *
- * New Chat needs a complete device-local view before choosing which compose
- * surface to resume. The live mirror remains authoritative over hydration, so
- * an edit or clear racing this read cannot be replaced by an older disk value.
- */
-export async function hydrateComposerDraftIndex(storage) {
-  const target = availableStorage(storage)
-  if (target) {
-    try {
-      for (let index = 0; index < target.length; index += 1) {
-        const key = target.key(index)
-        if (!key?.startsWith('draft:')) continue
-        const chatId = key.slice('draft:'.length)
-        if (!chatId || liveDrafts.has(chatId)) continue
-        const raw = target.getItem(key)
-        if (raw) {
-          rememberLiveDraft(chatId, raw, 'session')
-        }
-      }
-    } catch { /* unavailable browser storage */ }
-  }
-
-  const generation = durableGeneration
-  let durableEntries = []
-  try { durableEntries = await idbEntries(durableDraftStore) } catch {}
-  if (generation !== durableGeneration) return composerDraftSnapshots()
-
-  const durableByChatId = new Map(durableEntries.map(([key, raw]) => [draftId(key), raw]))
-  for (const [chatId, current] of liveDrafts) {
-    if (current.source !== 'session' || !current.raw) continue
-    const durableRaw = durableByChatId.get(chatId)
-    const currentDecoded = decodeDraft(current.raw)
-    const durableDecoded = decodeDraft(durableRaw)
-    const currentIsLegacy = currentDecoded.updatedAt == null
-    const durableIsNewer = durableRaw && !currentIsLegacy && (
-      (durableDecoded.updatedAt ?? -1) > (currentDecoded.updatedAt ?? -1)
-    )
-    if (durableIsNewer) {
-      rememberLiveDraft(chatId, durableRaw, 'durable')
-      try { target?.setItem(`draft:${chatId}`, durableRaw) } catch {}
-    } else if (durableRaw !== current.raw) {
-      queueDurableDraftWrite(chatId, current.raw)
-    }
-    durableByChatId.delete(chatId)
-  }
-
-  for (const [chatId, raw] of durableByChatId) {
-    if (!raw) continue
-    const current = liveDrafts.get(chatId)
-    if (current?.source === 'live') continue
-    rememberLiveDraft(chatId, raw, 'durable')
-  }
-  return composerDraftSnapshots()
 }
 
 /**

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -62,7 +62,6 @@ import {
   createdChatDetailCache,
   currentReusableEmptyChat,
   mergeChatListWithCreatedGuards,
-  mostRecentConcreteChatId,
   newChatCandidateResolution,
   newChatPresentationIsCurrent,
   reconcileHydratedNewChatCandidate,
@@ -84,9 +83,9 @@ import {
 } from './chatListProjection.js'
 import {
   clearComposerDraft,
-  composerDraftSnapshots,
   consumeComposerHandoff,
-  hydrateComposerDraftIndex,
+  readComposerDraft,
+  readComposerDraftAsync,
   stageComposerHandoff,
 } from '../ChatView/composerDraft.js'
 import {
@@ -626,9 +625,6 @@ export default function Shell() {
   // still disables sends while unavailable, but does not repeat this status
   // beside the composer.
   const online = useOnlineStatus()
-  useEffect(() => {
-    void hydrateComposerDraftIndex()
-  }, [])
   const chatsLoadedRef = useRef(false)
   const knownExistingOffListChatIdsRef = useRef(new Set())
   // Always-current chats, for reading inside callbacks that may hold a stale
@@ -2426,9 +2422,9 @@ export default function Shell() {
   // so each caller can react appropriately (a toast vs a retry surface).
   //
   // `candidate`: an explicitly pre-captured identity with its provenance and optional
-  // local draft snapshot. When undefined, derive the current active blank. Arbitrary
-  // active/history candidates still need a fresh bounded detail read online; a local
-  // draft is stronger owner intent and resumes directly without sacrificing its data.
+  // local draft snapshot. When undefined, derive the current active blank. A plain
+  // active candidate still needs a fresh bounded detail read online; a local draft is
+  // stronger owner intent and resumes directly without sacrificing its data.
   async function resolveNewChatId({ candidate, draft, forceNew, exclude } = {}) {
     const derivedActive = candidate !== undefined
       ? null
@@ -2447,7 +2443,7 @@ export default function Shell() {
         : null)
     // A non-empty local draft is affirmative owner intent to resume that
     // compose surface. It stays usable offline and if another device has since
-    // added context; arbitrary history fallbacks still require fresh proof.
+    // added context; candidates without current-surface provenance are rejected.
     const candidateResolution = newChatCandidateResolution(reusable, { online })
     if (candidateResolution === 'reject') {
       reusable = null
@@ -2622,8 +2618,8 @@ export default function Shell() {
   async function newChat({ draft, forceNew, exclude, autoSend, focusComposer, recordHistory } = {}) {
     // Keep the active chat when it is still an untouched blank; only POST a
     // fresh row when this explicit New-chat action needs one. Never borrow an
-    // arbitrary off-screen blank: only a non-empty device-local draft is
-    // affirmative owner intent to resume that compose surface.
+    // off-screen blank or draft; a local draft only strengthens ownership of
+    // the blank that is already open.
     //
     // `forceNew` bypasses reuse for callers that NEED a fresh row —
     // moebius:new-chat events (the ChatView wouldn't remount on the
@@ -2635,16 +2631,10 @@ export default function Shell() {
     //
     // Resolve chatId BEFORE switching views — setting activeView='chat'
     // with the old chatId causes a visible flash of the previous chat.
-    // Standard mode has one foreground surface. If the owner temporarily
-    // replaced an unfinished blank chat with an app, "New chat" means return to
-    // that in-progress compose surface rather than silently allocate another
-    // blank and strand its saved draft. Builder mode deliberately does NOT take
-    // this branch: opening another chat there is additive by design.
-    //
-    // The history route only supplies a candidate id. The existing list guards
-    // plus fresh detail probe still prove that it is untouched before reuse, so
-    // a send from another browser cannot turn this convenience into reopening a
-    // conversation that has already started.
+    // Standard mode has one foreground surface. New chat may keep the untouched
+    // blank already on that surface, but it must not borrow an off-screen draft
+    // or navigation-history row. Those drafts remain owned by their original
+    // chats and restore when that chat is revisited.
     //
     const ws = workspaceStateRef.current.ws
     // Standard is one destination surface, so acknowledge an explicit New-chat
@@ -2678,12 +2668,13 @@ export default function Shell() {
       recoveredChatIds: recoveredChatIdsRef.current,
       streamingChatIds: streamingChatIdsRef.current,
     }
-    // Once the owner leaves a blank draft for another chat, activeChatId points
-    // at the conversation they are reading. Standard's New chat action should
-    // return to the most recently left unfinished composer, not manufacture a
-    // second blank and make the saved draft look lost. Builder remains additive.
+    // Candidate selection is intentionally scoped to the current surface.
+    // Persisted drafts never turn an explicit New chat action into navigation.
     let composeCandidate = standardNewChat
-      ? standardNewChatCandidate(chatsRef.current, composerDraftSnapshots(), {
+      ? standardNewChatCandidate(chatsRef.current, {
+          chatId: activeChatIdRef.current,
+          ...readComposerDraft(activeChatIdRef.current),
+        }, {
           ...reuseOptions,
           activeChatId: activeChatIdRef.current,
         })
@@ -2698,10 +2689,15 @@ export default function Shell() {
       { initialValue: leaseInitialValue },
     )
     if (standardNewChat) {
-      await hydrateComposerDraftIndex()
+      const activeDraft = composeCandidate
+        ? await readComposerDraftAsync(composeCandidate.chatId)
+        : null
       const hydratedCandidate = standardNewChatCandidate(
         chatsRef.current,
-        composerDraftSnapshots(),
+        activeDraft && {
+          chatId: composeCandidate.chatId,
+          ...activeDraft,
+        },
         { ...reuseOptions, activeChatId: activeChatIdRef.current },
       )
       const leaseWasEdited = touchFocusLeased
@@ -2728,23 +2724,9 @@ export default function Shell() {
         leaseCandidate = null
       }
     }
-    const resumeId = standardNewChat
-      && !composeCandidate
-      && activeChatIdRef.current == null
-      ? mostRecentConcreteChatId(navStackRef.current)
-      : null
-    const historyRow = resumeId == null
-      ? null
-      : currentReusableEmptyChat(chatsRef.current, {
-          ...reuseOptions,
-          activeChatId: resumeId,
-        })
     const resumeCandidate = !standardNewChat
       ? undefined
       : composeCandidate
-        || (historyRow
-          ? { chatId: historyRow.id, source: 'history', draft: null }
-          : null)
     const { chatId, reason } = await resolveNewChatId(
       resumeCandidate === undefined
         ? { draft, forceNew, exclude }

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -67,6 +67,7 @@ import {
   reconcileCreatedChatGuard,
   rememberCreatedChat,
   reusableChatDetailVerdict,
+  standardNewChatCandidate,
 } from './newChatPolicy.js'
 import {
   forgetConfirmedDeletion,
@@ -81,6 +82,7 @@ import {
 } from './chatListProjection.js'
 import {
   clearComposerDraft,
+  composerDraftHasContent,
   consumeComposerHandoff,
   stageComposerHandoff,
 } from '../ChatView/composerDraft.js'
@@ -2656,22 +2658,37 @@ export default function Shell() {
     const touchFocusLeased = !!focusComposer && beginTouchComposerFocusLease(
       composerFocusLeaseRef.current,
     )
-    const resumeId = (
-      (ws.viewMode === 'single')
+    const standardNewChat = ws.viewMode === 'single' && !draft && !forceNew
+    const reuseOptions = {
+      exclude,
+      recoveredChatIds: recoveredChatIdsRef.current,
+      streamingChatIds: streamingChatIdsRef.current,
+    }
+    // Once the owner leaves a blank draft for another chat, activeChatId points
+    // at the conversation they are reading. Standard's New chat action should
+    // return to the most recently left unfinished composer, not manufacture a
+    // second blank and make the saved draft look lost. Builder remains additive.
+    const composeCandidate = standardNewChat
+      ? standardNewChatCandidate(chatsRef.current, navStackRef.current, {
+          ...reuseOptions,
+          activeChatId: activeChatIdRef.current,
+          hasDraft: composerDraftHasContent,
+        })
+      : null
+    const resumeId = standardNewChat
+      && !composeCandidate
       && activeChatIdRef.current == null
-      && !draft
-      && !forceNew
-    )
       ? mostRecentConcreteChatId(navStackRef.current)
       : null
-    const resumeCandidate = resumeId == null
+    const resumeCandidate = !standardNewChat
       ? undefined
-      : currentReusableEmptyChat(chatsRef.current, {
-        activeChatId: resumeId,
-        exclude,
-        recoveredChatIds: recoveredChatIdsRef.current,
-        streamingChatIds: streamingChatIdsRef.current,
-      })
+      : composeCandidate
+        || (resumeId == null
+          ? null
+          : currentReusableEmptyChat(chatsRef.current, {
+              ...reuseOptions,
+              activeChatId: resumeId,
+            }))
     const { chatId, reason } = await resolveNewChatId(
       resumeCandidate === undefined
         ? { draft, forceNew, exclude }

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -63,7 +63,9 @@ import {
   currentReusableEmptyChat,
   mergeChatListWithCreatedGuards,
   mostRecentConcreteChatId,
+  newChatCandidateResolution,
   newChatPresentationIsCurrent,
+  reconcileHydratedNewChatCandidate,
   reconcileCreatedChatGuard,
   rememberCreatedChat,
   reusableChatDetailVerdict,
@@ -82,12 +84,14 @@ import {
 } from './chatListProjection.js'
 import {
   clearComposerDraft,
-  composerDraftHasContent,
+  composerDraftSnapshots,
   consumeComposerHandoff,
+  hydrateComposerDraftIndex,
   stageComposerHandoff,
 } from '../ChatView/composerDraft.js'
 import {
   beginTouchComposerFocusLease,
+  composerFocusLeaseHandoff,
   releaseComposerFocusLease,
 } from './composerFocusLease.js'
 import {
@@ -622,6 +626,9 @@ export default function Shell() {
   // still disables sends while unavailable, but does not repeat this status
   // beside the composer.
   const online = useOnlineStatus()
+  useEffect(() => {
+    void hydrateComposerDraftIndex()
+  }, [])
   const chatsLoadedRef = useRef(false)
   const knownExistingOffListChatIdsRef = useRef(new Set())
   // Always-current chats, for reading inside callbacks that may hold a stale
@@ -2418,14 +2425,13 @@ export default function Shell() {
   // { chatId, reason }: reason is 'offline' | 'inflight' | 'error' when chatId is null,
   // so each caller can react appropriately (a toast vs a retry surface).
   //
-  // `candidate`: an explicitly pre-captured reusable row (the materialize path, which
-  // captured it from the pre-transition active chat). When undefined, derive it fresh
-  // from the current active chat (the user newChat path). The list is only a candidate
-  // source — cross-client sends can make has_messages stale — so online reuse needs one
-  // fresh, bounded detail read; any error/unfamiliar response fails closed to creating.
+  // `candidate`: an explicitly pre-captured identity with its provenance and optional
+  // local draft snapshot. When undefined, derive the current active blank. Arbitrary
+  // active/history candidates still need a fresh bounded detail read online; a local
+  // draft is stronger owner intent and resumes directly without sacrificing its data.
   async function resolveNewChatId({ candidate, draft, forceNew, exclude } = {}) {
-    let empty = candidate !== undefined
-      ? candidate
+    const derivedActive = candidate !== undefined
+      ? null
       : currentReusableEmptyChat(chatsRef.current, {
         activeChatId: activeChatIdRef.current,
         draft: !!draft,
@@ -2434,11 +2440,23 @@ export default function Shell() {
         recoveredChatIds: recoveredChatIdsRef.current,
         streamingChatIds: streamingChatIdsRef.current,
       })
-    if (empty && online) {
+    let reusable = candidate !== undefined
+      ? candidate
+      : (derivedActive
+        ? { chatId: derivedActive.id, source: 'active', draft: null }
+        : null)
+    // A non-empty local draft is affirmative owner intent to resume that
+    // compose surface. It stays usable offline and if another device has since
+    // added context; arbitrary history fallbacks still require fresh proof.
+    const candidateResolution = newChatCandidateResolution(reusable, { online })
+    if (candidateResolution === 'reject') {
+      reusable = null
+    }
+    if (reusable && candidateResolution === 'probe') {
       try {
-        const staleEmptyId = empty.id
+        const staleEmptyId = reusable.chatId
         const res = await apiFetch(
-          `/chats/${encodeURIComponent(empty.id)}?limit=1`,
+          `/chats/${encodeURIComponent(staleEmptyId)}?limit=1`,
           { timeoutMs: 5000 },
         )
         let detail = null
@@ -2449,7 +2467,7 @@ export default function Shell() {
           detail,
         })
         if (verdict !== 'empty') {
-          empty = null
+          reusable = null
           reconcileCreatedChatGuard(
             recentlyCreatedChatsRef.current,
             staleEmptyId,
@@ -2484,10 +2502,10 @@ export default function Shell() {
           }
         }
       } catch {
-        empty = null
+        reusable = null
       }
     }
-    if (empty) return { chatId: empty.id, reason: null }
+    if (reusable) return { chatId: reusable.chatId, reason: null }
     // Creating a fresh chat needs the server (POST allocates the row, and a chat is
     // only useful once the server-side agent can run). The reuse branch already handled
     // the offline-friendly case, so reaching here offline means we truly need network.
@@ -2542,8 +2560,11 @@ export default function Shell() {
       // Re-look-up the captured candidate by id (the list may have changed since the
       // request). Missing → no reuse, straight to create. Explicit candidate (may be
       // null) so resolveNewChatId does not re-derive from the now-different active chat.
-      const candidate = pending.candidateId != null
+      const candidateRow = pending.candidateId != null
         ? (chatsRef.current.find(c => String(c.id) === String(pending.candidateId)) || null)
+        : null
+      const candidate = candidateRow
+        ? { chatId: candidateRow.id, source: 'active', draft: null }
         : null
       const { chatId, reason } = pending.resolvedChatId != null
         ? { chatId: pending.resolvedChatId, reason: null }
@@ -2601,8 +2622,8 @@ export default function Shell() {
   async function newChat({ draft, forceNew, exclude, autoSend, focusComposer, recordHistory } = {}) {
     // Keep the active chat when it is still an untouched blank; only POST a
     // fresh row when this explicit New-chat action needs one. Never borrow an
-    // off-screen blank: another browser may have started it while this tab's
-    // chat-list cache still says has_messages=false.
+    // arbitrary off-screen blank: only a non-empty device-local draft is
+    // affirmative owner intent to resume that compose surface.
     //
     // `forceNew` bypasses reuse for callers that NEED a fresh row —
     // moebius:new-chat events (the ChatView wouldn't remount on the
@@ -2651,13 +2672,6 @@ export default function Shell() {
         current === presentation ? null : current
       ))
     }
-    // A phone keyboard can only be raised from the tap's live user-activation
-    // task. The modal drawer remains history-open but is no longer displayed,
-    // so no asynchronous traversal can blur this lease before the chat-bound
-    // composer accepts it. The lease also carries any early typing.
-    const touchFocusLeased = !!focusComposer && beginTouchComposerFocusLease(
-      composerFocusLeaseRef.current,
-    )
     const standardNewChat = ws.viewMode === 'single' && !draft && !forceNew
     const reuseOptions = {
       exclude,
@@ -2668,27 +2682,69 @@ export default function Shell() {
     // at the conversation they are reading. Standard's New chat action should
     // return to the most recently left unfinished composer, not manufacture a
     // second blank and make the saved draft look lost. Builder remains additive.
-    const composeCandidate = standardNewChat
-      ? standardNewChatCandidate(chatsRef.current, navStackRef.current, {
+    let composeCandidate = standardNewChat
+      ? standardNewChatCandidate(chatsRef.current, composerDraftSnapshots(), {
           ...reuseOptions,
           activeChatId: activeChatIdRef.current,
-          hasDraft: composerDraftHasContent,
         })
       : null
+    let leaseCandidate = composeCandidate
+    let leaseInitialValue = composeCandidate?.draft?.input || ''
+    // A phone keyboard can only be raised from the tap's live user-activation
+    // task. Prime the lease with the complete resumed text so early typing
+    // extends that draft instead of replacing it.
+    const touchFocusLeased = !!focusComposer && beginTouchComposerFocusLease(
+      composerFocusLeaseRef.current,
+      { initialValue: leaseInitialValue },
+    )
+    if (standardNewChat) {
+      await hydrateComposerDraftIndex()
+      const hydratedCandidate = standardNewChatCandidate(
+        chatsRef.current,
+        composerDraftSnapshots(),
+        { ...reuseOptions, activeChatId: activeChatIdRef.current },
+      )
+      const leaseWasEdited = touchFocusLeased
+        && composerFocusLeaseRef.current?.value !== leaseInitialValue
+      const hydration = reconcileHydratedNewChatCandidate(
+        composeCandidate,
+        hydratedCandidate,
+        { leaseWasEdited },
+      )
+      composeCandidate = hydration.candidate
+      if (hydration.primeLease) {
+        leaseCandidate = hydration.candidate
+        leaseInitialValue = hydration.candidate.draft?.input || ''
+        if (touchFocusLeased) {
+          const lease = composerFocusLeaseRef.current
+          lease.value = leaseInitialValue
+          const end = lease.value.length
+          try { lease.setSelectionRange(end, end) } catch {}
+        }
+      } else if (!hydration.candidate && hydratedCandidate?.source === 'draft') {
+        // The owner began a fresh thought before a durable older draft became
+        // discoverable. Keep those as two drafts rather than guessing a merge
+        // and overwriting either one.
+        leaseCandidate = null
+      }
+    }
     const resumeId = standardNewChat
       && !composeCandidate
       && activeChatIdRef.current == null
       ? mostRecentConcreteChatId(navStackRef.current)
       : null
+    const historyRow = resumeId == null
+      ? null
+      : currentReusableEmptyChat(chatsRef.current, {
+          ...reuseOptions,
+          activeChatId: resumeId,
+        })
     const resumeCandidate = !standardNewChat
       ? undefined
       : composeCandidate
-        || (resumeId == null
-          ? null
-          : currentReusableEmptyChat(chatsRef.current, {
-              ...reuseOptions,
-              activeChatId: resumeId,
-            }))
+        || (historyRow
+          ? { chatId: historyRow.id, source: 'history', draft: null }
+          : null)
     const { chatId, reason } = await resolveNewChatId(
       resumeCandidate === undefined
         ? { draft, forceNew, exclude }
@@ -2733,10 +2789,20 @@ export default function Shell() {
       && !!(draft || forceNew || drawerPushedRef.current || recordHistory)
     const suppliedDraft = draft ? String(draft) : ''
     const leasedDraft = touchFocusLeased ? composerFocusLeaseRef.current?.value || '' : ''
-    const draftText = suppliedDraft || leasedDraft
-    if (draftText) {
-      stageComposerHandoff(chatId, draftText, {
-        autoSend: suppliedDraft ? autoSend : false,
+    const handoff = composerFocusLeaseHandoff({
+      autoSend,
+      initialValue: leaseInitialValue,
+      leaseCandidate,
+      leaseValue: leasedDraft,
+      leased: touchFocusLeased,
+      resolvedChatId: chatId,
+      suppliedDraft,
+    })
+    if (handoff.shouldStage) {
+      stageComposerHandoff(chatId, handoff.text, {
+        allowEmpty: true,
+        attachments: handoff.attachments,
+        autoSend: handoff.autoSend,
       })
     }
     // Keep history writes inside useNavigation so the entry gets its route,
@@ -2773,7 +2839,7 @@ export default function Shell() {
     }
     if (focusComposer) {
       requestComposer(chatId, {
-        draft: draftText || undefined,
+        draft: handoff.shouldStage ? handoff.text : undefined,
         focus: true,
       })
     }

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -1006,17 +1006,20 @@ export default function Shell() {
       setNewChatPresentation(current => (
         current === presentation ? releasing : current
       ))
-      // The keyboard lease is deliberately NOT released here. Display-ready only
-      // unblocks the composerRequest (gated on surfaceVisible); the destination
-      // composer accepts focus one animation frame later. Releasing now blurs
-      // the lease a frame early, leaving nothing focused — Android drops and
-      // re-raises the soft keyboard (the New-chat "bounce"). On this success
-      // path the composer's own focus atomically takes the keyboard from the
-      // lease and the lease's onBlur clears it; only the abandon paths (failed
-      // or superseded allocation) release the lease explicitly.
+      // Display readiness owns the lease-to-composer transfer. Requesting focus
+      // when allocation resolves lets ChatView consume it before this boundary,
+      // so a later presentation change can leave the new composer unfocused.
+      // The composer's focus takes the keyboard from the lease atomically; its
+      // onBlur clears the lease, while abandon paths release it explicitly.
+      requestComposer(id, { focus: true })
     }
     finishDrawerNavigationPresentation()
-  }, [finishDrawerNavigationPresentation, focusedPaneViewIdRef, workspaceStateRef])
+  }, [
+    finishDrawerNavigationPresentation,
+    focusedPaneViewIdRef,
+    requestComposer,
+    workspaceStateRef,
+  ])
 
   const finishNewChatPresentationRelease = useCallback((presentation) => {
     if (!presentation?.releasing || newChatPresentationRef.current !== presentation) return
@@ -2819,7 +2822,10 @@ export default function Shell() {
         ))
       }
     }
-    if (focusComposer) {
+    // An immediate Standard presentation owns the keyboard lease until the
+    // destination reports a painted frame. Builder and an already-presented
+    // Standard blank have no pending presentation boundary, so focus now.
+    if (focusComposer && (!presentation || alreadyPresented)) {
       requestComposer(chatId, {
         draft: handoff.shouldStage ? handoff.text : undefined,
         focus: true,

--- a/frontend/src/components/Shell/__tests__/chatHandoff.test.js
+++ b/frontend/src/components/Shell/__tests__/chatHandoff.test.js
@@ -260,7 +260,7 @@ test('direct chat actions hand focus to the destination composer', () => {
     /beginTouchComposerFocusLease\([\s\S]*?await resolveNewChatId/,
     'New chat must reserve phone keyboard focus before its first async boundary')
   assert.match(shell,
-    /composerFocusLeaseRef\.current\?\.value[\s\S]*?requestComposer\(chatId, \{[\s\S]*?draft: draftText \|\| undefined,[\s\S]*?focus: true/,
+    /composerFocusLeaseRef\.current\?\.value[\s\S]*?composerFocusLeaseHandoff\(\{[\s\S]*?requestComposer\(chatId, \{[\s\S]*?draft: handoff\.shouldStage \? handoff\.text : undefined,[\s\S]*?focus: true/,
     'New chat must carry early lease typing into the focused destination composer')
   assert.match(shell,
     /className="shell__composer-focus-lease"[\s\S]*?aria-label="New chat message"/,

--- a/frontend/src/components/Shell/__tests__/chatHandoff.test.js
+++ b/frontend/src/components/Shell/__tests__/chatHandoff.test.js
@@ -260,8 +260,14 @@ test('direct chat actions hand focus to the destination composer', () => {
     /beginTouchComposerFocusLease\([\s\S]*?await resolveNewChatId/,
     'New chat must reserve phone keyboard focus before its first async boundary')
   assert.match(shell,
-    /composerFocusLeaseRef\.current\?\.value[\s\S]*?composerFocusLeaseHandoff\(\{[\s\S]*?requestComposer\(chatId, \{[\s\S]*?draft: handoff\.shouldStage \? handoff\.text : undefined,[\s\S]*?focus: true/,
-    'New chat must carry early lease typing into the focused destination composer')
+    /composerFocusLeaseRef\.current\?\.value[\s\S]*?composerFocusLeaseHandoff\(\{[\s\S]*?stageComposerHandoff\(chatId, handoff\.text/,
+    'New chat must carry early lease typing into the destination composer')
+  assert.match(shell,
+    /String\(presentation\?\.chatId \?\? ''\) === id[\s\S]*?requestComposer\(id, \{ focus: true \}\)/,
+    'an immediate New chat presentation must hand focus over at display readiness')
+  assert.match(shell,
+    /if \(focusComposer && \(!presentation \|\| alreadyPresented\)\) \{[\s\S]*?requestComposer\(chatId/,
+    'allocation must not consume the focus request before the presentation is ready')
   assert.match(shell,
     /className="shell__composer-focus-lease"[\s\S]*?aria-label="New chat message"/,
     'the keyboard lease must remain a named, programmatically focused text control')

--- a/frontend/src/components/Shell/__tests__/composerFocusLease.test.js
+++ b/frontend/src/components/Shell/__tests__/composerFocusLease.test.js
@@ -3,14 +3,17 @@ import assert from 'node:assert/strict'
 
 import {
   beginTouchComposerFocusLease,
+  composerFocusLeaseHandoff,
   releaseComposerFocusLease,
 } from '../composerFocusLease.js'
 
-test('touch focus lease starts synchronously with a clean control', () => {
+test('touch focus lease starts synchronously at the end of its draft snapshot', () => {
   const calls = []
+  const selections = []
   const el = {
     value: 'stale',
     focus: (...args) => calls.push(args),
+    setSelectionRange: (...args) => selections.push(args),
   }
   const touchMedia = query => ({
     matches: query === '(hover: none) and (pointer: coarse)',
@@ -19,9 +22,11 @@ test('touch focus lease starts synchronously with a clean control', () => {
   assert.equal(beginTouchComposerFocusLease(el, {
     matchMediaImpl: touchMedia,
     activeElement: null,
+    initialValue: 'unfinished',
   }), true)
-  assert.equal(el.value, '')
+  assert.equal(el.value, 'unfinished')
   assert.deepEqual(calls, [[{ preventScroll: true }]])
+  assert.deepEqual(selections, [[10, 10]])
 })
 
 test('touch focus lease stays inert on desktop and releases failed handoffs', () => {
@@ -40,4 +45,65 @@ test('touch focus lease stays inert on desktop and releases failed handoffs', ()
   releaseComposerFocusLease(el, { activeElement: el })
   assert.equal(blurred, 1)
   assert.equal(el.value, '')
+})
+
+test('early typing extends a resumed draft without dropping its attachments', () => {
+  const attachment = {
+    name: 'reference.png', size: 12, mime_type: 'image/png', status: 'done',
+  }
+  assert.deepEqual(composerFocusLeaseHandoff({
+    initialValue: 'unfinished',
+    leaseCandidate: {
+      chatId: 'draft-chat',
+      source: 'draft',
+      draft: { input: 'unfinished', attachments: [attachment] },
+    },
+    leaseValue: 'unfinished thought',
+    leased: true,
+    resolvedChatId: 'draft-chat',
+  }), {
+    attachments: [attachment],
+    autoSend: false,
+    shouldStage: true,
+    text: 'unfinished thought',
+  })
+})
+
+test('an untouched resumed lease leaves the durable draft owner unchanged', () => {
+  assert.deepEqual(composerFocusLeaseHandoff({
+    initialValue: 'unfinished',
+    leaseCandidate: {
+      chatId: 'draft-chat',
+      source: 'draft',
+      draft: { input: 'unfinished', attachments: [] },
+    },
+    leaseValue: 'unfinished',
+    leased: true,
+    resolvedChatId: 'draft-chat',
+  }), {
+    attachments: [],
+    autoSend: false,
+    shouldStage: false,
+    text: 'unfinished',
+  })
+})
+
+test('clearing resumed text keeps its completed attachment snapshot', () => {
+  const attachment = { name: 'reference.png', status: 'done' }
+  assert.deepEqual(composerFocusLeaseHandoff({
+    initialValue: 'remove this text',
+    leaseCandidate: {
+      chatId: 'draft-chat',
+      source: 'draft',
+      draft: { input: 'remove this text', attachments: [attachment] },
+    },
+    leaseValue: '',
+    leased: true,
+    resolvedChatId: 'draft-chat',
+  }), {
+    attachments: [attachment],
+    autoSend: false,
+    shouldStage: true,
+    text: '',
+  })
 })

--- a/frontend/src/components/Shell/__tests__/newChatDraftPolicy.test.js
+++ b/frontend/src/components/Shell/__tests__/newChatDraftPolicy.test.js
@@ -14,34 +14,26 @@ const empty = (id, extra = {}) => ({
   ...extra,
 })
 
-test('standard mode resumes the most recently left local draft chat', () => {
+test('New chat never promotes an off-screen saved draft', () => {
   const chats = [
     empty('older-draft'),
     empty('newer-draft'),
     empty('no-draft'),
     empty('now-running', { running: true }),
   ]
-  const candidate = standardNewChatCandidate(chats, [
-    { chatId: 'now-running', input: 'newest but active elsewhere', attachments: [] },
-    { chatId: 'newer-draft', input: 'keep this', attachments: [] },
-    { chatId: 'older-draft', input: 'older', attachments: [] },
-  ], {
+  assert.equal(standardNewChatCandidate(chats, {
+    chatId: 'newer-draft', input: 'keep this', attachments: [],
+  }, {
     activeChatId: 'reading-chat',
-  })
-
-  assert.deepEqual(candidate, {
-    chatId: 'newer-draft',
-    source: 'draft',
-    draft: { chatId: 'newer-draft', input: 'keep this', attachments: [] },
-  })
+  }), null)
 })
 
 test('the visible untouched blank outranks an older Standard draft', () => {
   const active = empty('active-blank')
   const olderDraft = empty('older-draft')
-  const candidate = standardNewChatCandidate([active, olderDraft], [
-    { chatId: 'older-draft', input: 'keep this', attachments: [] },
-  ], {
+  const candidate = standardNewChatCandidate([active, olderDraft], {
+    chatId: 'older-draft', input: 'keep this', attachments: [],
+  }, {
     activeChatId: 'active-blank',
   })
 
@@ -58,10 +50,9 @@ test('draft resume never borrows a populated, recovered, or streaming chat', () 
     empty('recovered'),
     empty('streaming'),
   ]
-  const drafts = chats.map(chat => ({
-    chatId: chat.id, input: 'draft', attachments: [],
-  }))
-  assert.equal(standardNewChatCandidate(chats, drafts, {
+  assert.equal(standardNewChatCandidate(chats, {
+    chatId: 'recovered', input: 'draft', attachments: [],
+  }, {
     activeChatId: 'reading-chat',
     recoveredChatIds: new Set(['recovered']),
     streamingChatIds: new Set(['streaming']),
@@ -75,7 +66,7 @@ test('an active blank with a draft carries its complete resume snapshot', () => 
     input: 'unfinished',
     attachments: [{ name: 'reference.png', status: 'done' }],
   }
-  assert.deepEqual(standardNewChatCandidate([active], [draft], {
+  assert.deepEqual(standardNewChatCandidate([active], draft, {
     activeChatId: 'active',
   }), {
     chatId: 'active',
@@ -84,7 +75,7 @@ test('an active blank with a draft carries its complete resume snapshot', () => 
   })
 })
 
-test('candidate provenance owns offline reuse and authoritative probing', () => {
+test('only current-surface provenance can be reused or probed', () => {
   const active = { chatId: 'active', source: 'active', draft: null }
   const draft = { chatId: 'draft', source: 'draft', draft: { input: 'keep' } }
   const history = { chatId: 'history', source: 'history', draft: null }
@@ -94,30 +85,17 @@ test('candidate provenance owns offline reuse and authoritative probing', () => 
   assert.equal(newChatCandidateResolution(draft, { online: false }), 'reuse')
   assert.equal(newChatCandidateResolution(draft, { online: true }), 'reuse')
   assert.equal(newChatCandidateResolution(history, { online: false }), 'reject')
-  assert.equal(newChatCandidateResolution(history, { online: true }), 'probe')
+  assert.equal(newChatCandidateResolution(history, { online: true }), 'reject')
 })
 
 test('late durable discovery never guesses a merge over early fresh typing', () => {
   const active = { chatId: 'active', source: 'active', draft: null }
   const durable = {
-    chatId: 'durable',
+    chatId: 'active',
     source: 'draft',
     draft: { input: 'older thought', attachments: [] },
   }
   assert.deepEqual(reconcileHydratedNewChatCandidate(active, durable, {
-    leaseWasEdited: true,
-  }), {
-    candidate: active,
-    primeLease: false,
-  })
-  assert.deepEqual(reconcileHydratedNewChatCandidate(active, {
-    ...durable,
-    chatId: 'active',
-  }, { leaseWasEdited: true }), {
-    candidate: null,
-    primeLease: false,
-  })
-  assert.deepEqual(reconcileHydratedNewChatCandidate(null, durable, {
     leaseWasEdited: true,
   }), {
     candidate: null,
@@ -129,7 +107,7 @@ test('late durable discovery never guesses a merge over early fresh typing', () 
     candidate: active,
     primeLease: false,
   })
-  assert.deepEqual(reconcileHydratedNewChatCandidate(null, durable), {
+  assert.deepEqual(reconcileHydratedNewChatCandidate(active, durable), {
     candidate: durable,
     primeLease: true,
   })

--- a/frontend/src/components/Shell/__tests__/newChatDraftPolicy.test.js
+++ b/frontend/src/components/Shell/__tests__/newChatDraftPolicy.test.js
@@ -28,6 +28,14 @@ test('New chat never promotes an off-screen saved draft', () => {
   }), null)
 })
 
+test('a populated current chat with no draft has no reusable candidate', () => {
+  assert.equal(standardNewChatCandidate([
+    empty('current', { has_messages: true }),
+  ], null, {
+    activeChatId: 'current',
+  }), null)
+})
+
 test('the visible untouched blank outranks an older Standard draft', () => {
   const active = empty('active-blank')
   const olderDraft = empty('older-draft')

--- a/frontend/src/components/Shell/__tests__/newChatDraftPolicy.test.js
+++ b/frontend/src/components/Shell/__tests__/newChatDraftPolicy.test.js
@@ -1,0 +1,136 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  newChatCandidateResolution,
+  reconcileHydratedNewChatCandidate,
+  standardNewChatCandidate,
+} from '../newChatPolicy.js'
+
+const empty = (id, extra = {}) => ({
+  id,
+  has_messages: false,
+  running: false,
+  ...extra,
+})
+
+test('standard mode resumes the most recently left local draft chat', () => {
+  const chats = [
+    empty('older-draft'),
+    empty('newer-draft'),
+    empty('no-draft'),
+    empty('now-running', { running: true }),
+  ]
+  const candidate = standardNewChatCandidate(chats, [
+    { chatId: 'now-running', input: 'newest but active elsewhere', attachments: [] },
+    { chatId: 'newer-draft', input: 'keep this', attachments: [] },
+    { chatId: 'older-draft', input: 'older', attachments: [] },
+  ], {
+    activeChatId: 'reading-chat',
+  })
+
+  assert.deepEqual(candidate, {
+    chatId: 'newer-draft',
+    source: 'draft',
+    draft: { chatId: 'newer-draft', input: 'keep this', attachments: [] },
+  })
+})
+
+test('the visible untouched blank outranks an older Standard draft', () => {
+  const active = empty('active-blank')
+  const olderDraft = empty('older-draft')
+  const candidate = standardNewChatCandidate([active, olderDraft], [
+    { chatId: 'older-draft', input: 'keep this', attachments: [] },
+  ], {
+    activeChatId: 'active-blank',
+  })
+
+  assert.deepEqual(candidate, {
+    chatId: 'active-blank',
+    source: 'active',
+    draft: null,
+  })
+})
+
+test('draft resume never borrows a populated, recovered, or streaming chat', () => {
+  const chats = [
+    empty('populated', { has_messages: true }),
+    empty('recovered'),
+    empty('streaming'),
+  ]
+  const drafts = chats.map(chat => ({
+    chatId: chat.id, input: 'draft', attachments: [],
+  }))
+  assert.equal(standardNewChatCandidate(chats, drafts, {
+    activeChatId: 'reading-chat',
+    recoveredChatIds: new Set(['recovered']),
+    streamingChatIds: new Set(['streaming']),
+  }), null)
+})
+
+test('an active blank with a draft carries its complete resume snapshot', () => {
+  const active = empty('active')
+  const draft = {
+    chatId: 'active',
+    input: 'unfinished',
+    attachments: [{ name: 'reference.png', status: 'done' }],
+  }
+  assert.deepEqual(standardNewChatCandidate([active], [draft], {
+    activeChatId: 'active',
+  }), {
+    chatId: 'active',
+    source: 'draft',
+    draft,
+  })
+})
+
+test('candidate provenance owns offline reuse and authoritative probing', () => {
+  const active = { chatId: 'active', source: 'active', draft: null }
+  const draft = { chatId: 'draft', source: 'draft', draft: { input: 'keep' } }
+  const history = { chatId: 'history', source: 'history', draft: null }
+
+  assert.equal(newChatCandidateResolution(active, { online: false }), 'reuse')
+  assert.equal(newChatCandidateResolution(active, { online: true }), 'probe')
+  assert.equal(newChatCandidateResolution(draft, { online: false }), 'reuse')
+  assert.equal(newChatCandidateResolution(draft, { online: true }), 'reuse')
+  assert.equal(newChatCandidateResolution(history, { online: false }), 'reject')
+  assert.equal(newChatCandidateResolution(history, { online: true }), 'probe')
+})
+
+test('late durable discovery never guesses a merge over early fresh typing', () => {
+  const active = { chatId: 'active', source: 'active', draft: null }
+  const durable = {
+    chatId: 'durable',
+    source: 'draft',
+    draft: { input: 'older thought', attachments: [] },
+  }
+  assert.deepEqual(reconcileHydratedNewChatCandidate(active, durable, {
+    leaseWasEdited: true,
+  }), {
+    candidate: active,
+    primeLease: false,
+  })
+  assert.deepEqual(reconcileHydratedNewChatCandidate(active, {
+    ...durable,
+    chatId: 'active',
+  }, { leaseWasEdited: true }), {
+    candidate: null,
+    primeLease: false,
+  })
+  assert.deepEqual(reconcileHydratedNewChatCandidate(null, durable, {
+    leaseWasEdited: true,
+  }), {
+    candidate: null,
+    primeLease: false,
+  })
+  assert.deepEqual(reconcileHydratedNewChatCandidate(active, active, {
+    leaseWasEdited: true,
+  }), {
+    candidate: active,
+    primeLease: false,
+  })
+  assert.deepEqual(reconcileHydratedNewChatCandidate(null, durable), {
+    candidate: durable,
+    primeLease: true,
+  })
+})

--- a/frontend/src/components/Shell/__tests__/newChatPolicy.test.js
+++ b/frontend/src/components/Shell/__tests__/newChatPolicy.test.js
@@ -9,7 +9,6 @@ import {
   detailIsUntouchedEmptyChat,
   enteredEmptySingleScreen,
   mergeChatListWithCreatedGuards,
-  mostRecentConcreteChatId,
   newChatPresentationIsCurrent,
   reconcileCreatedChatGuard,
   rememberCreatedChat,
@@ -133,21 +132,6 @@ test('drafts and force-new callers always require a fresh chat', () => {
   assert.equal(currentReusableEmptyChat([active], {
     activeChatId: 'active', forceNew: true,
   }), null)
-})
-
-test('the most recent concrete chat route can resume standard-mode composition', () => {
-  assert.equal(mostRecentConcreteChatId([
-    { view: 'chat', chatId: 'older' },
-    { view: 'canvas', appId: 4 },
-    { view: 'settings' },
-    { view: 'chat', chatId: 'draft' },
-    { view: 'canvas', appId: 7 },
-  ]), 'draft')
-  assert.equal(mostRecentConcreteChatId([
-    { view: 'chat', chatId: null, homeSeed: true },
-    { view: 'canvas', appId: 4 },
-  ]), null)
-  assert.equal(mostRecentConcreteChatId(null), null)
 })
 
 test('running, excluded, recovered, and populated active chats are rejected', () => {

--- a/frontend/src/components/Shell/__tests__/newChatPolicy.test.js
+++ b/frontend/src/components/Shell/__tests__/newChatPolicy.test.js
@@ -14,7 +14,6 @@ import {
   reconcileCreatedChatGuard,
   rememberCreatedChat,
   reusableChatDetailVerdict,
-  standardNewChatCandidate,
 } from '../newChatPolicy.js'
 import { chatQueries } from '../../../hooks/queries.js'
 
@@ -149,56 +148,6 @@ test('the most recent concrete chat route can resume standard-mode composition',
     { view: 'canvas', appId: 4 },
   ]), null)
   assert.equal(mostRecentConcreteChatId(null), null)
-})
-
-test('standard mode resumes the most recently left local draft chat', () => {
-  const chats = [
-    empty('older-draft'),
-    empty('newer-draft'),
-    empty('no-draft'),
-    empty('now-running', { running: true }),
-  ]
-  const drafted = new Set(['older-draft', 'newer-draft', 'now-running'])
-  const candidate = standardNewChatCandidate(chats, [
-    { view: 'chat', chatId: 'older-draft' },
-    { view: 'chat', chatId: 'newer-draft' },
-    { view: 'chat', chatId: 'no-draft' },
-    { view: 'chat', chatId: 'now-running' },
-    { view: 'canvas', appId: 7 },
-  ], {
-    activeChatId: 'reading-chat',
-    hasDraft: id => drafted.has(id),
-  })
-
-  assert.equal(candidate?.id, 'newer-draft')
-})
-
-test('the visible untouched blank outranks an older Standard draft', () => {
-  const active = empty('active-blank')
-  const olderDraft = empty('older-draft')
-  const candidate = standardNewChatCandidate([active, olderDraft], [
-    { view: 'chat', chatId: 'older-draft' },
-  ], {
-    activeChatId: 'active-blank',
-    hasDraft: id => id === 'older-draft',
-  })
-
-  assert.equal(candidate, active)
-})
-
-test('draft resume never borrows a populated, recovered, or streaming chat', () => {
-  const chats = [
-    empty('populated', { has_messages: true }),
-    empty('recovered'),
-    empty('streaming'),
-  ]
-  const routes = chats.map(chat => ({ view: 'chat', chatId: chat.id }))
-  assert.equal(standardNewChatCandidate(chats, routes, {
-    activeChatId: 'reading-chat',
-    hasDraft: () => true,
-    recoveredChatIds: new Set(['recovered']),
-    streamingChatIds: new Set(['streaming']),
-  }), null)
 })
 
 test('running, excluded, recovered, and populated active chats are rejected', () => {

--- a/frontend/src/components/Shell/__tests__/newChatPolicy.test.js
+++ b/frontend/src/components/Shell/__tests__/newChatPolicy.test.js
@@ -14,6 +14,7 @@ import {
   reconcileCreatedChatGuard,
   rememberCreatedChat,
   reusableChatDetailVerdict,
+  standardNewChatCandidate,
 } from '../newChatPolicy.js'
 import { chatQueries } from '../../../hooks/queries.js'
 
@@ -148,6 +149,56 @@ test('the most recent concrete chat route can resume standard-mode composition',
     { view: 'canvas', appId: 4 },
   ]), null)
   assert.equal(mostRecentConcreteChatId(null), null)
+})
+
+test('standard mode resumes the most recently left local draft chat', () => {
+  const chats = [
+    empty('older-draft'),
+    empty('newer-draft'),
+    empty('no-draft'),
+    empty('now-running', { running: true }),
+  ]
+  const drafted = new Set(['older-draft', 'newer-draft', 'now-running'])
+  const candidate = standardNewChatCandidate(chats, [
+    { view: 'chat', chatId: 'older-draft' },
+    { view: 'chat', chatId: 'newer-draft' },
+    { view: 'chat', chatId: 'no-draft' },
+    { view: 'chat', chatId: 'now-running' },
+    { view: 'canvas', appId: 7 },
+  ], {
+    activeChatId: 'reading-chat',
+    hasDraft: id => drafted.has(id),
+  })
+
+  assert.equal(candidate?.id, 'newer-draft')
+})
+
+test('the visible untouched blank outranks an older Standard draft', () => {
+  const active = empty('active-blank')
+  const olderDraft = empty('older-draft')
+  const candidate = standardNewChatCandidate([active, olderDraft], [
+    { view: 'chat', chatId: 'older-draft' },
+  ], {
+    activeChatId: 'active-blank',
+    hasDraft: id => id === 'older-draft',
+  })
+
+  assert.equal(candidate, active)
+})
+
+test('draft resume never borrows a populated, recovered, or streaming chat', () => {
+  const chats = [
+    empty('populated', { has_messages: true }),
+    empty('recovered'),
+    empty('streaming'),
+  ]
+  const routes = chats.map(chat => ({ view: 'chat', chatId: chat.id }))
+  assert.equal(standardNewChatCandidate(chats, routes, {
+    activeChatId: 'reading-chat',
+    hasDraft: () => true,
+    recoveredChatIds: new Set(['recovered']),
+    streamingChatIds: new Set(['streaming']),
+  }), null)
 })
 
 test('running, excluded, recovered, and populated active chats are rejected', () => {

--- a/frontend/src/components/Shell/composerFocusLease.js
+++ b/frontend/src/components/Shell/composerFocusLease.js
@@ -10,11 +10,17 @@ const TOUCH_PRIMARY_QUERY = '(hover: none) and (pointer: coarse)'
 export function beginTouchComposerFocusLease(el, {
   matchMediaImpl = globalThis.matchMedia,
   activeElement = globalThis.document?.activeElement,
+  initialValue = '',
 } = {}) {
   if (!el || activeElement === el || typeof matchMediaImpl !== 'function') return false
   if (matchMediaImpl(TOUCH_PRIMARY_QUERY)?.matches !== true) return false
-  el.value = ''
-  return focusComposerElement(el)
+  el.value = String(initialValue)
+  const focused = focusComposerElement(el)
+  if (focused) {
+    const end = el.value.length
+    try { el.setSelectionRange?.(end, end) } catch {}
+  }
+  return focused
 }
 
 export function releaseComposerFocusLease(el, {
@@ -23,4 +29,32 @@ export function releaseComposerFocusLease(el, {
   if (!el) return
   if (activeElement === el && typeof el.blur === 'function') el.blur()
   el.value = ''
+}
+
+/** Settle the hidden touch buffer into one explicit composer handoff. */
+export function composerFocusLeaseHandoff({
+  autoSend = false,
+  initialValue = '',
+  leaseCandidate = null,
+  leaseValue = '',
+  leased = false,
+  resolvedChatId,
+  suppliedDraft = '',
+} = {}) {
+  if (suppliedDraft) {
+    return {
+      attachments: [],
+      autoSend: !!autoSend,
+      shouldStage: true,
+      text: String(suppliedDraft),
+    }
+  }
+  const sameCandidate = leaseCandidate
+    && String(leaseCandidate.chatId) === String(resolvedChatId)
+  return {
+    attachments: sameCandidate ? leaseCandidate.draft?.attachments || [] : [],
+    autoSend: false,
+    shouldStage: !!leased && leaseValue !== initialValue,
+    text: leased ? String(leaseValue) : '',
+  }
 }

--- a/frontend/src/components/Shell/newChatPolicy.js
+++ b/frontend/src/components/Shell/newChatPolicy.js
@@ -106,19 +106,18 @@ export function standardNewChatCandidate(chats, draft, {
     ...reuseOptions,
     activeChatId,
   })
-  const activeDraft = normalizedId(draft?.chatId) === normalizedId(active?.id)
+  if (!active) return null
+
+  const activeDraft = draft
+    && normalizedId(draft.chatId) === normalizedId(active.id)
     && (draft.input || draft.attachments?.length)
     ? draft
     : null
-  if (active) {
-    return {
-      chatId: active.id,
-      source: activeDraft ? 'draft' : 'active',
-      draft: activeDraft || null,
-    }
+  return {
+    chatId: active.id,
+    source: activeDraft ? 'draft' : 'active',
+    draft: activeDraft || null,
   }
-
-  return null
 }
 
 /** Decide whether candidate provenance is enough without a server round-trip. */

--- a/frontend/src/components/Shell/newChatPolicy.js
+++ b/frontend/src/components/Shell/newChatPolicy.js
@@ -88,16 +88,15 @@ export function currentReusableEmptyChat(chats, {
 
 /**
  * Choose the Standard compose surface without applying Builder's add-new rule.
- * The structured result keeps draft provenance and its complete snapshot
- * available to focus, offline, and handoff policy downstream.
+ * Only the currently open untouched blank is eligible. Saved drafts belong to
+ * their original chats and must never turn New chat into history navigation.
  */
-export function standardNewChatCandidate(chats, drafts, {
+export function standardNewChatCandidate(chats, draft, {
   activeChatId,
   exclude = null,
   recoveredChatIds = new Set(),
   streamingChatIds = new Set(),
 } = {}) {
-  const snapshots = Array.isArray(drafts) ? drafts : []
   const reuseOptions = {
     exclude,
     recoveredChatIds,
@@ -107,9 +106,10 @@ export function standardNewChatCandidate(chats, drafts, {
     ...reuseOptions,
     activeChatId,
   })
-  const activeDraft = snapshots.find(
-    draft => normalizedId(draft?.chatId) === normalizedId(active?.id),
-  )
+  const activeDraft = normalizedId(draft?.chatId) === normalizedId(active?.id)
+    && (draft.input || draft.attachments?.length)
+    ? draft
+    : null
   if (active) {
     return {
       chatId: active.id,
@@ -118,17 +118,6 @@ export function standardNewChatCandidate(chats, drafts, {
     }
   }
 
-  for (const draft of snapshots) {
-    const id = normalizedId(draft?.chatId)
-    if (!id) continue
-    const candidate = currentReusableEmptyChat(chats, {
-      ...reuseOptions,
-      activeChatId: id,
-    })
-    if (candidate) {
-      return { chatId: candidate.id, source: 'draft', draft }
-    }
-  }
   return null
 }
 
@@ -136,8 +125,8 @@ export function standardNewChatCandidate(chats, drafts, {
 export function newChatCandidateResolution(candidate, { online } = {}) {
   if (!candidate) return 'reject'
   if (candidate.source === 'draft') return 'reuse'
-  if (!online) return candidate.source === 'active' ? 'reuse' : 'reject'
-  return 'probe'
+  if (candidate.source !== 'active') return 'reject'
+  return online ? 'probe' : 'reuse'
 }
 
 /** Keep an early fresh edit separate when durable discovery arrives late. */
@@ -148,32 +137,10 @@ export function reconcileHydratedNewChatCandidate(
 ) {
   if (!hydratedCandidate) return { candidate: currentCandidate, primeLease: false }
   if (!leaseWasEdited) return { candidate: hydratedCandidate, primeLease: true }
-  const conflictsWithDiscoveredDraft = hydratedCandidate.source === 'draft'
-    && (!currentCandidate
-      || normalizedId(currentCandidate.chatId) === normalizedId(hydratedCandidate.chatId))
-  if (conflictsWithDiscoveredDraft && !currentCandidate?.draft) {
+  if (hydratedCandidate.source === 'draft' && !currentCandidate?.draft) {
     return { candidate: null, primeLease: false }
   }
   return { candidate: currentCandidate, primeLease: false }
-}
-
-/**
- * Find the concrete chat route the single-screen world most recently left.
- *
- * The navigation stack is newest-last. Home seed entries intentionally carry
- * no concrete id, so they are skipped along with app/settings routes. This is
- * only a candidate source: callers must still run the normal empty-chat checks
- * and authoritative detail probe before reusing the row.
- */
-export function mostRecentConcreteChatId(routes) {
-  const rows = Array.isArray(routes) ? routes : []
-  for (let index = rows.length - 1; index >= 0; index -= 1) {
-    const route = rows[index]
-    if (route?.view !== 'chat' || route.chatId == null) continue
-    const id = String(route.chatId).trim()
-    if (id) return id
-  }
-  return null
 }
 
 /**

--- a/frontend/src/components/Shell/newChatPolicy.js
+++ b/frontend/src/components/Shell/newChatPolicy.js
@@ -88,16 +88,16 @@ export function currentReusableEmptyChat(chats, {
 
 /**
  * Choose the Standard compose surface without applying Builder's add-new rule.
- * Draft ownership is device-local; the caller still freshly verifies any
- * off-screen empty candidate before reuse.
+ * The structured result keeps draft provenance and its complete snapshot
+ * available to focus, offline, and handoff policy downstream.
  */
-export function standardNewChatCandidate(chats, routes, {
+export function standardNewChatCandidate(chats, drafts, {
   activeChatId,
-  hasDraft,
   exclude = null,
   recoveredChatIds = new Set(),
   streamingChatIds = new Set(),
 } = {}) {
+  const snapshots = Array.isArray(drafts) ? drafts : []
   const reuseOptions = {
     exclude,
     recoveredChatIds,
@@ -107,25 +107,54 @@ export function standardNewChatCandidate(chats, routes, {
     ...reuseOptions,
     activeChatId,
   })
-  if (active || typeof hasDraft !== 'function') return active
+  const activeDraft = snapshots.find(
+    draft => normalizedId(draft?.chatId) === normalizedId(active?.id),
+  )
+  if (active) {
+    return {
+      chatId: active.id,
+      source: activeDraft ? 'draft' : 'active',
+      draft: activeDraft || null,
+    }
+  }
 
-  const seen = new Set()
-  const rows = Array.isArray(routes) ? routes : []
-  for (let index = rows.length - 1; index >= 0; index -= 1) {
-    const route = rows[index]
-    if (route?.view !== 'chat' || route.chatId == null) continue
-    const id = normalizedId(route.chatId)
-    if (!id || seen.has(id)) continue
-    seen.add(id)
-
-    if (!hasDraft(id)) continue
+  for (const draft of snapshots) {
+    const id = normalizedId(draft?.chatId)
+    if (!id) continue
     const candidate = currentReusableEmptyChat(chats, {
       ...reuseOptions,
       activeChatId: id,
     })
-    if (candidate) return candidate
+    if (candidate) {
+      return { chatId: candidate.id, source: 'draft', draft }
+    }
   }
   return null
+}
+
+/** Decide whether candidate provenance is enough without a server round-trip. */
+export function newChatCandidateResolution(candidate, { online } = {}) {
+  if (!candidate) return 'reject'
+  if (candidate.source === 'draft') return 'reuse'
+  if (!online) return candidate.source === 'active' ? 'reuse' : 'reject'
+  return 'probe'
+}
+
+/** Keep an early fresh edit separate when durable discovery arrives late. */
+export function reconcileHydratedNewChatCandidate(
+  currentCandidate,
+  hydratedCandidate,
+  { leaseWasEdited = false } = {},
+) {
+  if (!hydratedCandidate) return { candidate: currentCandidate, primeLease: false }
+  if (!leaseWasEdited) return { candidate: hydratedCandidate, primeLease: true }
+  const conflictsWithDiscoveredDraft = hydratedCandidate.source === 'draft'
+    && (!currentCandidate
+      || normalizedId(currentCandidate.chatId) === normalizedId(hydratedCandidate.chatId))
+  if (conflictsWithDiscoveredDraft && !currentCandidate?.draft) {
+    return { candidate: null, primeLease: false }
+  }
+  return { candidate: currentCandidate, primeLease: false }
 }
 
 /**

--- a/frontend/src/components/Shell/newChatPolicy.js
+++ b/frontend/src/components/Shell/newChatPolicy.js
@@ -87,6 +87,48 @@ export function currentReusableEmptyChat(chats, {
 }
 
 /**
+ * Choose the Standard compose surface without applying Builder's add-new rule.
+ * Draft ownership is device-local; the caller still freshly verifies any
+ * off-screen empty candidate before reuse.
+ */
+export function standardNewChatCandidate(chats, routes, {
+  activeChatId,
+  hasDraft,
+  exclude = null,
+  recoveredChatIds = new Set(),
+  streamingChatIds = new Set(),
+} = {}) {
+  const reuseOptions = {
+    exclude,
+    recoveredChatIds,
+    streamingChatIds,
+  }
+  const active = currentReusableEmptyChat(chats, {
+    ...reuseOptions,
+    activeChatId,
+  })
+  if (active || typeof hasDraft !== 'function') return active
+
+  const seen = new Set()
+  const rows = Array.isArray(routes) ? routes : []
+  for (let index = rows.length - 1; index >= 0; index -= 1) {
+    const route = rows[index]
+    if (route?.view !== 'chat' || route.chatId == null) continue
+    const id = normalizedId(route.chatId)
+    if (!id || seen.has(id)) continue
+    seen.add(id)
+
+    if (!hasDraft(id)) continue
+    const candidate = currentReusableEmptyChat(chats, {
+      ...reuseOptions,
+      activeChatId: id,
+    })
+    if (candidate) return candidate
+  }
+  return null
+}
+
+/**
  * Find the concrete chat route the single-screen world most recently left.
  *
  * The navigation stack is newest-last. Home seed entries intentionally carry


### PR DESCRIPTION
## Summary
- keep unsent text and completed attachments owned by their original chat
- ensure Standard New chat never pulls text from an off-screen draft or navigation history
- preserve the currently open untouched blank and Builder's additive New chat behavior
- keep mobile early typing, attachment-only drafts, and durable reload recovery lossless

## Testing
- full frontend unit and hook suites
- structural-test ratchet
- full frontend lint
- focused New chat, composer-draft, and mobile focus regressions