### PR TITLE
Make historical chat pagination seamless

### DIFF
--- a/frontend/src/components/ChatView/ChatView.css
+++ b/frontend/src/components/ChatView/ChatView.css
@@ -2289,12 +2289,26 @@
   transition: background 0.15s, color 0.15s, transform 0.08s;
 }
 .chat__question-nudge:hover,
-.chat__resume-nudge:hover {
+.chat__resume-nudge:hover,
+.chat__history-retry:hover {
   background: var(--accent); /* CONTRACT: vivid opaque accent fill */
   color: #fff;
 }
 .chat__question-nudge:active,
-.chat__resume-nudge:active { transform: scale(0.96); }
+.chat__resume-nudge:active,
+.chat__history-retry:active { transform: scale(0.96); }
+
+.chat__history-retry {
+  min-height: 36px;
+  margin: 0 auto;
+  padding: 8px 12px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--surface);
+  color: var(--text);
+  font: 600 12px/1.2 var(--font);
+  cursor: pointer;
+}
 
 .chat__offscreen-nudges > button + button { margin-top: 8px; }
 

--- a/frontend/src/components/ChatView/ChatView.css
+++ b/frontend/src/components/ChatView/ChatView.css
@@ -171,26 +171,6 @@
   min-height: calc(100% + 1px);
 }
 
