### PR TITLE
Fix temporary image previews in chat

### DIFF
--- a/backend/app/routes/media.py
+++ b/backend/app/routes/media.py
@@ -18,11 +18,28 @@ router = APIRouter(prefix="/api/chats", tags=["media"])
 
 _RASTER_MEDIA_TYPES = {
   "image/avif",
+  "image/bmp",
   "image/gif",
   "image/jpeg",
   "image/png",
   "image/webp",
 }
+
+_AGENT_TMP_ROOT = Path("/tmp")
+
+
+def _authorize_chat_media(chat_id, token_src, db):
+  """Validate the chat id and the owner-scoped media credential once."""
+  validate_chat_id(chat_id)
+  resolve_media_or_header_owner(
+    token_src.token, db, chat_id=chat_id, from_query=token_src.from_query,
+  )
+
+
+def _raster_media_type(file_path: Path) -> str | None:
+  guessed_type = mimetypes.guess_type(file_path.name)[0]
+  return guessed_type if guessed_type in _RASTER_MEDIA_TYPES else None
+
 
 def _serve_chat_image(chat_id, filename, token_src, db, *, preview=False):
   """Common auth + path-validation + FileResponse for a chat media file.
@@ -35,10 +52,7 @@ def _serve_chat_image(chat_id, filename, token_src, db, *, preview=False):
 
   App tokens are rejected on both paths.
   """
-  validate_chat_id(chat_id)
-  resolve_media_or_header_owner(
-    token_src.token, db, chat_id=chat_id, from_query=token_src.from_query,
-  )
+  _authorize_chat_media(chat_id, token_src, db)
 
   settings = get_settings()
   base = Path(settings.data_dir) / "chats" / chat_id / "media"
@@ -47,11 +61,7 @@ def _serve_chat_image(chat_id, filename, token_src, db, *, preview=False):
   if not file_path.is_file():
     raise HTTPException(status_code=404, detail="Image not found.")
 
-  guessed_type = mimetypes.guess_type(file_path.name)[0]
-  media_type = (
-    guessed_type if guessed_type in _RASTER_MEDIA_TYPES
-    else "application/octet-stream"
-  )
+  media_type = _raster_media_type(file_path) or "application/octet-stream"
   if preview and media_type in _RASTER_MEDIA_TYPES:
     preview_path = display_image_preview(file_path, base)
     if preview_path is not None:
