### PR TITLE
Allow app frames to reach a distinct API origin

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -315,6 +315,7 @@ _SHELL_CSP = shell_csp(os.environ.get("MOBIUS_SERVICE_GATEWAY_ORIGIN", ""))
 _APP_FRAME_CSP = app_frame_csp(
   settings.frontend_origin,
   os.environ.get("MOBIUS_SERVICE_GATEWAY_ORIGIN", ""),
+  settings.api_base_url,
 )
 
 # Published sites (`/sites/<token>/`) are public snapshots of the owner's own

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -315,7 +315,10 @@ _SHELL_CSP = shell_csp(os.environ.get("MOBIUS_SERVICE_GATEWAY_ORIGIN", ""))
 _APP_FRAME_CSP = app_frame_csp(
   settings.frontend_origin,
   os.environ.get("MOBIUS_SERVICE_GATEWAY_ORIGIN", ""),
-  settings.api_base_url,
+  # Only an explicitly configured browser-reachable API origin belongs in a
+  # frame policy. settings.api_base_url defaults to backend-local localhost
+  # for agents and jobs, which must not become the viewer's localhost.
+  os.environ.get("API_BASE_URL", ""),
 )
 
 # Published sites (`/sites/<token>/`) are public snapshots of the owner's own

--- a/backend/app/response_policy.py
+++ b/backend/app/response_policy.py
@@ -47,10 +47,18 @@ def _validated_frontend_origin(frontend_origin: str) -> str:
   return origin
 
 
-def app_frame_csp(frontend_origin: str, gateway_origin: str = "") -> str:
+def app_frame_csp(
+  frontend_origin: str,
+  gateway_origin: str = "",
+  api_origin: str = "",
+) -> str:
   """Complete policy for the opaque mini-app document."""
   origin = _validated_frontend_origin(frontend_origin)
   frame_sources = [origin]
+  connect_sources = [origin]
+  api = absolute_csp_origin(api_origin)
+  if api is not None and api != origin:
+    connect_sources.append(api)
   gateway = absolute_csp_origin(gateway_origin)
   if gateway is not None and gateway != origin:
     frame_sources.append(gateway)
@@ -63,7 +71,7 @@ def app_frame_csp(frontend_origin: str, gateway_origin: str = "") -> str:
     "blob: https://esm.sh; "
     f"style-src {origin} 'unsafe-inline' https://fonts.googleapis.com; "
     f"font-src {origin} https://fonts.gstatic.com https://cdn.openai.com; "
-    f"connect-src {origin}; "
+    f"connect-src {' '.join(connect_sources)}; "
     f"img-src {origin} data: blob:; "
     f"frame-src {' '.join(frame_sources)}; "
     "frame-ancestors 'self'"

--- a/backend/tests/test_security_headers.py
+++ b/backend/tests/test_security_headers.py
@@ -196,6 +196,16 @@ def test_backend_owns_complete_app_frame_policy():
     assert "'self'" not in sources
 
 
+def test_app_frame_policy_allows_a_distinct_configured_api_origin():
+  policy = app_frame_csp(
+    "https://app.example.test",
+    api_origin="http://localhost:8000",
+  )
+  assert "connect-src https://app.example.test http://localhost:8000" in policy
+  assert "script-src https://app.example.test" in policy
+  assert "img-src https://app.example.test data: blob:" in policy
+
+
 def test_app_frame_policy_drops_malformed_gateway_origin():
   policy = app_frame_csp(
     main.settings.frontend_origin,

--- a/backend/tests/test_security_headers.py
+++ b/backend/tests/test_security_headers.py
@@ -206,6 +206,12 @@ def test_app_frame_policy_allows_a_distinct_configured_api_origin():
   assert "img-src https://app.example.test data: blob:" in policy
 
 
+def test_app_frame_policy_does_not_infer_the_backend_localhost_default():
+  policy = app_frame_csp("https://app.example.test", api_origin="")
+  assert "connect-src https://app.example.test;" in policy
+  assert "localhost" not in policy
+
+
 def test_app_frame_policy_drops_malformed_gateway_origin():
   policy = app_frame_csp(
     main.settings.frontend_origin,


### PR DESCRIPTION
## Summary
- allow opaque mini-app frames to connect to a separately configured API origin
- keep script, image, and frame permissions limited to the public app origin
- cover the split-origin policy with a focused test

## Testing
- `scripts/wt-pytest.sh tests/test_security_headers.py -q`