### PR TITLE
Wake delegation parents before optional note publication

### DIFF
--- a/backend/app/chat.py
+++ b/backend/app/chat.py
@@ -3517,6 +3517,14 @@ async def run_chat(
           "agent scratch release hint skipped chat_id=%s",
           chat_id, exc_info=True,
         )
+    # Parent progress must not wait on optional summary generation.
+    try:
+      if chat_id and disposition in _DELEGATION_WAKE_DISPOSITIONS:
+        from app.delegations import wake_parent_after_child_settled
+        await wake_parent_after_child_settled(chat_id)
+    except Exception:
+      _get_logger().debug("delegation parent-wake skipped", exc_info=True)
+
     # Turn-end chat-note guarantee: when the chat SETTLED (no pending
     # follow-up), the platform's sole publisher updates its three summary
     # granularities. Runs AFTER the reply is sent → no user-facing latency;
@@ -3539,18 +3547,6 @@ async def run_chat(
         )
     except Exception:
       _get_logger().debug("chat-note guarantee skipped", exc_info=True)
-
-    # Auto-wake a delegation's parent chat when the child subagent settles.
-    # Gated to durable, non-resuming terminals; runs after the reply is sent and
-    # is best-effort (like the chat-note guarantee above) so it can never affect
-    # this turn. A non-delegation chat is a single indexed miss and returns fast.
-    try:
-      if chat_id and disposition in _DELEGATION_WAKE_DISPOSITIONS:
-        from app.delegations import wake_parent_after_child_settled
-        await wake_parent_after_child_settled(chat_id)
-    except Exception:
-      _get_logger().debug("delegation parent-wake skipped", exc_info=True)
-
 
 # The durable, settled, non-resuming terminals where a delegation child's
 # result is final and its ChatRun terminal status has committed (FinishRun ran

--- a/backend/tests/test_terminal_completion.py
+++ b/backend/tests/test_terminal_completion.py
@@ -1184,11 +1184,19 @@ def test_no_connected_agent_streams_and_persists_guidance(
   _seed_run("rt-12", "t12")
 
   note_modes = []
+  settlement_order = []
+
+  async def capture_wake(_chat_id):
+    settlement_order.append("wake")
 
   async def capture_note(_data_dir, _chat_id, *, deterministic=False):
+    settlement_order.append("note")
     note_modes.append(deterministic)
 
   monkeypatch.setattr(chat_mod, "_ensure_chat_note", capture_note)
+  monkeypatch.setattr(
+    "app.delegations.wake_parent_after_child_settled", capture_wake,
+  )
 
   chat_mod.mark_starting("t12")
   gen = chat_mod.current_run_generation("t12")
@@ -1216,6 +1224,7 @@ def test_no_connected_agent_streams_and_persists_guidance(
     "usage_json": chat_mod._NO_AGENT_USAGE_METRICS,
   }
   assert note_modes == [True]
+  assert settlement_order == ["wake", "note"]
   assert not chat_mod.registry.is_alive("t12"), "registry released"
 
 


### PR DESCRIPTION
## Summary
- wake a delegation parent immediately after the child terminal state is durable
- run optional chat-note publication afterward so summarizer latency cannot delay the waiting workflow
- keep both post-turn actions best-effort and preserve the existing terminal gate

## Testing
- `python3 -m py_compile backend/app/chat.py`
- `scripts/wt-pytest.sh backend/tests/test_terminal_completion.py -q` (39 passed)
