### PR TITLE
Keep app-to-chat handoffs visually stable

### DIFF
--- a/frontend/src/components/Shell/Shell.css
+++ b/frontend/src/components/Shell/Shell.css
@@ -339,6 +339,15 @@
   z-index: 2;
 }
 
+/* An app can be the outgoing visual surface too. Keep its already-painted frame
+   above a settling ChatView until display-ready, while AppCanvas remains an
+   inactive runtime for this short, inert handoff. */
+.shell__app-view--held {
+  visibility: visible;
+  pointer-events: none;
+  z-index: 2;
+}
+
 /* While New chat is allocating, the ordinary landing covers the outgoing
    ChatView and its z:2 handoff cover. */
 .shell__new-chat-presentation {

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -104,7 +104,6 @@ import PaneChatView from './PaneChatView.jsx'
 import {
   BUILDER_CHAT_WORLD,
   FOCUSED_BUILDER_CHAT_SURFACE,
-  STANDARD_CONTENT_SURFACE,
   STANDARD_CHAT_WORLD,
   deriveAppToChatCover,
   deriveChatSurfaceLayers,
@@ -397,8 +396,7 @@ export default function Shell() {
     )
     lastStandardSurfaceRef.current = standardSurface
     const current = appToChatCoverRef.current
-    if (current?.surface === next?.surface
-        && String(current?.appId ?? '') === String(next?.appId ?? '')
+    if (String(current?.appId ?? '') === String(next?.appId ?? '')
         && String(current?.chatId ?? '') === String(next?.chatId ?? '')) return
     appToChatCoverRef.current = next
     setAppToChatCover(next)
@@ -1042,7 +1040,7 @@ export default function Shell() {
     finishDrawerNavigationPresentation()
     const appCover = appToChatCoverRef.current
     if (
-      appCover?.surface === STANDARD_CONTENT_SURFACE
+      appCover
       && String(paneId) === String(paneModel.SINGLE_SLOT_PANE)
       && String(appCover.chatId) === id
     ) {
@@ -3343,11 +3341,11 @@ export default function Shell() {
           const tabKey = `app:${id}`
           const paned = workspaceChromeActive ? visibleTabRects.get(tabKey) : null
           const heldForChat = !paned
-            && appToChatCover?.surface === STANDARD_CONTENT_SURFACE
-            && String(appToChatCover.appId) === String(id)
+            && String(appToChatCover?.appId ?? '') === String(id)
           const fullBleed = !paned && (tabKey === fullBleedKey || heldForChat)
           const surfaceVisible = !!(paned || fullBleed)
           const appSurfaceInert = !surfaceVisible || heldForChat
+          const appRuntimeVisible = visibleAppIds.has(String(id)) && !heldForChat
           const posStyle = paned ? {
             top: paned.y,
             left: paned.x,
@@ -3393,11 +3391,11 @@ export default function Shell() {
               // Settings/immersive-solo/hidden panes exclude it (visibleAppIds).
               // A held app still paints its last frame as a chat handoff cover,
               // but it is no longer an active app runtime.
-              visible={visibleAppIds.has(String(id)) && !heldForChat}
+              visible={appRuntimeVisible}
               // Every visible pane remains painted beneath the modal scrim, but
               // suspend its iframe interaction while the drawer is open OR during any
               // mode scene (cross-origin app interaction is inert throughout).
-              interactive={visibleAppIds.has(String(id)) && !heldForChat
+              interactive={appRuntimeVisible
                 && !navigationSurfaceOpen && !modeBeatActive}
               version={versionForApp(id)}
               appName={app?.name}

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -104,9 +104,12 @@ import PaneChatView from './PaneChatView.jsx'
 import {
   BUILDER_CHAT_WORLD,
   FOCUSED_BUILDER_CHAT_SURFACE,
+  STANDARD_CONTENT_SURFACE,
   STANDARD_CHAT_WORLD,
+  deriveAppToChatCover,
   deriveChatSurfaceLayers,
   deriveChatSurfaceOwners,
+  standardContentSurface,
 } from './chatSurfaceModel.js'
 import { deriveWorkspaceVisualState } from './visualReadiness.js'
 import {
@@ -374,6 +377,32 @@ export default function Shell() {
       effectiveViewMode, focusedPaneViewId],
   )
   const { multiPane, single, focusedActiveKey, fullBleedKey, visibleAppIds } = contentVisibility
+  // ChatView keeps its transcript hidden during the first scroll/stream
+  // settlement frame. Chat-to-chat transitions retain the old ChatView as an
+  // opaque cover, but an app has no ChatView to retain. Hold the outgoing app
+  // until the destination reports display-ready instead of exposing that
+  // intentional partial frame (particularly visible for long, running chats).
+  const standardSurface = useMemo(
+    () => standardContentSurface({ single, fullBleedKey }),
+    [fullBleedKey, single],
+  )
+  const lastStandardSurfaceRef = useRef(null)
+  const appToChatCoverRef = useRef(null)
+  const [appToChatCover, setAppToChatCover] = useState(null)
+  useLayoutEffect(() => {
+    const next = deriveAppToChatCover(
+      lastStandardSurfaceRef.current,
+      standardSurface,
+      appToChatCoverRef.current,
+    )
+    lastStandardSurfaceRef.current = standardSurface
+    const current = appToChatCoverRef.current
+    if (current?.surface === next?.surface
+        && String(current?.appId ?? '') === String(next?.appId ?? '')
+        && String(current?.chatId ?? '') === String(next?.chatId ?? '')) return
+    appToChatCoverRef.current = next
+    setAppToChatCover(next)
+  }, [standardSurface])
   // The EFFECTIVE-mode-gated Settings takeover flag (finding F3): true only when the
   // takeover actually PAINTS — false in builder AND during a single-mode drag
   // preview (effectiveViewMode 'panes'). Every PAINT gate below reads
@@ -1011,6 +1040,15 @@ export default function Shell() {
       // or superseded allocation) release the lease explicitly.
     }
     finishDrawerNavigationPresentation()
+    const appCover = appToChatCoverRef.current
+    if (
+      appCover?.surface === STANDARD_CONTENT_SURFACE
+      && String(paneId) === String(paneModel.SINGLE_SLOT_PANE)
+      && String(appCover.chatId) === id
+    ) {
+      appToChatCoverRef.current = null
+      setAppToChatCover(null)
+    }
   }, [finishDrawerNavigationPresentation, focusedPaneViewIdRef, workspaceStateRef])
 
   const finishNewChatPresentationRelease = useCallback((presentation) => {
@@ -3304,9 +3342,12 @@ export default function Shell() {
         {renderedAppIds.map(id => {
           const tabKey = `app:${id}`
           const paned = workspaceChromeActive ? visibleTabRects.get(tabKey) : null
-          const fullBleed = !paned && tabKey === fullBleedKey
+          const heldForChat = !paned
+            && appToChatCover?.surface === STANDARD_CONTENT_SURFACE
+            && String(appToChatCover.appId) === String(id)
+          const fullBleed = !paned && (tabKey === fullBleedKey || heldForChat)
           const surfaceVisible = !!(paned || fullBleed)
-          const appSurfaceInert = !surfaceVisible
+          const appSurfaceInert = !surfaceVisible || heldForChat
           const posStyle = paned ? {
             top: paned.y,
             left: paned.x,
@@ -3325,7 +3366,7 @@ export default function Shell() {
             data-mode-pane-vt={paned ? paned.paneId : undefined}
             className={paned
               ? 'shell__view shell__app-view shell__view--paned'
-              : `shell__view shell__app-view ${fullBleed ? 'shell__view--active' : ''}`}
+              : `shell__view shell__app-view ${fullBleed ? 'shell__view--active' : ''}${heldForChat ? ' shell__app-view--held' : ''}`}
             style={posStyle || undefined}
             inert={appSurfaceInert || undefined}
             aria-hidden={appSurfaceInert ? 'true' : undefined}
@@ -3350,11 +3391,14 @@ export default function Shell() {
               // Visible in ANY pane: gates frame-visibility + nav-push (§5). A
               // background split's app keeps running and can install sentinels;
               // Settings/immersive-solo/hidden panes exclude it (visibleAppIds).
-              visible={visibleAppIds.has(String(id))}
+              // A held app still paints its last frame as a chat handoff cover,
+              // but it is no longer an active app runtime.
+              visible={visibleAppIds.has(String(id)) && !heldForChat}
               // Every visible pane remains painted beneath the modal scrim, but
               // suspend its iframe interaction while the drawer is open OR during any
               // mode scene (cross-origin app interaction is inert throughout).
-              interactive={visibleAppIds.has(String(id)) && !navigationSurfaceOpen && !modeBeatActive}
+              interactive={visibleAppIds.has(String(id)) && !heldForChat
+                && !navigationSurfaceOpen && !modeBeatActive}
               version={versionForApp(id)}
               appName={app?.name}
               appSlug={app?.slug}

--- a/frontend/src/components/Shell/__tests__/chatSurfaceModel.test.js
+++ b/frontend/src/components/Shell/__tests__/chatSurfaceModel.test.js
@@ -4,7 +4,6 @@ import assert from 'node:assert/strict'
 import {
   BUILDER_CHAT_WORLD,
   FOCUSED_BUILDER_CHAT_SURFACE,
-  STANDARD_CONTENT_SURFACE,
   STANDARD_CHAT_WORLD,
   chatSurfaceKey,
   deriveAppToChatCover,
@@ -189,7 +188,6 @@ test('an app remains a Standard cover until the destination chat is display-read
   )
 
   assert.deepEqual(cover, {
-    surface: STANDARD_CONTENT_SURFACE,
     appId: '39',
     chatId: 'audit',
   })
@@ -200,14 +198,12 @@ test('an app-to-chat cover follows rapid chat navigation without a blank frame',
     standardContentSurface({ single: true, fullBleedKey: 'chat:first' }),
     standardContentSurface({ single: true, fullBleedKey: 'chat:second' }),
     {
-      surface: STANDARD_CONTENT_SURFACE,
       appId: '39',
       chatId: 'first',
     },
   )
 
   assert.deepEqual(cover, {
-    surface: STANDARD_CONTENT_SURFACE,
     appId: '39',
     chatId: 'second',
   })

--- a/frontend/src/components/Shell/__tests__/chatSurfaceModel.test.js
+++ b/frontend/src/components/Shell/__tests__/chatSurfaceModel.test.js
@@ -4,10 +4,13 @@ import assert from 'node:assert/strict'
 import {
   BUILDER_CHAT_WORLD,
   FOCUSED_BUILDER_CHAT_SURFACE,
+  STANDARD_CONTENT_SURFACE,
   STANDARD_CHAT_WORLD,
   chatSurfaceKey,
+  deriveAppToChatCover,
   deriveChatSurfaceLayers,
   deriveChatSurfaceOwners,
+  standardContentSurface,
 } from '../chatSurfaceModel.js'
 import { SINGLE_SLOT_PANE } from '../paneModel.js'
 
@@ -176,4 +179,66 @@ test('focused Builder presentation never manufactures a stale outgoing cover', (
 
   assert.equal(layers.some(layer => layer.chatId === 'departed'), false)
   assert.equal(layers.every(layer => layer.role === 'active'), true)
+})
+
+test('an app remains a Standard cover until the destination chat is display-ready', () => {
+  const cover = deriveAppToChatCover(
+    standardContentSurface({ single: true, fullBleedKey: 'app:39' }),
+    standardContentSurface({ single: true, fullBleedKey: 'chat:audit' }),
+    null,
+  )
+
+  assert.deepEqual(cover, {
+    surface: STANDARD_CONTENT_SURFACE,
+    appId: '39',
+    chatId: 'audit',
+  })
+})
+
+test('an app-to-chat cover follows rapid chat navigation without a blank frame', () => {
+  const cover = deriveAppToChatCover(
+    standardContentSurface({ single: true, fullBleedKey: 'chat:first' }),
+    standardContentSurface({ single: true, fullBleedKey: 'chat:second' }),
+    {
+      surface: STANDARD_CONTENT_SURFACE,
+      appId: '39',
+      chatId: 'first',
+    },
+  )
+
+  assert.deepEqual(cover, {
+    surface: STANDARD_CONTENT_SURFACE,
+    appId: '39',
+    chatId: 'second',
+  })
+})
+
+test('only an app-to-chat Standard transition creates this cover', () => {
+  assert.equal(
+    deriveAppToChatCover(
+      standardContentSurface({ single: true, fullBleedKey: 'chat:a' }),
+      standardContentSurface({ single: true, fullBleedKey: 'chat:b' }),
+      null,
+    ),
+    null,
+  )
+  assert.equal(
+    deriveAppToChatCover(
+      standardContentSurface({ single: true, fullBleedKey: 'app:39' }),
+      standardContentSurface({ single: true, fullBleedKey: 'app:40' }),
+      null,
+    ),
+    null,
+  )
+})
+
+test('a Builder full-bleed item never enters the Standard app-to-chat handoff', () => {
+  assert.equal(
+    standardContentSurface({ single: false, fullBleedKey: 'app:39' }),
+    null,
+  )
+  assert.equal(
+    standardContentSurface({ single: false, fullBleedKey: 'chat:audit' }),
+    null,
+  )
 })

--- a/frontend/src/components/Shell/chatSurfaceModel.js
+++ b/frontend/src/components/Shell/chatSurfaceModel.js
@@ -8,12 +8,6 @@ export const STANDARD_CHAT_WORLD = 'standard'
 export const BUILDER_CHAT_WORLD = 'builder'
 export const FOCUSED_BUILDER_CHAT_SURFACE = '__builder-focused-chat__'
 
-// Standard's one full-bleed content slot can move directly from an app to a
-// chat. The app remains the visual cover until the destination chat has laid
-// out its restored transcript, so the cover needs a surface identity that is
-// independent from either item's tab key.
-export const STANDARD_CONTENT_SURFACE = 'standard-content'
-
 export function chatSurfaceKey(world, chatId) {
   return `${world}:chat:${chatId}`
 }
@@ -28,7 +22,6 @@ export function standardContentSurface({ single, fullBleedKey }) {
   const match = /^(app|chat):(.+)$/.exec(String(fullBleedKey || ''))
   if (!match) return null
   return {
-    surface: STANDARD_CONTENT_SURFACE,
     kind: match[1],
     id: match[2],
   }
@@ -43,25 +36,18 @@ export function standardContentSurface({ single, fullBleedKey }) {
  * live cover on rapid chat changes so an app never drops away between A -> B.
  */
 export function deriveAppToChatCover(previousSurface, currentSurface, cover) {
-  if (currentSurface?.kind !== 'chat'
-      || currentSurface.surface !== STANDARD_CONTENT_SURFACE) {
-    return null
-  }
+  if (currentSurface?.kind !== 'chat') return null
 
-  if (cover?.surface === currentSurface.surface) {
+  if (cover) {
     return {
       ...cover,
       chatId: currentSurface.id,
     }
   }
 
-  if (previousSurface?.kind !== 'app'
-      || previousSurface.surface !== currentSurface.surface) {
-    return null
-  }
+  if (previousSurface?.kind !== 'app') return null
 
   return {
-    surface: currentSurface.surface,
     appId: previousSurface.id,
     chatId: currentSurface.id,
   }

--- a/frontend/src/components/Shell/chatSurfaceModel.js
+++ b/frontend/src/components/Shell/chatSurfaceModel.js
@@ -8,8 +8,63 @@ export const STANDARD_CHAT_WORLD = 'standard'
 export const BUILDER_CHAT_WORLD = 'builder'
 export const FOCUSED_BUILDER_CHAT_SURFACE = '__builder-focused-chat__'
 
+// Standard's one full-bleed content slot can move directly from an app to a
+// chat. The app remains the visual cover until the destination chat has laid
+// out its restored transcript, so the cover needs a surface identity that is
+// independent from either item's tab key.
+export const STANDARD_CONTENT_SURFACE = 'standard-content'
+
 export function chatSurfaceKey(world, chatId) {
   return `${world}:chat:${chatId}`
+}
+
+/**
+ * Describe the item currently occupying Standard's full-bleed content
+ * surface. Settings and the New Chat landing intentionally return null: they
+ * are their own presentation surfaces and never retain an app as a cover.
+ */
+export function standardContentSurface({ single, fullBleedKey }) {
+  if (!single) return null
+  const match = /^(app|chat):(.+)$/.exec(String(fullBleedKey || ''))
+  if (!match) return null
+  return {
+    surface: STANDARD_CONTENT_SURFACE,
+    kind: match[1],
+    id: match[2],
+  }
+}
+
+/**
+ * Keep an app visible only while the next Standard chat reaches display-ready.
+ *
+ * Chat-to-chat transitions already have a retained ChatView cover. A direct
+ * app-to-chat transition has no outgoing ChatView to hold, which otherwise
+ * exposes ChatView's deliberate first-frame transcript settlement. Retarget a
+ * live cover on rapid chat changes so an app never drops away between A -> B.
+ */
+export function deriveAppToChatCover(previousSurface, currentSurface, cover) {
+  if (currentSurface?.kind !== 'chat'
+      || currentSurface.surface !== STANDARD_CONTENT_SURFACE) {
+    return null
+  }
+
+  if (cover?.surface === currentSurface.surface) {
+    return {
+      ...cover,
+      chatId: currentSurface.id,
+    }
+  }
+
+  if (previousSurface?.kind !== 'app'
+      || previousSurface.surface !== currentSurface.surface) {
+    return null
+  }
+
+  return {
+    surface: currentSurface.surface,
+    appId: previousSurface.id,
+    chatId: currentSurface.id,
+  }
 }
 
 function activeChatOwner(workspace, paneId) {

--- a/frontend/src/lib/__tests__/frameInteractivityContract.test.js
+++ b/frontend/src/lib/__tests__/frameInteractivityContract.test.js
@@ -17,7 +17,14 @@ const frameCacheModel = readFileSync(
 test('drawer suspension reaches the live app frame before paint', () => {
   // Pane assembly/scatter also suspends iframe interaction throughout either beat:
   // painted apps stay visible, but a moving cross-origin frame cannot intercept input.
-  assert.match(shell, /interactive=\{visibleAppIds\.has\(String\(id\)\) && !navigationSurfaceOpen && !modeBeatActive\}/)
+  assert.match(
+    shell,
+    /interactive=\{visibleAppIds\.has\(String\(id\)\) && !heldForChat\s*&& !navigationSurfaceOpen && !modeBeatActive\}/,
+  )
+  assert.match(
+    shell,
+    /visible=\{visibleAppIds\.has\(String\(id\)\) && !heldForChat\}/,
+  )
   assert.match(canvas, /useLayoutEffect\(\(\) => \{[\s\S]*sendInteractivity\(swap\.liveVersion, interactive, visible\)/)
   assert.match(canvas, /suspendScrolling:\s*visible\s*&&\s*!enabled/)
   assert.match(canvas, /moebius:frame-interactivity/)

--- a/frontend/src/lib/__tests__/frameInteractivityContract.test.js
+++ b/frontend/src/lib/__tests__/frameInteractivityContract.test.js
@@ -14,17 +14,7 @@ const frameCacheModel = readFileSync(
   'utf8',
 )
 
-test('drawer suspension reaches the live app frame before paint', () => {
-  // Pane assembly/scatter also suspends iframe interaction throughout either beat:
-  // painted apps stay visible, but a moving cross-origin frame cannot intercept input.
-  assert.match(
-    shell,
-    /interactive=\{visibleAppIds\.has\(String\(id\)\) && !heldForChat\s*&& !navigationSurfaceOpen && !modeBeatActive\}/,
-  )
-  assert.match(
-    shell,
-    /visible=\{visibleAppIds\.has\(String\(id\)\) && !heldForChat\}/,
-  )
+test('frame suspension reaches the live app before paint', () => {
   assert.match(canvas, /useLayoutEffect\(\(\) => \{[\s\S]*sendInteractivity\(swap\.liveVersion, interactive, visible\)/)
   assert.match(canvas, /suspendScrolling:\s*visible\s*&&\s*!enabled/)
   assert.match(canvas, /moebius:frame-interactivity/)


### PR DESCRIPTION
## Summary

- keep the outgoing app's already-painted frame visible only in the Standard single-screen view while the destination chat completes its initial layout
- release the app only after the chat is ready, preventing partial transcript and question-card frames
- keep the visual cover inert and its app runtime inactive, including during rapid chat selection

## Context

Extends #542's chat-to-chat presentation guard to the missing app-to-chat path, while preserving Builder's independent pane presentation.

## Testing

- `npm run lint`
- `npm test`
- Vite build deferred while the host is under active memory pressure from unrelated work