### PR TITLE
Keep touch tab actions on the shared hold timer

### DIFF
--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -722,6 +722,11 @@ test('one held drawer-row gesture resolves menu, reorder, or workspace drag', ()
     'a stationary tab hold opens actions from the shared hold timer, while still held')
   assert.doesNotMatch(drawerPointerUp, /openTabMenuAtRef/,
     'releasing a tab hold no longer opens actions — the hold timer does, like the drawer')
+  assert.match(
+    dragBinding,
+    /ctxListener = \(ev\) => \{[\s\S]*?preventDefault\(\)[\s\S]*?stopImmediatePropagation\(\)/,
+    'touch contextmenu must not bypass the shared hold timer',
+  )
   assert.doesNotMatch(dragBinding, /addEventListener\('touchmove'/)
   assert.match(shell, /const drawerRowGesturesRef = useRef\(new Map\(\)\)/)
   assert.match(drawer, /const registry = drawerRowGesturesRef\.current[\s\S]*?registry\.set\(key, drawerGestureHandlerRef\)/)

--- a/frontend/src/components/Shell/useWorkspaceDrag.js
+++ b/frontend/src/components/Shell/useWorkspaceDrag.js
@@ -362,7 +362,9 @@ export default function useWorkspaceDrag({
 
       // iOS callout/selection suppression begins NOW (pointerdown), scoped to the
       // source, for the WHOLE hold window — not at arm, when the magnifier has
-      // already won. `contextmenu` is prevented for a touch source too.
+      // already won. Swallow touch `contextmenu` in capture phase so it cannot
+      // bypass the shared hold timer through a tab or row's own handler. Mouse
+      // right-click is untouched because this listener exists only for touch.
       let ctxListener = null
       if (isTouch) {
         prevBodySelect = document.body.style.userSelect
@@ -370,7 +372,10 @@ export default function useWorkspaceDrag({
         document.body.style.webkitUserSelect = 'none'
         srcEl.style.webkitTouchCallout = 'none'
         srcEl.style.userSelect = 'none'
-        ctxListener = (ev) => ev.preventDefault()
+        ctxListener = (ev) => {
+          ev.preventDefault()
+          ev.stopImmediatePropagation()
+        }
         window.addEventListener('contextmenu', ctxListener, true)
       }
 


### PR DESCRIPTION
## Summary
- swallow touch-generated `contextmenu` before tab or drawer-row handlers can see it
- keep touch actions on the existing movement-aware hold timer
- leave mouse right-click behavior unchanged

## Why
The drag owner prevented the native touch callout but still let the same `contextmenu` event reach React handlers. That opened actions on the browser's long-press threshold and bypassed the shared hold delay entirely.

This follows the touch-interaction ownership established in #574 and closes the remaining tab/row event path without adding another timer.

## Testing
- workspace UI suite (88 passed)
- structural-test budget
- ESLint (0 errors)
- `git diff --check`