### PR TITLE
Keep app frames stable through chat handoffs

### DIFF
--- a/frontend/src/components/AppCanvas/AppCanvas.jsx
+++ b/frontend/src/components/AppCanvas/AppCanvas.jsx
@@ -243,18 +243,15 @@ const AppCanvas = forwardRef(function AppCanvas({
   // status-bar-preserving chrome collapse, or null. One value keeps safe-area
   // forwarding and the runtime echo from observing contradictory booleans.
   immersiveMode = null,
-  // Whether this app is the active tab of any painted workspace pane. This
-  // owns navigation and capability access; a frame kept briefly as a visual
-  // handoff cover remains inactive here.
-  //
-  // Immersive gating — Shell's immersive holder is GLOBAL
+  // Whether this app owns the focused pane. Shell's immersive holder is GLOBAL
   //     last-writer-wins, so immersive intent may only be forwarded/replayed
   //     while this canvas is active; otherwise a hidden cached app (or its
   //     freshly-promoted rebuild) steals chrome/insets from the app on screen.
   // Defaults true so any caller that omits it keeps apps un-paused (back-compat).
   active = true,
-  // An app visible in a background split still runs and can install nested-view
-  // sentinels. `visible` gates those concerns, while `active`
+  // Whether this app is the active tab of any painted pane. An app visible in a
+  // background split still runs and can install nested-view sentinels. `visible`
+  // gates navigation and capabilities, while `active`
   // (the FOCUSED pane's app) stays focused-pane-only and continues to gate
   // safe-area insets + the immersive holder (global last-writer-wins). Defaults
   // to `active` so a single-pane caller (where visible === focused) is unchanged.

--- a/frontend/src/components/AppCanvas/AppCanvas.jsx
+++ b/frontend/src/components/AppCanvas/AppCanvas.jsx
@@ -243,26 +243,27 @@ const AppCanvas = forwardRef(function AppCanvas({
   // status-bar-preserving chrome collapse, or null. One value keeps safe-area
   // forwarding and the runtime echo from observing contradictory booleans.
   immersiveMode = null,
-  // Whether this app is the currently-visible canvas (canvas view + active
-  // app). One prop, two consumers:
-  //   - `moebius:frame-visibility` — the shell keeps recently-used apps
-  //     MOUNTED and merely toggles `visibility:hidden` on the inactive ones
-  //     (Shell.css .shell__view), which does NOT change a nested iframe's
-  //     Page Visibility state, so the verdict is forwarded to the frame and
-  //     an app can pause background work (audio, rAF, timers) on navigate-away.
-  //   - Immersive gating — Shell's immersive holder is GLOBAL
+  // Whether this app is the active tab of any painted workspace pane. This
+  // owns navigation and capability access; a frame kept briefly as a visual
+  // handoff cover remains inactive here.
+  //
+  // Immersive gating — Shell's immersive holder is GLOBAL
   //     last-writer-wins, so immersive intent may only be forwarded/replayed
   //     while this canvas is active; otherwise a hidden cached app (or its
   //     freshly-promoted rebuild) steals chrome/insets from the app on screen.
   // Defaults true so any caller that omits it keeps apps un-paused (back-compat).
   active = true,
-  // Whether this app is the active tab of ANY visible pane (design §5). Drives
-  // the frame-visibility signal and the nav-push gate — an app visible in a
-  // background split still runs and can install nested-view sentinels. `active`
+  // An app visible in a background split still runs and can install nested-view
+  // sentinels. `visible` gates those concerns, while `active`
   // (the FOCUSED pane's app) stays focused-pane-only and continues to gate
   // safe-area insets + the immersive holder (global last-writer-wins). Defaults
   // to `active` so a single-pane caller (where visible === focused) is unchanged.
   visible = active,
+  // The frame's foreground signal normally follows its logical pane visibility.
+  // A shell-owned visual handoff may keep the already-painted frame foreground
+  // for a few frames after its pane became inactive, without reviving app
+  // navigation or capabilities.
+  frameVisible = visible,
   // Whether the live frame may receive direct interaction. This differs from
   // `visible` while the shell drawer is open: each pane remains painted behind
   // the scrim, but compositor momentum inside its iframe must be cancelled so
@@ -474,6 +475,8 @@ const AppCanvas = forwardRef(function AppCanvas({
   interactiveRef.current = interactive
   const visibleRef = useRef(visible)
   visibleRef.current = visible
+  const frameVisibleRef = useRef(frameVisible)
+  frameVisibleRef.current = frameVisible
   const capabilityContractRef = useRef(capabilityContract)
   capabilityContractRef.current = capabilityContract
   const capabilityHostRef = useRef(null)
@@ -1096,7 +1099,7 @@ const AppCanvas = forwardRef(function AppCanvas({
   }
 
   // ── In-shell foreground/background signal ────────────────────────
-  // Forward whether THIS app is the visible canvas. The shell keeps recently-
+  // Forward whether THIS app's frame is visually foreground. The shell keeps recently-
   // used apps mounted and hides the inactive ones with `visibility:hidden` on a
   // shell ancestor — which does NOT change the nested iframe's
   // document.visibilityState (no visibilitychange/blur/pagehide fires). So an
@@ -1111,27 +1114,27 @@ const AppCanvas = forwardRef(function AppCanvas({
   // A buffered incoming frame is invisible by construction, so it gets an
   // explicit `visible:false` at load (handleFrameLoad) — a rebuild that boots
   // in the hidden buffer must not start audio/rAF work before promotion. The
-  // effect below re-sends on every `active` flip AND on promotion
+  // effect below re-sends on every foreground-frame flip AND on promotion
   // (swap.liveVersion change), so a freshly-promoted frame immediately learns
   // whether it is foreground.
   function sendVisibility(v, visible) {
     postToFrame(v, { type: 'moebius:frame-visibility', visible })
   }
 
-  function sendInteractivity(v, enabled, visible = visibleRef.current) {
+  function sendInteractivity(v, enabled, frameIsVisible = frameVisibleRef.current) {
     postToFrame(v, {
       type: 'moebius:frame-interactivity',
       interactive: enabled,
-      suspendScrolling: visible && !enabled,
+      suspendScrolling: frameIsVisible && !enabled,
     })
   }
 
   useEffect(() => {
     if (loadedDocsRef.current.has(swap.liveVersion)) {
-      sendVisibility(swap.liveVersion, visible)
+      sendVisibility(swap.liveVersion, frameVisible)
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [visible, swap.liveVersion])
+  }, [frameVisible, swap.liveVersion])
 
   // Layout timing is deliberate. A drawer-open render removes the shell canvas
   // from hit-testing and sends this message before paint; app-frame.html then
@@ -1140,10 +1143,10 @@ const AppCanvas = forwardRef(function AppCanvas({
   // coast visibly beneath the newly-open drawer.
   useLayoutEffect(() => {
     if (loadedDocsRef.current.has(swap.liveVersion)) {
-      sendInteractivity(swap.liveVersion, interactive, visible)
+      sendInteractivity(swap.liveVersion, interactive, frameVisible)
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [interactive, visible, swap.liveVersion])
+  }, [interactive, frameVisible, swap.liveVersion])
 
   useEffect(() => {
     for (const v of framesRef.current.keys()) {
@@ -1336,15 +1339,15 @@ const AppCanvas = forwardRef(function AppCanvas({
     // A booting incoming frame is invisible by construction and must not
     // start audio/rAF work before promotion, so it learns `visible:false`
     // here; the live frame gets the real visible verdict. Promotion re-sends
-    // via the [visible, swap.liveVersion] effect above. Interactivity is a
+    // via the [frameVisible, swap.liveVersion] effect above. Interactivity is a
     // separate gate (drawer-open momentum cancel); its "painted" argument tracks
-    // `visible` post active->visible split, its enabled argument tracks
+    // `frameVisible` post active->visible split, its enabled argument tracks
     // `interactive` (focused pane, drawer-aware).
-    sendVisibility(v, v === liveVersionRef.current ? visibleRef.current : false)
+    sendVisibility(v, v === liveVersionRef.current ? frameVisibleRef.current : false)
     sendInteractivity(
       v,
       v === liveVersionRef.current ? interactiveRef.current : false,
-      v === liveVersionRef.current ? visibleRef.current : false,
+      v === liveVersionRef.current ? frameVisibleRef.current : false,
     )
   }
 

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -3345,7 +3345,14 @@ export default function Shell() {
           const fullBleed = !paned && (tabKey === fullBleedKey || heldForChat)
           const surfaceVisible = !!(paned || fullBleed)
           const appSurfaceInert = !surfaceVisible || heldForChat
-          const appRuntimeVisible = visibleAppIds.has(String(id)) && !heldForChat
+          const appRuntimeVisible = visibleAppIds.has(String(id))
+          // The held app is the visual handoff cover. Keep its frame visibly
+          // foreground until the chat has painted: apps may legitimately clear
+          // their own UI after `frame-visibility:false`, which would otherwise
+          // reveal the chat's still-settling frame beneath this wrapper. Its
+          // logical runtime remains inactive, so it cannot navigate or claim a
+          // capability during the handoff.
+          const appFrameVisible = appRuntimeVisible || heldForChat
           const posStyle = paned ? {
             top: paned.y,
             left: paned.x,
@@ -3386,16 +3393,19 @@ export default function Shell() {
               // Focused-pane-only: gates safe-area insets + the immersive holder
               // (global last-writer-wins).
               active={tabKey === focusedActiveKey}
-              // Visible in ANY pane: gates frame-visibility + nav-push (§5). A
+              // Visible in ANY pane: gates app navigation and capabilities. A
               // background split's app keeps running and can install sentinels;
               // Settings/immersive-solo/hidden panes exclude it (visibleAppIds).
-              // A held app still paints its last frame as a chat handoff cover,
-              // but it is no longer an active app runtime.
+              // Logical ownership controls app navigation and capabilities.
               visible={appRuntimeVisible}
+              // The cover owns the frame's visual lifetime, independently of
+              // logical app ownership, so its already-painted pixels remain
+              // stable until the chat takes over.
+              frameVisible={appFrameVisible}
               // Every visible pane remains painted beneath the modal scrim, but
               // suspend its iframe interaction while the drawer is open OR during any
               // mode scene (cross-origin app interaction is inert throughout).
-              interactive={appRuntimeVisible
+              interactive={appRuntimeVisible && !heldForChat
                 && !navigationSurfaceOpen && !modeBeatActive}
               version={versionForApp(id)}
               appName={app?.name}

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -3345,7 +3345,7 @@ export default function Shell() {
           const fullBleed = !paned && (tabKey === fullBleedKey || heldForChat)
           const surfaceVisible = !!(paned || fullBleed)
           const appSurfaceInert = !surfaceVisible || heldForChat
-          const appRuntimeVisible = visibleAppIds.has(String(id))
+          const appRuntimeVisible = visibleAppIds.has(String(id)) && !heldForChat
           // The held app is the visual handoff cover. Keep its frame visibly
           // foreground until the chat has painted: apps may legitimately clear
           // their own UI after `frame-visibility:false`, which would otherwise
@@ -3405,7 +3405,7 @@ export default function Shell() {
               // Every visible pane remains painted beneath the modal scrim, but
               // suspend its iframe interaction while the drawer is open OR during any
               // mode scene (cross-origin app interaction is inert throughout).
-              interactive={appRuntimeVisible && !heldForChat
+              interactive={appRuntimeVisible
                 && !navigationSurfaceOpen && !modeBeatActive}
               version={versionForApp(id)}
               appName={app?.name}

--- a/frontend/src/components/Shell/__tests__/chatHandoff.test.js
+++ b/frontend/src/components/Shell/__tests__/chatHandoff.test.js
@@ -225,12 +225,12 @@ test('only the painted workspace world can expose its handoff layers', () => {
   )
   assert.match(
     shell,
-    /const appRuntimeVisible = visibleAppIds\.has\(String\(id\)\)[\s\S]*?const appFrameVisible = appRuntimeVisible \|\| heldForChat/,
+    /const appRuntimeVisible = visibleAppIds\.has\(String\(id\)\) && !heldForChat[\s\S]*?const appFrameVisible = appRuntimeVisible \|\| heldForChat/,
     'the visual cover must not turn the outgoing app back into the active runtime',
   )
   assert.match(
     shell,
-    /visible=\{appRuntimeVisible\}[\s\S]*?frameVisible=\{appFrameVisible\}[\s\S]*?interactive=\{appRuntimeVisible && !heldForChat/,
+    /visible=\{appRuntimeVisible\}[\s\S]*?frameVisible=\{appFrameVisible\}[\s\S]*?interactive=\{appRuntimeVisible/,
     'the visually retained app keeps its frame foreground while navigation and interaction stay inactive',
   )
 })

--- a/frontend/src/components/Shell/__tests__/chatHandoff.test.js
+++ b/frontend/src/components/Shell/__tests__/chatHandoff.test.js
@@ -223,6 +223,16 @@ test('only the painted workspace world can expose its handoff layers', () => {
     /aria-hidden=\{!surfaceVisible \|\| settingsOverlay \|\| role !== 'active'/,
     'a retained chat in the parked workspace world must leave the accessibility tree',
   )
+  assert.match(
+    shell,
+    /const appRuntimeVisible = visibleAppIds\.has\(String\(id\)\)[\s\S]*?const appFrameVisible = appRuntimeVisible \|\| heldForChat/,
+    'the visual cover must not turn the outgoing app back into the active runtime',
+  )
+  assert.match(
+    shell,
+    /visible=\{appRuntimeVisible\}[\s\S]*?frameVisible=\{appFrameVisible\}[\s\S]*?interactive=\{appRuntimeVisible && !heldForChat/,
+    'the visually retained app keeps its frame foreground while navigation and interaction stay inactive',
+  )
 })
 
 test('app-supplied drafts update retained composers as well as remounted chats', () => {

--- a/frontend/src/lib/__tests__/frameInteractivityContract.test.js
+++ b/frontend/src/lib/__tests__/frameInteractivityContract.test.js
@@ -15,8 +15,10 @@ const frameCacheModel = readFileSync(
 )
 
 test('frame suspension reaches the live app before paint', () => {
-  assert.match(canvas, /useLayoutEffect\(\(\) => \{[\s\S]*sendInteractivity\(swap\.liveVersion, interactive, visible\)/)
-  assert.match(canvas, /suspendScrolling:\s*visible\s*&&\s*!enabled/)
+  assert.match(canvas, /frameVisible = visible/)
+  assert.match(canvas, /useEffect\(\(\) => \{[\s\S]*sendVisibility\(swap\.liveVersion, frameVisible\)/)
+  assert.match(canvas, /useLayoutEffect\(\(\) => \{[\s\S]*sendInteractivity\(swap\.liveVersion, interactive, frameVisible\)/)
+  assert.match(canvas, /suspendScrolling:\s*frameIsVisible\s*&&\s*!enabled/)
   assert.match(canvas, /moebius:frame-interactivity/)
 })
 


### PR DESCRIPTION
## Summary

- Follow up #736 by keeping the outgoing app frame foreground until an app-to-chat handoff completes.
- Separate the visual foreground signal from runtime ownership, so the retained app cannot navigate or use capabilities.

## Testing

- `node --test src/lib/__tests__/frameInteractivityContract.test.js`
- `node --test src/components/Shell/__tests__/chatHandoff.test.js`
- `node scripts/check-structural-test-budget.mjs`