-/* ── Load earlier ──────────────────────────────────── */
-
-.chat__older { text-align: center; }
-
-.chat__older button {
-  background: none;
-  border: 1px solid var(--border-light); /* CONTRACT: subtle 1px hairline on opaque fill */
-  border-radius: 20px;
-  color: var(--muted); /* CONTRACT: low-contrast text on opaque fill */
-  font-size: 12px;
-  padding: 5px 16px;
-  cursor: pointer;
-  transition: color 0.15s, border-color 0.15s;
-}
-
-.chat__older button:hover {
-  color: var(--text); /* CONTRACT: high-contrast text on opaque fill */
-  border-color: var(--border); /* CONTRACT: 1px line on top of the inherited opaque fill */
-}
-
 /* ── Empty state ───────────────────────────────────── */
 
 .chat__empty {

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -751,6 +751,7 @@ export default function ChatView({
   // gates the scroll-handler in useScrollMode from misclassifying
   // post-prepend scroll-clamps as user gestures.
   const loadingOlder = useRef(false)
+  const [olderHistoryError, setOlderHistoryError] = useState(false)
 
   // ── Scroll subsystem ─────────────────────────────────────────────
   //
@@ -2069,6 +2070,7 @@ export default function ChatView({
     const el = scrollRef.current
     if (!el || loadingOlder.current || loading || before <= 0) return
     loadingOlder.current = true
+    setOlderHistoryError(false)
     // Snapshot the topmost rendered msg + its current offset for
     // post-prepend restore. The anchor key/offset is stable: after
     // the prepend, the SAME message has a larger offsetTop (older
@@ -2133,7 +2135,10 @@ export default function ChatView({
           }
         })
       })
-      .catch(() => { loadingOlder.current = false })
+      .catch(() => {
+        loadingOlder.current = false
+        setOlderHistoryError(true)
+      })
   }
 
   // A tall viewport or an unusually compact page can have older history but no
@@ -4345,6 +4350,15 @@ export default function ChatView({
             </div>
           )}
           <div className="chat__offscreen-nudges">
+            {olderHistoryError && offset > 0 && (
+              <button
+                type="button"
+                className="chat__history-retry"
+                onClick={() => loadOlderMessages()}
+              >
+                Earlier messages didn’t load — retry
+              </button>
+            )}
             {hasPendingQuestion && pendingCardOffscreen && (
               <button
                 type="button"

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -16,6 +16,7 @@ import { chatMessagesQueryKey } from '../../hooks/queries.js'
 import useStreamConnection from './useStreamConnection.js'
 import useScrollMode, {
   isNearContentBottom,
+  olderHistoryRetryShown,
   olderHistoryShouldLoad,
   remapSavedReadingAnchor,
   retireSavedReadingPosition,
@@ -4332,7 +4333,7 @@ export default function ChatView({
             <>
               {offscreenControlsVisible && (
                 <div className="chat__offscreen-nudges">
-                  {olderHistoryError && offset > 0 && (
+                  {olderHistoryRetryShown(olderHistoryError, offset) && (
                     <button
                       type="button"
                       className="chat__history-retry"

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -16,6 +16,7 @@ import { chatMessagesQueryKey } from '../../hooks/queries.js'
 import useStreamConnection from './useStreamConnection.js'
 import useScrollMode, {
   isNearContentBottom,
+  olderHistoryShouldLoad,
   remapSavedReadingAnchor,
   retireSavedReadingPosition,
   savedReadingAnchorHasNestedPart,
@@ -2064,9 +2065,9 @@ export default function ChatView({
   // lands the user at the same visual position.
   // (loadingOlder ref is declared earlier alongside the useScrollMode
   // hook call — it's passed to the hook to gate the scroll handler.)
-  function loadOlderMessages() {
+  function loadOlderMessages(before = offset) {
     const el = scrollRef.current
-    if (!el || loadingOlder.current || loading || offset <= 0) return
+    if (!el || loadingOlder.current || loading || before <= 0) return
     loadingOlder.current = true
     // Snapshot the topmost rendered msg + its current offset for
     // post-prepend restore. The anchor key/offset is stable: after
@@ -2085,7 +2086,7 @@ export default function ChatView({
     // them at the new anchor; the next gesture (or send) writes a
     // fresh mode.
     apiFetch(
-      `/chats/${chatId}?limit=20&before=${offset}&compact=1`,
+      `/chats/${chatId}?limit=20&before=${before}&compact=1`,
       { timeoutMs: CHAT_FETCH_TIMEOUT_MS },
     )
       .then(r => jsonOrThrow(r, 'Earlier messages failed to load'))
@@ -2110,7 +2111,8 @@ export default function ChatView({
         if (anchorKey) {
           anchorPagination(anchorKey, anchorOffset)
         }
-        commitMessages(prev => [...older, ...prev], data.offset || 0)
+        const nextOffset = data.offset || 0
+        commitMessages(prev => [...older, ...prev], nextOffset)
         requestAnimationFrame(() => {
           // The layout effect has run with ANCHOR_AT — applyMode
           // landed the topmost-pre-prepend msg at the same visual
@@ -2120,10 +2122,28 @@ export default function ChatView({
           // subsequent layout events (incoming tokens, etc). Their
           // next gesture (or send) writes a fresh mode.
           loadingOlder.current = false
+          const scrollEl = scrollRef.current
+          if (
+            scrollEl
+            && nextOffset > 0
+            && nextOffset < before
+            && olderHistoryShouldLoad(scrollEl)
+          ) {
+            loadOlderMessages(nextOffset)
+          }
         })
       })
       .catch(() => { loadingOlder.current = false })
   }
+
+  // A tall viewport or an unusually compact page can have older history but no
+  // scroll range. Fill only until scrolling becomes possible; subsequent pages
+  // remain user-driven and bounded.
+  useLayoutEffect(() => {
+    const el = scrollRef.current
+    if (!el || loadingOlder.current || loading || offset <= 0) return
+    if (olderHistoryShouldLoad(el)) loadOlderMessages()
+  })
 
   // Jump-to-latest visibility (contract R5a): a pure geometry READ — it never
   // writes scrollTop, so it lives outside the scroll controller's ownership
@@ -2144,16 +2164,11 @@ export default function ChatView({
     updateJumpToLatest()
     const el = scrollRef.current
     if (!el || loadingOlder.current || loading) return
-    // Gesture guard: applyMode's programmatic scrolls (e.g., PIN_USER_MSG
-    // landing near scrollTop=0 when the user msg is high in the list,
-    // or FOLLOW_BOTTOM after a pagination prepend) can satisfy
-    // `scrollTop < 5 && offset > 0` and trigger an unwanted pagination
-    // load. Only paginate while the shared controller says the reader owns
-    // scrolling: from pointer/wheel/touch/key input through its first scroll,
-    // then through the short momentum window.
+    // Programmatic scrolls can land near the top, so the shared gesture window
+    // still owns intent. Prefetch before the loaded-page boundary can become a
+    // visible interruption instead of waiting for the absolute top.
     const userDriven = performance.now() < gestureWindowUntilRef.current
-    if (!userDriven) return
-    if (el.scrollTop < 5 && offset > 0) {
+    if (offset > 0 && olderHistoryShouldLoad(el, { userDriven })) {
       loadOlderMessages()
     }
   }
@@ -3658,7 +3673,6 @@ export default function ChatView({
     }
   }, [ensureRuntimeStreamConnected, hidden, reconcileRuntimeState])
 
-  const hasMore = offset > 0
   // Empty-state is the "I have nothing to show because nothing happened
   // yet" view. If the initial chat fetch errored, we have no idea
   // whether the chat is empty — surfacing that branch separately keeps
@@ -4129,12 +4143,6 @@ export default function ChatView({
             non-empty chat, including after unmount/remount. Keep the list's
             elastic min-height out of the spacer formula at all times. */}
         <ul className="chat__list" style={{ minHeight: 0 }}>
-          {hasMore && (
-            <li className="chat__older">
-              <button onClick={loadOlderMessages}>Load earlier messages</button>
-            </li>
-          )}
-
           {messages.map((msg, i) => {
             if (msg.hidden) return null
             const continuationMarker = isContinuationMessage(msg)

--- a/frontend/src/components/ChatView/__tests__/historyPagination.test.js
+++ b/frontend/src/components/ChatView/__tests__/historyPagination.test.js
@@ -1,0 +1,32 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  olderHistoryRetryShown,
+  olderHistoryShouldLoad,
+} from '../useScrollMode.js'
+
+function scrollEl({ scrollHeight, scrollTop, clientHeight }) {
+  return { scrollHeight, scrollTop, clientHeight }
+}
+
+test('older history prefetches near its boundary and fills a short page', () => {
+  assert.equal(olderHistoryShouldLoad(scrollEl({
+    scrollHeight: 2000, scrollTop: 240, clientHeight: 800,
+  }), { userDriven: true }), true)
+  assert.equal(olderHistoryShouldLoad(scrollEl({
+    scrollHeight: 2000, scrollTop: 600, clientHeight: 800,
+  }), { userDriven: true }), false)
+  assert.equal(olderHistoryShouldLoad(scrollEl({
+    scrollHeight: 800, scrollTop: 0, clientHeight: 800,
+  })), true)
+  assert.equal(olderHistoryShouldLoad(scrollEl({
+    scrollHeight: 2000, scrollTop: 0, clientHeight: 800,
+  })), false)
+})
+
+test('failed pagination exposes retry only while older pages remain', () => {
+  assert.equal(olderHistoryRetryShown(true, 20), true)
+  assert.equal(olderHistoryRetryShown(false, 20), false)
+  assert.equal(olderHistoryRetryShown(true, 0), false)
+})

--- a/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
+++ b/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
@@ -27,6 +27,7 @@ import {
   modeAfterReaderGesture,
   modeAfterSpacerResize,
   modeAfterTerminalLayout,
+  olderHistoryShouldLoad,
   physicalBottomAnchorModeFromScroll,
   readerInputActivatesDisclosure,
   readerInputMayScroll,
@@ -193,6 +194,29 @@ test('deferred layout waits for the first scroll instead of timing Infinity', ()
   assert.equal(gestureLayoutRetryDelay(Number.POSITIVE_INFINITY, 1000), null)
   assert.equal(gestureLayoutRetryDelay(1250, 1000), 251)
   assert.equal(gestureLayoutRetryDelay(999, 1000), 1)
+})
+
+test('older history loads before its boundary appears and fills a short page', () => {
+  assert.equal(olderHistoryShouldLoad(makeScrollEl({
+    scrollHeight: 2000,
+    scrollTop: 240,
+    clientHeight: 800,
+  }), { userDriven: true }), true)
+  assert.equal(olderHistoryShouldLoad(makeScrollEl({
+    scrollHeight: 2000,
+    scrollTop: 600,
+    clientHeight: 800,
+  }), { userDriven: true }), false)
+  assert.equal(olderHistoryShouldLoad(makeScrollEl({
+    scrollHeight: 800,
+    scrollTop: 0,
+    clientHeight: 800,
+  })), true)
+  assert.equal(olderHistoryShouldLoad(makeScrollEl({
+    scrollHeight: 2000,
+    scrollTop: 0,
+    clientHeight: 800,
+  })), false, 'layout-owned top landings must not fetch history')
 })
 
 test('only scrolling keys claim reader ownership', () => {

--- a/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
+++ b/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
@@ -219,6 +219,21 @@ test('older history loads before its boundary appears and fills a short page', (
   })), false, 'layout-owned top landings must not fetch history')
 })
 
+test('failed short-page pagination leaves an explicit retry path', () => {
+  const source = readFileSync(
+    new URL('../ChatView.jsx', import.meta.url),
+    'utf8',
+  )
+  assert.match(
+    source,
+    /\.catch\(\(\) => \{[\s\S]*?setOlderHistoryError\(true\)[\s\S]*?\}\)/,
+  )
+  assert.match(
+    source,
+    /olderHistoryError && offset > 0[\s\S]*?onClick=\{\(\) => loadOlderMessages\(\)\}[\s\S]*?Earlier messages didn’t load — retry/,
+  )
+})
+
 test('only scrolling keys claim reader ownership', () => {
   assert.equal(readerInputMayScroll('keydown', 'a'), false)
   assert.equal(readerInputMayScroll('keydown', 'Enter'), false)

--- a/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
+++ b/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
@@ -27,7 +27,6 @@ import {
   modeAfterReaderGesture,
   modeAfterSpacerResize,
   modeAfterTerminalLayout,
-  olderHistoryShouldLoad,
   physicalBottomAnchorModeFromScroll,
   readerInputActivatesDisclosure,
   readerInputMayScroll,
@@ -196,43 +195,7 @@ test('deferred layout waits for the first scroll instead of timing Infinity', ()
   assert.equal(gestureLayoutRetryDelay(999, 1000), 1)
 })
 
-test('older history loads before its boundary appears and fills a short page', () => {
-  assert.equal(olderHistoryShouldLoad(makeScrollEl({
-    scrollHeight: 2000,
-    scrollTop: 240,
-    clientHeight: 800,
-  }), { userDriven: true }), true)
-  assert.equal(olderHistoryShouldLoad(makeScrollEl({
-    scrollHeight: 2000,
-    scrollTop: 600,
-    clientHeight: 800,
-  }), { userDriven: true }), false)
-  assert.equal(olderHistoryShouldLoad(makeScrollEl({
-    scrollHeight: 800,
-    scrollTop: 0,
-    clientHeight: 800,
-  })), true)
-  assert.equal(olderHistoryShouldLoad(makeScrollEl({
-    scrollHeight: 2000,
-    scrollTop: 0,
-    clientHeight: 800,
-  })), false, 'layout-owned top landings must not fetch history')
-})
 
-test('failed short-page pagination leaves an explicit retry path', () => {
-  const source = readFileSync(
-    new URL('../ChatView.jsx', import.meta.url),
-    'utf8',
-  )
-  assert.match(
-    source,
-    /\.catch\(\(\) => \{[\s\S]*?setOlderHistoryError\(true\)[\s\S]*?\}\)/,
-  )
-  assert.match(
-    source,
-    /olderHistoryError && offset > 0[\s\S]*?onClick=\{\(\) => loadOlderMessages\(\)\}[\s\S]*?Earlier messages didn’t load — retry/,
-  )
-})
 
 test('only scrolling keys claim reader ownership', () => {
   assert.equal(readerInputMayScroll('keydown', 'a'), false)

--- a/frontend/src/components/ChatView/useScrollMode.js
+++ b/frontend/src/components/ChatView/useScrollMode.js
@@ -92,6 +92,18 @@ const PENDING_GESTURE_CAP_MS = 2000
 // rounding at the scroll extent.
 const PHYSICAL_BOTTOM_EPSILON_PX = 4
 
+// Start the next bounded history read before the loaded-page boundary can
+// enter the viewport. A non-scrollable page also needs one immediately because
+// the browser cannot emit the scroll event that normally drives pagination.
+export const HISTORY_PREFETCH_PX = 240
+
+
+export function olderHistoryShouldLoad(scrollEl, { userDriven = false } = {}) {
+  if (!scrollEl) return false
+  return scrollEl.scrollHeight <= scrollEl.clientHeight + 1
+    || (userDriven && scrollEl.scrollTop <= HISTORY_PREFETCH_PX)
+}
+
 // Bounded, content-free diagnostics. Recurring scroll bugs used to require
 // reconstructing races from screenshots and guesses; this keeps the last
 // controller transitions and actual automatic writes without recording any

--- a/frontend/src/components/ChatView/useScrollMode.js
+++ b/frontend/src/components/ChatView/useScrollMode.js
@@ -98,6 +98,10 @@ const PHYSICAL_BOTTOM_EPSILON_PX = 4
 export const HISTORY_PREFETCH_PX = 240
 
 
+export function olderHistoryRetryShown(error, offset) {
+  return Boolean(error) && Number(offset) > 0
+}
+
 export function olderHistoryShouldLoad(scrollEl, { userDriven = false } = {}) {
   if (!scrollEl) return false
   return scrollEl.scrollHeight <= scrollEl.clientHeight + 1

--- a/tests/frontend.spec.mjs
+++ b/tests/frontend.spec.mjs
@@ -917,7 +917,7 @@ test.describe('Scroll position', () => {
 
     await page.goto(`${BASE}/shell/?chat=${chatId}`, { waitUntil: 'domcontentloaded' })
     await page.waitForFunction(
-      () => document.querySelector('[data-chat-surface="painted"] .chat__scroll'),
+      () => document.querySelector('[data-key="history-cid-44"]'),
       { timeout: 10000 },
     )
     // Older pages now prefetch from the reader's near-top gesture instead of

--- a/tests/frontend.spec.mjs
+++ b/tests/frontend.spec.mjs
@@ -916,9 +916,19 @@ test.describe('Scroll position', () => {
     })
 
     await page.goto(`${BASE}/shell/?chat=${chatId}`, { waitUntil: 'domcontentloaded' })
-    await expect(page.getByRole('button', { name: 'Load earlier messages' }))
-      .toBeVisible({ timeout: 10000 })
-    await page.getByRole('button', { name: 'Load earlier messages' }).click()
+    await page.waitForFunction(
+      () => document.querySelector('[data-chat-surface="painted"] .chat__scroll'),
+      { timeout: 10000 },
+    )
+    // Older pages now prefetch from the reader's near-top gesture instead of
+    // exposing a manual Load button. Drive that owning interaction directly.
+    await page.evaluate(() => {
+      const el = document.querySelector('[data-chat-surface="painted"] .chat__scroll')
+      if (!el) throw new Error('missing paginated scroll surface')
+      el.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }))
+      el.scrollTop = 0
+      el.dispatchEvent(new Event('scroll', { bubbles: true }))
+    })
     await page.waitForFunction(
       () => document.querySelector('[data-key="history-cid-10"]'),
       { timeout: 5000 },


### PR DESCRIPTION
## Summary
- remove the visible "Load earlier messages" boundary from chat history
- prefetch the next bounded 20-message page before the reader reaches the loaded-history edge
- preserve user-owned scroll anchoring and ignore programmatic top landings
- silently fill unusually short history windows without unbounding initial reads

## Why
The fallback control can enter view before the existing top-of-scroll trigger, interrupting ordinary upward scrolling. This keeps bounded compact history loading while making pagination invisible.

## Testing
- frontend unit and hook suites
- focused chat-scroll tests on the current upstream base
- production frontend/PWA builds
- rendered long-chat verification for programmatic and reader-owned scrolling