### PR TITLE
Clear the open-question marker on the recovered-answer path

### DIFF
--- a/backend/app/chat_writer.py
+++ b/backend/app/chat_writer.py
@@ -2230,6 +2230,15 @@ class ChatWriterActor:
     else:
       pending.append(new_msg)
     chat.pending_messages = pending
+    if applied:
+      # The recovered-answer path (an answer submitted after a restart, when no
+      # in-memory pending question survives) reaches AppendPending instead of
+      # AnswerQuestion, so clear the durable marker here too — mirroring
+      # _answer_question. Otherwise it stays set for the whole recovered turn and
+      # every read surface, the composer's queue/steer lock included, keeps
+      # treating the chat as awaiting an answer. Gated on `applied` so an
+      # ordinary queue-behind send never disturbs a genuinely open question.
+      chat.pending_question_id = None
     chat.updated_at = datetime.now(UTC)
     chat.activity_at = datetime.now(UTC)
     if not _commit_or_rollback(db):

--- a/backend/tests/test_chats_stream_answer_race.py
+++ b/backend/tests/test_chats_stream_answer_race.py
@@ -300,6 +300,78 @@ def test_answer_recovers_durable_question_without_live_pending(
   asyncio.run(go())
 
 
+def test_recovered_answer_clears_pending_question_marker(
+  client, auth, chat, monkeypatch,
+):
+  """The recovered-answer path must clear the durable pending_question_id.
+
+  After a restart, ParkRun re-derives `pending_question_id` from the open tail
+  question, and the in-memory future is gone — so the answer submit takes the
+  RECOVERED path (AppendPending, not AnswerQuestion). If that path merges the
+  answer but leaves the marker set, the marker stays on for the entire recovered
+  turn, so the composer stays question-blocked (Stop-only; no queue, no steer)
+  until the turn finishes. This regression pins that the marker clears the
+  instant the answer is recorded.
+  """
+  scheduled: list[dict] = []
+
+  def fake_schedule_continuation(**kwargs):
+    scheduled.append(kwargs)
+    chat_mod.discard_starting(kwargs["chat_id"])
+
+  monkeypatch.setattr(
+    chats_stream, "_schedule_continuation", fake_schedule_continuation,
+  )
+
+  async def go():
+    qid = "q-marker-clear"
+    _seed_question_block(chat.id, qid)
+    # A real restart's ParkRun leaves the durable marker set to the open
+    # question. Reproduce that starting condition.
+    db = SessionLocal()
+    try:
+      row = db.query(models.Chat).filter(models.Chat.id == chat.id).first()
+      row.pending_question_id = qid
+      db.commit()
+    finally:
+      db.close()
+    assert questions.get(chat.id) is None
+
+    res = await asyncio.get_event_loop().run_in_executor(
+      None,
+      lambda: client.post(
+        f"/api/chats/{chat.id}/messages",
+        json={
+          "content": "- Pick one: b",
+          "hidden": True,
+          "answers": {"Pick one": "b"},
+          "question_id": qid,
+        },
+        headers=auth,
+      ),
+    )
+
+    assert res.status_code == 202, res.text
+    assert res.json()["status"] == "started"
+    assert scheduled, "recovered answer should start a hidden continuation"
+
+    db = SessionLocal()
+    try:
+      row = db.query(models.Chat).filter(models.Chat.id == chat.id).first()
+      question = [
+        b for b in row.messages[1]["blocks"]
+        if b.get("type") == "question"
+      ][0]
+      assert question["answers"] == {"Pick one": "b"}
+      # The marker MUST be cleared so the composer unblocks with the answer,
+      # not only when the recovered turn eventually ends.
+      assert row.pending_question_id is None
+    finally:
+      db.close()
+
+  asyncio.run(go())
+
+
 def test_answer_after_completed_stop_recovers_durable_question(
   client, auth, chat, monkeypatch,
 ):


### PR DESCRIPTION
## Problem

When a server restart lands while a chat has an open `AskUserQuestion`, the in-memory pending future is lost. Answering the card then takes the **recovered** path: the answer is merged into the durable transcript and a fresh continuation turn is promoted (`_append_pending` / `AppendPending`), rather than the same-turn `AnswerQuestion` path.

That recovered path merged the answer but never cleared the durable `pending_question_id` marker (added in #670). So the marker stayed set for the **entire** recovered turn, and every surface that reads it kept treating the chat as still awaiting an answer. In the UI this pins the composer's question barrier: the primary action stays **Stop-only**, so the owner cannot send, queue, or steer a message for the whole turn — it only unblocks once the turn finishes and `FinishRun` clears the marker.

## Fix

`_append_pending` now clears `pending_question_id` in the same commit whenever an answer actually merged into the tail question (`apply_answers_to_last_question` returned `True`), mirroring `_answer_question` on the same-turn path. The clear is gated on `applied`, so an ordinary queue-behind send (no answers) never disturbs a genuinely open question.

## Test

Adds `test_recovered_answer_clears_pending_question_marker`: it reproduces the restart scenario (marker set by `ParkRun`'s re-derive, no in-memory pending future), submits the answer through the recovered path, and asserts the marker clears the instant the answer is recorded. It fails before this change and passes after.

## Related work

- #670 introduced the durable `pending_question_id` field this fix maintains.
- #716 keeps a resumable park's open question (`ParkRun` re-derives the marker) — the mechanism that carries the marker into the recovered-answer path.
- #741 (open) addresses a distinct, frontend-side case: keeping a parked question card visible over a stale stream snapshot and letting the barrier own the composer action. This change is complementary — it fixes the backend marker never being cleared on the recovered-answer path and touches only `chat_writer.py` plus a test, which #741 does not.