### PR TITLE
Remove retired embedded recovery cleanup

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -43,10 +43,9 @@ This split is why a section can read either "this is intentionally hackable, don
 
 ```
 Dockerfile (root)     Single-container image: frontend build + backend + CLI tools
-docker-compose.yml    Self-hosted: Caddy (TLS) + app; on-demand recovery profile
+docker-compose.yml    Self-hosted: Caddy (TLS) + app
 ├── caddy             HTTPS reverse proxy — forwards everything to app:8000
-├── app               FastAPI serves the API + the frontend static files
-└── recovery profile  stopped-app root target + read-only worker on loopback
+└── app               FastAPI serves the API + the frontend static files
 ```
 
 The image bundles everything the agent needs at runtime (the Claude and Codex CLIs, Rolldown, Node) so the platform works out of the box. To join an existing Caddy setup instead of the bundled one, use `docker-compose.override.example.yml`.

--- a/backend/tests/test_deploy_disk_policy.py
+++ b/backend/tests/test_deploy_disk_policy.py
@@ -15,8 +15,6 @@ deploy_support = importlib.util.module_from_spec(_SPEC)
 _SPEC.loader.exec_module(deploy_support)
 HELPERS_START = "# ── deploy disk policy helpers"
 HELPERS_END = "# ── end deploy disk policy helpers"
-LEGACY_HELPER_START = "# ── legacy embedded-recovery retirement helper"
-LEGACY_HELPER_END = "# ── end legacy embedded-recovery retirement helper"
 
 
 def _read() -> str:
@@ -27,13 +25,6 @@ def _helpers() -> str:
   text = _read()
   start = text.index(HELPERS_START)
   end = text.index(HELPERS_END, start)
-  return text[start:end]
-
-
-def _legacy_helper() -> str:
-  text = _read()
-  start = text.index(LEGACY_HELPER_START)
-  end = text.index(LEGACY_HELPER_END, start)
   return text[start:end]
 
 
@@ -267,69 +258,6 @@ def test_reflection_refresh_is_cheap_and_runs_after_success_cache_cleanup():
 
   assert "REFLECTION_RESOURCE_DEEP_SCAN=skip" in text
   assert success_notification < cache_cleanup < refresh_call < deploy_complete
-
-
-def _run_legacy_cleanup(tmp_path, identity):
-  docker_log = tmp_path / "legacy-docker.log"
-  harness = _legacy_helper() + textwrap.dedent(f"""\
-    info() {{ printf 'INFO %s\n' "$1"; }}
-    ok() {{ printf 'OK %s\n' "$1"; }}
-    fail() {{ printf 'FAIL %s\n' "$1" >&2; }}
-    intent() {{ printf 'INTENT %s\n' "$1"; }}
-    docker() {{
-      printf '%s\n' "$*" >>{str(docker_log)!r}
-      if [ "$1" = container ] && [ "$2" = ls ]; then
-        printf 'legacy-id\n'
-      elif [ "$1" = inspect ]; then
-        printf '%s\n' {identity!r}
-      elif [ "$1" = rm ] && [ "$2" = -f ]; then
-        return 0
-      else
-        return 1
-      fi
-    }}
-    TARGET=prod
-    retire_legacy_recoveryd
-  """)
-  result = subprocess.run(
-    ["bash", "-c", harness], capture_output=True, text=True,
-  )
-  return result, docker_log.read_text(encoding="utf-8")
-
-
-def test_legacy_recovery_cleanup_verifies_exact_identity_before_remove(tmp_path):
-  result, calls = _run_legacy_cleanup(
-    tmp_path, "/mobius-recoveryd|mobius|recoveryd",
-  )
-
-  assert result.returncode == 0, result.stderr
-  lines = calls.splitlines()
-  discover = next(i for i, line in enumerate(lines) if line.startswith("container ls"))
-  inspect = next(i for i, line in enumerate(lines) if line.startswith("inspect -f"))
-  remove = next(i for i, line in enumerate(lines) if line == "rm -f mobius-recoveryd")
-  assert "name=^/mobius-recoveryd$" in lines[discover]
-  assert discover < inspect < remove
-
-
-def test_legacy_recovery_cleanup_refuses_label_mismatch(tmp_path):
-  result, calls = _run_legacy_cleanup(
-    tmp_path, "/mobius-recoveryd|another-project|recoveryd",
-  )
-
-  assert result.returncode != 0
-  assert "unexpected identity" in result.stderr
-  assert "rm -f mobius-recoveryd" not in calls
-
-
-def test_legacy_recovery_cleanup_is_post_success_and_never_rolls_back_app():
-  text = _read()
-  public_verification = text.rindex("# Tell open PWAs to reload")
-  cleanup_call = text.rindex("retire_legacy_recoveryd")
-  cache_cleanup = text.rindex("prune_old_build_cache")
-
-  assert public_verification < cleanup_call < cache_cleanup
-  assert "outside attempt_rollback()" in text[public_verification:cleanup_call]
-  assert text.count("retire_legacy_recoveryd") == 2  # definition + one call
 
 
 def test_deploy_script_still_parses():

