### PR TITLE
Show Claude and Codex edits as bounded diffs

### DIFF
--- a/backend/app/claude_events.py
+++ b/backend/app/claude_events.py
@@ -53,6 +53,7 @@ except ImportError:
 
 from app import activity
 from app.sdk_emit import emit_unknown_enabled, unknown_event
+from app.tool_edit_preview import claude_edit_preview
 from app.tool_summaries import summarize_tool_input
 from app.tool_sources import normalize_tool_sources, sources_from_websearch_text
 from app.usage_metrics import normalize_claude_usage
@@ -424,12 +425,14 @@ def dispatch_sdk_message(
           "tool_use_id": block.id,
         })
         summary = summarize_tool_input(block.name, block.input)
-        if summary:
+        edit_preview = claude_edit_preview(block.name, block.input)
+        if summary or edit_preview:
           bc.publish({
             "type": "tool_input",
             "tool": block.name,
             "input": summary,
             "tool_use_id": block.id,
+            **({"edit_preview": edit_preview} if edit_preview else {}),
           })
         # Skill observability: when the agent loads a skill, surface it
         # as its own `skill_loaded` event (the frontend stamps a chip

--- a/backend/app/claude_events.py
+++ b/backend/app/claude_events.py
@@ -532,6 +532,7 @@ def dispatch_sdk_message(
           "content": output,
           "tool_use_id": block.tool_use_id,
           "output_complete": True,
+          **({"output_exit_code": 1} if block.is_error else {}),
         })
         if output.startswith("Web search results for query"):
           sources = sources_from_websearch_text(output)

--- a/backend/app/codex_events.py
+++ b/backend/app/codex_events.py
@@ -16,6 +16,7 @@ from typing import Any
 
 from app.codex_appserver import _extract_bash_command
 from app.json_safety import json_safe
+from app.tool_edit_preview import codex_edit_preview
 from app.tool_sources import normalize_tool_sources
 
 log = logging.getLogger("moebius.chat")
@@ -595,10 +596,12 @@ def _tool_start_event(item: Any, sdk: dict[str, Any]) -> dict[str, Any] | None:
   if isinstance(item, sdk["FileChangeThreadItem"]):
     first = item.changes[0] if item.changes else None
     path = _model_dump(first).get("path", "") if first is not None else ""
+    edit_preview = _file_change_edit_preview(item.changes)
     return {
       "type": "tool_start",
       "tool": "Edit",
       "input": path,
+      **({"edit_preview": edit_preview} if edit_preview else {}),
     }
   if isinstance(item, sdk["McpToolCallThreadItem"]):
     tool_name = f"{item.server}:{item.tool}" if item.server else item.tool
@@ -955,3 +958,8 @@ def _file_change_patch_summary(changes: list[Any]) -> str:
     if line:
       lines.append(line)
   return "\n".join(lines)
+
+
+def _file_change_edit_preview(changes: list[Any]) -> dict | None:
+  """Normalize SDK file changes into the shared bounded diff preview."""
+  return codex_edit_preview([_model_dump(change) for change in changes])

--- a/backend/app/codex_sdk_runner.py
+++ b/backend/app/codex_sdk_runner.py
@@ -104,6 +104,7 @@ from app.codex_events import (
   _skill_names_in_command,
   _observe_skill_reads,
   _file_change_patch_summary,
+  _file_change_edit_preview,
 )
 from app.process_groups import lower_process_group_priority
 from app.providers import get_skill_path
