### PR TITLE
Use the connected background provider by default

### DIFF
--- a/backend/app/background_agents.py
+++ b/backend/app/background_agents.py
@@ -82,6 +82,7 @@ def _same_choice(a: dict | None, b: dict | None) -> bool:
 
 def _system_choices(data_dir: str) -> list[dict]:
   """The ordered, de-duplicated system provider choices from Settings."""
+  default_provider = providers.resolve_default_provider(data_dir)
   global_settings = providers._load_agent_settings(data_dir)
   raw = global_settings.get("background_agents")
   background = raw if isinstance(raw, dict) else {}
@@ -96,7 +97,7 @@ def _system_choices(data_dir: str) -> list[dict]:
 
   if not choices:
     primary = _clean_choice(background.get("primary"),
-                            default_provider=DEFAULT_PROVIDER, label="system primary")
+                            default_provider=default_provider, label="system primary")
     fallback = _clean_choice(background.get("fallback"), label="system fallback")
     if primary:
       choices.append(primary)
@@ -105,14 +106,14 @@ def _system_choices(data_dir: str) -> list[dict]:
 
   if not choices:
     primary = _clean_choice(
-      {"provider": DEFAULT_PROVIDER, "model": global_settings.get("model"),
+      {"provider": default_provider, "model": global_settings.get("model"),
        "effort": global_settings.get("effort")},
-      default_provider=DEFAULT_PROVIDER, label="system default")
+      default_provider=default_provider, label="system default")
     if primary:
       choices.append(primary)
 
   if not choices:
-    choices.append({"provider": DEFAULT_PROVIDER, "model": None, "effort": None})
+    choices.append({"provider": default_provider, "model": None, "effort": None})
   return choices
 
 

--- a/backend/tests/test_background_agents.py
+++ b/backend/tests/test_background_agents.py
@@ -133,3 +133,16 @@ def test_no_settings_file_falls_back_to_provider_default(tmp_path):
   # No agent-settings.json at all → system default (claude, SDK-default model).
   out = bg.resolve_background_agents(str(tmp_path), None)
   assert out["primary"]["provider"] == "claude"
+
+
+def test_no_settings_file_uses_the_only_connected_provider(tmp_path):
+  codex_home = tmp_path / "cli-auth" / "codex"
+  codex_home.mkdir(parents=True)
+  (codex_home / "auth.json").write_text("{}")
+
+  out = bg.resolve_background_agents(str(tmp_path), None)
+
+  assert out["primary"] == {
+    "provider": "codex", "model": None, "effort": None,
+  }
+  assert out["fallback"] is None


### PR DESCRIPTION
## Summary
- resolve the background-agent default through the same connected-provider policy used by chats and Settings
- keep explicit background-provider ordering authoritative
- cover a fresh install with Codex as its only connected provider

## Testing
- `pytest backend/tests/test_background_agents.py backend/tests/test_settings.py backend/tests/test_app_jobs.py` (90 passed)