### PR TITLE
Document the external recovery boundary accurately

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,9 @@ Möbius uses provider sign-in, so the default setup does not require a separate 
 
 ![Möbius Launch showing workspace health, included Railway credit, and live resource usage](assets/product/mobius-launch-deployment.png)
 
-Your chats, files, apps, credentials, and agent activity stay inside that deployment. Möbius Launch stores only the account and infrastructure data needed to create and manage it.
+During normal use, your chats, files, apps, credentials, and agent activity stay inside that deployment. Möbius Launch stores the account and infrastructure data needed to manage it.
+
+If the Möbius interface is unavailable, open its deployment card in Möbius Launch and choose **Open Recovery**. The launcher creates a separate temporary worker, where you connect Codex or Claude and work on the exact live container through Railway's native Secure Shell (SSH) endpoint. Recovery does not restart or redeploy Möbius, and the worker is removed when you finish or the session expires.
 
 ### Deploy on your own server
 
@@ -147,7 +149,7 @@ a root shell in the running container without recreating it:
 docker compose exec -u 0 app bash
 ```
 
-The in-product agent has passwordless full root inside its Mobius container by
+The in-product agent has passwordless full root inside its Möbius container by
 default. To use the operator kill switch, set `MOBIUS_AGENT_SUDO=0` in `.env`
 and recreate the app with `docker compose up -d --force-recreate app`.
 

--- a/backend/app/routes/fs.py
+++ b/backend/app/routes/fs.py
@@ -100,8 +100,9 @@ _DENY_RELPATHS = (
 )
 # Defense in depth: a secret-shaped filename anywhere in the tree is denied,
 # in case one is copied outside its canonical home. The two `.recovery-*`
-# entries are retired legacy credentials and remain denied until old instances
-# have naturally removed them.
+# entries are retired credentials but remain denied because an upgraded or
+# restored volume may still contain them. This protects old data; no current
+# runtime code consumes either file.
 _SECRET_NAMES = {
   ".env", ".secret-key", ".recovery-secret", ".recovery-owner.json",
   ".credentials.json", "service-token.txt",

--- a/backend/scripts/backup-data.py
+++ b/backend/scripts/backup-data.py
@@ -46,11 +46,11 @@ default). Routed into two archives:
   secrets.tar.*   cli-auth/, app-secrets/, push/, service-token.txt,
                   .secret-key.
 
-Retired embedded-recovery credentials/sentinels are never captured. Normal
-boot removes `.recovery-secret`, `.recovery-owner.json`, and `.recover-pending`
-before importing persisted code. The user-authored legacy
-`recovery_chat.jsonl` transcript is retained as ordinary owner data and is
-included in `data.tar.gz` when present.
+Retired embedded-recovery credentials/sentinels are never captured. Older
+volumes may still contain `.recovery-secret`, `.recovery-owner.json`, or
+`.recover-pending`, but the current runtime neither reads nor writes them. The
+user-authored legacy `recovery_chat.jsonl` transcript is retained as ordinary
+owner data and is included in `data.tar.gz` when present.
 
 Encryption policy (secrets never plaintext-offsite)
 ---------------------------------------------------

--- a/backend/scripts/restore-data.py
+++ b/backend/scripts/restore-data.py
@@ -39,8 +39,8 @@ tar + (for encrypted secrets) age and the identity file, writing only under
 not a cold-restore transport. Modern backups omit retired embedded-recovery
 credentials and sentinels while preserving a legacy `recovery_chat.jsonl`
 transcript as owner data. Restoring an older artifact may temporarily recreate
-the retired files; the next normal boot removes them before importing persisted
-platform code.
+the retired files. The current runtime does not consume them, the file API keeps
+historic credential names inaccessible, and subsequent backups omit them.
 
 The rehearsed restore drill (proven end to end, per-slug throwaway
 container)


### PR DESCRIPTION
## Summary
- correct stale claims that normal boot deletes retired recovery credential files
- document the public managed Recovery path and its no-redeploy boundary
- keep historic credential filenames denied and backup-excluded as data safety

## Validation
- `git diff --check`
- `pytest --noconftest -q backend/tests/test_recovery_boundary.py backend/tests/test_backup_restore_script.py` (29 passed)