@@ -2149,6 +2150,16 @@ async def run_codex_sdk_turn(
           continue
 
         if isinstance(payload, sdk["FileChangePatchUpdatedNotification"]):
+          edit_preview = _file_change_edit_preview(payload.changes)
+          if edit_preview:
+            first = _model_dump(payload.changes[0]) if payload.changes else {}
+            event = {
+              "type": "tool_input",
+              "input": first.get("path", "") if isinstance(first, dict) else "",
+              "edit_preview": edit_preview,
+            }
+            _stamp_notification_item_id(event, payload)
+            bc.publish(event)
           summary = _file_change_patch_summary(payload.changes)
           if summary:
             event = {"type": "tool_output", "content": summary}

--- a/backend/app/events.py
+++ b/backend/app/events.py
@@ -614,6 +614,8 @@ def _process_tool_event(event: dict, assistant_blocks: list) -> bool:
       block["tool_use_id"] = tool_use_id
     if isinstance(event.get("recall"), dict):
       block["recall"] = event["recall"]
+    if isinstance(event.get("edit_preview"), dict):
+      block["edit_preview"] = event["edit_preview"]
     assistant_blocks.append(block)
     return True
 
@@ -629,6 +631,8 @@ def _process_tool_event(event: dict, assistant_blocks: list) -> bool:
       # that authorizes the later output phase to cite notes.
       if isinstance(event.get("recall"), dict):
         blk["recall"] = event["recall"]
+      if isinstance(event.get("edit_preview"), dict):
+        blk["edit_preview"] = event["edit_preview"]
 
     tool_use_id = event.get("tool_use_id")
     if tool_use_id:

--- a/backend/app/tool_edit_preview.py
+++ b/backend/app/tool_edit_preview.py
@@ -1,0 +1,124 @@
+"""Build bounded unified-diff previews for provider edit tools."""
+
+from __future__ import annotations
+
+import difflib
+import json
+from typing import Any
+
+
+# Edit previews live inline with the tool block so they are immediately
+# available when its disclosure opens. Keep that durable payload comparable to
+# the ordinary bounded tool-output preview rather than copying whole files into
+# every transcript.
+MAX_EDIT_PREVIEW_CHARS = 20_000
+
+
+def _bounded_preview(diff: str, *, relative: bool = False) -> dict | None:
+  if not diff:
+    return None
+  truncated = len(diff) > MAX_EDIT_PREVIEW_CHARS
+  return {
+    "diff": diff[:MAX_EDIT_PREVIEW_CHARS],
+    "truncated": truncated,
+    **({"relative": True} if relative else {}),
+  }
+
+
+def _quoted_path(path: str) -> str:
+  if any(char.isspace() or char in {'"', "\\"} for char in path):
+    return json.dumps(path, ensure_ascii=False)
+  return path
+
+
+def _git_path(side: str, path: str) -> str:
+  # Absolute paths intentionally become a//data/...; the canonical parser
+  # removes the a/ or b/ side and preserves the leading slash.
+  return _quoted_path(f"{side}/{path}")
+
+
+def _selection_hunk(edit: dict[str, Any]) -> list[str]:
+  old = edit.get("old_string")
+  new = edit.get("new_string")
+  if not isinstance(old, str) or not isinstance(new, str):
+    return []
+  # Discard the ---/+++ headers: every selection belongs to the one file entry
+  # declared by claude_edit_preview, while each @@ section remains independent.
+  return list(difflib.unified_diff(
+    old.splitlines(), new.splitlines(), lineterm="",
+  ))[2:]
+
+
+def claude_edit_preview(tool: str, inp: Any) -> dict | None:
+  """Build an honest selection-relative preview from Claude edit arguments."""
+  if not isinstance(inp, dict) or tool not in {"Edit", "MultiEdit"}:
+    return None
+  path = inp.get("file_path")
+  if not isinstance(path, str) or not path:
+    return None
+  raw_edits = inp.get("edits") if tool == "MultiEdit" else [inp]
+  edits = raw_edits if isinstance(raw_edits, list) else []
+  hunks = [
+    line
+    for edit in edits if isinstance(edit, dict)
+    for line in _selection_hunk(edit)
+  ]
+  if not hunks:
+    return None
+  header = [
+    "diff --git "
+    f"{_git_path('a', path)} {_git_path('b', path)}",
+    f"--- {_git_path('a', path)}",
+    f"+++ {_git_path('b', path)}",
+  ]
+  return _bounded_preview("\n".join([*header, *hunks]), relative=True)
+
+
+def codex_edit_preview(changes: Any) -> dict | None:
+  """Build a unified preview from Codex FileUpdateChange dictionaries."""
+  if not isinstance(changes, list):
+    return None
+  sections: list[str] = []
+  for change in changes:
+    if not isinstance(change, dict):
+      continue
+    path = change.get("path")
+    patch = change.get("diff")
+    if not isinstance(path, str) or not path or not isinstance(patch, str):
+      continue
+    if patch.startswith("diff --git "):
+      sections.append(patch)
+      continue
+    raw_kind = change.get("kind")
+    kind = raw_kind if isinstance(raw_kind, dict) else {}
+    kind_type = str(kind.get("type") or "update")
+    move_path = kind.get("move_path")
+    new_path = move_path if isinstance(move_path, str) and move_path else path
+    header = [
+      "diff --git "
+      f"{_git_path('a', path)} {_git_path('b', new_path)}",
+    ]
+    if kind_type == "add":
+      header.extend([
+        "new file mode 100644",
+        "--- /dev/null",
+        f"+++ {_git_path('b', new_path)}",
+      ])
+    elif kind_type == "delete":
+      header.extend([
+        "deleted file mode 100644",
+        f"--- {_git_path('a', path)}",
+        "+++ /dev/null",
+      ])
+    else:
+      if new_path != path:
+        header.extend([
+          f"rename from {_quoted_path(path)}",
+          f"rename to {_quoted_path(new_path)}",
+        ])
+      header.extend([
+        f"--- {_git_path('a', path)}",
+        f"+++ {_git_path('b', new_path)}",
+      ])
+    sections.append("\n".join([*header, patch]))
+  return _bounded_preview("\n".join(sections))

--- a/backend/tests/test_claude_sdk_runner.py
+++ b/backend/tests/test_claude_sdk_runner.py
@@ -1258,6 +1258,26 @@ def test_dispatch_claude_edit_carries_shared_diff_preview(tmp_path):
   assert "-before\n+after" in bus.events[1]["edit_preview"]["diff"]
 
 
+def test_failed_claude_edit_result_carries_explicit_failure_status():
+  bus = _Bus()
+  msg = UserMessage(content=[ToolResultBlock(
+    tool_use_id="edit-1",
+    content="old_string was not found",
+    is_error=True,
+  )])
+
+  dispatch_sdk_message(msg, bus, None)
+
+  assert bus.events[0] == {
+    "type": "tool_output",
+    "content": "old_string was not found",
+    "tool_use_id": "edit-1",
+    "output_complete": True,
+    "output_exit_code": 1,
+  }
+  assert bus.events[1] == {"type": "tool_end", "tool_use_id": "edit-1"}
+
+
 def test_dispatch_skill_tool_emits_skill_loaded_and_logs(monkeypatch):
   """A Skill tool_use emits a skill_loaded event AFTER its tool_start
   and appends one skill_loaded record to the activity log."""

--- a/backend/tests/test_claude_sdk_runner.py
+++ b/backend/tests/test_claude_sdk_runner.py
@@ -1239,6 +1239,25 @@ def test_dispatch_assistant_tool_use_emits_tool_start():
   assert "tool_start" in types
 
 
+def test_dispatch_claude_edit_carries_shared_diff_preview(tmp_path):
+  path = tmp_path / "app.py"
+  bus = _Bus()
+  msg = AssistantMessage(
+    content=[ToolUseBlock(id="edit-1", name="Edit", input={
+      "file_path": str(path),
+      "old_string": "before",
+      "new_string": "after",
+    })],
+    model="claude-opus",
+  )
+
+  dispatch_sdk_message(msg, bus, None)
+
+  assert [event["type"] for event in bus.events] == ["tool_start", "tool_input"]
+  assert bus.events[1]["input"] == str(path)
+  assert "-before\n+after" in bus.events[1]["edit_preview"]["diff"]
+
+
 def test_dispatch_skill_tool_emits_skill_loaded_and_logs(monkeypatch):
   """A Skill tool_use emits a skill_loaded event AFTER its tool_start
   and appends one skill_loaded record to the activity log."""

--- a/backend/tests/test_tool_edit_preview.py
+++ b/backend/tests/test_tool_edit_preview.py
@@ -1,0 +1,116 @@
+"""Provider edit tools preserve bounded, renderable diff previews."""
+
+from app.codex_events import _tool_start_event
+from app.events import process_event
+from app.tool_edit_preview import (
+  MAX_EDIT_PREVIEW_CHARS,
+  claude_edit_preview,
+  codex_edit_preview,
+)
+
+
+def test_claude_edit_preview_uses_only_the_supplied_selection(tmp_path):
+  path = tmp_path / "hello world.py"
+  preview = claude_edit_preview("Edit", {
+    "file_path": str(path),
+    "old_string": "old value",
+    "new_string": "new value",
+  })
+
+  assert preview["relative"] is True
+  assert preview["truncated"] is False
+  assert f'"a/{path}" "b/{path}"' in preview["diff"]
+  assert "@@ -1 +1 @@" in preview["diff"]
+  assert "-old value\n+new value" in preview["diff"]
+
+
+def test_claude_multi_edit_preview_keeps_each_selection_as_one_hunk(tmp_path):
+  preview = claude_edit_preview("MultiEdit", {
+    "file_path": str(tmp_path / "app.py"),
+    "edits": [
+      {"old_string": "before", "new_string": "after"},
+      {"old_string": "left", "new_string": "right"},
+    ],
+  })
+
+  assert preview["relative"] is True
+  assert "-before\n+after" in preview["diff"]
+  assert "-left\n+right" in preview["diff"]
+  assert preview["diff"].count("@@ -1 +1 @@") == 2
+
+
+def test_codex_patch_preview_keeps_multiple_file_kinds_and_bounds_payload():
+  preview = codex_edit_preview([
+    {
+      "path": "/data/hello world.py",
+      "kind": {"type": "update"},
+      "diff": "@@ -1 +1 @@\n-old\n+new",
+    },
+    {
+      "path": "new.py",
+      "kind": {"type": "add"},
+      "diff": "@@ -0,0 +1 @@\n+hello",
+    },
+  ])
+
+  assert 'diff --git "a//data/hello world.py"' in preview["diff"]
+  assert "new file mode 100644" in preview["diff"]
+  assert "diff --git a/new.py b/new.py" in preview["diff"]
+
+  large = codex_edit_preview([{
+    "path": "large.txt",
+    "kind": {"type": "add"},
+    "diff": "@@ -0,0 +1 @@\n+" + ("x" * (MAX_EDIT_PREVIEW_CHARS + 100)),
+  }])
+  assert large["truncated"] is True
+  assert len(large["diff"]) == MAX_EDIT_PREVIEW_CHARS
+
+
+def test_preview_quoting_preserves_unicode_paths():
+  preview = codex_edit_preview([{
+    "path": "/data/café file.py",
+    "kind": {"type": "update"},
+    "diff": "@@ -1 +1 @@\n-old\n+new",
+  }])
+
+  assert '"a//data/café file.py"' in preview["diff"]
+  assert "\\u00e9" not in preview["diff"]
+
+
+def test_codex_file_change_start_carries_shared_edit_preview():
+  class FileChangeThreadItem:
+    changes = [{
+      "path": "src/app.js",
+      "kind": {"type": "update"},
+      "diff": "@@ -1 +1 @@\n-old\n+new",
+    }]
+
+  sdk = {
+    "CommandExecutionThreadItem": type("CommandExecutionThreadItem", (), {}),
+    "FileChangeThreadItem": FileChangeThreadItem,
+    "McpToolCallThreadItem": type("McpToolCallThreadItem", (), {}),
+    "DynamicToolCallThreadItem": type("DynamicToolCallThreadItem", (), {}),
+    "WebSearchThreadItem": type("WebSearchThreadItem", (), {}),
+  }
+
+  event = _tool_start_event(FileChangeThreadItem(), sdk)
+  assert event["tool"] == "Edit"
+  assert event["input"] == "src/app.js"
+  assert "-old\n+new" in event["edit_preview"]["diff"]
+
+
+def test_tool_lifecycle_persists_preview_from_start_and_input_updates():
+  first = {"diff": "diff --git a/a b/a", "truncated": False}
+  final = {"diff": "diff --git a/a b/a\n@@ -1 +1 @@\n-a\n+b", "truncated": False}
+  blocks = []
+
+  process_event({
+    "type": "tool_start", "tool": "Edit", "input": "a",
+    "tool_use_id": "edit-1", "edit_preview": first,
+  }, blocks)
+  process_event({
+    "type": "tool_input", "input": "a", "tool_use_id": "edit-1",
+    "edit_preview": final,
+  }, blocks)
+
+  assert blocks[0]["edit_preview"] == final

--- a/frontend/src/components/ChatView/ChatView.css
+++ b/frontend/src/components/ChatView/ChatView.css
@@ -1101,6 +1101,103 @@
   gap: 8px;
 }
 
