### PR TITLE
Make shell reload handoffs generation-safe

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -229,92 +229,14 @@
       // navigator.serviceWorker throws there, and it must not register or
       // control a worker anyway. Keep the stripped route entirely in-memory.
       if (window.location.pathname !== '/shell/embed/chat' && 'serviceWorker' in navigator) {
-        // The flag prevents a reload loop during one update handoff. Clear it
-        // on the next page load so later shell rebuilds in the same PWA
-        // session can still auto-activate.
-        if (sessionStorage.getItem('sw-auto-reloaded') === '1') {
-          sessionStorage.removeItem('sw-auto-reloaded')
-        }
-        // `sw-skip-initiated` is a one-shot marker Shell.performShellReload sets
-        // right before it posts SKIP_WAITING at an idle apply-boundary. It tells
-        // the controllerchange handler below that a resulting controllerchange
-        // is OURS (an expected apply), not a spontaneous background SW flip to
-        // suppress. Clear it on the next load so a later spontaneous
-        // controllerchange can't be mistaken for a page-initiated apply.
-        if (sessionStorage.getItem('sw-skip-initiated') === '1') {
-          sessionStorage.removeItem('sw-skip-initiated')
-        }
         // A page that loaded WITHOUT a controller is a first-ever SW install:
         // the worker claiming this page is NOT an update (it just re-fetches the
         // same bundle), so reloading is a wasted splash-flash for real first-time
-        // users AND — in e2e — a navigation that destroys the running test's
-        // execution context mid-action (app-canvas/steer/handleStop flakes). Only
-        // reload when the page was ALREADY controlled and a NEW worker takes over
-        // (a genuine deploy/update).
+        // users. It is also not permission for this boot script to reload a live
+        // page. Shell's apply-on-idle controller is the ONE owner of generation
+        // handoff and reload; this script only discovers registrations and stale
+        // precache state for that controller to claim safely after mount.
         const hadControllerAtLoad = !!navigator.serviceWorker.controller
-        const rememberShellStateForAutoReload = () => {
-          try {
-            const activeView = localStorage.getItem('moebius_active_view') || 'chat'
-            const rawAppId = localStorage.getItem('moebius_active_app')
-            const activeAppId = rawAppId ? Number(rawAppId) : null
-            sessionStorage.setItem('shell-reload', JSON.stringify({
-              activeView,
-              activeAppId: Number.isFinite(activeAppId) ? activeAppId : null,
-              drawerOpen: false,
-              activeChatId: localStorage.getItem('moebius_active_chat') || null,
-            }))
-          } catch (_) {
-            // Best-effort: a failed storage read should not block an update.
-          }
-        }
-        const reloadAfterControllerChange = () => {
-          // Reload on a controllerchange ONLY when the page itself asked the
-          // waiting worker to take over — Shell.performShellReload set
-          // `sw-skip-initiated` before posting SKIP_WAITING at an idle
-          // boundary. The SW no longer skipWaiting()s on its own, so the only
-          // legitimate controllerchange here is one we initiated; a spontaneous
-          // one (a background generation flip) must NEVER reload a live turn.
-          // This is the belt-and-suspenders fast path — Shell also reloads
-          // directly — and the shared `sw-auto-reloaded` guard keeps it to one.
-          if (!sessionStorage.getItem('sw-skip-initiated')) return
-          if (hadControllerAtLoad
-              && navigator.serviceWorker.controller
-              && !sessionStorage.getItem('sw-auto-reloaded')) {
-            sessionStorage.setItem('sw-auto-reloaded', '1')
-            // Shell.performShellReload captures its live ref-backed route
-            // before requesting the worker handoff. Keep that authoritative
-            // snapshot: localStorage mirrors React state in effects and can
-            // still describe the previous view during a just-mounted cold
-            // deep-link. The early boot handler is only a fallback for a
-            // controller change that has no Shell-owned snapshot.
-            if (!sessionStorage.getItem('shell-reload')) {
-              rememberShellStateForAutoReload()
-            }
-            window.location.reload()
-          }
-        }
-        navigator.serviceWorker.addEventListener(
-          'controllerchange',
-          reloadAfterControllerChange,
-        )
-        const watchWorker = (worker) => {
-          if (!worker) return
-          if (worker.state === 'activated') {
-            reloadAfterControllerChange()
-            return
-          }
-          worker.addEventListener('statechange', () => {
-            if (worker.state === 'activated') reloadAfterControllerChange()
-          })
-        }
-        const watchRegistration = (reg) => {
-          if (!reg) return
-          watchWorker(reg.waiting)
-          watchWorker(reg.installing)
-          reg.addEventListener('updatefound', () => {
-            watchWorker(reg.installing)
-          })
-        }
         // Stale-precache escape hatch.
         //
         // The normal path is: /sw.js updates → controllerchange → reload onto
@@ -372,23 +294,21 @@
             // Best-effort self-heal only; never block shell boot.
           }
         }