@@ -74,4 +84,35 @@ def serve_chat_media(
   """Serves an agent-attached image or its bounded transcript preview."""
   return _serve_chat_image(
     chat_id, filename, token_src, db, preview=preview,
+  )
+
+
+@router.get("/{chat_id}/tmp-images/{filename:path}")
+def serve_agent_tmp_image(
+  chat_id: str,
+  filename: str,
+  token_src: TokenSource = Depends(get_auth_token_source),
+  db: Session = Depends(get_db),
+):
+  """Serve a raster image viewed by the agent from inside ``/tmp``.
+
+  Codex's native image-view event records only the file path, not a duplicate
+  base64 result. This narrow route lets the owner's chat render that exact
+  temporary image while keeping every non-image file and every path outside
+  ``/tmp`` inaccessible. The ordinary short-lived, chat-scoped media token
+  protects browser image requests just like durable chat media.
+  """
+  _authorize_chat_media(chat_id, token_src, db)
+  file_path = validate_path_within_base(filename, _AGENT_TMP_ROOT)
+  if not file_path.is_file():
+    raise HTTPException(status_code=404, detail="Image not found.")
+
+  media_type = _raster_media_type(file_path)
+  if media_type is None:
+    raise HTTPException(status_code=415, detail="File is not a supported image.")
+
+  return FileResponse(
+    str(file_path),
+    media_type=media_type,
+    headers={"Cache-Control": "private, no-store"},
   )

--- a/backend/scripts/seed-skills/visual-testing.md
+++ b/backend/scripts/seed-skills/visual-testing.md
@@ -40,11 +40,12 @@ atomic-output checks. Raw capture remains appropriate for non-Möbius pages.
 
 Core moves once a page is open: `set viewport "$VIEWPORT_WIDTH" "$VIEWPORT_HEIGHT" "$VIEWPORT_PIXEL_RATIO"` (the helper sets the complete geometry for you; needed when driving raw non-Möbius pages), `snapshot` (a11y tree with `@eN` refs), `click/fill/type @eN`, `wait` (on a signal — `wait @eN` / `--text` / `--fn` / `--url` — not a guessed duration), `batch "cmd1" "cmd2"` (ordered, fewer round-trips), `diff snapshot` / `diff screenshot --baseline <before>.png`.
 
-**Write a viewable image once, at its final home.** Any screenshot, render,
-crop, montage, or other raster image you intend to pass to `Read`/`view_image`
-must be created directly under `/data/chats/$CHAT_ID/media/`, not created in
-`/tmp` and copied afterward. The chat shell deliberately cannot serve
-arbitrary `/tmp` files. Mint a unique final path before the producing command:
+**Write a shareable image once, at its final home.** Any screenshot, render,
+crop, montage, or other raster image you intend to embed in your reply must be
+created directly under `/data/chats/$CHAT_ID/media/`, not created in `/tmp` and
+copied afterward. The chat can preview raster files you inspect under `/tmp`
+inside the protected tool activity, but temporary files still cannot be used as
+durable message embeds. Mint a unique final path before the producing command:
 
 ```bash
 MEDIA_DIR="/data/chats/$CHAT_ID/media"
@@ -54,10 +55,11 @@ bash "$SCRIPTS_DIR/agent-screenshot.sh" --current-page <route> "$OUT"
 ```
 
 `/tmp` remains correct for logs, diffs, test workspaces, disposable browser
-warm-ups, and images that will never be inspected or shown. When an external
-tool controls its own output location, publish that unavoidable pre-existing
-file once with `publish_chat_image.py`; do not make `/tmp` the default for
-images you create yourself.
+warm-ups, and images you only need to inspect through `Read`/`view_image`. When
+an external tool controls its own output location and you need to show that
+image in your reply, publish the unavoidable pre-existing file once with
+`publish_chat_image.py`; do not make `/tmp` the default for shareable images
+you create yourself.
 
 For textboxes, use `fill @eN "value"` directly. Do not split that into
 `click`, `Control+A`, and a selector-less `type`; the extra commands add
@@ -106,7 +108,7 @@ Two gotchas every session:
 
 Loading a PNG into your vision (`Read` on Claude, `view_image` on Codex) lets YOU inspect it. The partner sees ONLY your text plus any `![caption](/api/chats/$CHAT_ID/media/<name>.png)` embeds you explicitly write. The failure mode: you view it, describe it ("the grid rendered beautifully"), but never embed — so the partner trusts an unverified claim. Pattern:
 
-1. `Bash`: capture with `bash "$SCRIPTS_DIR/agent-screenshot.sh" <route>` — with no output path it lands in the chat's served media dir (`/data/chats/$CHAT_ID/media/shot-*.png`) and prints the path **plus a ready-to-paste `![screenshot](/api/chats/…)` embed line** — copy that line into your reply (step 3) so the shot actually shows. For an already-open Möbius state, mint the unique final media path first and use the same helper with `--current-page`; reserve raw `agent-browser screenshot "$OUT"` for non-Möbius pages. Only files under that dir embed; an image created under `/tmp` cannot preview in the chat.
+1. `Bash`: capture with `bash "$SCRIPTS_DIR/agent-screenshot.sh" <route>` — with no output path it lands in the chat's served media dir (`/data/chats/$CHAT_ID/media/shot-*.png`) and prints the path **plus a ready-to-paste `![screenshot](/api/chats/…)` embed line** — copy that line into your reply (step 3) so the shot actually shows. For an already-open Möbius state, mint the unique final media path first and use the same helper with `--current-page`; reserve raw `agent-browser screenshot "$OUT"` for non-Möbius pages. Only files under that dir embed in replies; `/tmp` images preview only inside their protected tool activity.
 2. `Read` / `view_image`: the path it printed.
 3. **Text** (same message, BEFORE interpreting): `![first render](/api/chats/$CHAT_ID/media/<name>.png)` — the embed path must match the file and carry the resolved chat id — a literal `$CHAT_ID` only expands in Bash, never in your markdown. Then a one-line description.
 4. Continue.

--- a/backend/tests/test_media.py
+++ b/backend/tests/test_media.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from PIL import Image
 
+import app.routes.media as media_routes
 from app.config import get_settings
 
 
@@ -157,6 +158,55 @@ def test_serve_chat_media_rejects_directory(client, auth, chat):
     headers=auth,
   )
   assert response.status_code == 404
