### PR TITLE
Publish an image for every main commit

### DIFF
--- a/.github/workflows/main-image.yml
+++ b/.github/workflows/main-image.yml
@@ -9,10 +9,6 @@ permissions:
   contents: read
   packages: write
 
-concurrency:
-  group: mobius-main-image
-  cancel-in-progress: false
-
 env:
   DOCKER_BUILD_RECORD_UPLOAD: 'false'
   MOBIUS_IMAGE_REPOSITORY: ghcr.io/mobius-os/mobius
@@ -20,6 +16,8 @@ env:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    outputs:
+      digest: ${{ steps.publish.outputs.digest }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
@@ -30,7 +28,8 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
+      - id: publish
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
         with:
           context: .
           push: true
@@ -40,6 +39,76 @@ jobs:
             BUILD_SHA=${{ github.sha }}
           tags: |
             ${{ env.MOBIUS_IMAGE_REPOSITORY }}:sha-${{ github.sha }}
-            ${{ env.MOBIUS_IMAGE_REPOSITORY }}:main
           cache-from: type=gha
           cache-to: type=gha,mode=max,ignore-error=true
+      - name: Verify immutable tag resolves to this build
+        env:
+          EXPECTED_DIGEST: ${{ steps.publish.outputs.digest }}
+          SHA_IMAGE: ${{ env.MOBIUS_IMAGE_REPOSITORY }}:sha-${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          resolve_digest() {
+            local image_ref="$1"
+            local manifest=""
+            local attempt
+            for attempt in $(seq 1 12); do
+              if manifest="$(
+                docker buildx imagetools inspect "$image_ref" \
+                  --format '{{json .Manifest}}' 2>/dev/null
+              )" && [ -n "$manifest" ]; then
+                jq -er '.digest' <<<"$manifest"
+                return
+              fi
+              sleep 5
+            done
+            echo "GHCR did not resolve $image_ref after publication." >&2
+            return 1
+          }
+
+          sha_digest="$(resolve_digest "$SHA_IMAGE")"
+          if [ "$sha_digest" != "$EXPECTED_DIGEST" ]; then
+            echo "Immutable SHA tag resolved to $sha_digest, expected $EXPECTED_DIGEST." >&2
+            exit 1
+          fi
+
+  promote-main:
+    needs: publish
+    runs-on: ubuntu-latest
+    concurrency:
+      group: mobius-main-image-promotion
+      cancel-in-progress: false
+    steps:
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Promote the current branch head to main
+        env:
+          EXPECTED_DIGEST: ${{ needs.publish.outputs.digest }}
+          GH_TOKEN: ${{ github.token }}
+          SHA_IMAGE: ${{ env.MOBIUS_IMAGE_REPOSITORY }}:sha-${{ github.sha }}
+          MAIN_IMAGE: ${{ env.MOBIUS_IMAGE_REPOSITORY }}:main
+        run: |
+          set -euo pipefail
+
+          current_sha="$(
+            gh api "repos/$GITHUB_REPOSITORY/commits/main" --jq '.sha'
+          )"
+          if [ "$current_sha" != "$GITHUB_SHA" ]; then
+            echo "Skipping main promotion: $GITHUB_SHA is no longer branch head $current_sha."
+            exit 0
+          fi
+
+          docker buildx imagetools create --tag "$MAIN_IMAGE" "$SHA_IMAGE"
+          main_manifest="$(
+            docker buildx imagetools inspect "$MAIN_IMAGE" \
+              --format '{{json .Manifest}}'
+          )"
+          main_digest="$(jq -er '.digest' <<<"$main_manifest")"
+          if [ "$main_digest" != "$EXPECTED_DIGEST" ]; then
+            echo "Moving main tag resolved to $main_digest, expected $EXPECTED_DIGEST." >&2
+            exit 1
+          fi

