### PR TITLE
Show detected skill reads as chat activity

### DIFF
--- a/backend/app/activity.py
+++ b/backend/app/activity.py
@@ -545,12 +545,12 @@ def _yield_events_from(path: Path):
 
 
 def log_skill_load(chat_id: str | None, skill: str, ts: str | None = None) -> None:
-  """Records one Skill-tool invocation in the activity log.
+  """Records one detected skill load in the activity log.
 
   Thin wrapper over `log_event` so the runner has a single, named call
   site for the skill-observability path and doesn't repeat the event
-  vocabulary. A blank skill name is dropped — an empty chip carries no
-  signal and would only pollute the "most-used" aggregation.
+  vocabulary. A blank skill name is dropped — an unnamed read carries no
+  useful signal and would only pollute the "most-used" aggregation.
   """
   skill = (skill or "").strip()
   if not skill:

--- a/backend/app/chat_transcript.py
+++ b/backend/app/chat_transcript.py
@@ -244,6 +244,18 @@ def _distinctive_activity(block: dict, binding: RecallBinding) -> bool:
   """Keep notable one-line activity beats out of a folded metadata run."""
   if block.get("type") != "tool":
     return False
+  skills = block.get("skills")
+  if (
+    isinstance(skills, list)
+    and any(isinstance(skill, str) and skill.strip() for skill in skills)
+  ):
+    return True
+  if (
+    block.get("tool") == "Skill"
+    and isinstance(block.get("skill"), str)
+    and block["skill"].strip()
+  ):
+    return True
   # Consulting Memory is a beat worth seeing on its own, not shell housekeeping
   # folded into "ran commands". New blocks carry a marker from the event
   # funnel; older Codex blocks recover the same bounded marker from their exact
@@ -400,9 +412,10 @@ def compact_messages_for_detail(
 
   Single activity entries stay inline: introducing a network boundary for one
   ordinary tool/thought would cost more complexity than it saves. Distinctive
-  image-view beats also stay independent, preserving the transcript's visual
-  punctuation. Question-tool twins are omitted when the message already owns
-  the canonical question card, matching the frontend's historical repair.
+  image-view, skill-read, and Memory beats also stay independent, preserving
+  the transcript's visual punctuation. Question-tool twins are omitted when
+  the message already owns the canonical question card, matching the
+  frontend's historical repair.
   """
   projected: list[dict] | None = None
   for page_index, message in enumerate(messages):

--- a/backend/app/claude_events.py
+++ b/backend/app/claude_events.py
@@ -432,8 +432,8 @@ def dispatch_sdk_message(
             "tool_use_id": block.id,
           })
         # Skill observability: when the agent loads a skill, surface it
-        # as its own `skill_loaded` event (the frontend stamps a chip
-        # onto the Skill tool block) and append a record to the activity
+        # as its own targeted `skill_loaded` event (the frontend presents the
+        # owning tool as a skill-read block) and append a record to the activity
         # log so "most-used skills" can be aggregated. This fires
         # whenever the Skill tool runs at all; whether skills are even
         # OFFERED to the agent is the separate, gated `skills_enabled`
