### PR TITLE
Hydrate missed parked question cards

### DIFF
--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -102,6 +102,7 @@ import {
   isOwnerUserMessage,
   jumpToLatestShown,
   openAppCtaViewModel,
+  pendingQuestionIsHydrated,
   shouldShowOpenAppCta,
   shouldAttachRunningStream,
   shouldRetryStopAfterConfirm,
@@ -485,6 +486,10 @@ export default function ChatView({
   // read is forward-compat: harmlessly null today, it would pick up a
   // persisted pending_question_id if one is ever added.)
   const [liveQuestionId, setLiveQuestionId] = useState(() => cached?.pending_question_id ?? null)
+  // Runtime polling stays small, but a parked question is a transcript-owned
+  // control. Keep its necessary detail refresh single-flight per exact owner;
+  // the invariant below retries naturally after an honest fetch failure.
+  const parkedQuestionHydrationRef = useRef(null)
   // The pending-question and resume "tap to jump to it" nudges each track
   // whether their card is scrolled out of the viewport. Both use one shared
   // observer hook (useOffscreenNudge, below); their booleans are computed near
@@ -1034,12 +1039,13 @@ export default function ChatView({
         data, cachedGoalObjective,
       )
       setActiveGoalObjective(runtimeGoalObjective)
-      setLiveQuestionId(data.pending_question_id || null)
+      const pendingQuestionId = data.pending_question_id || null
+      setLiveQuestionId(pendingQuestionId)
       updateChatRuntimeCache(queryClient, chatMessagesQueryKey(chatId), {
         running: !!data.running,
         activeGoalObjective: runtimeGoalObjective,
         pending_messages: serverPending,
-        pending_question_id: data.pending_question_id || null,
+        pending_question_id: pendingQuestionId,
       })
       // Don't let the fallback poll add/clobber the queue while a turn is live
       // (localAuthoritative, above) — the optimistic queue + confirmQueued
@@ -1047,9 +1053,27 @@ export default function ChatView({
       if (!localAuthoritative) {
         pendingQueue.hydrate(serverPending)
       }
+      // A question closes SSE replay by design: nothing can arrive before the
+      // owner answers. If this view missed that event, read the compact detail
+      // page that owns the card rather than inventing a runtime-only card.
+      const hydrationKey = pendingQuestionId ? `${chatId}:${pendingQuestionId}` : null
+      if (
+        hydrationKey
+        && !pendingQuestionIsHydrated(messagesRef.current, pendingQuestionId)
+        && parkedQuestionHydrationRef.current !== hydrationKey
+      ) {
+        parkedQuestionHydrationRef.current = hydrationKey
+        fetchMessages({ force: true }).finally(() => {
+          if (parkedQuestionHydrationRef.current === hydrationKey) {
+            parkedQuestionHydrationRef.current = null
+          }
+        })
+      }
     } catch { /* background reconciliation is best-effort */ }
   }, [
     chatId,
+    fetchMessages,
+    messagesRef,
     pendingQueue.hydrate,
     queryClient,
   ])

--- a/frontend/src/components/ChatView/__tests__/chatRuntimeState.test.js
+++ b/frontend/src/components/ChatView/__tests__/chatRuntimeState.test.js
@@ -13,6 +13,7 @@ import {
   isOwnerUserMessage,
   jumpToLatestShown,
   openAppCtaViewModel,
+  pendingQuestionIsHydrated,
   previewReadyAnnouncement,
   previewUpdatedAnnouncement,
   serverSnapshotBehindLocal,
@@ -134,6 +135,22 @@ test('a parked owner question uses compact history until its answer resumes the 
     running: false,
     pendingQuestionId: null,
   }), false)
+})
+
+test('a runtime question marker requires its durable card in the transcript', () => {
+  const pendingQuestionId = 'question-1'
+  const messages = [{
+    role: 'assistant',
+    blocks: [{ type: 'question', question_id: pendingQuestionId, questions: [] }],
+  }]
+
+  assert.equal(pendingQuestionIsHydrated(messages, pendingQuestionId), true)
+  assert.equal(pendingQuestionIsHydrated([], pendingQuestionId), false)
+  assert.equal(pendingQuestionIsHydrated([{
+    ...messages[0],
+    blocks: [{ ...messages[0].blocks[0], answers: { pick: 'yes' } }],
+  }], pendingQuestionId), false)
+  assert.equal(pendingQuestionIsHydrated(messages, 'question-2'), false)
 })
 
 test('a pathological cold transcript is prepared as stable prefix frames', () => {

--- a/frontend/src/components/ChatView/chatRuntimeState.js
+++ b/frontend/src/components/ChatView/chatRuntimeState.js
@@ -129,6 +129,22 @@ export function shouldAttachRunningStream({
   return !!running && !pendingQuestionId
 }
 
+/**
+ * The runtime endpoint deliberately omits transcript blocks, but an open
+ * question is only actionable when its durable card is in the mounted
+ * transcript. A runtime marker without that card means a live viewer missed
+ * the question event and must refresh the compact detail page.
+ */
+export function pendingQuestionIsHydrated(messages, pendingQuestionId) {
+  if (!pendingQuestionId || !Array.isArray(messages)) return false
+  return messages.some(message => message?.role === 'assistant'
+    && (message.blocks || []).some(block => (
+      block?.type === 'question'
+      && block.question_id === pendingQuestionId
+      && !block.answers
+    )))
+}
+
 function coldBlockRenderCost(block) {
   if (block?.type !== 'text') return 1
   // Markdown reports create work roughly in proportion to their source size,


### PR DESCRIPTION
## Problem

A mounted chat can miss the live question event after a connection interruption. Its lightweight runtime check then correctly sees that an answer is required, but it deliberately does not reconnect to the paused stream and never reloads the stored card. The chat appears stuck with no way to answer.

## Fix

When the runtime check reports an unanswered question that is absent from the mounted transcript, load the compact chat detail once for that exact chat and question. The card remains owned solely by the durable transcript; no second question state or fallback UI is introduced. A failed detail load is retried by the existing runtime check.

## Tests

- Focused runtime-state coverage for the matching durable question card.

Builds on the durable open-question contract from #670; this fixes the separate missed-client-delivery path.