### PR TITLE
Keep composer caret and floating chat actions stable

### DIFF
--- a/frontend/src/components/ChatView/ChatInputBar.jsx
+++ b/frontend/src/components/ChatView/ChatInputBar.jsx
@@ -107,7 +107,10 @@ import {
   textareaUsesNativeSizing,
   syncComposerTallClass,
 } from './composerTextareaSizing.js'
-import { focusComposerElement } from './composerFocusPolicy.js'
+import {
+  focusComposerElement,
+  placeCaretAtTextEnd,
+} from './composerFocusPolicy.js'
 
 
 // Detect touch-primary once (same heuristic ChatView uses).
@@ -664,7 +667,7 @@ export default function ChatInputBar({
     onInputChange(value)
     // The textarea never lost focus (rows suppress pointerdown), but a click
     // accept still needs the caret put back after the controlled update.
-    inputRef?.current?.focus({ preventScroll: true })
+    focusComposerElement(inputRef?.current)
   }
 
   function handleKeyDown(e) {
@@ -832,7 +835,10 @@ export default function ChatInputBar({
               onChange={handleTextareaChange}
               onPaste={handlePaste}
               onKeyDown={handleKeyDown}
-              onFocus={() => setSlashInputFocused(true)}
+              onFocus={(event) => {
+                placeCaretAtTextEnd(event.currentTarget)
+                setSlashInputFocused(true)
+              }}
               onBlur={() => setSlashInputFocused(false)}
               placeholder="Message Möbius…"
               aria-label="Message Möbius…"

--- a/frontend/src/components/ChatView/ChatView.css
+++ b/frontend/src/components/ChatView/ChatView.css
@@ -1974,11 +1974,24 @@
 .chat__foot .chat__question-nudge,
 .chat__foot .chat__resume-nudge,
 .chat__foot .chat__jump-latest,
-.chat__foot .chat__open-app,
 .chat__foot .chat__progress-step--toggle,
 .chat__foot .slash-menu,
 .chat__foot .chat__pill,
 .chat__foot .composer-plus { pointer-events: auto; }
+
+/* One geometry-neutral stack for every control that floats above the measured
+   footer. Keeping cards and viewport cues in this same lane makes them clear
+   one another without changing --composer-h or the transcript scroll tail. */
+.chat__floating-actions {
+  position: absolute;
+  left: 12px;
+  right: 12px;
+  bottom: calc(100% + var(--chat-foot-card-gap));
+  display: flex;
+  flex-direction: column;
+  gap: var(--chat-foot-card-gap);
+  pointer-events: none;
+}
 
 /* Embedded composer: the app sheet (not the chat) owns the device
    safe area, so any `env(safe-area-inset-bottom)` reservation here
@@ -2269,20 +2282,17 @@
 }
 .chat__steer:hover { background: var(--accent-hover); /* CONTRACT: vivid opaque accent on hover */ }
 
-/* Pending-question nudge — shown in the foot when an unanswered
+/* Pending-question nudge — shown in the floating stack when an unanswered
    AskUserQuestion card sits outside the viewport, so the frozen turn
    doesn't read as a hang. A tap scrolls the card into view (user-initiated
    — the no-auto-scroll contract stays intact). Same frosted accent chip
    recipe as .chat__open-app-btn: it must read as a card over the chat
    scrolling behind the transparent foot. Centered, because it speaks for
-   the whole conversation rather than the queued tray. The positioning layer
-   sits immediately above the flow-owned footer: viewport visibility may mount
-   or unmount either nudge without changing transcript geometry. */
+   the whole conversation rather than the queued tray. Its parent stack owns
+   the absolute position; this lane only orders nearby floating controls. */
 .chat__offscreen-nudges {
-  position: absolute;
-  right: 12px;
-  bottom: 100%;
-  left: 12px;
+  width: min(100%, 720px);
+  margin: 0 auto;
   pointer-events: none;
 }
 
@@ -2960,8 +2970,8 @@
 }
 
 .chat__open-app {
-  max-width: 720px;
-  margin: 0 auto 8px;
+  width: min(100%, 720px);
+  margin: 0 auto;
   display: flex;
   /* One CTA row per built app, stacked and right-aligned (most recent last). */
   flex-direction: column;

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -3931,6 +3931,16 @@ export default function ChatView({
   const resumeCardOffscreen = useOffscreenNudge(
     scrollRef, hasPendingResume, resumeCardEl,
   )
+  const questionNudgeShown = hasPendingQuestion && pendingCardOffscreen
+  const resumeNudgeShown = hasPendingResume && resumeCardOffscreen
+  const jumpToLatestVisible = jumpToLatestShown({
+    awayFromTail: awayFromLatest,
+    questionNudgeShown,
+    resumeNudgeShown,
+  })
+  const offscreenControlsVisible = questionNudgeShown
+    || resumeNudgeShown
+    || jumpToLatestVisible
 
   // The ONE active <li> carries this data-key for both DB and live payloads.
   // ANCHOR_AT resolves `[data-key]`, so source selection must never change it.
@@ -4304,99 +4314,84 @@ export default function ChatView({
 
       <div ref={footRef} className="chat__foot">
         {/* Foot order, top to bottom:
-            attention actions → build-progress rail → connection/retry → queued
-            messages → composer. The shell owns the one persistent offline
-            explanation; the composer retains contextual send-failure copy. */}
-        {/* A LOST connection hides transient actions: while the terminal
-            'disconnected' state is set, nudges hide so the one thing on screen
-            is the problem and its Retry
-            (owner ask, 2026-07-17). ONLY 'disconnected' gates: 'retrying'
-            is a transient bare-EOF auto-reconnect that clears itself in
-            ~300ms — blanking and popping the whole stack on every mobile
-            blip would be flicker, not signal (review 2026-07-17; the
-            reconnect effect keys on the same distinction). The healthy
-            sleep/wake reattach note (`reconnecting`) likewise hides
-            nothing — the stream is being replaced, not failing. */}
-        {connectionError !== 'disconnected' && (
-          <>
-          {openAppCtas.length > 0 && (
-            <div className="chat__open-app">
-              {openAppCtas.map(({ app, vm }) => {
-                const pulsing = pulsedAppId === Number(app.id)
-                return (
-                  <button
-                    key={app.id}
-                    className={`chat__open-app-btn${pulsing ? ' chat__open-app-btn--pulse' : ''}`}
-                    aria-label={pulsing ? `Preview updated for ${app.name || 'app'}` : vm.ariaLabel}
-                    onClick={() => onOpenApp?.(app, { final: !turnActive })}
-                  >
-                    {pulsing ? 'Preview updated ✓' : `${vm.label} →`}
-                  </button>
-                )
-              })}
-            </div>
+            floating actions overlay the transcript without joining the measured
+            footer; build-progress rail → connection/retry → queued messages →
+            composer remain in normal footer flow. The shell owns the one persistent
+            offline explanation; the composer retains contextual send-failure copy. */}
+        <div className="chat__floating-actions">
+          {/* Contribution staged from THIS chat: approve it where the work
+              happened, but keep the transient card out of composer-height
+              measurement so confirmation cannot move the transcript. */}
+          {!embedded && (
+            <ContributionReviewCard
+              chatId={chatId}
+              turnActive={turnActive}
+              onOpenApp={onOpenApp}
+            />
           )}
-          <div className="chat__offscreen-nudges">
-            {hasPendingQuestion && pendingCardOffscreen && (
-              <button
-                type="button"
-                className="chat__question-nudge"
-                onClick={revealConversationTail}
-              >
-                Möbius asked you something — tap to answer
-              </button>
-            )}
-            {hasPendingResume && resumeCardOffscreen && (
-              <button
-                type="button"
-                className="chat__resume-nudge"
-                onClick={revealConversationTail}
-              >
-                {pendingResumeBlock?.pause?.resets_at
-                  ? 'Rate limit reached — tap to resume'
-                  : 'Turn paused — tap to resume'}
-              </button>
-            )}
-            {/* Jump-to-latest: same one-shot tail navigation as the nudges
-                (contract R5a — lands as a settled hold, never live-follow),
-                shown once the reader has scrolled away from the end. Yields
-                to a visible nudge, which goes to the same place with more
-                context. */}
-            {jumpToLatestShown({
-              awayFromTail: awayFromLatest,
-              questionNudgeShown: hasPendingQuestion && pendingCardOffscreen,
-              resumeNudgeShown: hasPendingResume && resumeCardOffscreen,
-            }) && (
-              <button
-                type="button"
-                className="chat__jump-latest"
-                aria-label="Jump to the latest message"
-                title="Jump to latest"
-                onClick={revealConversationTail}
-              >
-                <ArrowDown size={18} strokeWidth={2.25} aria-hidden="true" />
-              </button>
-            )}
-          </div>
-          </>
-        )}
+          {/* The viewport cues and post-turn cards share one floating stack so
+              they clear each other without entering footer or scroll geometry. */}
+          {connectionError !== 'disconnected' && (
+            <>
+              {offscreenControlsVisible && (
+                <div className="chat__offscreen-nudges">
+                  {questionNudgeShown && (
+                    <button
+                      type="button"
+                      className="chat__question-nudge"
+                      onClick={revealConversationTail}
+                    >
+                      Möbius asked you something — tap to answer
+                    </button>
+                  )}
+                  {resumeNudgeShown && (
+                    <button
+                      type="button"
+                      className="chat__resume-nudge"
+                      onClick={revealConversationTail}
+                    >
+                      {pendingResumeBlock?.pause?.resets_at
+                        ? 'Rate limit reached — tap to resume'
+                        : 'Turn paused — tap to resume'}
+                    </button>
+                  )}
+                  {jumpToLatestVisible && (
+                    <button
+                      type="button"
+                      className="chat__jump-latest"
+                      aria-label="Jump to the latest message"
+                      title="Jump to latest"
+                      onClick={revealConversationTail}
+                    >
+                      <ArrowDown size={18} strokeWidth={2.25} aria-hidden="true" />
+                    </button>
+                  )}
+                </div>
+              )}
+              {openAppCtas.length > 0 && (
+                <div className="chat__open-app">
+                  {openAppCtas.map(({ app, vm }) => {
+                    const pulsing = pulsedAppId === Number(app.id)
+                    return (
+                      <button
+                        key={app.id}
+                        className={`chat__open-app-btn${pulsing ? ' chat__open-app-btn--pulse' : ''}`}
+                        aria-label={pulsing ? `Preview updated for ${app.name || 'app'}` : vm.ariaLabel}
+                        onClick={() => onOpenApp?.(app, { final: !turnActive })}
+                      >
+                        {pulsing ? 'Preview updated ✓' : `${vm.label} →`}
+                      </button>
+                    )
+                  })}
+                </div>
+              )}
+            </>
+          )}
+        </div>
         <ProgressRail
           items={progressRail}
           ariaLabel={visibleGoalObjective ? 'Goal progress' : 'Build progress'}
         />
-        {/* Contribution staged from THIS chat: approve it where the work
-            happened. Renders nothing unless something is actually waiting.
-            Owner-shell only: an app-embedded chat runs on a capability token
-            that is deliberately scoped to one chat, so it can neither list apps
-            nor take a public GitHub action, and there is no owner surface there
-            to approve one. */}
-        {!embedded && (
-          <ContributionReviewCard
-            chatId={chatId}
-            turnActive={turnActive}
-            onOpenApp={onOpenApp}
-          />
-        )}
         <ConnectionStatus
           error={connectionError}
           reconnecting={reconnecting}

--- a/frontend/src/components/ChatView/ContributionReviewCard.css
+++ b/frontend/src/components/ChatView/ContributionReviewCard.css
@@ -1,14 +1,11 @@
-/* The chat's contribution review card — docked between the transcript and the
-   composer, so approving the work happens where the work happened. Deliberately
-   quieter than a chat message: it is a pending action, not part of the
-   conversation, and it disappears the moment nothing is staged. */
+/* The chat's contribution review card — floated over the transcript above the
+   composer, so approving the work happens where the work happened without its
+   arrival or confirmation moving the text. Deliberately quieter than a chat
+   message: it is a pending action, not part of the conversation. */
 
-/* The card is a child of `.chat__foot`, which is a transparent absolutely
-   positioned overlay with `pointer-events: none` so the transcript scrolls behind
-   the composer. Every real control in there has to opt back in — the composer
-   pill, the `+` button, the open-app row all do. Without this the card renders
-   perfectly and silently ignores every tap, because the hit test falls straight
-   through to the messages underneath. */
+/* The floating action layer is pointer-transparent so the transcript remains
+   usable around the card. The real card opts back in here. Without this it
+   renders perfectly and silently ignores every tap. */
 .contrib-card-stack,
 .contrib-card {
   pointer-events: auto;
@@ -18,7 +15,6 @@
   box-sizing: border-box;
   width: min(100%, 640px);
   margin-inline: auto;
-  margin-bottom: var(--chat-foot-card-gap);
   display: flex;
   flex-direction: column;
   gap: 8px;
@@ -27,7 +23,6 @@
 
 .contrib-card-stack--grouped {
   gap: 0;
-  margin-top: 8px;
   padding: 0;
   overflow-y: auto;
   overscroll-behavior: contain;
@@ -275,7 +270,7 @@
 }
 
 /* ONE scroller for the whole disclosure. An expanded review can be long (the
-   published text is quoted verbatim), and it is docked above the composer, so it
+   published text is quoted verbatim), and it floats above the composer, so it
    must not push the conversation off the screen. Nesting a second scroller
    inside the quoted text made the two fight on a phone. */
 .contrib-card__details {

--- a/frontend/src/components/ChatView/QuestionCard.jsx
+++ b/frontend/src/components/ChatView/QuestionCard.jsx
@@ -7,6 +7,7 @@ import {
   writeQuestionDraft,
 } from './questionDraft.js'
 import { textareaUsesNativeSizing } from './composerTextareaSizing.js'
+import { placeCaretAtTextEnd } from './composerFocusPolicy.js'
 import {
   pointerSelectionChangedWithin,
   textSelectionSnapshot,
@@ -82,6 +83,7 @@ function CustomAnswerArea({
       rows={1}
       value={value}
       onChange={e => onChange(e.target.value)}
+      onFocus={e => placeCaretAtTextEnd(e.currentTarget)}
       readOnly={answered}
       disabled={disabled && !answered}
       onKeyDown={e => {

--- a/frontend/src/components/ChatView/__tests__/composerFocusPolicy.test.js
+++ b/frontend/src/components/ChatView/__tests__/composerFocusPolicy.test.js
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict'
 
 import {
   focusComposerElement,
+  placeCaretAtTextEnd,
   shouldApplyComposerFocusRequest,
 } from '../composerFocusPolicy.js'
 
@@ -39,9 +40,15 @@ test('draft-only and embedded requests do not focus the composer', () => {
 
 test('focusComposerElement preserves scroll when the browser supports it', () => {
   const calls = []
-  const el = { focus: (...args) => calls.push(args) }
+  const selections = []
+  const el = {
+    value: 'saved draft',
+    focus: (...args) => calls.push(args),
+    setSelectionRange: (...args) => selections.push(args),
+  }
   assert.equal(focusComposerElement(el), true)
   assert.deepEqual(calls, [[{ preventScroll: true }]])
+  assert.deepEqual(selections, [[11, 11]])
 })
 
 test('focusComposerElement falls back for older focus implementations', () => {
@@ -54,4 +61,16 @@ test('focusComposerElement falls back for older focus implementations', () => {
   }
   assert.equal(focusComposerElement(el), true)
   assert.deepEqual(calls, [[{ preventScroll: true }], []])
+})
+
+test('text controls land at the end whenever their focus surface activates', () => {
+  const selections = []
+  const el = {
+    value: 'custom answer',
+    setSelectionRange: (...args) => selections.push(args),
+  }
+
+  assert.equal(placeCaretAtTextEnd(el), true)
+  assert.deepEqual(selections, [[13, 13]])
+  assert.equal(placeCaretAtTextEnd({ value: 'unsupported' }), false)
 })

--- a/frontend/src/components/ChatView/__tests__/contributionReviewModel.test.js
+++ b/frontend/src/components/ChatView/__tests__/contributionReviewModel.test.js
@@ -289,7 +289,7 @@ test('the payoff line matches who benefits and keeps acceptance conditional', ()
   for (const line of [platform, app]) assert.match(line, /^If it's accepted/)
 })
 
-test('the docked card reduces a multi-line diff stat to its aggregate', () => {
+test('the floating card reduces a multi-line diff stat to its aggregate', () => {
   assert.equal(
     diffStatSummary(
       ' frontend/src/a.js | 12 +++++\n backend/app/b.py | 3 ---\n 2 files changed, 12 insertions(+), 3 deletions(-)',

--- a/frontend/src/components/ChatView/__tests__/offlineFooter.test.js
+++ b/frontend/src/components/ChatView/__tests__/offlineFooter.test.js
@@ -6,9 +6,10 @@ const chatView = readFileSync(new URL('../ChatView.jsx', import.meta.url), 'utf8
 const chatInputBar = readFileSync(new URL('../ChatInputBar.jsx', import.meta.url), 'utf8')
 const connectionStatus = readFileSync(new URL('../ConnectionStatus.jsx', import.meta.url), 'utf8')
 const chatCss = readFileSync(new URL('../ChatView.css', import.meta.url), 'utf8')
+const scrollMode = readFileSync(new URL('../useScrollMode.js', import.meta.url), 'utf8')
 const shell = readFileSync(new URL('../../Shell/Shell.jsx', import.meta.url), 'utf8')
 
-test('footer stacks notices → rail → connection → queued → composer', () => {
+test('floating actions precede the measured rail → connection → queued → composer stack', () => {
   const footStart = chatView.indexOf('<div ref={footRef} className="chat__foot">')
   const composer = chatView.indexOf('<ChatInputBar', footStart)
   const foot = chatView.slice(footStart, composer)
@@ -23,6 +24,9 @@ test('footer stacks notices → rail → connection → queued → composer', ()
   )
   assert.ok(rail < connection, 'the progress rail stacks above connection/retry')
   assert.ok(connection < queued, 'connection/retry stacks directly above the queued input tray')
+  const floatingActions = foot.indexOf('className="chat__floating-actions"')
+  assert.ok(floatingActions >= 0 && floatingActions < rail,
+    'transient post-turn actions must render in the separate floating layer')
   for (const notice of [
     'className="chat__open-app"',
     'className="chat__question-nudge"',
@@ -31,8 +35,28 @@ test('footer stacks notices → rail → connection → queued → composer', ()
     const noticeIndex = foot.indexOf(notice)
     assert.ok(noticeIndex >= 0, `${notice} must be present in the footer`)
     assert.ok(noticeIndex < rail,
-      `${notice} must stack above the progress rail`)
+      `${notice} must render before the progress rail`)
   }
+  assert.match(
+    chatCss,
+    /\.chat__floating-actions\s*\{[\s\S]*?position:\s*absolute;[\s\S]*?bottom:\s*calc\(100% \+ var\(--chat-foot-card-gap\)\);[\s\S]*?pointer-events:\s*none;/,
+    'open-app and contribution actions must stay outside measured footer flow',
+  )
+  assert.match(
+    chatView,
+    /className="chat__floating-actions"[\s\S]*?<ContributionReviewCard[\s\S]*?className="chat__offscreen-nudges"[\s\S]*?className="chat__open-app"[\s\S]*?<ProgressRail/,
+    'cards and viewport cues should share one ordered overlay before measured footer content',
+  )
+  assert.match(
+    chatCss,
+    /\.chat__open-app\s*\{[\s\S]*?width:\s*min\(100%,\s*720px\);[\s\S]*?align-items:\s*flex-end;/,
+    'Open app keeps its original right edge inside the composer column',
+  )
+  assert.doesNotMatch(
+    scrollMode,
+    /floatingAction|floatingActions/,
+    'floating cards must not add or retain transcript spacer height',
+  )
 })
 
 test('the shell is the one persistent connection owner while send failures stay contextual', () => {

--- a/frontend/src/components/ChatView/__tests__/questionCardState.test.js
+++ b/frontend/src/components/ChatView/__tests__/questionCardState.test.js
@@ -40,6 +40,8 @@ test('unanswered question cards do not have a stale gray state', () => {
     'the custom answer should stay mounted and retain submitted custom text')
   assert.match(component, /rows=\{1\}/,
     'the custom answer should begin as one compact writing line')
+  assert.match(component, /onFocus=\{e => placeCaretAtTextEnd\(e\.currentTarget\)\}/,
+    'returning to a custom answer should put the caret after its saved text')
   assert.match(component, /readOnly=\{answered\}[\s\S]*?disabled=\{disabled && !answered\}/,
     'a submitted multiline answer should stay scrollable but not editable')
   assert.match(component, /resizeCustomAnswer|textareaUsesNativeSizing/,

--- a/frontend/src/components/ChatView/__tests__/resumeAffordance.test.js
+++ b/frontend/src/components/ChatView/__tests__/resumeAffordance.test.js
@@ -173,12 +173,18 @@ test('viewport-derived nudges never participate in footer geometry', () => {
     'the resume cue shares the same geometry owner')
 
   const layerCss = css.match(/\.chat__offscreen-nudges\s*\{[\s\S]*?\}/)?.[0] ?? ''
-  assert.match(layerCss, /position:\s*absolute/,
-    'showing or hiding a viewport cue must not resize the footer')
-  assert.match(layerCss, /bottom:\s*100%/,
-    'the cue remains immediately above the flow-owned footer controls')
+  assert.doesNotMatch(layerCss, /position:\s*absolute|bottom:/,
+    'the cue uses the shared floating stack instead of overlapping sibling cards')
+  assert.match(layerCss, /width:\s*min\(100%,\s*720px\)/,
+    'the cue stays inside the composer column')
   assert.match(layerCss, /pointer-events:\s*none/,
     'the overlay lane itself must not block transcript interaction')
+
+  const stackCss = css.match(/\.chat__floating-actions\s*\{[\s\S]*?\}/)?.[0] ?? ''
+  assert.match(stackCss, /position:\s*absolute/,
+    'the shared parent keeps every cue outside measured footer geometry')
+  assert.match(stackCss, /bottom:\s*calc\(100% \+ var\(--chat-foot-card-gap\)\)/,
+    'the shared stack clears every flow-owned footer control')
 
   const nudgeCss = css.match(
     /\.chat__question-nudge,\s*\n\.chat__resume-nudge\s*\{[\s\S]*?\}/,

--- a/frontend/src/components/ChatView/composerFocusPolicy.js
+++ b/frontend/src/components/ChatView/composerFocusPolicy.js
@@ -9,6 +9,17 @@ export function shouldApplyComposerFocusRequest({
   return String(focusRequest.chatId) === String(chatId)
 }
 
+export function placeCaretAtTextEnd(el) {
+  if (!el || typeof el.setSelectionRange !== 'function') return false
+  const end = String(el.value ?? '').length
+  try {
+    el.setSelectionRange(end, end)
+  } catch {
+    return false
+  }
+  return true
+}
+
 export function focusComposerElement(el) {
   if (!el || typeof el.focus !== 'function') return false
   try {
@@ -16,5 +27,6 @@ export function focusComposerElement(el) {
   } catch {
     el.focus()
   }
+  placeCaretAtTextEnd(el)
   return true
 }

--- a/frontend/src/components/Shell/composerFocusLease.js
+++ b/frontend/src/components/Shell/composerFocusLease.js
@@ -15,12 +15,7 @@ export function beginTouchComposerFocusLease(el, {
   if (!el || activeElement === el || typeof matchMediaImpl !== 'function') return false
   if (matchMediaImpl(TOUCH_PRIMARY_QUERY)?.matches !== true) return false
   el.value = String(initialValue)
-  const focused = focusComposerElement(el)
-  if (focused) {
-    const end = el.value.length
-    try { el.setSelectionRange?.(end, end) } catch {}
-  }
-  return focused
+  return focusComposerElement(el)
 }
 
 export function releaseComposerFocusLease(el, {


### PR DESCRIPTION
## Summary

- place the caret at the end of restored chat drafts and custom Q&A answers when they regain focus
- float Contribute and Open app actions without changing footer or transcript spacer geometry
- order review, attention, and app actions in one lane while keeping Open app right-aligned

## Root cause

Focus restoration returned the keyboard but did not own text selection. The review and app actions were part of the measured footer, while the question, resume, and jump controls used an independent overlay at the same anchor. Moving the cards without consolidating those owners either shifted the transcript or let controls overlap.

## Testing

- component/library tests: 2,459 passed
- hook tests: 79 passed
- focused live-tree tests: 69 passed
- authenticated rendered geometry check: combined actions did not intersect or change scroll, spacer, or footer height
- local production build validation was deferred twice by the memory-admission guard before compilation began

## Prior work

Builds on #523, which preserved composer focus through picker interactions. This extends the shared focus policy to caret placement and separately fixes post-turn action geometry.