### PR TITLE
Show provider context compaction in chat

### DIFF
--- a/backend/app/chat_event_sink.py
+++ b/backend/app/chat_event_sink.py
@@ -241,7 +241,10 @@ class ChatEventSink:
   # here: publish() rejects question events outright — they go through
   # publish_question()'s save-before-broadcast barrier instead.)
   _IMMEDIATE_SAVE_TYPES = frozenset(
-    {"tool_start", "tool_end", "task_start", "task_done", "error"}
+    {
+      "context_compacted", "tool_start", "tool_end", "task_start",
+      "task_done", "error",
+    }
   )
 
   def __init__(

--- a/backend/app/claude_sdk_runner.py
+++ b/backend/app/claude_sdk_runner.py
@@ -932,11 +932,11 @@ async def run_claude_sdk_turn(
     del hook_input, tool_use_id, context
     return {"continue_": True}
 
-  # Observability parity with the Codex runner's ContextCompactedNotification
-  # log line. The Claude SDK fires PreCompact before it auto- or manually
-  # compacts the running session; Möbius takes NO action (compaction is the
-  # SDK's own memory management) but records it, so a long Claude chat that
-  # compacts leaves the same operator-facing signal Codex already does.
+  # The Claude SDK fires PreCompact before it auto- or manually compacts the
+  # running session. Möbius does not influence that memory-management action;
+  # it publishes a small product event so the moment is visible in the same
+  # timeline position as Codex's ContextCompactedNotification, then logs it for
+  # operators too.
   # Returns continue_=True — the established "observe and proceed" shape in this
   # file — so compaction is never blocked.
   async def precompact_hook(
@@ -945,10 +945,23 @@ async def run_claude_sdk_turn(
     context: dict[str, Any],
   ) -> dict[str, Any]:
     del tool_use_id, context
+    trigger = _precompact_log_trigger(hook_input)
     log.info(
       "Claude context compacted for chat %s (trigger=%s)",
-      chat_id, _precompact_log_trigger(hook_input),
+      chat_id, trigger,
     )
+    try:
+      event = {"type": "context_compacted", "provider": "claude"}
+      if trigger is not None:
+        event["trigger"] = trigger
+      bc.publish(event)
+    except Exception:
+      # Visibility must never interfere with the provider's own compaction.
+      log.warning(
+        "Claude context-compaction marker failed for chat %s",
+        chat_id,
+        exc_info=True,
+      )
     return {"continue_": True}
 
   # Per-chat model/effort overrides flow in via `agent_settings`

--- a/backend/app/codex_sdk_runner.py
+++ b/backend/app/codex_sdk_runner.py
@@ -2209,6 +2209,19 @@ async def run_codex_sdk_turn(
 
         if isinstance(payload, sdk["ContextCompactedNotification"]):
           log.info("Codex context compacted for chat %s", chat_id)
+          try:
+            bc.publish({
+              "type": "context_compacted",
+              "provider": "codex",
+            })
+          except Exception:
+            # Visibility must never interfere with the provider's own
+            # compaction or the rest of its turn.
+            log.warning(
+              "Codex context-compaction marker failed for chat %s",
+              chat_id,
+              exc_info=True,
+            )
           continue
 
         ratelimit_cls = sdk.get("AccountRateLimitsUpdatedNotification")

--- a/backend/app/events.py
+++ b/backend/app/events.py
@@ -61,6 +61,7 @@ EventType = Literal[
   "text_final",
   "thinking",
   "text_boundary",
+  "context_compacted",
   "tool_start",
   "tool_input",
   "tool_output",
@@ -240,7 +241,7 @@ def _persisted_block(block: dict) -> dict:
 # Event types that begin (or belong to) a DIFFERENT visible content block and
 # therefore legitimately END a trailing thinking run. This is EXACTLY the set of
 # branches below that APPEND a new sibling block: text, text_final, text_boundary,
-# tool_start, error, question.
+# context_compacted, tool_start, error, question.
 #
 # Every OTHER event type must be TRANSPARENT to thinking coalescing:
 #  - Provider bookkeeping/heartbeats forwarded as "unknown_sdk_event" (a periodic
@@ -258,6 +259,7 @@ _THINKING_INTERRUPTING_TYPES: frozenset[str] = frozenset({
   "text",
   "text_final",
   "text_boundary",
+  "context_compacted",
   "tool_start",
   "question",
   "error",
@@ -914,6 +916,22 @@ def process_event(event: dict, assistant_blocks: list) -> bool:
       assistant_blocks.append({"type": "text_boundary"})
       return True
     return False
+
+  if event_type == "context_compacted":
+    # Provider-native compaction is a chronological product event, not tool
+    # activity and not the readable cross-provider handoff summary stored as a
+    # top-level ``kind=compaction`` message. Keep a deliberately small block so
+    # it survives live snapshots, final persistence, and compact transcript
+    # reads without pretending the provider exposed its private summary.
+    block = {"type": "context_compaction"}
+    provider = event.get("provider")
+    if provider in ("claude", "codex"):
+      block["provider"] = provider
+    trigger = event.get("trigger")
+    if trigger in ("auto", "manual"):
+      block["trigger"] = trigger
+    assistant_blocks.append(block)
+    return True
 
   if event_type in _TOOL_EVENT_TYPES:
     return _process_tool_event(event, assistant_blocks)

--- a/backend/tests/test_chat_transcript_compact.py
+++ b/backend/tests/test_chat_transcript_compact.py
@@ -188,6 +188,29 @@ def test_repeated_activity_metadata_is_bounded_by_variety():
   ] == ["Bash", "Bash", "Edit"]
 
 
+def test_context_compaction_stays_between_separate_activity_runs():
+  blocks = [
+    {"type": "thinking", "duration_ms": 100},
+    {"type": "tool", "tool": "Read", "status": "done"},
+    {"type": "context_compaction", "provider": "codex"},
+    {"type": "thinking", "duration_ms": 200},
+    {"type": "tool", "tool": "Bash", "status": "done"},
+  ]
+
+  compact = compact_messages_for_detail(
+    [{"role": "assistant", "blocks": blocks}],
+    message_offset=7,
+    binding=EMPTY_RECALL_BINDING,
+  )
+
+  assert [block["type"] for block in compact[0]["blocks"]] == [
+    "activity", "context_compaction", "activity",
+  ]
+  assert compact[0]["blocks"][1] == blocks[2]
+  assert compact[0]["blocks"][0]["end"] == 2
+  assert compact[0]["blocks"][2]["start"] == 3
+
+
 def test_long_activity_runs_are_split_into_fetchable_ranges():
   blocks = [
     {

--- a/backend/tests/test_claude_sdk_runner.py
+++ b/backend/tests/test_claude_sdk_runner.py
@@ -1143,6 +1143,61 @@ async def test_run_claude_sdk_turn_requests_summarized_thinking(monkeypatch):
   }
 
 
+@pytest.mark.asyncio
+async def test_precompact_hook_publishes_context_compaction_marker(monkeypatch):
+  captured: dict = {}
+
+  class _FakeClient:
+    def __init__(self, options):
+      captured["options"] = options
+
+    async def connect(self):
+      return None
+
+    async def query(self, message):
+      del message
+
+    async def disconnect(self):
+      return None
+
+    async def receive_response(self):
+      yield ResultMessage(
+        subtype="success",
+        duration_ms=10,
+        duration_api_ms=5,
+        is_error=False,
+        num_turns=1,
+        session_id="sess-compaction",
+        stop_reason="end_turn",
+        total_cost_usd=0.01,
+        usage={"input_tokens": 1, "output_tokens": 1},
+      )
+
+  monkeypatch.setattr(claude_sdk_runner, "ClaudeSDKClient", _FakeClient)
+  bus = _Bus()
+  await run_claude_sdk_turn(
+    "hello",
+    session_id=None,
+    base_env={},
+    cwd="/data",
+    chat_id="chat-compaction",
+    skill_text="system",
+    bc=bus,
+    pending_questions={},
+    db=None,
+  )
+
+  matcher = captured["options"].hooks["PreCompact"][0]
+  result = await matcher.hooks[0]({"trigger": "manual"}, None, {})
+
+  assert result == {"continue_": True}
+  assert {
+    "type": "context_compacted",
+    "provider": "claude",
+    "trigger": "manual",
+  } in bus.events
+
+
 def test_dispatch_input_json_delta_emits_unknown(monkeypatch):
   monkeypatch.setenv("MOBIUS_EMIT_UNKNOWN", "1")
   bus = _Bus()

--- a/backend/tests/test_codex_sdk_runner.py
+++ b/backend/tests/test_codex_sdk_runner.py
@@ -2011,6 +2011,59 @@ def test_run_codex_sdk_turn_cleans_up_active_session_on_stream_exception(
   assert mark_finished_calls == [True]
 
 
+def test_run_codex_sdk_turn_publishes_context_compaction_marker(monkeypatch):
+  class ContextCompactedNotification:
+    pass
+
+  completed_turn = SimpleNamespace(id="turn-1", usage=None, error=None)
+  turn_handle = _FakeTurnHandle([
+    SimpleNamespace(
+      method="thread/compacted",
+      payload=ContextCompactedNotification(),
+    ),
+    SimpleNamespace(
+      method="turn/completed",
+      payload=_FakeTurnCompletedNotification(completed_turn),
+    ),
+  ])
+  thread = _FakeThread("thread-1", turn_handle)
+
+  class FakeAsyncCodex:
+    def __init__(self, config=None):
+      self.config = config
+
+    async def __aenter__(self):
+      return self
+
+    async def __aexit__(self, _exc_type, _exc, _tb):
+      return None
+
+    async def thread_start(self, *_args, **_kwargs):
+      return thread
+
+  sdk = _fake_sdk(FakeAsyncCodex)
+  sdk["ContextCompactedNotification"] = ContextCompactedNotification
+  monkeypatch.setattr(codex_sdk_runner, "_sdk_imports", lambda: sdk)
+
+  bc = _FakeBroadcast()
+  result = asyncio.run(codex_sdk_runner.run_codex_sdk_turn(
+    user_message="hello",
+    session_id=None,
+    base_env={},
+    cwd="/tmp",
+    chat_id="chat-compaction",
+    bc=bc,
+    pending_questions={},
+    db=None,
+  ))
+
+  assert result["error"] is None
+  assert {
+    "type": "context_compacted",
+    "provider": "codex",
+  } in bc.events
+
+
 class _KilledTransportError(_SdkTransportClosedError):
   """A subclass of the SDK's own TransportClosedError.
 

--- a/backend/tests/test_events.py
+++ b/backend/tests/test_events.py
@@ -717,6 +717,40 @@ def test_thinking_event_after_tool_starts_fresh_block():
   assert [b["duration_ms"] for b in thinking_blocks] == [0, 0]
 
 
+def test_context_compaction_is_a_persistent_thinking_boundary():
+  blocks = []
+  process_event({"type": "thinking", "content": "before", "ts": 1000}, blocks)
+  changed = process_event({
+    "type": "context_compacted",
+    "provider": "codex",
+    "trigger": "auto",
+  }, blocks)
+  process_event({"type": "thinking", "content": "after", "ts": 2000}, blocks)
+
+  assert changed is True
+  assert [block["type"] for block in blocks] == [
+    "thinking", "context_compaction", "thinking",
+  ]
+  assert blocks[1] == {
+    "type": "context_compaction",
+    "provider": "codex",
+    "trigger": "auto",
+  }
+  assert build_assistant_message(blocks)["blocks"][1] == blocks[1]
+
+
+def test_context_compaction_discards_untrusted_display_metadata():
+  blocks = []
+  process_event({
+    "type": "context_compacted",
+    "provider": "other",
+    "trigger": "surprise",
+    "summary": "provider-private text",
+  }, blocks)
+
+  assert blocks == [{"type": "context_compaction"}]
+
+
 def test_thinking_survives_interleaved_unknown_event():
   # A provider `ping` heartbeat is forwarded as an "unknown_sdk_event" and lands
   # BETWEEN two thinking_delta chunks (it can even split mid-word). It must NOT

--- a/frontend/src/components/ChatView/ContextCompactionMarker.css
+++ b/frontend/src/components/ChatView/ContextCompactionMarker.css
@@ -1,0 +1,36 @@
+/* Borderless timeline treatment for provider-native context compaction. */
+
+/* Provider-native compaction is chronology, not a summary card and not tool
+   activity. The hairlines make the boundary visible while the borderless,
+   muted treatment stays quieter than MarkerCard's accent surface. */
+.chat__context-compaction {
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: min(100%, 720px);
+  margin: 8px 0;
+  color: var(--muted);
+  font-size: 11px;
+  line-height: 1.3;
+  white-space: nowrap;
+}
+
+.chat__context-compaction::before,
+.chat__context-compaction::after {
+  content: '';
+  height: 1px;
+  min-width: 16px;
+  flex: 1;
+  background: var(--border-light);
+}
+
+.chat__context-compaction-label {
+  color: color-mix(in srgb, var(--text) 68%, var(--muted));
+  font-weight: 550;
+}
+
+.chat__context-compaction-meta {
+  color: var(--muted);
+  font-size: 10.5px;
+}

--- a/frontend/src/components/ChatView/ContextCompactionMarker.jsx
+++ b/frontend/src/components/ChatView/ContextCompactionMarker.jsx
@@ -1,0 +1,32 @@
+/* A quiet timeline marker for provider-native context compaction. */
+
+import './ContextCompactionMarker.css'
+
+const PROVIDER_LABELS = {
+  claude: 'Claude',
+  codex: 'Codex',
+}
+
+function compactionMeta(block) {
+  const provider = PROVIDER_LABELS[block?.provider] || null
+  const trigger = block?.trigger === 'manual' ? 'manual' : null
+  return [provider, trigger].filter(Boolean).join(' · ')
+}
+
+export default function ContextCompactionMarker({ block }) {
+  const meta = compactionMeta(block)
+  const ariaLabel = meta
+    ? `Context compacted — ${meta}`
+    : 'Context compacted'
+
+  // Intentionally not MarkerCard: native provider compaction exposes no
+  // readable briefing and asks for no interaction. A borderless rule keeps it
+  // chronological and visible without borrowing the accent card reserved for
+  // deliberate conversation summaries and provider handoffs.
+  return (
+    <div className="chat__context-compaction" role="note" aria-label={ariaLabel}>
+      <span className="chat__context-compaction-label">Context compacted</span>
+      {meta && <span className="chat__context-compaction-meta">{meta}</span>}
+    </div>
+  )
+}

--- a/frontend/src/components/ChatView/MsgContent.jsx
+++ b/frontend/src/components/ChatView/MsgContent.jsx
@@ -16,6 +16,7 @@ import {
 } from './streamReducers.js'
 import { stripAugmentation } from './msgText.js'
 import ErrorCard from './ErrorCard.jsx'
+import ContextCompactionMarker from './ContextCompactionMarker.jsx'
 import { assistantBlockKey } from './streamPromotion.js'
 
 
@@ -151,7 +152,7 @@ function MsgContentInner({
 
     // Render a stretch-breaking block by type. Activity entries (tool/thinking)
     // are folded into an ActivityStretch below; this renders only the `single`
-    // nodes — text, question, error.
+    // nodes — text, question, error, and provider context compaction.
     const renderBlock = (block, i) => {
       if (block.type === 'activity' && Array.isArray(block.entries)) {
         return (
@@ -198,10 +199,18 @@ function MsgContentInner({
           </div>
         )
       }
+      if (block.type === 'context_compaction') {
+        return (
+          <ContextCompactionMarker
+            key={assistantBlockKey(block, i)}
+            block={block}
+          />
+        )
+      }
       // tool + thinking blocks never reach renderBlock: groupActivityRuns folds
       // every contiguous run of them (including a lone one) into a group node,
       // rendered by ActivityStretch below. renderBlock only sees the block types
-      // that BREAK a stretch — text (above), question, and error.
+      // that BREAK a stretch — text/compaction (above), question, and error.
       if (block.type === 'question') {
         // Suppress if this exact question is currently live in
         // streamItems — the streaming <li> is already rendering it.

--- a/frontend/src/components/ChatView/__tests__/activityGrouping.test.js
+++ b/frontend/src/components/ChatView/__tests__/activityGrouping.test.js
@@ -26,3 +26,15 @@ test('activity grouping handles empty and non-activity-only input', () => {
   assert.deepEqual(groupActivityRuns([]), [])
   assert.deepEqual(groupActivityRuns([question]), [{ single: question }])
 })
+
+test('context compaction breaks activity stretches instead of joining tools', () => {
+  const before = entry('tool', { tool: 'Read' })
+  const compaction = entry('context_compaction', { provider: 'codex' })
+  const after = entry('thinking')
+
+  assert.deepEqual(groupActivityRuns([before, compaction, after]), [
+    { group: [before] },
+    { single: compaction },
+    { group: [after] },
+  ])
+})

--- a/frontend/src/components/ChatView/__tests__/streamPromotion.test.js
+++ b/frontend/src/components/ChatView/__tests__/streamPromotion.test.js
@@ -54,6 +54,24 @@ test('streamItemsToAssistantPayload preserves text boundaries in legacy content'
   assert.equal(payload.blocks[1].status, 'done')
 })
 
+test('context compaction survives live promotion as its own block', () => {
+  const item = {
+    type: 'context_compaction', provider: 'codex', trigger: 'auto',
+  }
+  const payload = streamItemsToAssistantPayload([
+    { type: 'tool', tool: 'Read', status: 'done' },
+    item,
+    { type: 'text', content: 'continued' },
+  ])
+
+  assert.deepEqual(payload.blocks[1], item)
+  assert.equal(payload.content, 'continued')
+  assert.equal(assistantStreamCoversMessage({
+    role: 'assistant',
+    blocks: [item],
+  }, [item, { type: 'text', content: 'continued' }]), true)
+})
+
 test('source switch preserves the active answer block key namespace', () => {
   const dbBlocks = [
     { type: 'text', content: 'Inspecting' },

--- a/frontend/src/components/ChatView/streamPromotion.js
+++ b/frontend/src/components/ChatView/streamPromotion.js
@@ -51,6 +51,13 @@ export function streamItemToBlock(item, { finalize = true } = {}) {
       ...(item.pause ? { pause: item.pause } : {}),
     }
   }
+  if (item.type === 'context_compaction') {
+    return {
+      type: 'context_compaction',
+      ...(item.provider ? { provider: item.provider } : {}),
+      ...(item.trigger ? { trigger: item.trigger } : {}),
+    }
+  }
   const status = finalize && item.status === 'running' ? 'done' : item.status
   return { type: 'tool', ...item, status }
 }
@@ -129,6 +136,9 @@ function streamBlocksCoverMessageBlocks(msgBlocks, streamBlocks) {
       if (!thinkingBlockCovers(streamBlock, msgBlock)) return false
     } else if (msgBlock.type === 'error') {
       if ((msgBlock.message || '') !== (streamBlock.message || '')) return false
+    } else if (msgBlock.type === 'context_compaction') {
+      if ((msgBlock.provider || '') !== (streamBlock.provider || '')) return false
+      if ((msgBlock.trigger || '') !== (streamBlock.trigger || '')) return false
     } else {
       return false
     }
@@ -157,6 +167,7 @@ function blockWeight(block) {
       + (block.answers ? 20 : 0)
   }
   if (block.type === 'error') return 40 + normalizeMirrorText(block.message).length
+  if (block.type === 'context_compaction') return 20
   return 0
 }
 
@@ -189,6 +200,10 @@ function blocksLookLikeSameTurn(a, b) {
   if (a.type === 'tool') return !!(a.tool && a.tool === b.tool)
   if (a.type === 'question') return questionKey(a) === questionKey(b)
   if (a.type === 'error') return (a.message || '') === (b.message || '')
+  if (a.type === 'context_compaction') {
+    return (a.provider || '') === (b.provider || '')
+      && (a.trigger || '') === (b.trigger || '')
+  }
   return false
 }
 
@@ -249,6 +264,10 @@ export function messageCoversAssistantStream(msg, items) {
     if (block.type === 'tool') return sameToolBlock(msgBlock, block)
     if (block.type === 'question') return questionKey(msgBlock) === questionKey(block)
     if (block.type === 'error') return (msgBlock.message || '') === (block.message || '')
+    if (block.type === 'context_compaction') {
+      return (msgBlock.provider || '') === (block.provider || '')
+        && (msgBlock.trigger || '') === (block.trigger || '')
+    }
     return false
   })
 }

--- a/frontend/src/components/ChatView/useStreamConnection.js
+++ b/frontend/src/components/ChatView/useStreamConnection.js
@@ -133,6 +133,9 @@ const BROADCAST_REGISTRATION_WINDOW_MS = 1500
  *                         { question_id, questions: [...] }. Renders a
  *                         card, absorbing the call's own tool_start
  *                         block in place (see streamReducers.js).
+ *   context_compacted     Provider condensed its native context window.
+ *                         Appends a quiet, standalone timeline marker; this
+ *                         is not tool activity or a handoff summary.
  *   queued_turn_starting  Backend about to promote a queued message
  *                         { ts }. Notifies caller via callback.
  *   steered_into_turn     THE CUT. The transcript split has committed: the
@@ -951,6 +954,17 @@ export default function useStreamConnection(chatId, {
                 event,
               ))
             }
+          } else if (event.type === 'context_compacted') {
+            // A first-class chronology boundary: flush prose so the marker
+            // lands exactly where the provider compacted, then append the same
+            // small block shape the backend persists. MsgContent deliberately
+            // renders it outside ActivityStretch and outside MarkerCard.
+            flushBuffer()
+            applyStreamItems(prev => [...prev, {
+              type: 'context_compaction',
+              ...(event.provider ? { provider: event.provider } : {}),
+              ...(event.trigger ? { trigger: event.trigger } : {}),
+            }])
           } else if (event.type === 'tool_start') {
             flushBuffer()
             // Codex identifies Memory here; Claude may add the same marker on


### PR DESCRIPTION
## Summary
- show Codex and Claude native context compaction at the point it occurs
- keep the marker separate from tool activity and the existing conversation-summary card
- persist the marker so it remains visible after reconnecting or reopening a chat

## Testing
- focused backend event, runner, and transcript-projection tests
- backend fast contract suite
- full frontend behavioral and hook suites
- production frontend build