--- a/.github/workflows/main-image.yml
+++ b/.github/workflows/main-image.yml
@@ -51,8 +51,7 @@ jobs:
           resolve_digest() {
             local image_ref="$1"
             local manifest=""
-            local attempt
-            for attempt in $(seq 1 12); do
+            for _ in $(seq 1 12); do
               if manifest="$(
                 docker buildx imagetools inspect "$image_ref" \
                   --format '{{json .Manifest}}' 2>/dev/null

--- a/tests/navigation.spec.mjs
+++ b/tests/navigation.spec.mjs
@@ -2167,25 +2167,37 @@ test.describe('Drawer close paths converge through handleBack', () => {
         layout: element.offsetWidth,
       }
     })
-    const box = await handle.boundingBox()
-    expect(box).not.toBeNull()
-
-    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2)
+    await handle.evaluate((element) => {
+      element.addEventListener('pointerdown', (event) => {
+        element.dataset.testPointerId = String(event.pointerId)
+        element.dataset.testPointerX = String(event.clientX)
+        element.dataset.testPointerY = String(event.clientY)
+      }, { once: true })
+    })
+    // Ask Playwright to resolve and hit-test the live handle after moving the
+    // drawer. A cached bounding box can lag that style change under CI load.
+    await handle.hover()
     await page.mouse.down()
-    await page.mouse.move(box.x + box.width / 2 + 48, box.y + box.height / 2)
+    const pointer = await handle.evaluate((element) => ({
+      id: Number(element.dataset.testPointerId),
+      x: Number(element.dataset.testPointerX),
+      y: Number(element.dataset.testPointerY),
+    }))
+    expect(Number.isInteger(pointer.id)).toBe(true)
+    expect(Number.isFinite(pointer.x)).toBe(true)
+    expect(Number.isFinite(pointer.y)).toBe(true)
+    await page.mouse.move(pointer.x + 48, pointer.y)
     const released = await handle.evaluate((element) => {
-      for (let pointerId = 1; pointerId <= 5; pointerId += 1) {
-        if (!element.hasPointerCapture(pointerId)) continue
-        // A programmatic releasePointerCapture() only flushes lostpointercapture
-        // on the next pointer-event dispatch, so dispatch the capture-loss event
-        // the browser itself delivers when a drag's capture is interrupted.
-        element.dispatchEvent(new PointerEvent('lostpointercapture', {
-          pointerId,
-          bubbles: true,
-        }))
-        return true
-      }
-      return false
+      const pointerId = Number(element.dataset.testPointerId)
+      if (!Number.isInteger(pointerId) || !element.hasPointerCapture(pointerId)) return false
+      // A programmatic releasePointerCapture() only flushes lostpointercapture
+      // on the next pointer-event dispatch, so dispatch the capture-loss event
+      // the browser itself delivers when a drag's capture is interrupted.
+      element.dispatchEvent(new PointerEvent('lostpointercapture', {
+        pointerId,
+        bubbles: true,
+      }))
+      return true
     })
     expect(released).toBe(true)
 


### PR DESCRIPTION
## Summary

- publish every main commit to its immutable `sha-<commit>` tag without workflow-level concurrency cancellation
- verify the immutable registry tag resolves to the digest produced by that build
- serialize only moving-tag promotion, and allow only the current main head to update `:main`
- verify `:main` resolves to the promoted digest
- make the drawer pointer-capture E2E use the live handle geometry and actual pointer identity

## Why

The old image itself was not stale: the recent immutable tag and `:main` still matched core `main`. The durability gap was that GitHub concurrency can replace a pending workflow run during a burst of pushes. Separating immutable publication from moving-tag promotion guarantees an artifact for every main commit while preventing an older build from leaving `:main` behind the branch head.

## Verification

- actionlint passes on the workflow
- backend, frontend, privacy, and complete E2E merge-queue checks pass
- focused drawer pointer-capture test passes 20/20 against a fresh candidate image after the deterministic geometry fix
- merge workflow run 31895850811 published `sha-b73de99904b59587c85a8b85574b9bad2e5040f0` and promoted `:main`
- immutable SHA and `:main` resolve to the same digest: `sha256:f096a7a157a923f161c090f3337889688023ab7a10ddd28f97e7e58c6915f57b`
- a pulled `:main` container passes strict health and reports baked, served, and platform SHA `b73de99904b59587c85a8b85574b9bad2e5040f0`