+
+
+def test_serve_agent_tmp_image_with_chat_scoped_token(
+  client, auth, chat, tmp_path, monkeypatch,
+):
+  monkeypatch.setattr(media_routes, "_AGENT_TMP_ROOT", tmp_path)
+  source = tmp_path / "renders" / "preview.png"
+  source.parent.mkdir()
+  source.write_bytes(b"temporary-image-bytes")
+
+  response = client.get(
+    f"/api/chats/{chat.id}/tmp-images/renders/preview.png",
+    params={"token": _media_token(client, auth, chat.id)},
+  )
+
+  assert response.status_code == 200
+  assert response.content == b"temporary-image-bytes"
+  assert response.headers["content-type"] == "image/png"
+  assert response.headers["cache-control"] == "private, no-store"
+
+
+def test_serve_agent_tmp_image_rejects_non_images(
+  client, auth, chat, tmp_path, monkeypatch,
+):
+  monkeypatch.setattr(media_routes, "_AGENT_TMP_ROOT", tmp_path)
+  source = tmp_path / "not-an-image.txt"
+  source.write_text("private temporary text", encoding="utf-8")
+
+  response = client.get(
+    f"/api/chats/{chat.id}/tmp-images/not-an-image.txt",
+    headers=auth,
+  )
+
+  assert response.status_code == 415
+
+
+def test_serve_agent_tmp_image_rejects_symlink_escape(
+  client, auth, chat, tmp_path, monkeypatch,
+):
+  monkeypatch.setattr(media_routes, "_AGENT_TMP_ROOT", tmp_path)
+  link = tmp_path / "outside.png"
+  link.symlink_to("/etc/hosts")
+
+  response = client.get(
+    f"/api/chats/{chat.id}/tmp-images/outside.png",
+    headers=auth,
+  )
+
+  assert response.status_code == 400
 
 
 def test_serve_media_rejects_non_uuid_chat_id(client, auth):