-        // Watchdog: if the registration we just installed sees a NEW
-        // SW available, refresh once it activates. Attach to the registration
-        // returned by register() immediately; waiting for
-        // navigator.serviceWorker.ready can miss updatefound on Android PWAs.
+        // Register immediately so a new generation can install while React
+        // starts. Do not attach a reload listener here: Shell owns the route
+        // snapshot, cache flush, worker takeover and the one resulting reload.
         navigator.serviceWorker.register('/sw.js', { updateViaCache: 'none' })
         .then(reg => {
-          watchRegistration(reg)
           recoverStalePrecacheIfNeeded(reg)
           // Poll for a new SW whenever the PWA returns to the foreground.
           // The explicit `shell_rebuilt` SSE event (Shell.jsx) handles a
           // PWA with a LIVE connection, but a backgrounded/reopened install
           // may have dropped its EventSource and would otherwise keep
           // running the old shell until a hard reload. reg.update() re-fetches
-          // sw.js; if the deploy shipped a new one, the `updatefound` watchdog
-          // above takes over and soft-reloads once it activates. Cheap (one
+          // sw.js. Shell's foreground watcher observes the resulting waiting
+          // generation and claims it at a safe apply boundary. Cheap (one
           // conditional GET, server sends 304 when unchanged) and only on
-          // visible, so it's not a polling loop.
+          // visible, so this is not a polling loop.
           document.addEventListener('visibilitychange', () => {
             if (document.visibilityState === 'visible') {
               reg.update().catch(() => {})
@@ -396,7 +316,6 @@
           })
         }).catch(() => {})
         navigator.serviceWorker.ready.then(reg => {
-          watchRegistration(reg)
           recoverStalePrecacheIfNeeded(reg)
         }).catch(() => {})
       }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -8,7 +8,6 @@ import { api, beginEphemeralAuth, getToken, setToken, BASE } from './api/client.
 import * as setupSession from './lib/setupSession.js'
 import { setupQueries, versionQueries } from './hooks/queries.js'
 import { queryClient, persistOptions } from './queryClient.js'
-import { shellReload } from './lib/shellReloadState.js'
 import { beginEmbedBootstrap } from './lib/chatEmbedBootstrap.js'
 import { startInstallPromptCapture } from './lib/installPrompt.js'
 import { readInstallPass, withoutInstallPass } from './lib/installPassUrl.js'