+.chat__tool-diff-section { gap: 5px; }
+
+.chat__tool-diff-files {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0;
+}
+
+.chat__tool-diff-file {
+  min-width: 0;
+  overflow: hidden;
+  border: 1px solid var(--border-light);
+  border-radius: 8px;
+  background: var(--bg);
+}
+
+.chat__tool-diff-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  min-height: 30px;
+  padding: 4px 8px;
+  border-bottom: 1px solid var(--border-light);
+  background: var(--surface2);
+}
+
+.chat__tool-diff-head code {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text);
+  font: 500 11.5px/1.35 var(--mono);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chat__tool-diff-stat {
+  display: inline-flex;
+  flex: 0 0 auto;
+  gap: 6px;
+  font: 600 11px/1.2 var(--mono);
+  font-variant-numeric: tabular-nums;
+}
+
+.chat__tool-diff-add { color: var(--green); }
+.chat__tool-diff-delete { color: var(--danger); }
+
+.chat__tool-diff-scroll {
+  min-width: 0;
+  /* The chat transcript owns vertical scrolling. A capped scroller here made
+     wheel and trackpad gestures stop inside the diff, especially once they hit
+     an edge. Keep this surface horizontally scrollable for long code lines,
+     but let its full height participate in the one continuous transcript. */
+  overflow-x: auto;
+  overflow-y: hidden;
+}
+
+/* Shell scrollbars stay hidden on touch devices. On pointer-accurate web
+   clients, opt this genuinely two-dimensional content back into a visible
+   horizontal affordance instead of requiring Shift+wheel discovery. */
+@media (hover: hover) and (pointer: fine) {
+  .chat__tool-diff-scroll {
+    --shell-scrollbar-width: thin;
+    --shell-scrollbar-display: block;
+    scrollbar-color: color-mix(in srgb, var(--muted) 32%, transparent) transparent;
+  }
+
+  .chat__tool-diff-scroll::-webkit-scrollbar { height: 10px; }
+  .chat__tool-diff-scroll::-webkit-scrollbar-thumb {
+    border: 3px solid transparent;
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--muted) 32%, transparent);
+    background-clip: padding-box;
+  }
+}
+
+.chat__tool-diff-scroll .diff-view {
+  border: 0;
+  border-radius: 0;
+}
+
+.chat__tool-diff-section--relative .diff-view__hunk-header {
+  grid-template-columns: minmax(max-content, 1fr);
+}
+
+.chat__tool-diff-section--relative .diff-view__line {
+  grid-template-columns: 2ch minmax(max-content, 1fr);
+}
+
+.chat__tool-diff-section--relative :is(
+  .diff-view__hunk-gutter,
+  .diff-view__numbers
+) {
+  display: none;
+}
+
 .chat__tool-copy {
   display: inline-flex;
   align-items: center;

--- a/frontend/src/components/ChatView/ToolBlock.jsx
+++ b/frontend/src/components/ChatView/ToolBlock.jsx
@@ -1,6 +1,10 @@
 import { useEffect, useId, useMemo, useRef, useState } from 'react'
 import { Check, Copy } from '@openai/apps-sdk-ui/components/Icon'
-import { formatToolResult, toolResultCopyText } from './toolResultFormat.js'
+import {
+  formatToolResult,
+  toolBlockFailed,
+  toolResultCopyText,
+} from './toolResultFormat.js'
 import { copyPlainText } from './messageCopy.js'
 import { fetchLazyText } from './lazySidecar.js'
 import {
@@ -125,12 +129,13 @@ function GenericToolBlock({ t, chatId, compact = false, disclosureKey }) {
   const iconKind = toolActivityIcon(effectiveName)
   const isImageTool = effectiveName === 'ViewImage'
   const hasEditPreview = typeof t.edit_preview?.diff === 'string'
+  const failed = toolBlockFailed(t)
   // Historical activities can contain many closed edits. Keep the durable
   // marker cheap and defer parsing until this disclosure is prepared.
   const wantsPreparation = prepareRequested || desiredOpen
   const editPreview = useMemo(
-    () => (wantsPreparation ? toolEditPreview(t.edit_preview) : null),
-    [t.edit_preview, wantsPreparation],
+    () => (wantsPreparation && !failed ? toolEditPreview(t.edit_preview) : null),
+    [failed, t.edit_preview, wantsPreparation],
   )
   const durableImage = useMemo(() => (
     isImageTool ? durableImageReference(t.input) : null
@@ -275,7 +280,6 @@ function GenericToolBlock({ t, chatId, compact = false, disclosureKey }) {
   const exitCode = t.output_exit_code != null
     ? t.output_exit_code
     : (r && r.kind === 'terminal' ? r.exitCode : null)
-  const failed = exitCode != null && exitCode !== 0
   const excerptOnly = !!t.output_truncated && (
     t.status === 'running'
     || missingOutput

--- a/frontend/src/components/ChatView/ToolBlock.jsx
+++ b/frontend/src/components/ChatView/ToolBlock.jsx
@@ -22,6 +22,8 @@ import {
   textSelectionSnapshot,
 } from '../../lib/selectableTextControl.js'
 import { useToolImagePreview } from './useToolImagePreview.js'
+import ToolEditPreview from './ToolEditPreview.jsx'
+import { toolEditPreview } from './toolEditPreview.js'
 
 // Render an already-formatted tool result (see toolResultFormat.js) so shell
 // output reads as a terminal (stdout / stderr / exit code) and a structured
@@ -122,6 +124,14 @@ function GenericToolBlock({ t, chatId, compact = false, disclosureKey }) {
   const label = toolCallLabel(t)
   const iconKind = toolActivityIcon(effectiveName)
   const isImageTool = effectiveName === 'ViewImage'
+  const hasEditPreview = typeof t.edit_preview?.diff === 'string'
+  // Historical activities can contain many closed edits. Keep the durable
+  // marker cheap and defer parsing until this disclosure is prepared.
+  const wantsPreparation = prepareRequested || desiredOpen
+  const editPreview = useMemo(
+    () => (wantsPreparation ? toolEditPreview(t.edit_preview) : null),
+    [t.edit_preview, wantsPreparation],
+  )
   const durableImage = useMemo(() => (
     isImageTool ? durableImageReference(t.input) : null
   ), [isImageTool, t.input])
@@ -129,7 +139,7 @@ function GenericToolBlock({ t, chatId, compact = false, disclosureKey }) {
   // end of the message (MessageSources), where they belong to the answer
   // rather than to the one search that found them. They deliberately do not
   // make a tool row expandable on their own.
-  const hasDetail = !!(t.input || t.output || t.output_truncated)
+  const hasDetail = !!(t.input || t.output || t.output_truncated || hasEditPreview)
 
   useEffect(() => {
     // `loadingPreview` is intentionally not a dependency or start guard. Setting
@@ -243,7 +253,6 @@ function GenericToolBlock({ t, chatId, compact = false, disclosureKey }) {
     && t.tool_use_id
   )
   const previewReady = !waitsForPreview
-  const wantsPreparation = prepareRequested || desiredOpen
   const imagePreview = useToolImagePreview(imageReference, {
     enabled: isImageTool && wantsPreparation && previewReady,
     onSettled: revealBeforeReady,
@@ -474,7 +483,9 @@ function GenericToolBlock({ t, chatId, compact = false, disclosureKey }) {
         <div
           ref={detailRef}
           id={detailId}
-          className="chat__tool-detail"
+          className={`chat__tool-detail${
+            editPreview ? ' chat__tool-detail--edit' : ''
+          }`}
           role="region"
           aria-labelledby={headerId}
           tabIndex={open ? 0 : undefined}
@@ -493,6 +504,7 @@ function GenericToolBlock({ t, chatId, compact = false, disclosureKey }) {
               </pre>
             </div>
           )}
+          {open && editPreview && <ToolEditPreview preview={editPreview} />}
           {open && (r || t.output_truncated || isImageTool) && (
             <div className={isImageTool ? 'chat__tool-image-result' : 'chat__tool-section'}>
               {!isImageTool && (

--- a/frontend/src/components/ChatView/ToolEditPreview.css
+++ b/frontend/src/components/ChatView/ToolEditPreview.css
@@ -1,0 +1,12 @@
+/* Edit previews belong to the transcript's one vertical scroll surface. */
+
+/* Generic command/result details are deliberately capped. An edit diff is
+   different: it is reading content, already bounded at the provider boundary,
+   and its own code surface handles long lines horizontally. Letting the generic
+   200px detail scroller survive here creates two vertical owners; wheel/touch
+   gestures then spill from the tool into the transcript and make the dynamic
+   tail reservation appear to jump. */
+.chat__tool-detail.chat__tool-detail--edit {
+  max-height: none;
+  overflow-y: visible;
+}

--- a/frontend/src/components/ChatView/ToolEditPreview.jsx
+++ b/frontend/src/components/ChatView/ToolEditPreview.jsx
@@ -1,0 +1,51 @@
+/* Render an edit tool's changed files as immediately visible diffs. */
+
+import DiffView from '../DiffView/DiffView.jsx'
+import './ToolEditPreview.css'
+
+function FileStat({ file }) {
+  return (
+    <span
+      className="chat__tool-diff-stat"
+      role="img"
+      aria-label={`${file.insertions || 0} additions, ${file.deletions || 0} deletions`}
+    >
+      <span className="chat__tool-diff-add">+{file.insertions || 0}</span>
+      <span className="chat__tool-diff-delete">−{file.deletions || 0}</span>
+    </span>
+  )
+}
+
+export default function ToolEditPreview({ preview }) {
+  if (!preview?.files?.length) return null
+  return (
+    <div className={`chat__tool-section chat__tool-diff-section${
+      preview.relative ? ' chat__tool-diff-section--relative' : ''
+    }`}>
+      <span className="chat__tool-section-label">Changes</span>
+      <div className="chat__tool-diff-files">
+        {preview.files.map((file, index) => (
+          <div className="chat__tool-diff-file" key={`${file.path}-${index}`}>
+            <div className="chat__tool-diff-head">
+              <code title={file.path}>{file.path || 'Unknown file'}</code>
+              <FileStat file={file} />
+            </div>
+            <div className="chat__tool-diff-scroll">
+              <DiffView file={file} />
+            </div>
+          </div>
+        ))}
+      </div>
+      {preview.relative && (
+        <span className="chat__tool-output-more">
+          Preview is based on the edited selection.
+        </span>
+      )}
+      {preview.truncated && (
+        <span className="chat__tool-output-more">
+          Diff preview truncated.
+        </span>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/ChatView/__tests__/streamReducers.test.js
+++ b/frontend/src/components/ChatView/__tests__/streamReducers.test.js
@@ -31,6 +31,7 @@ import {
   repairInterleavedQuestionText,
   replaceTextItem,
   startToolLifecycle,
+  attachToolInput,
 } from '../streamReducers.js'
 import { questionKey } from '../questionKey.js'
 
@@ -56,6 +57,35 @@ test('Codex tool start preserves provider-neutral Memory recall metadata', () =>
   })
   assert.deepEqual(items[0].recall, { status: 'searching' })
   assert.equal(items[0].tool_use_id, 'cmd-1')
+})
+
+test('tool start preserves the shared edit preview for either provider', () => {
+  const editPreview = {
+    diff: 'diff --git a/a b/a\n@@ -1 +1 @@\n-a\n+b',
+    truncated: false,
+  }
+  const items = startToolLifecycle([], {
+    tool: 'Edit', input: 'a', tool_use_id: 'edit-1', edit_preview: editPreview,
+  })
+
+  assert.equal(items[0].edit_preview, editPreview)
+})
+
+test('a later Codex patch update replaces the live edit preview by identity', () => {
+  const first = { diff: 'diff --git a/a b/a', truncated: false }
+  const final = {
+    diff: 'diff --git a/a b/a\n@@ -1 +1 @@\n-a\n+b',
+    truncated: false,
+  }
+  const started = startToolLifecycle([], {
+    tool: 'Edit', input: 'a', tool_use_id: 'edit-1', edit_preview: first,
+  })
+  const updated = attachToolInput(started, {
+    type: 'tool_input', input: 'a', tool_use_id: 'edit-1', edit_preview: final,
+  })
+
+  assert.equal(updated[0].edit_preview, final)
+  assert.equal(started[0].edit_preview, first, 'the live snapshot stays immutable')
 })
 
 test('text item identity keeps late deltas before an interleaved question', () => {

--- a/frontend/src/components/ChatView/__tests__/toolBlockPresentation.test.js
+++ b/frontend/src/components/ChatView/__tests__/toolBlockPresentation.test.js
@@ -85,6 +85,14 @@ test('technical command failures stay behind the top-level disclosure', () => {
     'collapsed activity chrome stays visually neutral')
 })
 
+test('failed edit tools do not present proposed input as completed changes', () => {
+  assert.match(toolBlock, /const failed = toolBlockFailed\(t\)/)
+  assert.match(
+    toolBlock,
+    /wantsPreparation && !failed \? toolEditPreview\(t\.edit_preview\) : null/,
+  )
+})
+
 test('viewed images expand directly without repeating their path or result card', () => {
   assert.match(toolBlock, /open && t\.input && !isImageTool/,
     'the disclosure row already names a viewed image path')

--- a/frontend/src/components/ChatView/__tests__/toolBlockPresentation.test.js
+++ b/frontend/src/components/ChatView/__tests__/toolBlockPresentation.test.js
@@ -5,6 +5,7 @@ import assert from 'node:assert/strict'
 const toolBlock = readFileSync(new URL('../ToolBlock.jsx', import.meta.url), 'utf8')
 const toolImageResult = readFileSync(new URL('../ToolImageResult.jsx', import.meta.url), 'utf8')
 const toolImagePreview = readFileSync(new URL('../useToolImagePreview.js', import.meta.url), 'utf8')
+const toolEditPreviewCss = readFileSync(new URL('../ToolEditPreview.css', import.meta.url), 'utf8')
 const activityHeader = readFileSync(new URL('../ActivityLineHeader.jsx', import.meta.url), 'utf8')
 const chatCss = readFileSync(new URL('../ChatView.css', import.meta.url), 'utf8')
 const indexCss = readFileSync(new URL('../../../index.css', import.meta.url), 'utf8')
@@ -57,6 +58,19 @@ test('tool detail is a third nested level with labeled command and output', () =
     'only a settled empty command reports No output')
   assert.match(chatCss, /\.chat__activity-timeline \.chat__tool-detail\s*\{[^}]*margin-inline-start:\s*20px/s,
     'output aligns beneath the child label')
+})
+
+test('edit detail hands vertical scrolling to the transcript', () => {
+  assert.match(toolBlock,
+    /editPreview \? ' chat__tool-detail--edit' : ''/,
+    'only a successfully parsed edit preview escapes the generic output cap')
+  const editRule = toolEditPreviewCss.match(
+    /\.chat__tool-detail\.chat__tool-detail--edit\s*\{[^}]*\}/s,
+  )?.[0] || ''
+  assert.match(editRule, /max-height:\s*none/)
+  assert.match(editRule, /overflow-y:\s*visible/,
+    'an edit card must not retain a second vertical scroll owner')
+  assert.doesNotMatch(editRule, /overflow-y:\s*(?:auto|scroll)/)
 })
 
 test('technical command failures stay behind the top-level disclosure', () => {

--- a/frontend/src/components/ChatView/__tests__/toolEditPreview.test.js
+++ b/frontend/src/components/ChatView/__tests__/toolEditPreview.test.js
@@ -1,0 +1,86 @@
+/* Both provider diff shapes parse into the canonical viewer model. */
+
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+import { toolEditPreview } from '../toolEditPreview.js'
+import ToolEditPreview from '../ToolEditPreview.jsx'
+
+test('Codex multi-file patches retain paths, kinds, and line stats', () => {
+  const preview = toolEditPreview({
+    diff: [
+      'diff --git "a//data/café file.js" "b//data/café file.js"',
+      '--- "a//data/café file.js"',
+      '+++ "b//data/café file.js"',
+      '@@ -1 +1 @@',
+      '-old',
+      '+new',
+      'diff --git a/new.js b/new.js',
+      'new file mode 100644',
+      '--- /dev/null',
+      '+++ b/new.js',
+      '@@ -0,0 +1 @@',
+      '+hello',
+    ].join('\n'),
+    truncated: false,
+  })
+
+  assert.deepEqual(preview.files.map(file => file.path), [
+    '/data/café file.js',
+    'new.js',
+  ])
+  assert.deepEqual(preview.files.map(file => file.status), ['M', 'A'])
+  assert.deepEqual(
+    preview.files.map(file => [file.insertions, file.deletions]),
+    [[1, 1], [1, 0]],
+  )
+})
+
+test('Claude detached edits retain the honest relative-line marker', () => {
+  const preview = toolEditPreview({
+    diff: [
+      'diff --git a/file.js b/file.js',
+      '--- a/file.js',
+      '+++ b/file.js',
+      '@@ -1 +1 @@',
+      '-before',
+      '+after',
+    ].join('\n'),
+    relative: true,
+    truncated: true,
+  })
+
+  assert.equal(preview.relative, true)
+  assert.equal(preview.truncated, true)
+  assert.equal(preview.files[0].hunks[0].header, 'Changed selection')
+  assert.equal(preview.files[0].hunks[0].lines[1].text, 'after')
+})
+
+test('missing or unparsable previews remain an ordinary absent detail', () => {
+  assert.equal(toolEditPreview(null), null)
+  assert.equal(toolEditPreview({ diff: 'not a unified diff' }), null)
+})
+
+test('expanded preview renders changed lines and provider result metadata', () => {
+  const preview = toolEditPreview({
+    diff: [
+      'diff --git a/app.js b/app.js',
+      '--- a/app.js',
+      '+++ b/app.js',
+      '@@ -1 +1 @@',
+      '-before',
+      '+after',
+    ].join('\n'),
+    truncated: true,
+  })
+  const html = renderToStaticMarkup(createElement(ToolEditPreview, { preview }))
+
+  assert.match(html, />Changes</)
+  assert.match(html, />app\.js</)
+  assert.match(html, />before</)
+  assert.match(html, />after</)
+  assert.match(html, />\+1</)
+  assert.match(html, /Diff preview truncated\./)
+})

--- a/frontend/src/components/ChatView/__tests__/toolOutputLazy.test.js
+++ b/frontend/src/components/ChatView/__tests__/toolOutputLazy.test.js
@@ -49,6 +49,18 @@ test('explicit copy fetches full output without retaining it in React state', ()
     'copy success and failure are announced independently of the button label')
 })
 
+test('edit previews parse only when their tool disclosure is prepared', () => {
+  const src = readFileSync(new URL('../ToolBlock.jsx', import.meta.url), 'utf8')
+  assert.match(src, /const hasEditPreview = typeof t\.edit_preview\?\.diff === 'string'/,
+    'a cheap durable marker keeps a closed edit row inspectable')
+  assert.match(src,
+    /const wantsPreparation = prepareRequested \|\| desiredOpen[\s\S]*?wantsPreparation \? toolEditPreview\(t\.edit_preview\) : null/,
+    'opening a historical activity must not parse every still-closed diff')
+  assert.match(src,
+    /t\.input \|\| t\.output \|\| t\.output_truncated \|\| hasEditPreview/,
+    'deferring the parse must not turn the closed edit row into a dead label')
+})
+
 test('the live stream forwards reduction metadata into its tool item', () => {
   const src = readFileSync(new URL('../useStreamConnection.js', import.meta.url), 'utf8')
   assert.match(src, /attachToolOutput\(prev, event\.content, event\)/,

--- a/frontend/src/components/ChatView/__tests__/toolOutputLazy.test.js
+++ b/frontend/src/components/ChatView/__tests__/toolOutputLazy.test.js
@@ -54,7 +54,7 @@ test('edit previews parse only when their tool disclosure is prepared', () => {
   assert.match(src, /const hasEditPreview = typeof t\.edit_preview\?\.diff === 'string'/,
     'a cheap durable marker keeps a closed edit row inspectable')
   assert.match(src,
-    /const wantsPreparation = prepareRequested \|\| desiredOpen[\s\S]*?wantsPreparation \? toolEditPreview\(t\.edit_preview\) : null/,
+    /const wantsPreparation = prepareRequested \|\| desiredOpen[\s\S]*?wantsPreparation && !failed \? toolEditPreview\(t\.edit_preview\) : null/,
     'opening a historical activity must not parse every still-closed diff')
   assert.match(src,
     /t\.input \|\| t\.output \|\| t\.output_truncated \|\| hasEditPreview/,

--- a/frontend/src/components/ChatView/streamReducers.js
+++ b/frontend/src/components/ChatView/streamReducers.js
@@ -47,8 +47,46 @@ export function startToolLifecycle(prev, event) {
     output: '',
     status: 'running',
     ...(event?.recall ? { recall: event.recall } : {}),
+    ...(event?.edit_preview ? { edit_preview: event.edit_preview } : {}),
     ...(event?.tool_use_id ? { tool_use_id: event.tool_use_id } : {}),
   }]
+}
+
+/** Backfill a tool's final input and provider metadata through stable identity. */
+export function attachToolInput(prev, event) {
+  const updated = [...prev]
+  let i = event?.tool_use_id
+    ? updated.findIndex(
+        block => block.type === 'tool' && block.tool_use_id === event.tool_use_id,
+      )
+    : -1
+  if (i < 0 && event?.tool_use_id) {
+    let candidate = -1
+    for (let index = 0; index < updated.length; index += 1) {
+      const block = updated[index]
+      if (block.type !== 'tool' || block.status === 'done'
+          || block.tool_use_id || block.input) continue
+      if (candidate !== -1) {
+        candidate = -1
+        break
+      }
+      candidate = index
+    }
+    i = candidate
+  } else if (i < 0) {
+    i = updated.findIndex(block => block.type === 'tool' && !block.input)
+  }
+  if (i === -1) return prev
+  updated[i] = {
+    ...updated[i],
+    input: event?.input || '',
+    ...(event?.recall ? { recall: event.recall } : {}),
+    ...(event?.edit_preview ? { edit_preview: event.edit_preview } : {}),
+    ...(event?.tool_use_id && !updated[i].tool_use_id
+      ? { tool_use_id: event.tool_use_id }
+      : {}),
+  }
+  return updated
 }
 
 /**

--- a/frontend/src/components/ChatView/toolEditPreview.js
+++ b/frontend/src/components/ChatView/toolEditPreview.js
@@ -1,0 +1,26 @@
+/* Parse the bounded provider-neutral diff carried by edit tool blocks. */
+
+import { parseUnifiedDiff } from '../DiffView/parseUnifiedDiff.js'
+
+export function toolEditPreview(value) {
+  if (!value || typeof value !== 'object' || typeof value.diff !== 'string') {
+    return null
+  }
+  const relative = value.relative === true
+  const parsedFiles = parseUnifiedDiff(value.diff)
+  const files = relative
+    ? parsedFiles.map(file => ({
+        ...file,
+        hunks: file.hunks.map((hunk, index) => ({
+          ...hunk,
+          header: `Changed selection${file.hunks.length > 1 ? ` ${index + 1}` : ''}`,
+        })),
+      }))
+    : parsedFiles
+  if (files.length === 0) return null
+  return {
+    files,
+    relative,
+    truncated: value.truncated === true,
+  }
+}

--- a/frontend/src/components/ChatView/useStreamConnection.js
+++ b/frontend/src/components/ChatView/useStreamConnection.js
@@ -18,6 +18,7 @@ import {
   appendTextItem,
   replaceTextItem,
   startToolLifecycle,
+  attachToolInput,
 } from './streamReducers.js'
 import {
   readStoredStreamSnapshot,
@@ -974,44 +975,7 @@ export default function useStreamConnection(chatId, {
             // Backfill by stable identity. Older id-less events retain their
             // earliest-input-less fallback; a late id may be adopted only when
             // there is one unambiguous id-less candidate.
-            applyStreamItems(prev => {
-              const updated = [...prev]
-              let i = event.tool_use_id
-                ? updated.findIndex(
-                    b => b.type === 'tool' && b.tool_use_id === event.tool_use_id,
-                  )
-                : -1
-              if (i < 0 && event.tool_use_id) {
-                let candidate = -1
-                for (let idx = 0; idx < updated.length; idx++) {
-                  const block = updated[idx]
-                  if (block.type !== 'tool' || block.status === 'done'
-                      || block.tool_use_id || block.input) continue
-                  if (candidate !== -1) {
-                    candidate = -1
-                    break
-                  }
-                  candidate = idx
-                }
-                i = candidate
-              } else if (i < 0) {
-                i = updated.findIndex(b => b.type === 'tool' && !b.input)
-              }
-              if (i !== -1) {
-                updated[i] = {
-                  ...updated[i],
-                  input: event.input,
-                  // A Memory lookup names itself from its command, so the live
-                  // line can read "Searching Memory…" while the search runs
-                  // rather than a generic "Running a command".
-                  ...(event.recall ? { recall: event.recall } : {}),
-                  ...(event.tool_use_id && !updated[i].tool_use_id
-                    ? { tool_use_id: event.tool_use_id }
-                    : {}),
-                }
-              }
-              return updated
-            })
+            applyStreamItems(prev => attachToolInput(prev, event))
           } else if (event.type === 'tool_output') {
             // Targets the tool's stable identity; legacy id-less events use the
             // last open lifecycle. An absorbed question still swallows its


### PR DESCRIPTION
## Summary
- show Claude and Codex edit tools as per-file diffs inside their existing activity disclosures
- reuse the canonical diff parser and renderer instead of introducing a second diff system
- bound persisted preview payloads and defer parsing historical edits until their disclosure opens
- keep vertical scrolling owned by the transcript while preserving horizontal code scrolling
- preserve honest selection-relative presentation for Claude edits and full file metadata for Codex patches

## Why
Edit tools currently expose only command metadata, so reviewing what an agent changed requires leaving the conversation and reconstructing the edit elsewhere. Both providers already expose enough structured edit information to create a safe bounded preview.

The preview stays inside the existing tool lifecycle and canonical diff surface. It does not read files after the edit, retain whole-file bodies, or create another transcript scroll owner.

## Testing
- focused backend edit/event/runner suites (264 passed)
- focused frontend tool, stream reducer, and canonical diff suites (102 passed)
- clean current-upstream carrier with no diff warnings