### PR TITLE
Fold skill reads into ordinary chat activity

### DIFF
--- a/frontend/src/components/ChatView/__tests__/groupBlocks.test.js
+++ b/frontend/src/components/ChatView/__tests__/groupBlocks.test.js
@@ -79,18 +79,22 @@ test('original entry metadata is carried through untouched', () => {
   assert.deepEqual(nodes[0].group.map(x => x.idx), [7, 8])
 })
 
-test('a read-based skill receipt reclassifies its owning tool as one block', () => {
-  const items = [{
-    item: tool({
-      tool: 'Bash', tool_use_id: 'cmd-1', skills: ['recovery', 'theming'],
-    }),
-    idx: 4,
-  }]
+test('a read-based skill receipt joins the surrounding activity stretch', () => {
+  const items = [
+    { item: tool({ tool: 'Read', tool_use_id: 'read-1' }), idx: 3 },
+    {
+      item: tool({
+        tool: 'Bash', tool_use_id: 'cmd-1', skills: ['recovery', 'theming'],
+      }),
+      idx: 4,
+    },
+    { item: tool({ tool: 'Bash', tool_use_id: 'cmd-2' }), idx: 5 },
+  ]
   const nodes = groupActivityRuns(items)
   assert.equal(nodes.length, 1)
-  assert.equal(nodes[0].group[0], items[0])
-  assert.equal(effectiveToolName(nodes[0].group[0].item), 'Skill')
-  assert.equal(isDistinctiveActivityTool(nodes[0].group[0].item), true)
+  assert.deepEqual(nodes[0].group, items)
+  assert.equal(effectiveToolName(nodes[0].group[1].item), 'Skill')
+  assert.equal(isDistinctiveActivityTool(nodes[0].group[1].item), false)
 })
 
 test('a native Skill tool is not duplicated by its own receipt', () => {

--- a/frontend/src/components/ChatView/toolActivityLabel.js
+++ b/frontend/src/components/ChatView/toolActivityLabel.js
@@ -229,10 +229,10 @@ export function effectiveToolName(tool) {
 // files, ran commands" summary (owner ref 2026-07-17). The read/grep/edit/bash
 // plumbing is the agent's background housekeeping — one calm folded line is
 // right — but a notable beat like viewing an image is worth seeing on its own,
-// so scanning the transcript tells the story. Skill reads use the same lane:
-// effectiveToolName reclassifies their receipt-bearing Read/Bash block without
-// losing its expandable raw details.
-const DISTINCTIVE_ACTIVITIES = new Set(['ViewImage', 'MemoryRecall', 'Skill'])
+// so scanning the transcript tells the story. Skill reads are housekeeping too:
+// effectiveToolName still gives them an honest label and expandable details,
+// while the ordinary activity stretch folds them beside reads and commands.
+const DISTINCTIVE_ACTIVITIES = new Set(['ViewImage', 'MemoryRecall'])
 
 // The one-line story of a memory lookup, including honest operational failure.
 // Reading the count from the result set the backend already parsed keeps the


### PR DESCRIPTION
## Summary
- group routine skill reads with the surrounding chat activity instead of giving each one a separate row
- keep the exact skill names and tool details available when the activity is expanded
- retain standalone rows for image views and Memory lookups

## Testing
- `npm run lint`
- `npm run test:lib`
- `node --test frontend/src/components/ChatView/__tests__/groupBlocks.test.js`