### PR TITLE
Roll out live recovery capability identity

### DIFF
--- a/backend/recovery_target/CAPABILITIES.md
+++ b/backend/recovery_target/CAPABILITIES.md
@@ -40,6 +40,11 @@ all tokens from the previous process even if Railway retains its deployment id.
 Missing or invalid local identity disables the live target without blocking the
 normal Möbius app.
 
+Existing managed services receive the instance id and verification key only
+through a digest-bound core rollout. Keep live-session admission disabled until
+every eligible service has restarted on that rollout and proved its exact
+deployment and boot identity; quarantined services remain fail-closed.
+
 The entrypoint spawns the target early, best-effort, and never probes or waits
 for it, so target initialization or bind failure cannot delay the normal app.
 A unique root-owned `mktemp` file keeps normal target endpoints at


### PR DESCRIPTION
This is the code-neutral managed-core successor needed to install MOBIUS_INSTANCE_ID and the launcher Ed25519 verification key on existing eligible services through the digest-bound fleet controller. It documents the rollout gate; the image code remains the already-tested targetd implementation. Live-session admission stays disabled until the controller proves every eligible deployment and boot. Quarantined services remain fail-closed.