@@ -231,16 +230,6 @@ function AppRoot() {
   }, [hasToken])
 
   useEffect(() => {
-    // shell-reload: skip splash entirely, go straight to shell.
-    // shellReloadState parsed and removed the one-shot storage key at module
-    // load. App and useNavigation both share that same captured value.
-    if (shellReload) {
-      const splash = document.getElementById('splash')
-      if (splash) splash.remove()
-      setStatus('shell')
-      return
-    }
-
     if (hasToken) {
       // Clear stale provider-wizard state from pre-contextual onboarding.
       if (savedResumeStep && !resumeStep) setupSession.clearResumeStep()

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -567,7 +567,6 @@ export default function ChatView({
   const queuedContinuationRef = useRef(null)
   const sendIntentByCidRef = useRef(new Map())
   const runtimeReconnectInFlightRef = useRef(false)
-  const swReloadHoldTimerRef = useRef(null)
 
   // DOM refs
   const scrollRef = useRef(null)
@@ -3575,22 +3574,6 @@ export default function ChatView({
   // the visible fast-forward affordance and its keyboard shortcut inert while
   // the stream is unavailable; otherwise the tray disappears but the composer
   // can still offer an action whose request cannot reach the running turn.
-  useEffect(() => {
-    try {
-      if (swReloadHoldTimerRef.current) {
-        clearTimeout(swReloadHoldTimerRef.current)
-        swReloadHoldTimerRef.current = null
-      }
-      sessionStorage.setItem('sw-auto-reloaded', '1')
-      if (!turnActive) {
-        swReloadHoldTimerRef.current = setTimeout(() => {
-          try { sessionStorage.removeItem('sw-auto-reloaded') } catch {}
-          swReloadHoldTimerRef.current = null
-        }, 5000)
-      }
-    } catch {}
-  }, [turnActive])
-
   useEffect(() => {
     if (hidden) return
     const hasQueue = pendingQueue.pendingMessages.length > 0

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -191,6 +191,9 @@ export default function Shell() {
     storage: localStorage,
     legacyStorage: sessionStorage,
   })
+  // Navigation reads the current claimant synchronously without closing over
+  // reload-controller state declared later in this component.
+  const beforeNavigateRef = useRef(null)
 
   const {
     activeView,
@@ -213,6 +216,7 @@ export default function Shell() {
     blobValid,
     replaceImplicitBootTab,
     dragActiveRef,
+    beforeNavigateRef,
   })
 
   // A mobile drawer is a history-backed virtual route. A desktop sidebar is a
@@ -1480,7 +1484,10 @@ export default function Shell() {
     voiceDictationActiveRef.current = voiceDictationActive
   }, [voiceDictationActive])
 
-  const { requestShellReload } = useShellReloadController({
+  const {
+    requestShellReload,
+    claimPendingShellReloadNavigation,
+  } = useShellReloadController({
     win: window,
     doc: document,
     nav: navigator,
@@ -1499,6 +1506,7 @@ export default function Shell() {
     activeChatId,
     multiPaneBuilderVisible,
   })
+  beforeNavigateRef.current = claimPendingShellReloadNavigation
 
   // Stable callbacks for ChatView — identity must not change across
   // renders or ChatView's onStreamEnd-handler memoization breaks. The

--- a/frontend/src/components/Shell/__tests__/shellReloadController.test.js
+++ b/frontend/src/components/Shell/__tests__/shellReloadController.test.js
@@ -45,3 +45,40 @@ test('settings takeover changes only the reload surface, not workspace content i
     drawerOpen: false,
   })
 })
+
+test('a claimed Settings destination is serialized before the outgoing view paints', () => {
+  const workspace = {
+    ...paneModel.seedFromFlatTabs([{ kind: 'chat', id: 'kept' }]),
+    singleScreen: { kind: 'chat', id: 'kept' },
+  }
+
+  assert.deepEqual(deriveShellReloadState({
+    workspace,
+    activeView: 'chat',
+    drawerOpen: true,
+    destination: { view: 'settings', chatId: 'kept', appId: null },
+  }), {
+    activeView: 'settings',
+    activeAppId: null,
+    activeChatId: 'kept',
+    drawerOpen: false,
+  })
+})
+
+test('a claimed content destination becomes the reload route', () => {
+  const workspace = paneModel.seedFromFlatTabs([{ kind: 'chat', id: 'old' }])
+
+  assert.deepEqual(deriveShellReloadState({
+    workspace,
+    activeView: 'chat',
+    drawerOpen: true,
+    destination: {
+      view: 'chat', chatId: 'new', appId: null,
+    },
+  }), {
+    activeView: 'chat',
+    activeAppId: null,
+    activeChatId: 'new',
+    drawerOpen: false,
+  })
+})

--- a/frontend/src/components/Shell/__tests__/shellReloadController.test.js
+++ b/frontend/src/components/Shell/__tests__/shellReloadController.test.js
@@ -1,7 +1,10 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import * as paneModel from '../paneModel.js'
-import { deriveShellReloadState } from '../useShellReloadController.js'
+import useShellReloadController, {
+  deriveShellReloadState,
+} from '../useShellReloadController.js'
+import { renderHook } from '../../ChatView/hooks/__tests__/react-hook-shim.mjs'
 
 test('reload snapshot derives content from the current workspace authority', () => {
   // In single mode the reload authority is the Standard SLOT (never the focused
@@ -81,4 +84,53 @@ test('a claimed content destination becomes the reload route', () => {
     activeChatId: 'new',
     drawerOpen: false,
   })
+})
+
+test('an in-flight passive reload does not swallow disruptive chat navigation', () => {
+  const ref = current => ({ current })
+  const win = {
+    Event: class {},
+    addEventListener() {},
+    removeEventListener() {},
+    clearTimeout() {},
+    setTimeout() { return 1 },
+    dispatchEvent() {},
+    location: { reload() {} },
+  }
+  const doc = {
+    activeElement: null,
+    visibilityState: 'visible',
+    addEventListener() {},
+    removeEventListener() {},
+  }
+  const registrationPending = new Promise(() => {})
+  const inputs = {
+    win,
+    doc,
+    nav: {
+      onLine: true,
+      serviceWorker: { getRegistration: () => registrationPending },
+    },
+    storage: { getItem: () => null, setItem() {}, removeItem() {} },
+    queryClient: {},
+    persistWorkspaceSnapshot() {},
+    workspaceStateRef: ref({ ws: paneModel.seedFromFlatTabs([]) }),
+    activeViewRef: ref('canvas'),
+    activeChatIdRef: ref(null),
+    drawerOpenRef: ref(false),
+    multiPaneBuilderVisibleRef: ref(false),
+    streamingChatIdsRef: ref(new Set()),
+    activeChatWaitingOnQuestionRef: ref(false),
+    voiceDictationActiveRef: ref(false),
+    activeView: 'canvas',
+    activeChatId: null,
+    multiPaneBuilderVisible: false,
+  }
+  const { result } = renderHook(useShellReloadController, inputs)
+
+  result.current.requestShellReload({ passive: true })
+
+  assert.equal(result.current.claimPendingShellReloadNavigation({
+    view: 'chat', chatId: 'next', appId: null,
+  }), false)
 })

--- a/frontend/src/components/Shell/__tests__/swHandoff.test.js
+++ b/frontend/src/components/Shell/__tests__/swHandoff.test.js
@@ -4,8 +4,10 @@ import assert from 'node:assert/strict'
 import {
   reloadIfGenerationStale,
   reloadWhenWorkerTakesOver,
+  settleNewestWorkerForHandoff,
   shouldRearmShellApply,
   watchForShellUpdateOnForeground,
+  SW_DISCOVERY_SETTLE_TIMEOUT_MS,
   SW_TAKEOVER_TIMEOUT_MS,
 } from '../swHandoff.js'
 
@@ -44,7 +46,18 @@ function makeSwWith(reg, { controller = null, onUpdate } = {}) {
   }
 }
 function makeReg({ waiting = null, active = null, installing = null, onUpdate } = {}) {
-  const reg = { waiting, active, installing }
+  const listeners = {}
+  const reg = {
+    waiting,
+    active,
+    installing,
+    addEventListener(t, fn) { (listeners[t] ||= []).push(fn) },
+    removeEventListener(t, fn) {
+      listeners[t] = (listeners[t] || []).filter(f => f !== fn)
+    },
+    emit(t) { (listeners[t] || []).slice().forEach(fn => fn()) },
+    count(t) { return (listeners[t] || []).length },
+  }
   reg.update = async () => { if (onUpdate) onUpdate(reg) }
   return reg
 }
@@ -258,6 +271,83 @@ function fakeTimers() {
   }
 }
 
+test('settleNewestWorkerForHandoff: waits for the newest install before choosing a waiting worker', async () => {
+  const workerA = { id: 'A' }
+  const installingB = makeInstalling('installing')
+  let updates = 0
+  const reg = makeReg({
+    waiting: workerA,
+    onUpdate: (current) => {
+      updates += 1
+      current.installing = installingB
+    },
+  })
+
+  let settled = false
+  const handoffReady = settleNewestWorkerForHandoff({
+    registration: reg,
+    setTimeoutFn: null,
+  }).then(() => { settled = true })
+  await flush()
+  assert.equal(updates, 1, 'the handoff forces a fresh generation check')
+  assert.equal(settled, false, 'the older waiting worker is not chosen while B installs')
+  assert.equal(installingB.count('statechange'), 1)
+
+  reg.waiting = { id: 'B' }
+  installingB.become('installed')
+  await handoffReady
+  assert.equal(settled, true)
+  assert.equal(reg.waiting.id, 'B', 'the caller now sees the newest waiting generation')
+  assert.equal(installingB.count('statechange'), 0)
+})
+
+test('settleNewestWorkerForHandoff: observes an installing worker published after update resolves', async () => {
+  const workerA = { id: 'A' }
+  const installingB = makeInstalling('installing')
+  const queuedTasks = []
+  const reg = makeReg({ waiting: workerA })
+  let settled = false
+
+  const handoffReady = settleNewestWorkerForHandoff({
+    registration: reg,
+    setTimeoutFn: fn => { queuedTasks.push(fn); return queuedTasks.length },
+    clearTimeoutFn: () => {},
+  }).then(() => { settled = true })
+  await flush()
+  assert.equal(queuedTasks.length, 1, 'the helper yields for the queued registration update')
+
+  reg.installing = installingB
+  reg.emit('updatefound')
+  queuedTasks.shift()()
+  await flush()
+  assert.equal(settled, false, 'the newly-published worker owns the handoff wait')
+
+  reg.waiting = { id: 'B' }
+  installingB.become('installed')
+  await handoffReady
+  assert.equal(settled, true)
+  assert.equal(reg.count('updatefound'), 0)
+})
+
+test('settleNewestWorkerForHandoff: a wedged install has a bounded escape', async () => {
+  const installing = makeInstalling('installing')
+  const reg = makeReg({ installing })
+  const timers = fakeTimers()
+  let settled = false
+  const handoffReady = settleNewestWorkerForHandoff({
+    registration: reg,
+    setTimeoutFn: timers.setTimeoutFn,
+    clearTimeoutFn: timers.clearTimeoutFn,
+  }).then(() => { settled = true })
+  await flush()
+  assert.equal(settled, false)
+  assert.equal(timers.count(), 1)
+  timers.fire()
+  await handoffReady
+  assert.equal(settled, true)
+  assert.equal(installing.count('statechange'), 0)
+})
+
 test('reloadWhenWorkerTakesOver: no waiting worker reloads immediately', () => {
   let reloads = 0
   reloadWhenWorkerTakesOver({
@@ -370,6 +460,7 @@ test('reloadWhenWorkerTakesOver: a worker already activated at attach reloads im
 
 test('SW_TAKEOVER_TIMEOUT_MS is a sane bounded fallback', () => {
   assert.ok(SW_TAKEOVER_TIMEOUT_MS >= 1000 && SW_TAKEOVER_TIMEOUT_MS <= 3000)
+  assert.ok(SW_DISCOVERY_SETTLE_TIMEOUT_MS >= 1000 && SW_DISCOVERY_SETTLE_TIMEOUT_MS <= 3000)
 })
 
 test('shouldRearmShellApply: healthy page (controller is the active worker) does not re-arm', () => {

--- a/frontend/src/components/Shell/swHandoff.js
+++ b/frontend/src/components/Shell/swHandoff.js
@@ -14,6 +14,70 @@
 // covers a wedged install, where we reload anyway so an apply is never lost (the
 // boot-time re-arm net then catches a stale landing).
 export const SW_TAKEOVER_TIMEOUT_MS = 2000
+export const SW_DISCOVERY_SETTLE_TIMEOUT_MS = 2000
+
+// Force the registration to discover the newest shell generation and wait for
+// that worker's install attempt to settle before choosing `registration.waiting`.
+// `registration.update()` resolves after a newly-found worker enters
+// `installing`, not after its install event settles. Choosing the waiting worker
+// at that earlier instant can hand off to generation N while N+1 is still
+// installing, producing a second immediate reload when N+1 becomes ready.
+//
+// The wait is bounded: a wedged install must not strand the page. On timeout the
+// caller proceeds with the best currently-usable registration state and the
+// boot re-arm net can recover a later generation.
+export async function settleNewestWorkerForHandoff({
+  registration,
+  timeoutMs = SW_DISCOVERY_SETTLE_TIMEOUT_MS,
+  setTimeoutFn = (typeof setTimeout !== 'undefined' ? setTimeout : null),
+  clearTimeoutFn = (typeof clearTimeout !== 'undefined' ? clearTimeout : null),
+} = {}) {
+  if (!registration) return registration
+  let installing = registration.installing
+  const onUpdateFound = () => {
+    installing = registration.installing || installing
+  }
+  registration.addEventListener?.('updatefound', onUpdateFound)
+  if (typeof registration.update === 'function') {
+    try { await registration.update() } catch { /* offline/transient — use current state */ }
+  }
+
+  installing = registration.installing || installing
+  // The specification queues the registration object's `installing` update and
+  // `updatefound` event before resolving update(), so allow that queued task to
+  // publish the worker before deciding that no install exists.
+  if (!installing && setTimeoutFn) {
+    await new Promise(resolve => setTimeoutFn(resolve, 0))
+    installing = registration.installing || installing
+  }
+  registration.removeEventListener?.('updatefound', onUpdateFound)
+  const isSettled = () => (
+    !installing
+    || installing.state === 'installed'
+    || installing.state === 'redundant'
+  )
+  if (isSettled() || typeof installing.addEventListener !== 'function') {
+    return registration
+  }
+
+  await new Promise(resolve => {
+    let finished = false
+    let timer = null
+    const finish = () => {
+      if (finished) return
+      finished = true
+      if (timer != null && clearTimeoutFn) clearTimeoutFn(timer)
+      installing.removeEventListener?.('statechange', onStateChange)
+      resolve()
+    }
+    const onStateChange = () => { if (isSettled()) finish() }
+    installing.addEventListener('statechange', onStateChange)
+    if (setTimeoutFn) timer = setTimeoutFn(finish, timeoutMs)
+    // The worker can settle between the state read and listener attachment.
+    if (isSettled()) finish()
+  })
+  return registration
+}
 
 // Reload only once the waiting worker has actually taken over — not on a blind
 // timer. The previous code posted SKIP_WAITING fire-and-forget and reloaded a

--- a/frontend/src/components/Shell/useShellReloadController.js
+++ b/frontend/src/components/Shell/useShellReloadController.js
@@ -53,6 +53,7 @@ export default function useShellReloadController(inputs) {
   const lastInteractionAtRef = useRef(0)
   const heldSinceRef = useRef(0)
   const performingRef = useRef(false)
+  const performingPassiveRef = useRef(false)
   const destinationRef = useRef(null)
   const navigationCommittedRef = useRef(false)
 
@@ -155,6 +156,7 @@ export default function useShellReloadController(inputs) {
       return
     }
     performingRef.current = true
+    performingPassiveRef.current = passive
     pendingRef.current = false
     passiveRef.current = false
     heldSinceRef.current = 0
@@ -254,7 +256,11 @@ export default function useShellReloadController(inputs) {
     if (!destination?.view) return false
     if (!pendingRef.current && !performingRef.current) return false
     if (navigationCommittedRef.current) return false
-    const passive = passiveRef.current
+    // performReload clears queued state before its async handoff. Keep the
+    // claimant on that request's immutable policy until it commits or defers.
+    const passive = performingRef.current
+      ? performingPassiveRef.current
+      : passiveRef.current
     if (wouldDisruptUser({
       passive,
       destination,

--- a/frontend/src/components/Shell/useShellReloadController.js
+++ b/frontend/src/components/Shell/useShellReloadController.js
@@ -7,7 +7,10 @@ import {
 } from '../../queryClient.js'
 import * as paneModel from './paneModel.js'
 import { shouldDeferShellReload } from './shellReloadPolicy.js'
-import { reloadWhenWorkerTakesOver } from './swHandoff.js'
+import {
+  reloadWhenWorkerTakesOver,
+  settleNewestWorkerForHandoff,
+} from './swHandoff.js'
 
 const RECHECK_MS = 6000
 
@@ -15,13 +18,22 @@ export function deriveShellReloadState({
   workspace,
   activeView,
   drawerOpen,
+  destination = null,
 }) {
   const content = paneModel.activeContentRoute(workspace)
+  const destinationView = destination?.view
+  const destinationIsSettings = destinationView === 'settings'
   return {
-    activeView: activeView === 'settings' ? 'settings' : content.view,
-    activeAppId: content.appId,
-    activeChatId: content.chatId,
-    drawerOpen,
+    activeView: destinationIsSettings
+      ? 'settings'
+      : (destinationView || (activeView === 'settings' ? 'settings' : content.view)),
+    activeAppId: destination && !destinationIsSettings
+      ? (destination.appId ?? null)
+      : content.appId,
+    activeChatId: destination && !destinationIsSettings
+      ? (destination.chatId ?? null)
+      : content.chatId,
+    drawerOpen: destination ? false : drawerOpen,
   }
 }
 
@@ -40,6 +52,9 @@ export default function useShellReloadController(inputs) {
   const timerRef = useRef(null)
   const lastInteractionAtRef = useRef(0)
   const heldSinceRef = useRef(0)
+  const performingRef = useRef(false)
+  const destinationRef = useRef(null)
+  const navigationCommittedRef = useRef(false)
 
   // The recent-interaction window is a POLITENESS debounce, not a safety
   // invariant: it exists so an apply does not land in the same breath as the
@@ -66,7 +81,11 @@ export default function useShellReloadController(inputs) {
       && activeChatIdRef.current != null
   }
 
-  function wouldDisruptUser({ passive = false } = {}) {
+  function wouldDisruptUser({
+    passive = false,
+    destination = null,
+    ignoreRecentInteraction = false,
+  } = {}) {
     const {
       doc,
       activeViewRef,
@@ -78,14 +97,14 @@ export default function useShellReloadController(inputs) {
     } = inputsRef.current
     return shouldDeferShellReload({
       activeElement: doc.activeElement,
-      activeView: activeViewRef.current,
-      activeChatId: activeChatIdRef.current,
+      activeView: destination?.view || activeViewRef.current,
+      activeChatId: destination?.chatId ?? activeChatIdRef.current,
       multiPaneBuilderVisible: multiPaneBuilderVisibleRef.current,
       streamingChatIds: streamingChatIdsRef.current,
       activeChatWaitingOnQuestion: activeChatWaitingOnQuestionRef.current,
       passiveRebuild: passive,
       voiceDictationActive: voiceDictationActiveRef.current,
-      lastUserInteractionAt: interactionGraceSpent()
+      lastUserInteractionAt: ignoreRecentInteraction || interactionGraceSpent()
         ? 0
         : lastInteractionAtRef.current,
       visibilityState: doc.visibilityState,
@@ -114,7 +133,11 @@ export default function useShellReloadController(inputs) {
     if (!hasStableVisibleHold(passiveRef.current)) scheduleCheck()
   }
 
-  async function performReload({ passive = false } = {}) {
+  async function performReload({ passive = false, destination = null } = {}) {
+    if (destination && !navigationCommittedRef.current) {
+      destinationRef.current = destination
+    }
+    if (performingRef.current) return
     const {
       win,
       nav,
@@ -131,6 +154,7 @@ export default function useShellReloadController(inputs) {
       deferReload({ passive })
       return
     }
+    performingRef.current = true
     pendingRef.current = false
     passiveRef.current = false
     heldSinceRef.current = 0
@@ -139,16 +163,28 @@ export default function useShellReloadController(inputs) {
       timerRef.current = null
     }
 
+    let registration = null
+    if (nav.serviceWorker?.getRegistration) {
+      try {
+        registration = await nav.serviceWorker.getRegistration()
+        await settleNewestWorkerForHandoff({ registration })
+      } catch {
+        registration = null
+      }
+    }
+
     win.dispatchEvent(new win.Event(BEFORE_SHELL_RELOAD_EVENT))
     await awaitCacheFlushBeforeReload(flushPersistedQueryCache(queryClient))
+    if (wouldDisruptUser({
+      passive,
+      destination: destinationRef.current,
+      ignoreRecentInteraction: destinationRef.current != null,
+    })) {
+      performingRef.current = false
+      deferReload({ passive })
+      return
+    }
     persistWorkspaceSnapshot()
-    storage.setItem('shell-reload', JSON.stringify(deriveShellReloadState({
-      workspace: workspaceStateRef.current.ws,
-      activeView: activeViewRef.current,
-      drawerOpen: drawerOpenRef.current,
-    })))
-    replaceNavEntry('base', '/shell/')
-    try { storage.setItem('sw-skip-initiated', '1') } catch { /* ignore */ }
 
     if (stalePrecache) {
       // Let the new worker replace its precache during activation. Deleting the
@@ -157,15 +193,35 @@ export default function useShellReloadController(inputs) {
       try { storage.setItem('sw-stale-precache-recovering', '1') } catch { /* ignore */ }
     }
 
-    const reload = () => win.location.reload()
-    if (nav.serviceWorker?.getRegistration) {
-      nav.serviceWorker.getRegistration()
-        .then(registration => reloadWhenWorkerTakesOver({
-          registration,
-          serviceWorker: nav.serviceWorker,
-          reload,
-        }))
-        .catch(reload)
+    // Commit the route at the LAST possible instant. A navigation during the
+    // worker handoff can still replace destinationRef and be revealed only by
+    // the incoming document instead of flashing in the outgoing one.
+    const reload = () => {
+      if (wouldDisruptUser({
+        passive,
+        destination: destinationRef.current,
+        ignoreRecentInteraction: destinationRef.current != null,
+      })) {
+        performingRef.current = false
+        deferReload({ passive })
+        return
+      }
+      navigationCommittedRef.current = true
+      storage.setItem('shell-reload', JSON.stringify(deriveShellReloadState({
+        workspace: workspaceStateRef.current.ws,
+        activeView: activeViewRef.current,
+        drawerOpen: drawerOpenRef.current,
+        destination: destinationRef.current,
+      })))
+      replaceNavEntry('base', '/shell/')
+      win.location.reload()
+    }
+    if (registration) {
+      reloadWhenWorkerTakesOver({
+        registration,
+        serviceWorker: nav.serviceWorker,
+        reload,
+      })
     } else {
       reload()
     }
@@ -186,11 +242,35 @@ export default function useShellReloadController(inputs) {
   }, [])
 
   const requestShellReload = useCallback(({ passive = false } = {}) => {
+    if (performingRef.current) return
     if (wouldDisruptUser({ passive })) {
       deferReload({ passive })
     } else {
       performReload({ passive })
     }
+  }, [])
+
+  const claimPendingShellReloadNavigation = useCallback((destination) => {
+    if (!destination?.view) return false
+    if (!pendingRef.current && !performingRef.current) return false
+    if (navigationCommittedRef.current) return false
+    const passive = passiveRef.current
+    if (wouldDisruptUser({
+      passive,
+      destination,
+      // The navigation tap is the apply boundary the owner just chose. Its own
+      // pointerdown must not re-arm the generic politeness debounce.
+      ignoreRecentInteraction: true,
+    })) {
+      // A newer navigation that cannot be folded into this reload wins. Clear
+      // any older claimed route so the final safety check sees the surface that
+      // navigation is about to paint.
+      destinationRef.current = null
+      return false
+    }
+    destinationRef.current = destination
+    if (!performingRef.current) void performReload({ passive, destination })
+    return true
   }, [])
 
   useEffect(() => {
@@ -231,5 +311,9 @@ export default function useShellReloadController(inputs) {
     inputs.multiPaneBuilderVisible,
   ])
 
-  return { requestShellReload, checkPendingShellReload }
+  return {
+    requestShellReload,
+    checkPendingShellReload,
+    claimPendingShellReloadNavigation,
+  }
 }

--- a/frontend/src/hooks/useNavigation.js
+++ b/frontend/src/hooks/useNavigation.js
@@ -129,6 +129,9 @@ export const coldRestoredCanvasAppId =
  *   replaceImplicitBootTab
  *                       true when the only boot tab is the unpinned home
  *                       surface, which an explicit deep link replaces.
+ *   beforeNavigateRef   optional synchronous destination claimant, run after
+ *                       validation/no-op detection but before history or
+ *                       workspace mutation.
  *
  * Three load-bearing pieces remain: `openDrawer` pushes one mobile sentinel;
  * `navTo` retags that sentinel or pushes one ordinary destination; every modal
@@ -144,6 +147,7 @@ export default function useNavigation({
   blobValid,
   replaceImplicitBootTab,
   dragActiveRef,
+  beforeNavigateRef,
 }) {
   // Monotonic presentation signal for re-revealing an already-active tab. The
   // semantic route remains a no-op (no history or workspace write), but a drawer
@@ -1026,6 +1030,11 @@ export default function useNavigation({
       if (drawerOpenRef.current) closeDrawer()
       return
     }
+
+    // Give the shell-generation controller one synchronous boundary before
+    // this destination mutates history or paints. A pending update can claim
+    // the semantic route and reveal it only in the new document.
+    if (beforeNavigateRef?.current?.(nextRoute) === true) return
 
     navigationEpochRef.current += 1
     const keepDrawerPresented = opts.preserveDrawerPresentation === true

--- a/frontend/src/lib/__tests__/shellControllerReload.test.js
+++ b/frontend/src/lib/__tests__/shellControllerReload.test.js
@@ -3,17 +3,60 @@ import { test } from 'node:test'
 import assert from 'node:assert/strict'
 
 const indexHtml = readFileSync(new URL('../../../index.html', import.meta.url), 'utf8')
+const controllerSource = readFileSync(
+  new URL('../../components/Shell/useShellReloadController.js', import.meta.url),
+  'utf8',
+)
+const navigationSource = readFileSync(
+  new URL('../../hooks/useNavigation.js', import.meta.url),
+  'utf8',
+)
+const shellSource = readFileSync(
+  new URL('../../components/Shell/Shell.jsx', import.meta.url),
+  'utf8',
+)
 
-test('controller-change reload preserves Shell live-route snapshot', () => {
-  const reloadHandler = indexHtml.slice(
-    indexHtml.indexOf('const reloadAfterControllerChange'),
-    indexHtml.indexOf("navigator.serviceWorker.addEventListener(\n          'controllerchange'"),
+test('the boot script discovers workers but never owns a shell reload', () => {
+  assert.match(indexHtml, /navigator\.serviceWorker\.register\('\/sw\.js'/)
+  assert.match(indexHtml, /recoverStalePrecacheIfNeeded/)
+  assert.doesNotMatch(indexHtml, /reloadAfterControllerChange/)
+  assert.doesNotMatch(indexHtml, /sw-skip-initiated|sw-auto-reloaded/)
+  assert.doesNotMatch(
+    indexHtml,
+    /navigator\.serviceWorker\.addEventListener\(\s*['"]controllerchange['"]/,
   )
+})
 
-  assert.match(reloadHandler, /if \(!sessionStorage\.getItem\('shell-reload'\)\) \{\s*rememberShellStateForAutoReload\(\)\s*\}/)
+test('the shell controller has one deduplicated reload executor', () => {
+  assert.match(controllerSource, /if \(performingRef\.current\) return/)
+  assert.match(controllerSource, /const reload = \(\) => \{/)
+  assert.match(controllerSource, /settleNewestWorkerForHandoff\(\{ registration \}\)/)
+  assert.doesNotMatch(controllerSource, /sw-skip-initiated|sw-auto-reloaded/)
+})
+
+test('a claimed destination runs before navigation history or view mutation', () => {
+  const navTo = navigationSource.indexOf('function navTo(')
+  const claim = navigationSource.indexOf(
+    'beforeNavigateRef?.current?.(nextRoute)', navTo,
+  )
+  const epoch = navigationSource.indexOf('navigationEpochRef.current += 1', claim)
+  const apply = navigationSource.indexOf('applyModeDestination(nextRoute)', claim)
   assert.ok(
-    reloadHandler.indexOf("sessionStorage.getItem('shell-reload')")
-      < reloadHandler.indexOf('rememberShellStateForAutoReload()'),
-    'the live Shell snapshot must be checked before the localStorage fallback writes',
+    navTo >= 0 && navTo < claim && claim < epoch && epoch < apply,
+    'the reload claim must happen before history and the outgoing document paint',
+  )
+  assert.doesNotMatch(
+    navigationSource.slice(0, navTo),
+    /beforeNavigateRef\?\.current\?\.\(nextRoute\)/,
+    'render-time route reconciliation has no nextRoute to claim',
+  )
+})
+
+test('Shell connects navigation to the current reload claimant through one ref', () => {
+  assert.match(shellSource, /const beforeNavigateRef = useRef\(null\)/)
+  assert.match(shellSource, /beforeNavigateRef,\s*\}\)/)
+  assert.match(
+    shellSource,
+    /beforeNavigateRef\.current = claimPendingShellReloadNavigation/,
   )
 })

--- a/frontend/src/lib/__tests__/shellReloadExport.test.js
+++ b/frontend/src/lib/__tests__/shellReloadExport.test.js
@@ -53,8 +53,9 @@ test('shellReload: returns null when sandbox storage is unavailable', () => {
   assert.equal(consumeShellReload(storage), null)
 })
 
-test('startup and navigation share the lightweight shell-reload reader', () => {
-  assert.match(APP_SOURCE, /from '\.\/lib\/shellReloadState\.js'/)
+test('navigation is the only startup consumer of reload state', () => {
+  assert.doesNotMatch(APP_SOURCE, /from '\.\/lib\/shellReloadState\.js'/)
   assert.match(NAV_SOURCE, /from '\.\.\/lib\/shellReloadState\.js'/)
   assert.doesNotMatch(APP_SOURCE, /from '\.\/hooks\/useNavigation\.js'/)
+  assert.doesNotMatch(APP_SOURCE, /if \(shellReload\)/)
 })

--- a/frontend/src/lib/__tests__/vite-env-loader.mjs
+++ b/frontend/src/lib/__tests__/vite-env-loader.mjs
@@ -25,6 +25,7 @@ const REACT_SHIM = new URL(
 // silently swap React out from under anything that later imports for real.
 const REACT_SHIMMED_MODULES = [
   '/components/Shell/useAppIntentNavigation.js',
+  '/components/Shell/useShellReloadController.js',
   '/components/ChatView/useFileUpload.js',
   '/components/ChatView/useScrollMode.js',
   '/hooks/useNavigation.js',


### PR DESCRIPTION
## Summary
- make the mounted shell the sole owner of update-triggered reloads
- wait for the newest discovered service-worker generation before takeover instead of reloading into an older waiting worker
- let a safe navigation arriving at the final handoff boundary become the destination restored after reload
- recheck editing, dictation, app activity, and pending chat work before takeover and again before the final reload
- remove the eager reload bypass so this composes cleanly with the stable launch cover in #756

## Why
The boot script and mounted shell could both react to a worker change, while the reload snapshot could be captured before a last-moment navigation or after user activity made the handoff disruptive. That split ownership allowed duplicate reloads, stale destinations, and reloads into an older installed generation.

This puts discovery, safety, destination claiming, worker takeover, and the single reload behind one mounted owner. It is an independent companion to #756 rather than a cumulative or malformed stack.

## Testing
- component and library tests: 2,466 passed
- hook tests: 79 passed
- focused reload, worker-handoff, navigation, and route tests: 48 passed
- structural-test budget and `git diff --check`
- ESLint reports no errors; only existing hook-dependency warnings

Local Playwright was not run because Docker is unavailable in this container; upstream CI should exercise the browser handoff path.