### PR TITLE
Make chat continuity incremental and activity-ordered

### DIFF
--- a/backend/app/chat.py
+++ b/backend/app/chat.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from app import (
@@ -3974,15 +3975,18 @@ async def _run_chat_impl_with_db(
   startup_context = ""
   if not session_id and run_policy is None:
     # `build_memory_block` is pure; the activity emit + envelope live here.
-    eligible_chat_ids = {
+    ordered_chat_ids = [
       row[0]
       for row in db.query(models.Chat.id).filter(
         models.Chat.deleted_at.is_(None),
+      ).order_by(
+        func.coalesce(models.Chat.activity_at, models.Chat.updated_at).desc(),
+        models.Chat.id.desc(),
       ).all()
-    }
+    ]
     block = memory.build_memory_block(
       settings.data_dir,
-      eligible_chat_ids=eligible_chat_ids,
+      ordered_chat_ids=ordered_chat_ids,
     )
     ctx = block.text
     # Observability only. Chat-summary injection is core continuity, not graph

--- a/backend/app/chat_notes.py
+++ b/backend/app/chat_notes.py
@@ -1,0 +1,47 @@
+"""Canonical readers for platform-owned per-chat continuity notes.
+
+Chat summaries are Markdown, so the cumulative ``## Summary`` may legitimately
+contain its own level-two headings (notably when a provider-free fallback
+preserves assistant prose).  The platform sections, not arbitrary Markdown
+headings, define the note boundary.  Keep that rule in one place so context
+inspection and provider handoff cannot disagree about what the summary is.
+"""
+
+from __future__ import annotations
+
+
+_SUMMARY_TERMINATORS = frozenset({"facts & intent", "related"})
+
+
+def extract_section(
+  text: str,
+  heading: str,
+  *,
+  terminators: frozenset[str] | None = None,
+) -> str | None:
+  """Return a platform note section without mistaking nested prose for it."""
+  lines = text.splitlines()
+  target = heading.strip().lower()
+  start: int | None = None
+  for index, line in enumerate(lines):
+    if line.strip().lower() == f"## {target}":
+      start = index + 1
+      break
+  if start is None:
+    return None
+
+  body: list[str] = []
+  for line in lines[start:]:
+    stripped = line.strip()
+    if stripped.startswith("## "):
+      found = stripped[3:].strip().lower()
+      if terminators is None or found in terminators:
+        break
+    body.append(line)
+  value = "\n".join(body).strip()
+  return value or None
+
+
+def extract_cumulative_summary(text: str) -> str | None:
+  """Read Summary through the next platform-owned peer section."""
+  return extract_section(text, "Summary", terminators=_SUMMARY_TERMINATORS)

--- a/backend/app/compaction.py
+++ b/backend/app/compaction.py
@@ -23,6 +23,7 @@ import signal
 import tempfile
 from pathlib import Path
 
+from app.chat_notes import extract_cumulative_summary
 from app.continuations import (
   continuation_actor_label,
   is_continuation_message,
@@ -92,23 +93,10 @@ def load_cumulative_summary(data_dir: str, chat_id: str) -> str | None:
   """Read the chat-maintained unbounded ``## Summary`` section, if present."""
   path = Path(data_dir) / "shared" / "memory" / "chats" / chat_id / "index.md"
   try:
-    lines = path.read_text(encoding="utf-8").splitlines()
+    text = path.read_text(encoding="utf-8")
   except OSError:
     return None
-  start: int | None = None
-  for index, line in enumerate(lines):
-    if line.strip().lower() == "## summary":
-      start = index + 1
-      break
-  if start is None:
-    return None
-  body: list[str] = []
-  for line in lines[start:]:
-    if line.strip().startswith("## "):
-      break
-    body.append(line)
-  summary = "\n".join(body).strip()
-  return summary or None
+  return extract_cumulative_summary(text)
 
 
 def build_transcript_text(

--- a/backend/app/memory.py
+++ b/backend/app/memory.py
@@ -18,6 +18,8 @@ from collections.abc import Collection
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from app.chat_notes import extract_section
+
 # Budget for the always-injected recent-chat digest portion.
 DEFAULT_BUDGET_BYTES = 25_000
 DEFAULT_MAX_NOTES = 12
@@ -117,7 +119,7 @@ def load_chat_summary_metadata(
   if not text.strip():
     return {"description": None, "digest": None}
   description = str(parse_frontmatter(text).get("description", "")).strip()
-  digest = _extract_section(text, "Digest")
+  digest = _note_section(text, "Digest")
   return {
     "description": description or None,
     "digest": digest.strip() if digest and digest.strip() else None,
@@ -145,6 +147,7 @@ def build_memory_block(
   budget_bytes: int = DEFAULT_BUDGET_BYTES,
   max_notes: int = DEFAULT_MAX_NOTES,
   eligible_chat_ids: Collection[str] | None = None,
+  ordered_chat_ids: Collection[str] | None = None,
 ) -> MemoryBlock:
   """Assembles the injected memory context.
 
@@ -172,7 +175,9 @@ def build_memory_block(
   # an unusually long newest note cannot hide every older short digest.
   note_limit = min(RECENT_CHAT_NOTES, max(0, max_notes))
   for note in _recent_chat_notes(
-    root, note_limit, eligible_chat_ids=eligible_chat_ids,
+    root, note_limit,
+    eligible_chat_ids=eligible_chat_ids,
+    ordered_chat_ids=ordered_chat_ids,
   ):
     name, digest = _chat_digest_parts(note)
     if not name and not digest:
@@ -211,14 +216,31 @@ def _recent_chat_notes(
   limit: int,
   *,
   eligible_chat_ids: Collection[str] | None = None,
+  ordered_chat_ids: Collection[str] | None = None,
 ) -> list[Path]:
-  """The per-chat note files (`chats/<id>/index.md`), most-recently-modified
-  first, capped at `limit`. Their bounded digests are injected at
-  session start. Tolerates a missing `chats/` dir (returns [])."""
+  """Return bounded chat notes in explicit activity order when supplied.
+
+  The mtime fallback serves legacy callers that only provide eligibility.
+  Tolerates a missing ``chats/`` directory.
+  """
   chats = root / "chats"
   if not chats.is_dir():
     return []
   eligible = set(eligible_chat_ids) if eligible_chat_ids is not None else None
+  if ordered_chat_ids is not None:
+    ordered: list[Path] = []
+    for chat_id in ordered_chat_ids:
+      if eligible is not None and chat_id not in eligible:
+        continue
+      path = chats / chat_id / "index.md"
+      try:
+        if path.is_file():
+          ordered.append(path)
+      except OSError:
+        continue
+      if len(ordered) >= limit:
+        break
+    return ordered
   candidates: list[tuple[float, Path]] = []
   try:
     paths = chats.glob("*/index.md")
@@ -251,25 +273,9 @@ def _strip_frontmatter(text: str) -> str:
   return rest[nl + 1:] if nl != -1 else ""
 
 
-def _extract_section(text: str, heading: str) -> str | None:
-  """Body under a level-2 `## <heading>` section, up to the next level-2
-  heading or EOF. Case-insensitive on the heading; None when it is absent."""
-  lines = _strip_frontmatter(text).splitlines()
-  target = heading.strip().lower()
-  start = None
-  for i, line in enumerate(lines):
-    s = line.strip()
-    if s.startswith("## ") and s[3:].strip().lower() == target:
-      start = i + 1
-      break
-  if start is None:
-    return None
-  collected: list[str] = []
-  for line in lines[start:]:
-    if line.strip().startswith("## "):
-      break
-    collected.append(line)
-  return "\n".join(collected).strip()
+def _note_section(text: str, heading: str) -> str | None:
+  """Read a section from the body of a platform-owned continuity note."""
+  return extract_section(_strip_frontmatter(text), heading)
 
 
 def _chat_digest_parts(note: Path) -> tuple[str, str]:
@@ -283,9 +289,9 @@ def _chat_digest_parts(note: Path) -> tuple[str, str]:
   if not text.strip():
     return "", ""
   desc = str(parse_frontmatter(text).get("description", "")).strip()
-  digest = _extract_section(text, "Digest")
+  digest = _note_section(text, "Digest")
   if digest is None:
-    digest = _extract_section(text, "Summary")
+    digest = _note_section(text, "Summary")
   if digest is None:
     digest = _strip_frontmatter(text).strip()
   return desc, _truncate_bytes(digest.strip(), DIGEST_MAX_BYTES).strip()

--- a/backend/app/routes/chats.py
+++ b/backend/app/routes/chats.py
@@ -1635,15 +1635,18 @@ def get_chat_agent_context(
   compaction_brief = _latest_compaction_brief(chat)
   chat_summary = load_cumulative_summary(data_dir, chat_id)
   chat_summary_metadata = memory.load_chat_summary_metadata(data_dir, chat_id)
-  eligible_chat_ids = {
+  ordered_chat_ids = [
     row[0]
     for row in db.query(models.Chat.id).filter(
       models.Chat.deleted_at.is_(None),
+    ).order_by(
+      func.coalesce(models.Chat.activity_at, models.Chat.updated_at).desc(),
+      models.Chat.id.desc(),
     ).all()
-  }
+  ]
   recent_chat_block = memory.build_memory_block(
     data_dir,
-    eligible_chat_ids=eligible_chat_ids,
+    ordered_chat_ids=ordered_chat_ids,
   )
   recent_chats = recent_chat_block.text or None
   return {

--- a/backend/scripts/chat_note.py
+++ b/backend/scripts/chat_note.py
@@ -22,9 +22,9 @@ of notes silently stopping.
 
 from __future__ import annotations
 
-import json
-import hashlib
 import asyncio
+import hashlib
+import json
 import os
 import re
 import sqlite3
@@ -34,6 +34,7 @@ import tempfile
 import urllib.request
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import NamedTuple
 
 DATA_DIR = Path(os.environ.get("DATA_DIR", "/data"))
 DB = DATA_DIR / "db" / "ultimate.db"
@@ -42,6 +43,11 @@ CLAUDE_CONFIG_DIR = DATA_DIR / "cli-auth" / "claude"
 CLI_PATH = "/usr/local/bin/claude"
 API_BASE_URL = os.environ.get("API_BASE_URL", "http://localhost:8000")
 SERVICE_TOKEN_FILE = DATA_DIR / "service-token.txt"
+BACKEND_DIR = Path(__file__).resolve().parents[1]
+if str(BACKEND_DIR) not in sys.path:
+  sys.path.insert(0, str(BACKEND_DIR))
+
+from app.chat_notes import extract_cumulative_summary, extract_section
 
 # When the configured provider has a demonstrably tool-free text mode we may
 # use it to distill the note.  There is always an extractive local fallback, so
@@ -103,28 +109,25 @@ Rules:
 """
 
 
-def _render_transcript(raw: str) -> str:
-  """Render the complete user-visible transcript as role-prefixed text.
-
-  Persisted assistant messages normally carry a flattened ``content`` string,
-  but question/error-only messages can have meaningful blocks with empty
-  content. Preserve those visible handoffs. Tool inputs/outputs and thinking
-  stay excluded: they can contain credentials or huge opaque payloads and are
-  not part of the conversational handoff.
-  """
-  if not raw:
-    return ""
+def _parsed_messages(raw: str) -> list[dict] | None:
   try:
-    msgs = json.loads(raw)
+    value = json.loads(raw)
   except (ValueError, TypeError):
-    return raw
+    return None
+  if not isinstance(value, list):
+    return None
+  return [item for item in value if isinstance(item, dict)]
+
+
+def _render_messages(msgs: list[dict], *, start_index: int = 0) -> str:
+  """Render user-visible messages as role-prefixed transcript text."""
   lines: list[str] = []
-  for m in msgs if isinstance(msgs, list) else []:
+  for m in msgs[max(0, start_index):]:
     # Provider handoffs are derived from this note. Re-ingesting them would
     # recursively duplicate the same context on every later re-switch.
-    if isinstance(m, dict) and m.get("kind") == "compaction":
+    if m.get("kind") == "compaction":
       continue
-    if isinstance(m, dict) and m.get("kind") in {
+    if m.get("kind") in {
       "continuation", "auto_continuation",
     }:
       reason = str(m.get("continuation_reason") or "automatic recovery")
@@ -134,8 +137,8 @@ def _render_transcript(raw: str) -> str:
         else f"automatic continuation ({reason})"
       )
     else:
-      role = m.get("role", "?") if isinstance(m, dict) else "?"
-    content = m.get("content") if isinstance(m, dict) else None
+      role = m.get("role", "?")
+    content = m.get("content")
     if isinstance(content, list):
       text = " ".join(
         str(b.get("text") or b.get("content") or "")
@@ -146,7 +149,7 @@ def _render_transcript(raw: str) -> str:
       text = content
     else:
       text = ""
-    if not text.strip() and isinstance(m, dict):
+    if not text.strip():
       visible: list[str] = []
       blocks = m.get("blocks") if isinstance(m.get("blocks"), list) else []
       for block in blocks:
@@ -176,6 +179,16 @@ def _render_transcript(raw: str) -> str:
   return "\n\n".join(lines)
 
 
+def _render_transcript(raw: str, *, start_index: int = 0) -> str:
+  """Render a persisted transcript without exposing tool or thinking data."""
+  if not raw:
+    return ""
+  messages = _parsed_messages(raw)
+  if messages is None:
+    return raw
+  return _render_messages(messages, start_index=start_index)
+
+
 def _apply_sqlite_policy(con: sqlite3.Connection) -> None:
   """Apply the runtime's shared SQLite policy to a raw connection.
 
@@ -199,7 +212,49 @@ def _apply_sqlite_policy(con: sqlite3.Connection) -> None:
     con.execute(pragma)
 
 
-def _read_chat_snapshot(chat_id: str) -> tuple[str, str] | None:
+class SourceCursor(NamedTuple):
+  message_count: int
+  messages_sha256: str
+
+
+class ChatSnapshot(NamedTuple):
+  transcript: str
+  updated_at: str
+  messages: list[dict] | None
+
+  @property
+  def message_count(self) -> int | None:
+    return len(self.messages) if self.messages is not None else None
+
+  def transcript_after(self, message_count: int) -> str:
+    if self.messages is None:
+      return self.transcript
+    return _render_messages(self.messages, start_index=message_count)
+
+  def cursor(self, message_count: int | None = None) -> SourceCursor | None:
+    if self.messages is None:
+      return None
+    count = len(self.messages) if message_count is None else message_count
+    if count < 0 or count > len(self.messages):
+      return None
+    return SourceCursor(count, _messages_sha256(self.messages[:count]))
+
+
+def _messages_sha256(messages: list[dict]) -> str:
+  digest = hashlib.sha256()
+  for message in messages:
+    encoded = json.dumps(
+      message,
+      ensure_ascii=False,
+      separators=(",", ":"),
+      sort_keys=True,
+    ).encode("utf-8")
+    digest.update(len(encoded).to_bytes(8, "big"))
+    digest.update(encoded)
+  return digest.hexdigest()
+
+
+def _read_chat_snapshot(chat_id: str) -> ChatSnapshot | None:
   """Return complete transcript + durable revision for one idle live chat."""
   try:
     con = sqlite3.connect(str(DB))
@@ -217,13 +272,13 @@ def _read_chat_snapshot(chat_id: str) -> tuple[str, str] | None:
     return None
   if not row or not row[0] or row[1] is None:
     return None
-  return _render_transcript(row[0]), str(row[1])
-
-
-def _read_transcript(chat_id: str) -> str:
-  """Compatibility wrapper used by tests and operator diagnostics."""
-  snapshot = _read_chat_snapshot(chat_id)
-  return snapshot[0] if snapshot else ""
+  raw = str(row[0])
+  messages = _parsed_messages(raw)
+  return ChatSnapshot(
+    transcript=_render_transcript(raw),
+    updated_at=str(row[1]),
+    messages=messages,
+  )
 
 
 def _note_path(chat_id: str) -> Path:
@@ -362,11 +417,72 @@ def _run_codex_tool_free(prompt: str) -> str:
 
 
 def _existing_section(existing: str, heading: str) -> str:
-  match = re.search(
-    rf"(?ims)^## {re.escape(heading)}\s*\n(.*?)(?=^## |\Z)",
-    existing,
+  value = (
+    extract_cumulative_summary(existing)
+    if heading.strip().lower() == "summary"
+    else extract_section(existing, heading)
   )
-  return match.group(1).strip() if match else ""
+  return value or ""
+
+
+def _frontmatter_bounds(note: str) -> tuple[int, int] | None:
+  if not note.startswith("---\n"):
+    return None
+  end = note.find("\n---", 4)
+  return (4, end) if end >= 0 else None
+
+
+def _source_cursor(note: str) -> SourceCursor | None:
+  bounds = _frontmatter_bounds(note)
+  if bounds is None:
+    return None
+  frontmatter = note[bounds[0]:bounds[1]]
+  count = re.search(r"(?m)^source_message_count:\s*(\d+)\s*$", frontmatter)
+  digest = re.search(
+    r"(?mi)^source_messages_sha256:\s*([a-f0-9]{64})\s*$",
+    frontmatter,
+  )
+  if count is None or digest is None:
+    return None
+  return SourceCursor(
+    int(count.group(1)),
+    digest.group(1).lower(),
+  )
+
+
+def _set_source_cursor(note: str, cursor: SourceCursor | None) -> str:
+  bounds = _frontmatter_bounds(note)
+  if bounds is None:
+    return note
+  frontmatter = [
+    line
+    for line in note[bounds[0]:bounds[1]].splitlines()
+    if not re.match(r"(?i)^source_(?:message_count|messages_sha256):", line)
+  ]
+  if cursor is not None:
+    frontmatter.extend([
+      f"source_message_count: {cursor.message_count}",
+      f"source_messages_sha256: {cursor.messages_sha256}",
+    ])
+  return note[:bounds[0]] + "\n".join(frontmatter) + note[bounds[1]:]
+
+
+def _incremental_start(
+  snapshot: ChatSnapshot,
+  cursor: SourceCursor | None,
+) -> int | None:
+  if (
+    cursor is None
+    or snapshot.message_count is None
+    or not 0 <= cursor.message_count < snapshot.message_count
+  ):
+    return None
+  prefix = snapshot.cursor(cursor.message_count)
+  return (
+    cursor.message_count
+    if prefix is not None and prefix.messages_sha256 == cursor.messages_sha256
+    else None
+  )
 
 
 def _deterministic_note(transcript: str, existing: str) -> str:
@@ -392,11 +508,19 @@ def _deterministic_note(transcript: str, existing: str) -> str:
     seed = user_entries[0] if user_entries else (entries[0] if entries else "chat")
     description = re.sub(r"\s+", " ", seed).strip()[:160] or "chat"
   recent = " ".join(entries[-4:])
-  digest = re.sub(r"\s+", " ", recent).strip()[:600]
+  digest = re.sub(r"\s+", " ", f"{description}. {recent}").strip()[:600]
   facts = _existing_section(existing, "Facts & intent")
   if not facts:
     facts = "- intent: continue the work and decisions captured in this chat"
   related = _existing_section(existing, "Related")
+  previous_summary = _existing_section(existing, "Summary")
+  summary = transcript.strip()
+  if previous_summary:
+    summary = (
+      f"{previous_summary}\n\n"
+      "### Undistilled latest transcript\n\n"
+      f"{transcript.strip()}"
+    )
   note = (
     "---\n"
     "type: chat\n"
@@ -405,8 +529,7 @@ def _deterministic_note(transcript: str, existing: str) -> str:
     "## Digest\n"
     f"{digest}\n\n"
     "## Summary\n"
-    "Complete transcript handoff (platform-generated; newest state last):\n\n"
-    f"{transcript.strip()}\n\n"
+    f"{summary}\n\n"
     "## Facts & intent\n"
     f"{facts}"
   )
@@ -583,8 +706,7 @@ def run() -> int:
   snapshot = _read_chat_snapshot(chat_id)
   if snapshot is None:
     return 0  # missing, deleted, or currently running
-  transcript, expected_updated_at = snapshot
-  if not transcript:
+  if not snapshot.transcript:
     return 0  # nothing to summarize yet
   note = _note_path(chat_id)
   try:
@@ -592,7 +714,22 @@ def run() -> int:
   except (OSError, UnicodeError) as exc:
     sys.stderr.write(f"note snapshot failed: {exc!r}\n")
     return 3
-  out = _clean_note_output(_summarize(transcript, existing))
+  previous_cursor = _source_cursor(existing)
+  current_cursor = snapshot.cursor()
+  if previous_cursor is not None and previous_cursor == current_cursor:
+    return 0
+  start_index = _incremental_start(snapshot, previous_cursor)
+  transcript = (
+    snapshot.transcript_after(start_index)
+    if start_index is not None
+    else snapshot.transcript
+  )
+  out = (
+    existing
+    if start_index is not None and not transcript
+    else _clean_note_output(_summarize(transcript, existing))
+  )
+  out = _set_source_cursor(out, current_cursor)
   if not _looks_like_note(out):
     sys.stderr.write("summarizer output is not a note\n")
     return 3
@@ -600,7 +737,7 @@ def run() -> int:
   try:
     published = _publish_if_current(
       chat_id,
-      expected_updated_at,
+      snapshot.updated_at,
       expected_note_revision,
       note,
       out,

--- a/backend/tests/test_chat_compact.py
+++ b/backend/tests/test_chat_compact.py
@@ -653,6 +653,19 @@ def test_cumulative_chat_summary_is_unbounded_compaction_source(tmp_path):
   assert "private fact" not in summary
 
 
+def test_cumulative_summary_keeps_markdown_h2_inside_handoff(tmp_path):
+  note = tmp_path / "shared" / "memory" / "chats" / "c1" / "index.md"
+  note.parent.mkdir(parents=True)
+  note.write_text(
+    "## Summary\nOpening\n\n## Implementation\nKept detail\n\n"
+    "## Facts & intent\n- private\n",
+    encoding="utf-8",
+  )
+  assert compaction.load_cumulative_summary(str(tmp_path), "c1") == (
+    "Opening\n\n## Implementation\nKept detail"
+  )
+
+
 def test_codex_agent_text_reads_completed_message():
   stdout = (
     b'{"type":"thread.started","thread_id":"t"}\n'

--- a/backend/tests/test_chat_note.py
+++ b/backend/tests/test_chat_note.py
@@ -208,6 +208,18 @@ def test_deterministic_note_preserves_an_existing_generated_name():
   assert "description: unrelated raw prompt text" not in note
 
 
+def test_deterministic_note_preserves_summary_with_internal_h2():
+  cn = _load_chat_note()
+  existing = (
+    "---\ntype: chat\ndescription: Useful name\n---\n"
+    "## Digest\nold\n\n## Summary\nDecision\n\n## Design\nDetail\n\n"
+    "## Facts & intent\n- intent: ship\n"
+  )
+  note = cn._deterministic_note("user: new evidence", existing)
+  assert "Decision\n\n## Design\nDetail" in note
+  assert "### Undistilled latest transcript\n\nuser: new evidence" in note
+
+
 def test_read_transcript_excludes_derived_provider_handoffs(tmp_path):
   cn = _load_chat_note()
   database = tmp_path / "chat.db"
@@ -236,7 +248,7 @@ def test_read_transcript_excludes_derived_provider_handoffs(tmp_path):
   con.close()
   cn.DB = database
 
-  transcript = cn._read_transcript("c1")
+  transcript = cn._read_chat_snapshot("c1").transcript
   assert "original request" in transcript
   assert "real response" in transcript
   assert "derived handoff" not in transcript
@@ -496,7 +508,9 @@ def test_first_summary_publication_replaces_the_opening_message_title(
   cn = _load_chat_note()
   monkeypatch.setattr(cn, "MEMORY_DIR", tmp_path / "memory")
   monkeypatch.setattr(
-    cn, "_read_chat_snapshot", lambda _cid: ("transcript", "r1"),
+    cn,
+    "_read_chat_snapshot",
+    lambda _cid: cn.ChatSnapshot("transcript", "r1", []),
   )
   monkeypatch.setattr(cn, "_read_note_snapshot", lambda _note: ("", "missing"))
   monkeypatch.setattr(
@@ -513,10 +527,79 @@ def test_first_summary_publication_replaces_the_opening_message_title(
   assert patched == [("c1", "Current work")]
 
 
+def test_incremental_cursor_prevents_repeated_fallback_transcripts():
+  cn = _load_chat_note()
+  messages = [
+    {"role": "user", "content": "old request"},
+    {"role": "assistant", "content": "old answer"},
+    {"role": "user", "content": "new request"},
+    {"role": "assistant", "content": "new answer"},
+  ]
+  snapshot = cn.ChatSnapshot(
+    cn._render_transcript(json.dumps(messages)), "r1", messages,
+  )
+  existing = cn._set_source_cursor(
+    _valid_note(summary="curated"), snapshot.cursor(2),
+  )
+
+  previous_cursor = cn._source_cursor(existing)
+  delta = snapshot.transcript_after(
+    cn._incremental_start(snapshot, previous_cursor),
+  )
+  note = cn._set_source_cursor(
+    cn._deterministic_note(delta, existing), snapshot.cursor(),
+  )
+
+  summary = cn._existing_section(note, "Summary")
+  assert summary.count("curated") == 1
+  assert summary.count("new request") == 1
+  assert "old request" not in summary
+  assert cn._source_cursor(note) == snapshot.cursor()
+  assert snapshot.transcript_after(cn._source_cursor(note).message_count) == ""
+
+
+def test_source_cursor_is_host_owned_frontmatter():
+  cn = _load_chat_note()
+  cursor = cn.SourceCursor(12, "a" * 64)
+  note = cn._set_source_cursor(
+    _valid_note(summary="source_message_count: 999"), cursor,
+  )
+  assert "source_message_count: 12" in note.split("---", 2)[1]
+  assert "source_messages_sha256: " + "a" * 64 in note.split("---", 2)[1]
+  assert "source_message_count: 999" in cn._existing_section(note, "Summary")
+  assert cn._source_cursor(note) == cursor
+  updated = cn._set_source_cursor(note, cn.SourceCursor(14, "b" * 64))
+  assert updated.split("---", 2)[1].count("source_message_count:") == 1
+  assert updated.split("---", 2)[1].count("source_messages_sha256:") == 1
+  assert cn._source_cursor(updated) == cn.SourceCursor(14, "b" * 64)
+
+
+def test_cursor_requires_an_unchanged_prefix_before_incremental_summary():
+  cn = _load_chat_note()
+  original = [
+    {"role": "user", "content": "request"},
+    {"role": "assistant", "content": "answer"},
+  ]
+  cursor = cn.ChatSnapshot("", "r1", original).cursor()
+  edited = cn.ChatSnapshot("", "r2", [
+    {"role": "user", "content": "edited request"},
+    {"role": "assistant", "content": "answer"},
+    {"role": "user", "content": "follow-up"},
+  ])
+  same_count_edit = cn.ChatSnapshot("", "r2", [
+    {"role": "user", "content": "edited request"},
+    {"role": "assistant", "content": "answer"},
+  ])
+
+  assert cn._incremental_start(edited, cursor) is None
+  assert same_count_edit.cursor() != cursor
+
+
 def test_two_backstops_publish_only_one_revision(tmp_path):
   cn = _load_chat_note()
   _snapshot_db(cn, tmp_path)
-  transcript, revision = cn._read_chat_snapshot("c1")
+  snapshot = cn._read_chat_snapshot("c1")
+  revision = snapshot.updated_at
   note = cn._note_path("c1")
   _existing, note_revision = cn._read_note_snapshot(note)
 
@@ -532,7 +615,7 @@ def test_two_backstops_publish_only_one_revision(tmp_path):
 def test_new_turn_or_delete_makes_summary_publication_stale(tmp_path):
   cn = _load_chat_note()
   db_path = _snapshot_db(cn, tmp_path)
-  _transcript, revision = cn._read_chat_snapshot("c1")
+  revision = cn._read_chat_snapshot("c1").updated_at
   note = cn._note_path("c1")
   _existing, note_revision = cn._read_note_snapshot(note)
   con = sqlite3.connect(db_path)
@@ -569,7 +652,7 @@ def test_new_turn_or_delete_makes_summary_publication_stale(tmp_path):
 def test_note_hash_cas_detects_same_mtime_replacement(tmp_path):
   cn = _load_chat_note()
   _snapshot_db(cn, tmp_path)
-  _transcript, revision = cn._read_chat_snapshot("c1")
+  revision = cn._read_chat_snapshot("c1").updated_at
   note = cn._note_path("c1")
   note.parent.mkdir(parents=True)
   note.write_text(_valid_note("old"))
@@ -589,7 +672,7 @@ def test_note_write_failure_does_not_advance_chat_revision(
 ):
   cn = _load_chat_note()
   db_path = _snapshot_db(cn, tmp_path)
-  _transcript, revision = cn._read_chat_snapshot("c1")
+  revision = cn._read_chat_snapshot("c1").updated_at
   note = cn._note_path("c1")
   _old, note_revision = cn._read_note_snapshot(note)
 

--- a/backend/tests/test_memory.py
+++ b/backend/tests/test_memory.py
@@ -58,6 +58,21 @@ def test_chat_digests_are_newest_first_and_budget_bounded(tmp_path):
   assert len(block.text.encode("utf-8")) <= 600
 
 
+def test_explicit_activity_order_beats_backfill_mtime(tmp_path):
+  root = tmp_path / "shared" / "memory"
+  older = _chat_note(root, "older", Digest="older activity")
+  newer = _chat_note(root, "newer", Digest="newer activity")
+  os.utime(older, (3000, 3000))
+  os.utime(newer, (1000, 1000))
+
+  block = memory.build_memory_block(
+    tmp_path,
+    ordered_chat_ids=["newer", "older"],
+  )
+
+  assert block.text.index("newer activity") < block.text.index("older activity")
+
+
 def test_chat_digest_entries_have_name_location_and_digest_without_repeated_copy(
   tmp_path,
 ):


### PR DESCRIPTION
## Summary
- order recent chat continuity by owner-visible activity rather than note publication time
- preserve Markdown subheadings inside cumulative summaries through one canonical note parser
- summarize only verified appended messages while forcing a full refresh when an earlier message changed
- store the verified cursor only in platform-owned frontmatter and preserve cumulative provider-free fallbacks

## Testing
- `python3 -m py_compile` on the affected backend modules
- focused continuity and memory suites (81 passed)
- `TMPDIR=/tmp scripts/wt-pytest.sh -q` (3,967 passed, 1 skipped)
