### PR TITLE
Dismiss app previews five seconds after first observation

### DIFF
--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -94,6 +94,7 @@ import {
   highlightSearchTerms,
 } from '../../lib/searchTermHighlight.js'
 import { composerHistoryFromMessages } from './composerHistory.js'
+import useOpenAppCtaAutoDismiss from './hooks/useOpenAppCtaAutoDismiss.js'
 import {
   isPendingQuestionSendFailure,
   sendFailureMessage,
@@ -114,7 +115,6 @@ import {
   jumpToLatestShown,
   openAppCtaViewModel,
   shouldRetireRestoredQuestionSnapshot,
-  shouldShowOpenAppCta,
   shouldAttachRunningStream,
   shouldRetryStopAfterConfirm,
   stopConfirmedIdle,
@@ -169,10 +169,6 @@ _touchMql?.addEventListener('change', (e) => { _isTouchPrimary = e.matches })
 const STOP_RETRY_DELAYS_MS = [0, 250, 700, 1200]
 const CHAT_FETCH_TIMEOUT_MS = 15000
 const MESSAGE_META_VISIBLE_MS = 5000
-// How long the settled "Open <app>" CTA lingers after a turn ends before it
-// auto-dismisses itself (a durable "final" acknowledgement). An ephemeral nudge,
-// not a permanent chat-foot fixture.
-const OPEN_APP_CTA_AUTO_DISMISS_MS = 8000
 // The floating jump-to-latest control is driven by follow-state plus physical
 // tail distance. Reserved reply room remains part of that range, so an upward
 // reader escape can reveal the control even while the latest row is visible.
@@ -3591,24 +3587,12 @@ export default function ChatView({
   // (The fast-forward identity/readiness gates are computed separately below.)
   const turnActive = sending || isStreaming || serverRunning
 
-  // Auto-dismiss the settled "Open <app>" CTA a few seconds after the turn
-  // ends, so it reads as an ephemeral nudge rather than a permanent chat-foot
-  // fixture. Only the settled (post-turn) CTA times out; a live in-turn preview
-  // link stays put while the app is still being built. Dismissal is the same
-  // durable "final" acknowledgement that opening performs — minus the
-  // navigation — so the button never reappears on a later refetch, and a click
-  // that lands first simply advances the same server truth and cancels this.
-  // (Declared here, after `turnActive`, so its dep array is out of the TDZ.)
-  useEffect(() => {
-    if (turnActive || !onDismissApp) return
-    const timers = builtApps
-      .filter(app => shouldShowOpenAppCta(app, false))
-      .map(app => setTimeout(
-        () => onDismissApp(app), OPEN_APP_CTA_AUTO_DISMISS_MS,
-      ))
-    if (timers.length === 0) return
-    return () => timers.forEach(clearTimeout)
-  }, [builtApps, turnActive, onDismissApp])
+  useOpenAppCtaAutoDismiss({
+    builtApps,
+    turnActive,
+    hidden,
+    onDismissApp,
+  })
 
   useEffect(() => {
     if (!turnActive) return

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -293,6 +293,10 @@ export default function ChatView({
   // the scroll controller's paneResized() below. Null for a single-pane chat (today's
   // behavior — the controller's own ResizeObserver owns resize there).
   paneContentHeight = null,
+  // Shell presentation is narrower than runtime activity: overlays and modal
+  // navigation can cover a mounted, active chat. App-preview observation uses
+  // this explicit surface fact so covered shortcuts do not expire unseen.
+  previewPresented = false,
   // True when this mounted chat is hidden behind the full-workspace Settings
   // overlay (design §2). Before path-unification the single ChatView UNMOUNTED on
   // Settings, which aborted the mic; now it stays mounted, so we must stop voice
@@ -3590,7 +3594,7 @@ export default function ChatView({
   useOpenAppCtaAutoDismiss({
     builtApps,
     turnActive,
-    hidden,
+    presented: previewPresented && connectionError !== 'disconnected',
     onDismissApp,
   })
 

--- a/frontend/src/components/ChatView/chatRuntimeState.js
+++ b/frontend/src/components/ChatView/chatRuntimeState.js
@@ -267,6 +267,10 @@ export function shouldShowOpenAppCta(builtApp, turnActive = false) {
   return !turnActive && !builtApp.preview_seen_final
 }
 
+// Start from the first frame in which the shortcut is visible to the owner,
+// rather than from build completion or eventual turn settlement.
+export const OPEN_APP_CTA_AUTO_DISMISS_MS = 5000
+
 export function openAppCtaViewModel(builtApp, turnActive) {
   if (!shouldShowOpenAppCta(builtApp, turnActive)) return null
   const name = builtApp.name || 'app'

--- a/frontend/src/components/ChatView/chatRuntimeState.js
+++ b/frontend/src/components/ChatView/chatRuntimeState.js
@@ -5,6 +5,9 @@
 
 import { groupActivityRuns } from './activityGrouping.js'
 import { hasPendingQuestionMessage } from '../../lib/chatDetailCache.js'
+import { shouldShowOpenAppCta } from './openAppCtaState.js'
+
+export { shouldShowOpenAppCta }
 
 export function isContinuationMessage(message) {
   return message?.kind === 'continuation'
@@ -253,23 +256,6 @@ export function coldTranscriptRenderFrames(
   frames[frames.length - 1] = messages
   return frames
 }
-
-export function shouldShowOpenAppCta(builtApp, turnActive = false) {
-  if (!builtApp?.id) return false
-  const seenCurrentBuild = Boolean(
-    builtApp.updated_at
-    && builtApp.preview_seen_updated_at === builtApp.updated_at
-  )
-  if (!seenCurrentBuild) return true
-  // Opening during the live turn acknowledges that preview only. The settled
-  // result surfaces once more even if the last source write happened before
-  // the turn ended; opening it then is the durable final acknowledgement.
-  return !turnActive && !builtApp.preview_seen_final
-}
-
-// Start from the first frame in which the shortcut is visible to the owner,
-// rather than from build completion or eventual turn settlement.
-export const OPEN_APP_CTA_AUTO_DISMISS_MS = 5000
 
 export function openAppCtaViewModel(builtApp, turnActive) {
   if (!shouldShowOpenAppCta(builtApp, turnActive)) return null

--- a/frontend/src/components/ChatView/hooks/__tests__/useOpenAppCtaAutoDismiss.test.js
+++ b/frontend/src/components/ChatView/hooks/__tests__/useOpenAppCtaAutoDismiss.test.js
@@ -1,0 +1,110 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import useOpenAppCtaAutoDismiss from '../useOpenAppCtaAutoDismiss.js'
+import { renderHook } from './react-hook-shim.mjs'
+
+const app = (overrides = {}) => ({
+  id: 42,
+  name: 'Habits',
+  updated_at: 'build-1',
+  preview_seen_updated_at: null,
+  preview_seen_final: false,
+  ...overrides,
+})
+
+function fakeTimers() {
+  let nextId = 1
+  const scheduled = new Map()
+  const cleared = []
+  return {
+    scheduled,
+    cleared,
+    setTimer(fn, delay) {
+      const id = nextId++
+      scheduled.set(id, { fn, delay })
+      return id
+    },
+    clearTimer(id) {
+      cleared.push(id)
+      scheduled.delete(id)
+    },
+    fire(id) {
+      const timer = scheduled.get(id)
+      scheduled.delete(id)
+      timer?.fn()
+    },
+  }
+}
+
+function args(overrides = {}) {
+  return {
+    builtApps: [app()],
+    turnActive: true,
+    hidden: false,
+    onDismissApp() {},
+    ...overrides,
+  }
+}
+
+test('the clock starts when a visible chat first presents the shortcut', () => {
+  const timers = fakeTimers()
+  const dismissed = []
+  const hookArgs = args({ onDismissApp: value => dismissed.push(value) })
+  const hook = renderHook(useOpenAppCtaAutoDismiss, hookArgs, timers)
+
+  assert.equal(timers.scheduled.size, 1)
+  const [timerId, timer] = [...timers.scheduled.entries()][0]
+  assert.equal(timer.delay, 5000)
+
+  // Turn completion changes the label, but the continuously visible shortcut
+  // keeps the clock that started when the owner first saw it.
+  hook.rerender({ ...hookArgs, turnActive: false }, timers)
+  assert.equal(timers.scheduled.size, 1)
+  assert.deepEqual(timers.cleared, [])
+
+  timers.fire(timerId)
+  assert.deepEqual(dismissed, [hookArgs.builtApps[0]])
+})
+
+test('a hidden chat starts no clock until the owner enters it', () => {
+  const timers = fakeTimers()
+  const hookArgs = args({ hidden: true })
+  const hook = renderHook(useOpenAppCtaAutoDismiss, hookArgs, timers)
+
+  assert.equal(timers.scheduled.size, 0)
+  hook.rerender({ ...hookArgs, hidden: false }, timers)
+  assert.equal(timers.scheduled.size, 1)
+})
+
+test('new previews do not reset shortcuts that are already counting down', () => {
+  const timers = fakeTimers()
+  const first = app()
+  const hookArgs = args({ builtApps: [first] })
+  const hook = renderHook(useOpenAppCtaAutoDismiss, hookArgs, timers)
+  const [firstTimerId] = timers.scheduled.keys()
+
+  const second = app({ id: 43, updated_at: 'build-2' })
+  hook.rerender({ ...hookArgs, builtApps: [first, second] }, timers)
+
+  assert.equal(timers.scheduled.size, 2)
+  assert.equal(timers.scheduled.has(firstTimerId), true)
+  assert.deepEqual(timers.cleared, [])
+  hook.unmount()
+  assert.equal(timers.scheduled.size, 0)
+})
+
+test('opening a preview cancels its pending retirement', () => {
+  const timers = fakeTimers()
+  const hookArgs = args()
+  const hook = renderHook(useOpenAppCtaAutoDismiss, hookArgs, timers)
+  const [timerId] = timers.scheduled.keys()
+
+  hook.rerender({
+    ...hookArgs,
+    builtApps: [app({ preview_seen_updated_at: 'build-1' })],
+  }, timers)
+
+  assert.equal(timers.scheduled.size, 0)
+  assert.deepEqual(timers.cleared, [timerId])
+})

--- a/frontend/src/components/ChatView/hooks/__tests__/useOpenAppCtaAutoDismiss.test.js
+++ b/frontend/src/components/ChatView/hooks/__tests__/useOpenAppCtaAutoDismiss.test.js
@@ -37,47 +37,81 @@ function fakeTimers() {
   }
 }
 
+function fakeEventTarget(visibilityState) {
+  const listeners = new Map()
+  return {
+    visibilityState,
+    addEventListener(type, listener) {
+      const current = listeners.get(type) || new Set()
+      current.add(listener)
+      listeners.set(type, current)
+    },
+    removeEventListener(type, listener) {
+      listeners.get(type)?.delete(listener)
+    },
+    emit(type) {
+      for (const listener of listeners.get(type) || []) listener()
+    },
+    listenerCount(type) {
+      return listeners.get(type)?.size || 0
+    },
+  }
+}
+
 function args(overrides = {}) {
   return {
     builtApps: [app()],
     turnActive: true,
-    hidden: false,
+    presented: true,
     onDismissApp() {},
     ...overrides,
   }
 }
 
-test('the clock starts when a visible chat first presents the shortcut', () => {
+test('the clock starts only when the shortcut is presented on a foreground page', () => {
   const timers = fakeTimers()
-  const dismissed = []
-  const hookArgs = args({ onDismissApp: value => dismissed.push(value) })
-  const hook = renderHook(useOpenAppCtaAutoDismiss, hookArgs, timers)
+  const documentTarget = fakeEventTarget('hidden')
+  const windowTarget = fakeEventTarget()
+  const io = { ...timers, documentTarget, windowTarget }
+  const firstDismiss = []
+  const latestDismiss = []
+  const hookArgs = args({
+    presented: false,
+    onDismissApp: value => firstDismiss.push(value),
+  })
+  const hook = renderHook(useOpenAppCtaAutoDismiss, hookArgs, io)
+
+  // Neither a covered surface nor a background page has been observed.
+  assert.equal(timers.scheduled.size, 0)
+  hook.rerender({ ...hookArgs, presented: true }, io)
+  assert.equal(timers.scheduled.size, 0)
+  documentTarget.emit('visibilitychange')
+  assert.equal(timers.scheduled.size, 0)
+
+  documentTarget.visibilityState = 'visible'
+  windowTarget.emit('pageshow')
 
   assert.equal(timers.scheduled.size, 1)
   const [timerId, timer] = [...timers.scheduled.entries()][0]
   assert.equal(timer.delay, 5000)
 
-  // Turn completion changes the label, but the continuously visible shortcut
-  // keeps the clock that started when the owner first saw it.
-  hook.rerender({ ...hookArgs, turnActive: false }, timers)
+  // Turn completion, a later cover, and callback replacement do not restart a
+  // clock whose shortcut the owner already saw.
+  hook.rerender({
+    ...hookArgs,
+    presented: false,
+    turnActive: false,
+    onDismissApp: value => latestDismiss.push(value),
+  }, io)
   assert.equal(timers.scheduled.size, 1)
   assert.deepEqual(timers.cleared, [])
 
   timers.fire(timerId)
-  assert.deepEqual(dismissed, [hookArgs.builtApps[0]])
+  assert.deepEqual(firstDismiss, [])
+  assert.deepEqual(latestDismiss, [hookArgs.builtApps[0]])
 })
 
-test('a hidden chat starts no clock until the owner enters it', () => {
-  const timers = fakeTimers()
-  const hookArgs = args({ hidden: true })
-  const hook = renderHook(useOpenAppCtaAutoDismiss, hookArgs, timers)
-
-  assert.equal(timers.scheduled.size, 0)
-  hook.rerender({ ...hookArgs, hidden: false }, timers)
-  assert.equal(timers.scheduled.size, 1)
-})
-
-test('new previews do not reset shortcuts that are already counting down', () => {
+test('other previews keep their clocks while a replacement build gets a new one', () => {
   const timers = fakeTimers()
   const first = app()
   const hookArgs = args({ builtApps: [first] })
@@ -90,8 +124,16 @@ test('new previews do not reset shortcuts that are already counting down', () =>
   assert.equal(timers.scheduled.size, 2)
   assert.equal(timers.scheduled.has(firstTimerId), true)
   assert.deepEqual(timers.cleared, [])
-  hook.unmount()
-  assert.equal(timers.scheduled.size, 0)
+
+  const secondTimerId = [...timers.scheduled.keys()]
+    .find(timerId => timerId !== firstTimerId)
+  const replacement = app({ updated_at: 'build-3' })
+  hook.rerender({ ...hookArgs, builtApps: [replacement, second] }, timers)
+
+  assert.equal(timers.scheduled.size, 2)
+  assert.equal(timers.scheduled.has(firstTimerId), false)
+  assert.equal(timers.scheduled.has(secondTimerId), true)
+  assert.deepEqual(timers.cleared, [firstTimerId])
 })
 
 test('opening a preview cancels its pending retirement', () => {
@@ -107,4 +149,21 @@ test('opening a preview cancels its pending retirement', () => {
 
   assert.equal(timers.scheduled.size, 0)
   assert.deepEqual(timers.cleared, [timerId])
+})
+
+test('unmount releases the page listeners and every pending clock', () => {
+  const timers = fakeTimers()
+  const documentTarget = fakeEventTarget('visible')
+  const windowTarget = fakeEventTarget()
+  const io = { ...timers, documentTarget, windowTarget }
+  const hook = renderHook(useOpenAppCtaAutoDismiss, args(), io)
+
+  assert.equal(timers.scheduled.size, 1)
+  assert.equal(documentTarget.listenerCount('visibilitychange'), 1)
+  assert.equal(windowTarget.listenerCount('pageshow'), 1)
+
+  hook.unmount()
+  assert.equal(timers.scheduled.size, 0)
+  assert.equal(documentTarget.listenerCount('visibilitychange'), 0)
+  assert.equal(windowTarget.listenerCount('pageshow'), 0)
 })

--- a/frontend/src/components/ChatView/hooks/useOpenAppCtaAutoDismiss.js
+++ b/frontend/src/components/ChatView/hooks/useOpenAppCtaAutoDismiss.js
@@ -1,10 +1,9 @@
-/* Retire each Open-app shortcut five seconds after this chat first presents it. */
+/* Retire each Open-app shortcut five seconds after the owner first sees it. */
 
 import { useEffect, useRef } from 'react'
-import {
-  OPEN_APP_CTA_AUTO_DISMISS_MS,
-  shouldShowOpenAppCta,
-} from '../chatRuntimeState.js'
+import { shouldShowOpenAppCta } from '../openAppCtaState.js'
+
+const AUTO_DISMISS_MS = 5000
 
 function appBuildKey(app) {
   return `${app?.id ?? ''}:${app?.updated_at ?? ''}`
@@ -13,11 +12,13 @@ function appBuildKey(app) {
 export default function useOpenAppCtaAutoDismiss({
   builtApps,
   turnActive,
-  hidden,
+  presented,
   onDismissApp,
 }, {
   setTimer = setTimeout,
   clearTimer = clearTimeout,
+  documentTarget = typeof document === 'undefined' ? null : document,
+  windowTarget = typeof window === 'undefined' ? null : window,
 } = {}) {
   const timersRef = useRef(new Map())
   const onDismissRef = useRef(onDismissApp)
@@ -25,35 +26,64 @@ export default function useOpenAppCtaAutoDismiss({
 
   useEffect(() => {
     const timers = timersRef.current
-    const eligibleApps = new Map(
-      (Array.isArray(builtApps) ? builtApps : [])
-        .filter(app => shouldShowOpenAppCta(app, turnActive))
-        .map(app => [appBuildKey(app), app]),
-    )
-
-    // A click, acknowledgement, or replacement build retires the old timer.
-    // Merely leaving the chat does not: once the shortcut was actually seen,
-    // its five-second clock keeps its original meaning.
-    for (const [key, entry] of timers) {
-      if (eligibleApps.has(key)) continue
-      clearTimer(entry.timerId)
-      timers.delete(key)
+    function pageIsVisible() {
+      return !documentTarget?.visibilityState
+        || documentTarget.visibilityState === 'visible'
     }
 
-    // Hidden chats must not consume a shortcut the owner has never seen.
-    if (hidden || typeof onDismissApp !== 'function') return
+    function reconcile() {
+      const eligibleApps = new Map(
+        (Array.isArray(builtApps) ? builtApps : [])
+          .filter(app => shouldShowOpenAppCta(app, turnActive))
+          .map(app => [appBuildKey(app), app]),
+      )
 
-    for (const [key, app] of eligibleApps) {
-      if (timers.has(key)) continue
-      const timerId = setTimer(() => {
-        const current = timersRef.current.get(key)
-        if (!current || current.timerId !== timerId) return
-        timersRef.current.delete(key)
-        onDismissRef.current?.(current.app)
-      }, OPEN_APP_CTA_AUTO_DISMISS_MS)
-      timers.set(key, { timerId, app })
+      // A click, acknowledgement, or replacement build retires the old timer.
+      // Covering a shortcut after it was seen does not: its original five-second
+      // clock keeps the meaning the owner already observed.
+      for (const [key, entry] of timers) {
+        if (eligibleApps.has(key)) continue
+        clearTimer(entry.timerId)
+        timers.delete(key)
+      }
+
+      // A retained chat, a shell-covered surface, a disconnected foot, or a
+      // background browser tab has not presented the shortcut to the owner yet.
+      if (!presented || !pageIsVisible() || typeof onDismissApp !== 'function') return
+
+      for (const [key, app] of eligibleApps) {
+        if (timers.has(key)) continue
+        const timerId = setTimer(() => {
+          const current = timersRef.current.get(key)
+          if (!current || current.timerId !== timerId) return
+          timersRef.current.delete(key)
+          onDismissRef.current?.(current.app)
+        }, AUTO_DISMISS_MS)
+        timers.set(key, { timerId, app })
+      }
     }
-  }, [builtApps, turnActive, hidden, onDismissApp, setTimer, clearTimer])
+
+    function reconcileForeground() {
+      if (pageIsVisible()) reconcile()
+    }
+
+    reconcile()
+    documentTarget?.addEventListener?.('visibilitychange', reconcileForeground)
+    windowTarget?.addEventListener?.('pageshow', reconcileForeground)
+    return () => {
+      documentTarget?.removeEventListener?.('visibilitychange', reconcileForeground)
+      windowTarget?.removeEventListener?.('pageshow', reconcileForeground)
+    }
+  }, [
+    builtApps,
+    turnActive,
+    presented,
+    onDismissApp,
+    setTimer,
+    clearTimer,
+    documentTarget,
+    windowTarget,
+  ])
 
   useEffect(() => () => {
     for (const entry of timersRef.current.values()) {

--- a/frontend/src/components/ChatView/hooks/useOpenAppCtaAutoDismiss.js
+++ b/frontend/src/components/ChatView/hooks/useOpenAppCtaAutoDismiss.js
@@ -1,0 +1,64 @@
+/* Retire each Open-app shortcut five seconds after this chat first presents it. */
+
+import { useEffect, useRef } from 'react'
+import {
+  OPEN_APP_CTA_AUTO_DISMISS_MS,
+  shouldShowOpenAppCta,
+} from '../chatRuntimeState.js'
+
+function appBuildKey(app) {
+  return `${app?.id ?? ''}:${app?.updated_at ?? ''}`
+}
+
+export default function useOpenAppCtaAutoDismiss({
+  builtApps,
+  turnActive,
+  hidden,
+  onDismissApp,
+}, {
+  setTimer = setTimeout,
+  clearTimer = clearTimeout,
+} = {}) {
+  const timersRef = useRef(new Map())
+  const onDismissRef = useRef(onDismissApp)
+  onDismissRef.current = onDismissApp
+
+  useEffect(() => {
+    const timers = timersRef.current
+    const eligibleApps = new Map(
+      (Array.isArray(builtApps) ? builtApps : [])
+        .filter(app => shouldShowOpenAppCta(app, turnActive))
+        .map(app => [appBuildKey(app), app]),
+    )
+
+    // A click, acknowledgement, or replacement build retires the old timer.
+    // Merely leaving the chat does not: once the shortcut was actually seen,
+    // its five-second clock keeps its original meaning.
+    for (const [key, entry] of timers) {
+      if (eligibleApps.has(key)) continue
+      clearTimer(entry.timerId)
+      timers.delete(key)
+    }
+
+    // Hidden chats must not consume a shortcut the owner has never seen.
+    if (hidden || typeof onDismissApp !== 'function') return
+
+    for (const [key, app] of eligibleApps) {
+      if (timers.has(key)) continue
+      const timerId = setTimer(() => {
+        const current = timersRef.current.get(key)
+        if (!current || current.timerId !== timerId) return
+        timersRef.current.delete(key)
+        onDismissRef.current?.(current.app)
+      }, OPEN_APP_CTA_AUTO_DISMISS_MS)
+      timers.set(key, { timerId, app })
+    }
+  }, [builtApps, turnActive, hidden, onDismissApp, setTimer, clearTimer])
+
+  useEffect(() => () => {
+    for (const entry of timersRef.current.values()) {
+      clearTimer(entry.timerId)
+    }
+    timersRef.current.clear()
+  }, [clearTimer])
+}

--- a/frontend/src/components/ChatView/openAppCtaState.js
+++ b/frontend/src/components/ChatView/openAppCtaState.js
@@ -1,0 +1,14 @@
+/* Eligibility policy shared by Open-app rendering and its retirement clock. */
+
+export function shouldShowOpenAppCta(builtApp, turnActive = false) {
+  if (!builtApp?.id) return false
+  const seenCurrentBuild = Boolean(
+    builtApp.updated_at
+    && builtApp.preview_seen_updated_at === builtApp.updated_at
+  )
+  if (!seenCurrentBuild) return true
+  // Opening during the live turn acknowledges that preview only. The settled
+  // result surfaces once more even if the last source write happened before
+  // the turn ended; opening it then is the durable final acknowledgement.
+  return !turnActive && !builtApp.preview_seen_final
+}

--- a/frontend/src/components/Shell/PaneChatView.jsx
+++ b/frontend/src/components/Shell/PaneChatView.jsx
@@ -26,6 +26,7 @@ function PaneChatView({
   paneId,
   apps,
   runtimeActive = true,
+  previewPresented = false,
   keepTranscriptPainted = false,
   focusedPresentation = false,
   paneContentHeight,
@@ -132,6 +133,7 @@ function PaneChatView({
         key={chatId}
         chatId={chatId}
         hidden={!runtimeActive}
+        previewPresented={previewPresented}
         keepTranscriptPainted={keepTranscriptPainted}
         paneContentHeight={paneContentHeight}
         externalRunSignal={externalRunSignal}

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -3927,6 +3927,7 @@ export default function Shell({ onInitialVisualReady }) {
                 // Runtime activity and painting are independent during a handoff:
                 // staging owns the work while held remains the visual cover.
                 runtimeActive={surfaceVisible && chatPanesVisible && role !== 'held'}
+                previewPresented={chatSurfaceInteractive}
                 keepTranscriptPainted={surfaceVisible && role === 'held'}
                 focusedPresentation={!standardOwner
                   && focusedPaneViewId != null

--- a/frontend/src/components/Shell/__tests__/paneChatProps.test.js
+++ b/frontend/src/components/Shell/__tests__/paneChatProps.test.js
@@ -38,6 +38,7 @@ function propBag(overrides = {}) {
     chatId: 'chat-a',
     paneId: 'pane-1',
     runtimeActive: true,
+    previewPresented: true,
     keepTranscriptPainted: false,
     paneContentHeight: 640,
     externalRunSignal: { startedAt: 1, activityAt: 2 },
@@ -114,6 +115,8 @@ test('Shell hands the pane only identity-stable props', () => {
   // navTo is declared per render in useNavigation; the pane gets the ref-backed
   // wrapper instead so its identity never churns.
   assert.match(slice, /navTo=\{stablePaneNavTo\}/)
+  assert.match(slice, /previewPresented=\{chatSurfaceInteractive\}/,
+    'preview expiry must use the shell surface that is actually presented')
   assert.match(shell, /const stablePaneNavTo = useCallback\(/)
   // loadTheme is a dependency of handleSystemEvent, which is itself a pane prop.
   assert.match(useTheme, /const loadTheme = useCallback\(/)


### PR DESCRIPTION
## Summary

- start the five-second retirement clock when an app-build shortcut first becomes visible, including during an active build turn
- defer the clock for hidden chats until the owner actually views the shortcut
- preserve each build's original clock across turn settlement and unrelated preview arrivals, while cancelling it when the preview is opened

## Testing

- `npm run test:hooks`
- focused chat runtime tests
- `npm run test:structure`
- `npm run build`
- verified in the live shell that an active-turn preview retires five seconds after first display