@@ -441,7 +441,11 @@ def dispatch_sdk_message(
         if block.name == "Skill":
           skill = _skill_name_from_input(block.input)
           if skill:
-            bc.publish({"type": "skill_loaded", "skill": skill})
+            bc.publish({
+              "type": "skill_loaded",
+              "skill": skill,
+              "tool_use_id": block.id,
+            })
             activity.log_skill_load(getattr(bc, "chat_id", None), skill)
         continue
       if isinstance(block, ServerToolUseBlock):

--- a/backend/app/claude_sdk_runner.py
+++ b/backend/app/claude_sdk_runner.py
@@ -705,10 +705,11 @@ def observe_skill_file_read(
   bc,
   chat_id: str,
   cwd: str,
+  tool_use_id: str | None = None,
 ) -> None:
   """Fire-and-forget skill observability for skill-file Reads.
 
-  Publishes the same `skill_loaded` event + activity record the Skill
+  Publishes the same targeted `skill_loaded` event + activity record the Skill
   tool path emits (see the dispatch below), so the activity log's
   most-used-skills cross-check sees Read-based loads too — before
   this, the cross-check endpoint returned empty every night because
@@ -720,7 +721,11 @@ def observe_skill_file_read(
     skill = _skill_file_read_name(tool_name, input_data, cwd)
     if not skill:
       return
-    bc.publish({"type": "skill_loaded", "skill": skill})
+    bc.publish({
+      "type": "skill_loaded",
+      "skill": skill,
+      **({"tool_use_id": tool_use_id} if tool_use_id else {}),
+    })
     activity.log_skill_load(chat_id, skill)
   except Exception:
     log.debug("skill_loaded read observability failed", exc_info=True)
@@ -840,7 +845,6 @@ async def run_claude_sdk_turn(
     input_data: dict[str, Any],
     context,
   ) -> PermissionResultAllow | PermissionResultDeny:
-    del context
     if run_policy is not None:
       nested_tools = {
         "Task", "TaskOutput", "TaskStop", "Workflow", "Workflows", "Agent",
@@ -873,6 +877,7 @@ async def run_claude_sdk_turn(
     if tool_name != "AskUserQuestion":
       observe_skill_file_read(
         tool_name, input_data, bc=bc, chat_id=chat_id, cwd=cwd,
+        tool_use_id=getattr(context, "tool_use_id", None),
       )
       return PermissionResultAllow(updated_input=input_data)
 

--- a/backend/app/codex_events.py
+++ b/backend/app/codex_events.py
@@ -891,12 +891,10 @@ def _skill_names_in_command(command: str, data_dir: str) -> list[str]:
   Codex has no Read tool and no `can_use_tool` hook — its closest
   interception point is the command-execution item stream, where a
   skill load can target either Möbius's authoritative shared tree or
-  Codex's project-local `.codex/skills` tree. A directory skill's scripts,
-  references, and other resources still belong to that skill, so any path
-  below its top-level directory counts. Any reference to a matching path in
-  a command counts as a load; that over-counts an edit-in-place, which is
-  acceptable for an aggregate most-used signal. Returns deduped names in
-  first-mention order.
+  Codex's project-local `.codex/skills` tree. Provider-neutral semantics count
+  only the entry document: a flat shared skill or a directory's SKILL.md.
+  Bundled scripts and references are use *after* loading, not another load.
+  Returns deduped names in first-mention order.
   """
   if not command:
     return []
@@ -913,17 +911,16 @@ def _skill_names_in_command(command: str, data_dir: str) -> list[str]:
   # is lexical on purpose and never reads the referenced file.
   boundary = r"(?<![A-Za-z0-9._/-])"
   name_part = r"[A-Za-z0-9][A-Za-z0-9._-]*"
-  resource_tail = r"/[^\s'\"`;&|()<>]+"
   shared_pattern = re.compile(
     boundary
     + rf"(?:{shared_root}|shared/skills)/"
     + rf"(?P<shared_name>{name_part})"
-    + rf"(?:\.md\b|{resource_tail})"
+    + r"(?:\.md\b|/(?i:SKILL\.md)\b)"
   )
   codex_pattern = re.compile(
     boundary
     + rf"(?:{codex_root}|\.codex/skills)/"
-    + rf"(?:\.system/)?(?P<codex_name>{name_part}){resource_tail}"
+    + rf"(?:\.system/)?(?P<codex_name>{name_part})/(?i:SKILL\.md)\b"
   )
 
   matches = [

--- a/backend/app/codex_events.py
+++ b/backend/app/codex_events.py
@@ -890,31 +890,53 @@ def _skill_names_in_command(command: str, data_dir: str) -> list[str]:
 
   Codex has no Read tool and no `can_use_tool` hook — its closest
   interception point is the command-execution item stream, where a
-  skill load looks like `cat /data/shared/skills/<name>.md` (flat) or
-  `cat /data/shared/skills/<id>/SKILL.md` (the directory shape installed
-  skills use), possibly via sed/head/grep over the same path. Any
-  reference to a skill file in a command counts as a load; that
-  over-counts an edit-in-place, which is acceptable for an aggregate
-  most-used signal. A directory skill is keyed by its DIRECTORY name —
-  the on-disk id — matching the Claude Read observer and the usage
-  aggregation; a deeper resource read inside the directory is not a
-  load. Returns deduped names in first-mention order.
+  skill load can target either Möbius's authoritative shared tree or
+  Codex's project-local `.codex/skills` tree. A directory skill's scripts,
+  references, and other resources still belong to that skill, so any path
+  below its top-level directory counts. Any reference to a matching path in
+  a command counts as a load; that over-counts an edit-in-place, which is
+  acceptable for an aggregate most-used signal. Returns deduped names in
+  first-mention order.
   """
   if not command:
     return []
   from app.skills import GENERATED_INDEX_STEMS
 
-  prefix = re.escape(
-    os.path.normpath(os.path.join(data_dir, "shared", "skills"))
+  shared_root = re.escape(os.path.normpath(
+    os.path.join(data_dir, "shared", "skills")
+  ))
+  codex_root = re.escape(os.path.normpath(
+    os.path.join(data_dir, ".codex", "skills")
+  ))
+  # The boundary keeps relative forms from matching the tail of an unrelated
+  # absolute path. Shell punctuation terminates a resource path; the detector
+  # is lexical on purpose and never reads the referenced file.
+  boundary = r"(?<![A-Za-z0-9._/-])"
+  name_part = r"[A-Za-z0-9][A-Za-z0-9._-]*"
+  resource_tail = r"/[^\s'\"`;&|()<>]+"
+  shared_pattern = re.compile(
+    boundary
+    + rf"(?:{shared_root}|shared/skills)/"
+    + rf"(?P<shared_name>{name_part})"
+    + rf"(?:\.md\b|{resource_tail})"
   )
+  codex_pattern = re.compile(
+    boundary
+    + rf"(?:{codex_root}|\.codex/skills)/"
+    + rf"(?:\.system/)?(?P<codex_name>{name_part}){resource_tail}"
+  )
+
+  matches = [
+    (match.start(), match.group("shared_name"))
+    for match in shared_pattern.finditer(command)
+  ]
+  matches.extend(
+    (match.start(), match.group("codex_name"))
+    for match in codex_pattern.finditer(command)
+  )
+
   names: list[str] = []
-  # Either `<id>/SKILL.md` (directory skill, id = the dir name, SKILL.md
-  # case-insensitive) or a flat `<name>.md` directly under skills/. The two
-  # alternatives are disjoint (a flat match can't span a `/`), so one pass in
-  # command order preserves first-mention order without double counting.
-  pattern = prefix + r"/([A-Za-z0-9._-]+)(?:/(?i:SKILL\.md)|\.md)\b"
-  for match in re.finditer(pattern, command):
-    name = match.group(1)
+  for _, name in sorted(matches):
     # Reading a generated index is consulting a listing, not loading a skill.
     if name not in names and name not in GENERATED_INDEX_STEMS:
       names.append(name)
@@ -926,8 +948,8 @@ def _observe_skill_reads(
 ) -> None:
   """Fire-and-forget `skill_loaded` events for skill-file shell reads.
 
-  Mirrors `observe_skill_file_read` in claude_sdk_runner: same wire
-  event (chip), same activity record (most-used-skills aggregation).
+  Mirrors `observe_skill_file_read` in claude_sdk_runner: same targeted wire
+  receipt, same activity record (most-used-skills aggregation).
   Never raises — observability must not break the notification loop.
   """
   try:
@@ -937,8 +959,13 @@ def _observe_skill_reads(
     from app.config import get_settings
     command = _extract_bash_command(item.command or "")
     skills = _skill_names_in_command(command, get_settings().data_dir)
+    tool_use_id = getattr(item, "id", None)
     for skill in skills:
-      bc.publish({"type": "skill_loaded", "skill": skill})
+      bc.publish({
+        "type": "skill_loaded",
+        "skill": skill,
+        **({"tool_use_id": tool_use_id} if tool_use_id else {}),
+      })
       activity.log_skill_load(chat_id, skill)
   except Exception:
     log.debug("codex skill_loaded observability failed", exc_info=True)

--- a/backend/app/events.py
+++ b/backend/app/events.py
@@ -704,20 +704,56 @@ def _process_tool_event(event: dict, assistant_blocks: list) -> bool:
     return True
 
   if event_type == "skill_loaded":
-    # Skill observability: the runner emits this alongside the Skill
-    # tool's tool_start. Stamp the skill name onto the most recent
-    # Skill tool block so the persisted transcript carries the chip
-    # data (the frontend reads `block.skill`); the same event drives
-    # the activity-log append on the runner side. No skill name is a
-    # no-op — an empty chip carries no signal.
-    skill = event.get("skill") or ""
+    # Skill observability belongs to the tool that performed the read. Both
+    # providers usually load skill files through Read/Bash rather than a
+    # first-class Skill tool, so keep a small deduped receipt on the owning
+    # running tool (matched by tool_use_id when available). The frontend
+    # presents that same tool as one distinctive,
+    # provider-neutral skill-read block; expanding it still reveals the raw
+    # command/read details. A native Skill tool keeps its singular `skill`
+    # field too, so its own row can name the skill directly.
+    skill = str(event.get("skill") or "").strip()
     if not skill:
       return False
-    for blk in reversed(assistant_blocks):
-      if blk.get("type") == "tool" and blk.get("tool") == "Skill":
-        blk["skill"] = skill
-        return True
-    return False
+
+    target = _tool_block_for_event(
+      assistant_blocks, event.get("tool_use_id"),
+    )
+    if target is None:
+      # A repeated/replayed observation after the tool settled is idempotent
+      # when the last tool already owns this receipt.
+      latest_tool = next((
+        blk for blk in reversed(assistant_blocks)
+        if blk.get("type") == "tool"
+      ), None)
+      latest_skills = (
+        latest_tool.get("skills") if isinstance(latest_tool, dict) else None
+      )
+      if isinstance(latest_skills, list) and skill in latest_skills:
+        return False
+
+    if target is not None:
+      skills = target.get("skills")
+      if not isinstance(skills, list):
+        skills = []
+      if skill not in skills:
+        target["skills"] = [*skills, skill]
+      if target.get("tool") == "Skill":
+        target["skill"] = skill
+      return True
+
+    # Defensive fallback for provider/event-order drift: the observation must
+    # stay visible even if no owning tool_start reached the reducer.
+    assistant_blocks.append({
+      "type": "tool",
+      "tool": "Skill",
+      "skill": skill,
+      "skills": [skill],
+      "input": "",
+      "output": "",
+      "status": "done",
+    })
+    return True
 
   return False
 

--- a/backend/tests/test_chat_transcript_compact.py
+++ b/backend/tests/test_chat_transcript_compact.py
@@ -373,6 +373,49 @@ def test_image_reads_stay_distinctive_and_question_twins_are_not_rendered():
   )
 
 
+def test_skill_reads_stay_distinctive_in_compact_history():
+  skill_read = {
+    "type": "tool",
+    "tool": "Bash",
+    "tool_use_id": "cmd-skills",
+    "status": "done",
+    "skills": ["recovery", "theming"],
+    "input": "cat /data/shared/skills/recovery.md",
+    "output": "skill text",
+  }
+  messages = [{
+    "role": "assistant",
+    "blocks": [
+      {"type": "thinking", "duration_ms": 10},
+      skill_read,
+      {"type": "tool", "tool": "Read", "input": "/tmp/note.txt"},
+      {"type": "thinking", "duration_ms": 20},
+    ],
+  }]
+
+  compact = compact_messages_for_detail(
+    messages, message_offset=0, binding=EMPTY_RECALL_BINDING,
+  )
+  blocks = compact[0]["blocks"]
+
+  visible_skill_read = next(
+    block for block in blocks
+    if isinstance(block, dict) and block.get("tool_use_id") == "cmd-skills"
+  )
+  assert visible_skill_read == skill_read
+  assert all(
+    not (
+      block.get("type") == "activity"
+      and any(
+        entry.get("item", {}).get("tool_use_id") == "cmd-skills"
+        for entry in block.get("entries", [])
+      )
+    )
+    for block in blocks
+    if isinstance(block, dict)
+  )
+
+
 def test_compact_route_defers_activity_detail_until_expansion(client, auth):
   messages = [{
     "role": "assistant",

--- a/backend/tests/test_claude_sdk_runner.py
+++ b/backend/tests/test_claude_sdk_runner.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import asyncio
 import os
 import tempfile
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -1260,16 +1261,17 @@ def test_dispatch_skill_tool_emits_skill_loaded_and_logs(monkeypatch):
   )
   dispatch_sdk_message(msg, bus, None)
   types = [e["type"] for e in bus.events]
-  # tool_start fires first, then the skill_loaded chip event.
+  # tool_start fires first, then the targeted skill-loaded receipt.
   assert types == ["tool_start", "tool_input", "skill_loaded"]
   loaded = [e for e in bus.events if e["type"] == "skill_loaded"]
-  assert loaded == [{"type": "skill_loaded", "skill": "humanizer"}]
+  assert loaded == [{
+    "type": "skill_loaded", "skill": "humanizer", "tool_use_id": "s1",
+  }]
   assert logged == [("chat-42", "humanizer")]
 
 
 def test_dispatch_skill_tool_without_name_does_not_emit(monkeypatch):
-  """A Skill tool_use with no resolvable skill name emits no chip and
-  logs nothing — an empty chip carries no signal."""
+  """A Skill tool_use with no resolvable name emits no receipt or log."""
   from app import activity
 
   logged: list[tuple] = []
@@ -1820,7 +1822,7 @@ def test_skill_file_read_name_ignores_generated_index():
   assert _skill_file_read_name("Read", {"file_path": path}, "/data") == ""
 
 
-def test_observe_skill_file_read_publishes_chip_and_activity(monkeypatch):
+def test_observe_skill_file_read_publishes_receipt_and_activity(monkeypatch):
   from app import activity
   from app.claude_sdk_runner import observe_skill_file_read
 
@@ -1858,7 +1860,7 @@ async def test_can_use_tool_read_of_skill_file_emits_skill_loaded(
   monkeypatch,
 ):
   """The canonical interception point: the runner's can_use_tool
-  callback observes skill-file Reads — chip event + activity record —
+  callback observes skill-file Reads — targeted receipt + activity record —
   and still allows the tool with its input unchanged."""
   from app import activity, claude_sdk_runner
   from claude_agent_sdk.types import PermissionResultAllow
@@ -1915,10 +1917,14 @@ async def test_can_use_tool_read_of_skill_file_emits_skill_loaded(
   can_use_tool = captured["options"].can_use_tool
   path = os.path.join(_skills_dir(), "notifications.md")
   input_data = {"file_path": path}
-  result = await can_use_tool("Read", input_data, None)
+  context = SimpleNamespace(tool_use_id="read-skill-1")
+  result = await can_use_tool("Read", input_data, context)
   assert isinstance(result, PermissionResultAllow)
   assert result.updated_input == input_data
-  assert {"type": "skill_loaded", "skill": "notifications"} in bus.events
+  assert {
+    "type": "skill_loaded", "skill": "notifications",
+    "tool_use_id": "read-skill-1",
+  } in bus.events
   assert logged == [("chat-42", "notifications")]
 
   # A Read outside the skills dir passes through silently.

--- a/backend/tests/test_codex_sdk_runner.py
+++ b/backend/tests/test_codex_sdk_runner.py
@@ -2934,7 +2934,7 @@ def test_skill_names_in_command_extracts_and_dedupes():
   assert names == ["memory", "building-apps"]
 
 
-def test_skill_names_in_command_attributes_codex_resources_to_their_skill():
+def test_skill_names_in_command_counts_entry_documents_not_resources():
   cmd = (
     "cat /data/.codex/skills/theming/SKILL.md && "
     "node /data/.codex/skills/impeccable/scripts/context.mjs "
@@ -2943,7 +2943,7 @@ def test_skill_names_in_command_attributes_codex_resources_to_their_skill():
     "cat .codex/skills/impeccable/reference/craft-floor.md"
   )
   names = codex_sdk_runner._skill_names_in_command(cmd, "/data")
-  assert names == ["theming", "impeccable"]
+  assert names == ["theming"]
 
 
 def test_skill_names_in_command_ignores_other_paths():

--- a/backend/tests/test_codex_sdk_runner.py
+++ b/backend/tests/test_codex_sdk_runner.py
@@ -2934,15 +2934,29 @@ def test_skill_names_in_command_extracts_and_dedupes():
   assert names == ["memory", "building-apps"]
 
 
+def test_skill_names_in_command_attributes_codex_resources_to_their_skill():
+  cmd = (
+    "cat /data/.codex/skills/theming/SKILL.md && "
+    "node /data/.codex/skills/impeccable/scripts/context.mjs "
+    "--target frontend/src/components/ChatView/ChatView.jsx && "
+    "cat /data/.codex/skills/impeccable/reference/optimize.md && "
+    "cat .codex/skills/impeccable/reference/craft-floor.md"
+  )
+  names = codex_sdk_runner._skill_names_in_command(cmd, "/data")
+  assert names == ["theming", "impeccable"]
+
+
 def test_skill_names_in_command_ignores_other_paths():
   fn = codex_sdk_runner._skill_names_in_command
   assert fn("cat /data/shared/memory/index.md", "/data") == []
   assert fn("cat /elsewhere/shared/skills/memory.md", "/data") == []
+  assert fn("cat /elsewhere/.codex/skills/theming/SKILL.md", "/data") == []
   assert fn("cat /data/shared/skills/notes.txt", "/data") == []
+  assert fn("cat /data/.codex/skills/.mobius-managed.json", "/data") == []
   assert fn("", "/data") == []
 
 
-def test_observe_skill_reads_publishes_chip_and_activity(monkeypatch):
+def test_observe_skill_reads_publishes_targeted_receipt_and_activity(monkeypatch):
   import os
 
   from app import activity
@@ -2957,13 +2971,17 @@ def test_observe_skill_reads_publishes_chip_and_activity(monkeypatch):
   class _Cmd:
     def __init__(self, command):
       self.command = command
+      self.id = "cmd-skill-1"
 
   sdk = {"CommandExecutionThreadItem": _Cmd}
   bc = _FakeBroadcast()
   skills = os.path.join(get_settings().data_dir, "shared", "skills")
   item = _Cmd(f"cat {skills}/cron.md")
   codex_sdk_runner._observe_skill_reads(item, sdk, bc=bc, chat_id="cx-1")
-  assert bc.events == [{"type": "skill_loaded", "skill": "cron"}]
+  assert bc.events == [{
+    "type": "skill_loaded", "skill": "cron",
+    "tool_use_id": "cmd-skill-1",
+  }]
   assert logged == [("cx-1", "cron")]
 
   # Non-command items and non-skill commands emit nothing.

--- a/backend/tests/test_events.py
+++ b/backend/tests/test_events.py
@@ -224,8 +224,7 @@ def test_explicit_unknown_tool_id_never_corrupts_a_batch():
 
 
 def test_skill_loaded_stamps_skill_onto_skill_tool_block():
-  """A skill_loaded event stamps the skill name onto the most recent
-  Skill tool block so the persisted transcript carries the chip data."""
+  """A native Skill tool keeps the exact name and shared read receipt."""
   blocks = [
     {"type": "tool", "tool": "Skill", "input": "humanizer",
      "output": "", "status": "running"},
@@ -235,17 +234,51 @@ def test_skill_loaded_stamps_skill_onto_skill_tool_block():
   )
   assert changed
   assert blocks[0]["skill"] == "humanizer"
+  assert blocks[0]["skills"] == ["humanizer"]
 
 
-def test_skill_loaded_without_skill_block_is_noop():
-  """No Skill tool block to attach to → no change, no crash."""
-  blocks = [{"type": "tool", "tool": "Bash", "input": "ls",
-             "output": "", "status": "done"}]
+def test_skill_loaded_attaches_to_the_running_read_tool_and_dedupes():
+  """Read-based loads survive even though providers rarely use Skill."""
+  blocks = [{"type": "tool", "tool": "Read", "input": "skill.md",
+             "output": "", "status": "running", "tool_use_id": "read-1"}]
+  changed = process_event(
+    {"type": "skill_loaded", "skill": "humanizer",
+     "tool_use_id": "read-1"}, blocks,
+  )
+  assert changed
+  assert blocks[0]["skills"] == ["humanizer"]
+
+  process_event({"type": "skill_loaded", "skill": "humanizer",
+                 "tool_use_id": "read-1"}, blocks)
+  process_event({"type": "skill_loaded", "skill": "theming",
+                 "tool_use_id": "read-1"}, blocks)
+  assert blocks[0]["skills"] == ["humanizer", "theming"]
+
+
+def test_skill_loaded_targets_its_parallel_read_by_id():
+  blocks = [
+    {"type": "tool", "tool": "Read", "status": "running",
+     "tool_use_id": "read-1"},
+    {"type": "tool", "tool": "Read", "status": "running",
+     "tool_use_id": "read-2"},
+  ]
+  process_event({"type": "skill_loaded", "skill": "memory",
+                 "tool_use_id": "read-1"}, blocks)
+  assert blocks[0]["skills"] == ["memory"]
+  assert "skills" not in blocks[1]
+
+
+def test_skill_loaded_without_an_owning_tool_appends_visible_fallback():
+  blocks = []
   changed = process_event(
     {"type": "skill_loaded", "skill": "humanizer"}, blocks,
   )
-  assert changed is False
-  assert "skill" not in blocks[0]
+  assert changed
+  assert blocks == [{
+    "type": "tool", "tool": "Skill", "skill": "humanizer",
+    "skills": ["humanizer"],
+    "input": "", "output": "", "status": "done",
+  }]
 
 
 def test_skill_loaded_empty_name_is_noop():

--- a/backend/tests/test_skills_platform.py
+++ b/backend/tests/test_skills_platform.py
@@ -1562,8 +1562,8 @@ def test_corrupt_sidecar_fails_install_closed_and_preserves_ownership(
   assert d.is_dir()
 
 
-def test_codex_usage_counts_directory_skill_by_id(skills_dir):
-  """A directory skill and its resources count under the directory id."""
+def test_codex_usage_counts_directory_entry_by_id(skills_dir):
+  """A directory entry counts by id; its resources are not another load."""
   from app.codex_sdk_runner import _skill_names_in_command
   from app.config import get_settings
 
@@ -1576,4 +1576,4 @@ def test_codex_usage_counts_directory_skill_by_id(skills_dir):
   assert _skill_names_in_command(cmd, data_dir) == ["pdf", "cron"]
   assert _skill_names_in_command(
     f"cat {data_dir}/shared/skills/pdf/reference.md", data_dir,
-  ) == ["pdf"]
+  ) == []

--- a/backend/tests/test_skills_platform.py
+++ b/backend/tests/test_skills_platform.py
@@ -1563,8 +1563,7 @@ def test_corrupt_sidecar_fails_install_closed_and_preserves_ownership(
 
 
 def test_codex_usage_counts_directory_skill_by_id(skills_dir):
-  """F-5: a `cat <skills>/pdf/SKILL.md` read counts pdf as loaded (keyed by the
-  directory id), matching the Claude Read observer."""
+  """A directory skill and its resources count under the directory id."""
   from app.codex_sdk_runner import _skill_names_in_command
   from app.config import get_settings
 
@@ -1572,6 +1571,9 @@ def test_codex_usage_counts_directory_skill_by_id(skills_dir):
   cmd = (
     f"cat {data_dir}/shared/skills/pdf/SKILL.md; "
     f"head {data_dir}/shared/skills/cron.md; "
-    f"cat {data_dir}/shared/skills/pdf/reference.md"  # resource: NOT a load
+    f"cat {data_dir}/shared/skills/pdf/reference.md"
   )
   assert _skill_names_in_command(cmd, data_dir) == ["pdf", "cron"]
+  assert _skill_names_in_command(
+    f"cat {data_dir}/shared/skills/pdf/reference.md", data_dir,
+  ) == ["pdf"]

--- a/frontend/src/components/ChatView/ActivityLineHeader.jsx
+++ b/frontend/src/components/ChatView/ActivityLineHeader.jsx
@@ -23,6 +23,7 @@ const ACTIVITY_ICONS = {
   web: Globe,
   plan: Tasks,
   image: ImageSquare,
+  skill: Sparkle,
 }
 
 export function ActivityTypeIcon({ kind }) {

--- a/frontend/src/components/ChatView/ChatView.css
+++ b/frontend/src/components/ChatView/ChatView.css
@@ -1050,18 +1050,6 @@
 }
 .chat__tool-icon--running { color: var(--accent); /* CONTRACT: vivid accent marks the active child step */ }
 
-.chat__tool-chip {
-  flex-shrink: 0;
-  padding: 1px 6px;
-  border-radius: 9px;
-  font-size: 12px; /* floor raised from 9.5px */
-  font-family: var(--mono); /* CONTRACT: monospace font stack, matches tool output */
-  color: var(--accent); /* CONTRACT: vivid accent text — marks the skill load */
-  background: color-mix(in srgb, var(--accent) 12%, transparent); /* CONTRACT: faint accent tint on the opaque tool fill */
-  border: 1px solid color-mix(in srgb, var(--accent) 28%, var(--border-light)); /* CONTRACT: accent-tinted hairline */
-  white-space: nowrap;
-}
-
 .chat__tool-detail {
   display: flex;
   flex-direction: column;
@@ -1072,6 +1060,25 @@
   max-height: 200px;
   overflow-y: auto;
   line-height: 1.5;
+}
+
+/* Skill reads are transcript landmarks, not technical output. A batched read
+   opens to one plain list before the original command/result detail, so narrow
+   screens stay calm without hiding which guidance the agent consulted. */
+.chat__skill-list {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  color: var(--text);
+  font-size: 12.5px;
+}
+
+.chat__skill-list li {
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 
 .chat__tool-detail:focus-visible {

--- a/frontend/src/components/ChatView/ToolBlock.jsx
+++ b/frontend/src/components/ChatView/ToolBlock.jsx
@@ -118,7 +118,10 @@ function GenericToolBlock({ t, chatId, compact = false, disclosureKey }) {
   const copyControllerRef = useRef(null)
   const pointerSelectionRef = useRef(null)
   const effectiveName = effectiveToolName(t)
-  const isShell = effectiveName === 'Bash' || effectiveName === 'shell'
+  // Skill reads keep the raw owning tool beneath their plain-language header.
+  // Use that raw identity for command/result formatting even though
+  // effectiveToolName intentionally classifies the collapsed row as Skill.
+  const isShell = t?.tool === 'Bash' || t?.tool === 'shell'
   const label = toolCallLabel(t)
   const iconKind = toolActivityIcon(effectiveName)
   const isImageTool = effectiveName === 'ViewImage'
@@ -129,7 +132,12 @@ function GenericToolBlock({ t, chatId, compact = false, disclosureKey }) {
   // end of the message (MessageSources), where they belong to the answer
   // rather than to the one search that found them. They deliberately do not
   // make a tool row expandable on their own.
-  const hasDetail = !!(t.input || t.output || t.output_truncated)
+  const skillNames = effectiveName === 'Skill' && Array.isArray(t.skills)
+    ? t.skills.filter(skill => typeof skill === 'string' && skill.trim())
+    : []
+  const hasDetail = !!(
+    t.input || t.output || t.output_truncated || skillNames.length > 1
+  )
 
   useEffect(() => {
     // `loadingPreview` is intentionally not a dependency or start guard. Setting
@@ -387,10 +395,6 @@ function GenericToolBlock({ t, chatId, compact = false, disclosureKey }) {
       >
         <ActivityTypeIcon kind={iconKind} />
       </span>
-      {/* Skill observability: when the Skill tool loaded a named
-          skill, show its name as a chip so the user can see which
-          skill the agent reached for this turn. */}
-      {t.skill && <span className="chat__tool-chip">skill: {t.skill}</span>}
       {/* The group header names the category ("Ran commands"); each child row
           names the concrete operation ("Ran git status -sb"). */}
       <span className="chat__tool-name" title={label}>
@@ -480,6 +484,14 @@ function GenericToolBlock({ t, chatId, compact = false, disclosureKey }) {
           tabIndex={open ? 0 : undefined}
           hidden={!open}
         >
+          {open && skillNames.length > 1 && (
+            <div className="chat__tool-section">
+              <span className="chat__tool-section-label">Skills</span>
+              <ul className="chat__skill-list">
+                {skillNames.map(skill => <li key={skill}>{skill}</li>)}
+              </ul>
+            </div>
+          )}
           {open && t.input && !isImageTool && (
             <div className="chat__tool-section">
               <span className="chat__tool-section-label">

--- a/frontend/src/components/ChatView/__tests__/groupBlocks.test.js
+++ b/frontend/src/components/ChatView/__tests__/groupBlocks.test.js
@@ -79,6 +79,31 @@ test('original entry metadata is carried through untouched', () => {
   assert.deepEqual(nodes[0].group.map(x => x.idx), [7, 8])
 })
 
+test('a read-based skill receipt reclassifies its owning tool as one block', () => {
+  const items = [{
+    item: tool({
+      tool: 'Bash', tool_use_id: 'cmd-1', skills: ['recovery', 'theming'],
+    }),
+    idx: 4,
+  }]
+  const nodes = groupActivityRuns(items)
+  assert.equal(nodes.length, 1)
+  assert.equal(nodes[0].group[0], items[0])
+  assert.equal(effectiveToolName(nodes[0].group[0].item), 'Skill')
+  assert.equal(isDistinctiveActivityTool(nodes[0].group[0].item), true)
+})
+
+test('a native Skill tool is not duplicated by its own receipt', () => {
+  const items = [{
+    item: tool({ tool: 'Skill', skill: 'humanizer', skills: ['humanizer'] }),
+    idx: 2,
+  }]
+  const nodes = groupActivityRuns(items)
+  assert.equal(nodes.length, 1)
+  assert.equal(nodes[0].group.length, 1)
+  assert.equal(nodes[0].group[0], items[0])
+})
+
 test('a thinking-first stretch keeps the thinking entry first for keying', () => {
   // The stretch is keyed by its FIRST entry, so a thinking-first stretch that
   // later gains a tool must keep the thinking entry (its idx) at position 0.
@@ -141,6 +166,15 @@ test('toolGroupSummary: an unknown tool name passes through raw', () => {
     toolGroupSummary([tool({ tool: 'FooTool' }), tool({ tool: 'Bash' })]),
     'FooTool · Running a command'
   )
+})
+
+test('activity memo identity changes when a command becomes a skill read', async () => {
+  const { activityMemoSig } = await import('../groupBlocks.js')
+  const command = [{ item: tool({ tool: 'Bash', status: 'running' }) }]
+  const skillRead = [{
+    item: tool({ tool: 'Bash', status: 'running', skills: ['recovery'] }),
+  }]
+  assert.notEqual(activityMemoSig(command), activityMemoSig(skillRead))
 })
 
 test('toolGroupSummary: the running tool leads while the run is live', () => {
@@ -207,6 +241,18 @@ test('toolCallLabel names the concrete nested step in progressive and past tense
   assert.equal(
     toolCallLabel({ tool: 'WebSearch', input: 'nested UI', status: 'done' }),
     'Searched the web for nested UI',
+  )
+  assert.equal(
+    toolCallLabel({
+      tool: 'Bash', skills: ['recovery'], status: 'done',
+    }),
+    'Read the recovery skill',
+  )
+  assert.equal(
+    toolCallLabel({
+      tool: 'Bash', skills: ['recovery', 'theming'], status: 'running',
+    }),
+    'Reading 2 skills',
   )
   assert.equal(toolCallLabel({ tool: 'Bash', status: 'done' }), 'Ran a command')
   assert.equal(

--- a/frontend/src/components/ChatView/__tests__/streamReducers.test.js
+++ b/frontend/src/components/ChatView/__tests__/streamReducers.test.js
@@ -31,6 +31,7 @@ import {
   repairInterleavedQuestionText,
   replaceTextItem,
   startToolLifecycle,
+  applySkillLoaded,
 } from '../streamReducers.js'
 import { questionKey } from '../questionKey.js'
 
@@ -56,6 +57,38 @@ test('Codex tool start preserves provider-neutral Memory recall metadata', () =>
   })
   assert.deepEqual(items[0].recall, { status: 'searching' })
   assert.equal(items[0].tool_use_id, 'cmd-1')
+})
+
+test('skill loads attach by tool id and accumulate without duplicates', () => {
+  const running = [
+    toolItem('Bash', { tool_use_id: 'cmd-1' }),
+    toolItem('Bash', { tool_use_id: 'cmd-2' }),
+  ]
+  const first = applySkillLoaded(running, {
+    skill: 'recovery', tool_use_id: 'cmd-1',
+  })
+  const duplicate = applySkillLoaded(first, {
+    skill: 'recovery', tool_use_id: 'cmd-1',
+  })
+  const second = applySkillLoaded(duplicate, {
+    skill: 'theming', tool_use_id: 'cmd-1',
+  })
+
+  assert.deepEqual(second[0].skills, ['recovery', 'theming'])
+  assert.equal(second[0].tool, 'Bash')
+  assert.equal(second[1].skills, undefined, 'a parallel tool is never misattributed')
+  assert.equal(running[0].skills, undefined, 'the prior live snapshot stays immutable')
+})
+
+test('skill loads remain visible when no owning tool start arrived', () => {
+  const items = applySkillLoaded([], { skill: 'humanizer' })
+  assert.deepEqual(items, [{
+    type: 'tool', tool: 'Skill', skill: 'humanizer',
+    skills: ['humanizer'],
+    input: '', output: '', status: 'done',
+  }])
+  assert.equal(applySkillLoaded(items, { skill: 'humanizer' }), items,
+    'a replayed settled receipt is idempotent')
 })
 
 test('text item identity keeps late deltas before an interleaved question', () => {

--- a/frontend/src/components/ChatView/groupBlocks.js
+++ b/frontend/src/components/ChatView/groupBlocks.js
@@ -167,7 +167,7 @@ export function activityMemoSig(entries, { liveThinkingTail = false } = {}) {
     .map(e => {
       const it = e?.item
       if (it?.type === 'tool') {
-        return `t:${it.tool || ''}:${it.status || ''}`
+        return `t:${effectiveToolName(it) || ''}:${it.status || ''}`
       }
       return 'k'
     })

--- a/frontend/src/components/ChatView/streamReducers.js
+++ b/frontend/src/components/ChatView/streamReducers.js
@@ -52,6 +52,70 @@ export function startToolLifecycle(prev, event) {
 }
 
 /**
+ * Attach one skill-read receipt to the tool that performed it.
+ *
+ * Skill loads arrive as a side-band event after Read/Bash/Skill starts. Keeping
+ * names on that owning tool makes repeated events idempotent and lets the
+ * renderer present one calm, provider-neutral block while preserving the raw
+ * tool details underneath. Mirrors backend/app/events.py exactly.
+ */
+export function applySkillLoaded(prev, event) {
+  const skill = typeof event?.skill === 'string' ? event.skill.trim() : ''
+  if (!skill) return prev
+
+  const updated = [...prev]
+  let target = event?.tool_use_id
+    ? updated.findIndex(item => (
+        item?.type === 'tool' && item.tool_use_id === event.tool_use_id
+      ))
+    : -1
+  if (target === -1 && event?.tool_use_id) {
+    const candidates = updated
+      .map((item, index) => ({ item, index }))
+      .filter(({ item }) => (
+        item?.type === 'tool' && item.status !== 'done' && !item.tool_use_id
+      ))
+    if (candidates.length === 1) target = candidates[0].index
+  } else if (target === -1) {
+    for (let i = updated.length - 1; i >= 0; i -= 1) {
+      if (updated[i]?.type === 'tool' && updated[i].status !== 'done') {
+        target = i
+        break
+      }
+    }
+  }
+
+  if (target !== -1) {
+    const tool = updated[target]
+    const skills = Array.isArray(tool.skills) ? tool.skills : []
+    updated[target] = {
+      ...tool,
+      skills: skills.includes(skill) ? skills : [...skills, skill],
+      ...(tool.tool === 'Skill' ? { skill } : {}),
+      ...(event?.tool_use_id && !tool.tool_use_id
+        ? { tool_use_id: event.tool_use_id }
+        : {}),
+    }
+    return updated
+  }
+
+  const latestTool = [...updated].reverse().find(item => item?.type === 'tool')
+  if (Array.isArray(latestTool?.skills) && latestTool.skills.includes(skill)) {
+    return prev
+  }
+
+  return [...updated, {
+    type: 'tool',
+    tool: 'Skill',
+    skill,
+    skills: [skill],
+    input: '',
+    output: '',
+    status: 'done',
+  }]
+}
+
+/**
  * Append a streamed text delta to its provider message item.
  *
  * A synchronous question can be published between two deltas belonging to

--- a/frontend/src/components/ChatView/toolActivityLabel.js
+++ b/frontend/src/components/ChatView/toolActivityLabel.js
@@ -27,7 +27,7 @@ const ACTIVITY_LABELS = new Map([
   ['Workflow', 'Working in the background'],
   ['TaskOutput', 'Working in the background'],
   ['AskUserQuestion', 'Asking you'],
-  ['Skill', 'Using a skill'],
+  ['Skill', 'Using skills'],
   // Image-viewing (owner ref 2026-07-17). Codex will emit ViewImage directly
   // once its ImageViewThreadItem is wired; a Claude image view is a Read of an
   // image file, mapped here by extension via effectiveToolName. Plural here —
@@ -61,7 +61,7 @@ const PAST_LABELS = new Map([
   ['Workflow', 'Worked in the background'],
   ['TaskOutput', 'Worked in the background'],
   ['AskUserQuestion', 'Asked you'],
-  ['Skill', 'Used a skill'],
+  ['Skill', 'Used skills'],
   ['ViewImage', 'Viewed images'],
   ['MemoryRecall', 'Recalled from Memory'],
 ])
@@ -76,11 +76,13 @@ const PRESENT_SINGULAR = new Map([
   ['Running commands', 'Running a command'],
   ['Reading files', 'Reading a file'],
   ['Viewing images', 'Viewing an image'],
+  ['Using skills', 'Using a skill'],
 ])
 const PAST_SINGULAR = new Map([
   ['Ran commands', 'Ran a command'],
   ['Read files', 'Read a file'],
   ['Viewed images', 'Viewed an image'],
+  ['Used skills', 'Used a skill'],
 ])
 
 // A small muted type glyph keyed off the FIRST activity in a settled line
@@ -102,7 +104,7 @@ const ACTIVITY_ICONS = new Map([
   ['TodoWrite', 'plan'],
   ['ToolSearch', 'plan'],
   ['AskUserQuestion', 'dot'],
-  ['Skill', 'dot'],
+  ['Skill', 'skill'],
   ['ViewImage', 'image'],
   ['MemoryRecall', 'search'],
 ])
@@ -162,6 +164,17 @@ export function toolCallLabel(tool) {
   // glance. "Nothing relevant" is stated explicitly, because a silent recall
   // is indistinguishable from never having looked.
   if (name === 'MemoryRecall') return memoryRecallLabel(tool)
+  if (name === 'Skill') {
+    const skills = Array.isArray(tool?.skills)
+      ? tool.skills.filter(skill => typeof skill === 'string' && skill.trim())
+      : (typeof tool?.skill === 'string' && tool.skill.trim() ? [tool.skill.trim()] : [])
+    if (skills.length === 1) {
+      return `${tool?.status === 'running' ? 'Reading' : 'Read'} the ${skills[0]} skill`
+    }
+    if (skills.length > 1) {
+      return `${tool?.status === 'running' ? 'Reading' : 'Read'} ${skills.length} skills`
+    }
+  }
   let input = typeof tool?.input === 'string' ? tool.input.trim() : ''
   if (name === 'ViewImage') input = imagePathFromInput(tool?.input) || input
   const verbs = INSTANCE_VERBS.get(name)
@@ -197,6 +210,7 @@ export function effectiveToolName(tool) {
   // point for both runners, and it keeps working after transcript compaction
   // strips the command string from a settled activity block.
   if (tool?.recall && typeof tool.recall === 'object') return 'MemoryRecall'
+  if (Array.isArray(tool?.skills) && tool.skills.length > 0) return 'Skill'
   if (IMAGE_TOOL_NAMES.has(name)) return 'ViewImage'
   if (name === 'Read') {
     // On the wire tool.input is the STRING summary the backend builds
@@ -215,11 +229,10 @@ export function effectiveToolName(tool) {
 // files, ran commands" summary (owner ref 2026-07-17). The read/grep/edit/bash
 // plumbing is the agent's background housekeeping — one calm folded line is
 // right — but a notable beat like viewing an image is worth seeing on its own,
-// so scanning the transcript tells the story. Extensible: skill reads, context
-// compaction, and subagent spawns join here once the backend surfaces their
-// events (today only image views are frontend-detectable — a Skill load is
-// swallowed into a chip, not a tool block).
-const DISTINCTIVE_ACTIVITIES = new Set(['ViewImage', 'MemoryRecall'])
+// so scanning the transcript tells the story. Skill reads use the same lane:
+// effectiveToolName reclassifies their receipt-bearing Read/Bash block without
+// losing its expandable raw details.
+const DISTINCTIVE_ACTIVITIES = new Set(['ViewImage', 'MemoryRecall', 'Skill'])
 
 // The one-line story of a memory lookup, including honest operational failure.
 // Reading the count from the result set the backend already parsed keeps the

--- a/frontend/src/components/ChatView/useStreamConnection.js
+++ b/frontend/src/components/ChatView/useStreamConnection.js
@@ -18,6 +18,7 @@ import {
   appendTextItem,
   replaceTextItem,
   startToolLifecycle,
+  applySkillLoaded,
 } from './streamReducers.js'
 import {
   readStoredStreamSnapshot,
@@ -119,9 +120,9 @@ const BROADCAST_REGISTRATION_WINDOW_MS = 1500
  *   tool_sources          WebSearch source metadata
  *                         { sources }. Stamps source chips onto block.
  *   tool_end              Marks the running tool done (status flip).
- *   skill_loaded          Agent loaded a skill { skill }. Stamps the
- *                         name onto the matching Skill tool block so
- *                         ToolBlock renders a chip.
+ *   skill_loaded          Agent loaded a skill { skill }. Adds a receipt to
+ *                         the running tool; the transcript derives a quiet,
+ *                         standalone skill-read activity from it.
  *   task_start            A delegating turn spawned a background helper
  *                         { task_id, description, task_type, tool_use_id }.
  *                         Upserts a live subagent chip (SubagentChips).
@@ -1026,20 +1027,9 @@ export default function useStreamConnection(chatId, {
               prev => closeToolLifecycle(prev, event.tool_use_id),
             )
           } else if (event.type === 'skill_loaded') {
-            // Skill observability: stamp the loaded skill's name onto
-            // the most recent Skill tool block so ToolBlock renders a
-            // chip. Mirrors backend/app/events.py:process_event so the
-            // live stream and the persisted transcript agree.
-            applyStreamItems(prev => {
-              const updated = [...prev]
-              for (let i = updated.length - 1; i >= 0; i--) {
-                if (updated[i].type === 'tool' && updated[i].tool === 'Skill') {
-                  updated[i] = { ...updated[i], skill: event.skill }
-                  break
-                }
-              }
-              return updated
-            })
+            // One pure reducer owns the live receipt shape; the backend event
+            // reducer mirrors it for reloads and transcript compaction.
+            applyStreamItems(prev => applySkillLoaded(prev, event))
           } else if (
             event.type === 'task_start'
             || event.type === 'task_progress'


### PR DESCRIPTION
## Summary
- present detected skill-file reads as a dedicated chat activity instead of a generic command
- attribute Codex skill entry files, context scripts, and reference files to their owning skill
- keep batched skill names and the original tool details inspectable
- preserve the activity across live streaming, parallel tool calls, and compacted history

## Testing
- 343 focused backend tests
- 2,542 frontend tests (after locally refreshing an already-stale generated runtime artifact; the artifact was discarded)
- frontend lint (0 errors)