### PR TITLE
Preserve an app chat’s selected provider on first send

### DIFF
--- a/backend/app/routes/chats_stream.py
+++ b/backend/app/routes/chats_stream.py
@@ -1033,8 +1033,18 @@ async def _send_message_locked(
     run_token = alloc_run_token()
     user_msg = _user_message_from_body(chat, body)
     owner = db.query(models.Owner).first()
-    default_provider = resolve_default_provider(
+    global_default_provider = resolve_default_provider(
       get_settings().data_dir, owner.provider if owner else None,
+    )
+    # An app-owned chat chooses its provider when the app creates the chat.
+    # Preserve that explicit contract through the first StartTurn instead of
+    # replacing it with whichever provider the owner most recently selected
+    # in an unrelated chat. Owner-created empty chats deliberately retain the
+    # live-default behavior documented by create_chat.
+    default_provider = (
+      (chat.provider or global_default_provider)
+      if chat.created_by_app_id is not None
+      else global_default_provider
     )
 
     ack = get_writer().submit(

--- a/backend/tests/test_app_chat_contract.py
+++ b/backend/tests/test_app_chat_contract.py
@@ -65,6 +65,75 @@ def test_app_token_can_create_and_send_to_own_chat(client, owner_token, db):
   assert r.status_code == 202, r.text
 
 
+def test_app_chat_first_send_preserves_provider_selected_at_create(
+  client, owner_token, db, monkeypatch,
+):
+  """An unrelated owner default cannot replace an app chat's provider."""
+  from app.routes import chats_stream
+
+  _, app_token = _make_app(client, owner_token, "provider-preserving-chat")
+  monkeypatch.setattr(
+    chats_stream, "resolve_default_provider", lambda *_: "claude",
+  )
+
+  for sender_token in (app_token, owner_token):
+    created = client.post(
+      "/api/app-chats",
+      json={"title": "Codex workflow", "provider": "codex"},
+      headers={"Authorization": f"Bearer {app_token}"},
+    )
+    assert created.status_code == 201, created.text
+    chat_id = created.json()["id"]
+
+    sent = client.post(
+      f"/api/chats/{chat_id}/messages",
+      json={"content": "run the selected workflow provider"},
+      headers={"Authorization": f"Bearer {sender_token}"},
+    )
+    assert sent.status_code == 202, sent.text
+    db.expire_all()
+    row = db.query(models.Chat).filter(models.Chat.id == chat_id).one()
+    assert row.provider == "codex"
+    run = db.query(models.ChatRun).filter(
+      models.ChatRun.chat_id == chat_id,
+    ).order_by(models.ChatRun.started_at.desc()).first()
+    assert run is not None
+    assert run.provider == "codex"
+
+
+def test_owner_chat_first_send_still_uses_live_default(
+  client, owner_token, db, monkeypatch,
+):
+  """The app-chat exception must not freeze an ordinary empty chat."""
+  from app.routes import chats_stream
+
+  created = client.post(
+    "/api/chats",
+    json={"title": "Empty owner chat"},
+    headers={"Authorization": f"Bearer {owner_token}"},
+  )
+  assert created.status_code == 200, created.text
+  chat_id = created.json()["id"]
+  monkeypatch.setattr(
+    chats_stream, "resolve_default_provider", lambda *_: "codex",
+  )
+
+  sent = client.post(
+    f"/api/chats/{chat_id}/messages",
+    json={"content": "use my current default"},
+    headers={"Authorization": f"Bearer {owner_token}"},
+  )
+  assert sent.status_code == 202, sent.text
+  db.expire_all()
+  row = db.query(models.Chat).filter(models.Chat.id == chat_id).one()
+  assert row.provider == "codex"
+  run = db.query(models.ChatRun).filter(
+    models.ChatRun.chat_id == chat_id,
+  ).order_by(models.ChatRun.started_at.desc()).first()
+  assert run is not None
+  assert run.provider == "codex"
+
+
 def test_owner_chat_list_includes_only_owner_visible_app_chats(
   client, owner_token, db
 ):


### PR DESCRIPTION
## Summary
- preserve the provider explicitly selected when an app creates a chat
- keep ordinary owner-created empty chats tied to the owner’s current default
- cover both app-token and owner-token first sends

## Why
An app-owned workflow chooses its provider when it creates the chat. The first message currently replaces that choice with whichever global provider the owner selected most recently in an unrelated chat. The run can therefore start on the wrong provider even though the chat was created correctly.

This keeps the app-owned creation contract authoritative without changing ordinary New Chat behavior.

## Testing
- `scripts/wt-pytest.sh -q backend/tests/test_app_chat_contract.py` (19 passed)