--- a/backend/tests/test_recovery_boundary.py
+++ b/backend/tests/test_recovery_boundary.py
@@ -29,6 +29,11 @@ def test_mobius_has_no_recovery_runtime_or_boot_mode():
   ):
     assert retired not in runtime
 
+  deployment = (ROOT / "scripts/deploy-prod.sh").read_text(encoding="utf-8")
+  architecture = (ROOT / "ARCHITECTURE.md").read_text(encoding="utf-8")
+  assert "recoveryd" not in deployment.lower()
+  assert "recovery profile" not in architecture.lower()
+
 
 def test_boot_fallback_never_moves_or_prunes_owner_platform_source():
   entrypoint = (ROOT / "backend/scripts/entrypoint.sh").read_text(

--- a/scripts/deploy-prod.sh
+++ b/scripts/deploy-prod.sh
@@ -421,51 +421,6 @@ external_prod_caddy_running() {
   [ "$TARGET" = "prod" ] && [ "$EDGE_TOPOLOGY" = "edge" ]
 }
 
-# ── legacy embedded-recovery retirement helper ────────────────────────
-# Old releases gave recoveryd a fixed name and Compose identity. Do not use a
-# broad orphan sweep here: this host carries sibling services, and a rollback
-# may still need their containers. Inspect the exact retired identity, then
-# remove only that one container after the replacement app has passed every
-# health/public verification gate.
-retire_legacy_recoveryd() {
-  [ "$TARGET" = "prod" ] || return 0
-  local legacy_name="mobius-recoveryd"
-  local legacy_ids=""
-  local identity=""
-
-  if ! legacy_ids=$(docker container ls -aq \
-    --filter "name=^/${legacy_name}$"); then
-    fail "could not inspect the retired ${legacy_name} container"
-    return 1
-  fi
-  if [ -z "$legacy_ids" ]; then
-    info "legacy embedded recovery container already absent"
-    return 0
-  fi
-  if [[ "$legacy_ids" == *$'\n'* ]]; then
-    fail "multiple containers matched the exact retired ${legacy_name} name; refusing cleanup"
-    return 1
-  fi
-  if ! identity=$(docker inspect -f \
-    '{{.Name}}|{{index .Config.Labels "com.docker.compose.project"}}|{{index .Config.Labels "com.docker.compose.service"}}' \
-    "$legacy_name"); then
-    fail "could not verify the retired ${legacy_name} Compose identity"
-    return 1
-  fi
-  if [ "$identity" != "/mobius-recoveryd|mobius|recoveryd" ]; then
-    fail "refusing to remove ${legacy_name}: unexpected identity '${identity}'"
-    return 1
-  fi
-
-  intent "docker rm -f ${legacy_name}  # exact name + mobius/recoveryd labels verified"
-  if ! docker rm -f "$legacy_name" >/dev/null; then
-    fail "could not remove retired ${legacy_name}; the healthy app remains deployed"
-    return 1
-  fi
-  ok "retired legacy embedded recovery container (${legacy_name})"
-}
-# ── end legacy embedded-recovery retirement helper ────────────────────
-
 # External networks referenced by the overlay must exist before compose up.
 # Creation is idempotent and safe: the edge stack declares the same name as
 # external, so whichever side runs first wins and both attach to one network.
@@ -1610,15 +1565,6 @@ if broadcast_shell_rebuilt; then
 else
   warn "could not broadcast shell_rebuilt (no service token, or /api/notify"
   warn "unreachable). Deploy is healthy; open PWAs reload on next manual open."
-fi
-
-# This is intentionally post-success and outside attempt_rollback(): removal of
-# the retired lifeboat must never influence which app image is served. A label
-# mismatch/removal failure exits nonzero for operator attention but leaves the
-# already-verified healthy app in place.
-if [ "$TARGET" = "prod" ]; then
-  step "[4c/4] retire legacy embedded recovery container"
-  retire_legacy_recoveryd
 fi
 
 # The rollback set was bounded before the build. After a fully successful


### PR DESCRIPTION
## Summary
- remove the post-deploy compatibility cleanup for the retired embedded recovery container
- correct the architecture tree so Compose contains only the app and Caddy
- make the recovery boundary test reject any future embedded recovery daemon/profile

## Why
The live production host no longer has the legacy container, and the recovery redesign has already migrated away from it. Keeping a compatibility-only cleanup path in the core deploy script would leave recovery code inside Möbius and create permanent debt.

## Verification
- `bash -n scripts/deploy-prod.sh`
- `git diff --check`
- `pytest -q tests/test_deploy_disk_policy.py tests/test_recovery_boundary.py` (22 passed)