--- a/frontend/src/components/ChatView/ToolBlock.jsx
+++ b/frontend/src/components/ChatView/ToolBlock.jsx
@@ -18,7 +18,7 @@ import { useDisclosureState } from './disclosureState.js'
 import MemoryRecallCard from './MemoryRecallCard.jsx'
 import ToolImageResult from './ToolImageResult.jsx'
 import {
-  durableImageReference,
+  servedImageReference,
   toolImageReference,
 } from './toolImageResult.js'
 import {
@@ -140,9 +140,9 @@ function GenericToolBlock({ t, chatId, compact = false, disclosureKey }) {
     () => (wantsPreparation && !failed ? toolEditPreview(t.edit_preview) : null),
     [failed, t.edit_preview, wantsPreparation],
   )
-  const durableImage = useMemo(() => (
-    isImageTool ? durableImageReference(t.input) : null
-  ), [isImageTool, t.input])
+  const servedImage = useMemo(() => (
+    isImageTool ? servedImageReference(t.input, chatId) : null
+  ), [isImageTool, t.input, chatId])
   // `t.sources` is NOT rendered here: the turn's sources surface once at the
   // end of the message (MessageSources), where they belong to the answer
   // rather than to the one search that found them. They deliberately do not
@@ -169,11 +169,11 @@ function GenericToolBlock({ t, chatId, compact = false, disclosureKey }) {
     // barrier then guarantees the final queued stash wins the query.
     if (t.status === 'running') return
     if (!t.output_truncated || previewOutput !== null || missingOutput) return
-    // Durable chat media and installed app icons can render through their
-    // existing narrow routes, avoiding the image tool's much larger base64
-    // sidecar altogether. An image viewed elsewhere needs the complete result
-    // (not the ordinary 20k text preview) so the fallback data URL is valid.
-    if (isImageTool && durableImage) return
+    // Protected chat media and /tmp rasters render through narrow routes,
+    // avoiding the image tool's much larger base64 sidecar. An image viewed
+    // elsewhere needs the complete result (not the ordinary 20k text preview)
+    // so the fallback data URL is valid.
+    if (isImageTool && servedImage) return
     if (!chatId) return
     // Contract rule 6: a reduced block carries a stable tool_use_id and fetches
     // its full text from the side-table endpoint. Every large block is tagged
@@ -224,7 +224,7 @@ function GenericToolBlock({ t, chatId, compact = false, disclosureKey }) {
     chatId,
     loadAttempt,
     isImageTool,
-    durableImage,
+    servedImage,
   ])
 
   // Show the larger bounded preview once it lands; until then the inline
@@ -246,8 +246,8 @@ function GenericToolBlock({ t, chatId, compact = false, disclosureKey }) {
     || !!t.output_truncated
     || (t.status !== 'running' && shownOutput === '')
   const imageReference = useMemo(
-    () => (isImageTool ? toolImageReference(t.input, shownOutput) : null),
-    [isImageTool, shownOutput, t.input],
+    () => (isImageTool ? toolImageReference(t.input, shownOutput, chatId) : null),
+    [isImageTool, shownOutput, t.input, chatId],
   )
   const r = useMemo(
     () => (hasOutput && !isImageTool
@@ -258,7 +258,7 @@ function GenericToolBlock({ t, chatId, compact = false, disclosureKey }) {
   const waitsForPreview = !!(
     t.output_truncated
     && t.status !== 'running'
-    && !durableImage
+    && !servedImage
     && previewOutput === null
     && !missingOutput
     && !loadError
@@ -367,7 +367,7 @@ function GenericToolBlock({ t, chatId, compact = false, disclosureKey }) {
     setLoadAttempt(value => value + 1)
   }
 
-  const showLazyStatus = !!t.output_truncated && !durableImage && (
+  const showLazyStatus = !!t.output_truncated && !servedImage && (
     t.status === 'running'
     || loadingPreview
     || missingOutput

--- a/frontend/src/components/ChatView/__tests__/toolImageResult.test.js
+++ b/frontend/src/components/ChatView/__tests__/toolImageResult.test.js
@@ -3,9 +3,10 @@ import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
 import {
   chatImageReference,
-  durableImageReference,
   imagePathFromInput,
   inlineImageReference,
+  servedImageReference,
+  temporaryImageReference,
   toolImageReference,
 } from '../toolImageResult.js'
 
@@ -53,6 +54,26 @@ test('paths outside chat-owned image storage do not become browser URLs', () => 
   assert.equal(chatImageReference('/data/apps/private.png'), null)
 })
 
+test('a viewed /tmp image resolves through the owning chat only', () => {
+  assert.deepEqual(
+    temporaryImageReference('/tmp/visuals/render one.png', 'chat-123'),
+    {
+      kind: 'tmp',
+      chatId: 'chat-123',
+      filename: 'visuals/render one.png',
+    },
+  )
+  assert.deepEqual(
+    servedImageReference(
+      JSON.stringify({ path: '/tmp/inspect.png', detail: 'original' }),
+      'chat-123',
+    ),
+    { kind: 'tmp', chatId: 'chat-123', filename: 'inspect.png' },
+  )
+  assert.equal(temporaryImageReference('/tmp/visual.png', ''), null)
+  assert.equal(temporaryImageReference('/var/tmp/visual.png', 'chat-123'), null)
+})
+
 test('a base64 image result is an explicit fallback for non-chat paths', () => {
   const output = JSON.stringify({
     type: 'image',
@@ -67,11 +88,15 @@ test('a base64 image result is an explicit fallback for non-chat paths', () => {
     { kind: 'inline', src: 'data:image/png;base64,aGVsbG8=' },
   )
   assert.deepEqual(
-    toolImageReference('/tmp/visual.png', output),
+    toolImageReference('/tmp/visual.png', output, 'chat-123'),
+    { kind: 'tmp', chatId: 'chat-123', filename: 'visual.png' },
+  )
+  assert.deepEqual(
+    toolImageReference('/var/tmp/visual.png', output, 'chat-123'),
     { kind: 'inline', src: 'data:image/png;base64,aGVsbG8=' },
   )
   assert.equal(
-    durableImageReference('/data/apps/example-app/icon.png'),
+    servedImageReference('/data/apps/example-app/icon.png'),
     null,
     'editable app files are not replaced by a potentially different runtime asset',
   )

--- a/frontend/src/components/ChatView/__tests__/toolOutputLazy.test.js
+++ b/frontend/src/components/ChatView/__tests__/toolOutputLazy.test.js
@@ -17,8 +17,8 @@ test('expansion keeps ordinary output bounded and image fallback cancellable', (
     'an intermediate sidecar is never read before the matching tool settles')
   assert.match(effect, /\+ \(isImageTool \? '' : '\?preview=1'\)/,
     'ordinary expansion stays server-bounded; only a visual image fallback requests its complete envelope')
-  assert.match(effect, /if \(isImageTool && durableImage\) return/,
-    'durable images use their existing protected route without fetching duplicated base64')
+  assert.match(effect, /if \(isImageTool && servedImage\) return/,
+    'served images use their protected route without fetching duplicated base64')
   assert.doesNotMatch(effect, /previewOutput !== null \|\| loadingPreview/,
     'loading state cannot prevent the request it just started from settling')
   const dependencies = effect.match(/\}, \[([^\]]+)\]\)/)?.[1] || ''

--- a/frontend/src/components/ChatView/toolImageResult.js
+++ b/frontend/src/components/ChatView/toolImageResult.js
@@ -1,6 +1,7 @@
 /* Resolve image-view tool results without handing their base64 payload to the generic text renderer. */
 
 const CHAT_IMAGE_PATH = /^\/data\/chats\/([A-Za-z0-9_-]+)\/(uploads|media)\/([^/]+)$/
+const TMP_IMAGE_PATH = /^\/tmp\/(.+)$/
 const INLINE_IMAGE_TYPES = new Set([
   'image/png',
   'image/jpeg',
@@ -41,10 +42,24 @@ export function chatImageReference(input) {
   }
 }
 
-/** References that can render from an existing durable URL without loading
- * the image tool's much larger base64 sidecar. */
-export function durableImageReference(input) {
-  return chatImageReference(input)
+/** A native Codex image-view event records only its path. Temporary raster
+ * images therefore use the owning chat's narrow, token-protected /tmp route
+ * instead of waiting for a base64 result that Codex never emits. */
+export function temporaryImageReference(input, chatId) {
+  if (!chatId) return null
+  const match = imagePathFromInput(input).match(TMP_IMAGE_PATH)
+  if (!match) return null
+  return {
+    kind: 'tmp',
+    chatId,
+    filename: match[1],
+  }
+}
+
+/** References that can render through an existing protected route without
+ * loading the image tool's much larger base64 sidecar. */
+export function servedImageReference(input, chatId) {
+  return chatImageReference(input) || temporaryImageReference(input, chatId)
 }
 
 /** Fallback for image tools that viewed a path outside chat media. This work
@@ -74,6 +89,6 @@ export function inlineImageReference(output) {
   }
 }
 
-export function toolImageReference(input, output) {
-  return durableImageReference(input) || inlineImageReference(output)
+export function toolImageReference(input, output, chatId) {
+  return servedImageReference(input, chatId) || inlineImageReference(output)
 }

--- a/frontend/src/components/ChatView/useToolImagePreview.js
+++ b/frontend/src/components/ChatView/useToolImagePreview.js
@@ -16,8 +16,13 @@ async function sourceForReference(reference) {
 
   const tokenParam = await mediaTokenParam(reference.chatId)
   if (!tokenParam) return ''
-  const path = `/api/chats/${encodeURIComponent(reference.chatId)}/${reference.collection}/`
-    + encodeURIComponent(reference.filename)
+  const encodedFilename = reference.filename
+    .split('/')
+    .map(encodeURIComponent)
+    .join('/')
+  const path = reference.kind === 'tmp'
+    ? `/api/chats/${encodeURIComponent(reference.chatId)}/tmp-images/${encodedFilename}`
+    : `/api/chats/${encodeURIComponent(reference.chatId)}/${reference.collection}/${encodedFilename}`
   return `${BASE}${path}${tokenParam}`
 }
 


### PR DESCRIPTION
## Summary
- render agent-viewed raster files in `/tmp` through a chat-scoped protected route instead of waiting for an image payload the native tool does not provide
- reject non-images, traversal, and symlink escapes without copying temporary files into durable chat media
- preserve original-resolution lightboxes while keeping the existing bounded previews for pasted chat images
- update visual-testing guidance and add backend/frontend coverage

## Testing
- `scripts/wt-pytest.sh backend/tests/test_media.py --tb=short -q`
- `scripts/test.sh --fast`
- `npm test`
- `npm run build`
- visually verified that both a 2400×1600 `/tmp` viewed-image activity and its lightbox decode the original source

## Prior work
Follow-up to [#334](https://github.com/mobius-os/mobius/pull/334). That change rendered protected chat media and tool-output image payloads while deliberately adding no `/tmp` route. Native Codex image-view events carry only the file path, so temporary images still had no browser-renderable source; this change closes that remaining path through a narrow chat-scoped raster route.