### PR TITLE
Pass source SHA to main image build

### DIFF
--- a/.github/workflows/main-image.yml
+++ b/.github/workflows/main-image.yml
@@ -34,6 +34,10 @@ jobs:
         with:
           context: .
           push: true
+          # The Dockerfile refuses an untraceable production image and uses
+          # this SHA to pin the baked platform checkout to the merged source.
+          build-args: |
+            BUILD_SHA=${{ github.sha }}
           tags: |
             ${{ env.MOBIUS_IMAGE_REPOSITORY }}:sha-${{ github.sha }}
             ${{ env.MOBIUS_IMAGE_REPOSITORY }}:main

--- a/backend/tests/test_verify_test_runtime.py
+++ b/backend/tests/test_verify_test_runtime.py
@@ -607,6 +607,7 @@ def test_manual_and_pull_request_runs_cover_suites_and_main_image():
   assert "workflow_dispatch:\n" in image_triggers
   assert "packages: write" in image_workflow
   assert "push: true" in image_workflow
+  assert "BUILD_SHA=${{ github.sha }}" in image_workflow
   assert "MOBIUS_IMAGE_REPOSITORY }}:sha-${{ github.sha }}" in image_workflow
   assert "MOBIUS_IMAGE_REPOSITORY }}:main" in image_workflow
   assert "recovery" not in image_workflow.lower()


### PR DESCRIPTION
## Summary
- pass the exact merged GitHub SHA into the Docker build
- keep the Dockerfile provenance guard enabled
- assert the publication workflow cannot regress to an untraceable build

## Validation
- focused workflow contract test passed
- reproduced the failed publication and verified the missing build argument is the failure cause