### PR TITLE
Keep New Chat composer options stable during allocation

### DIFF
--- a/frontend/src/components/ChatView/ChatView.css
+++ b/frontend/src/components/ChatView/ChatView.css
@@ -2522,6 +2522,17 @@
   color: var(--text); /* CONTRACT: high-contrast text on opaque fill */
 }
 
+/* A New Chat already has the same final composer geometry, even during its
+   very short allocation handoff. The options button stays deliberately inert
+   until the row exists, but it must not pop into the layout afterwards. */
+.chat__plus--pending:disabled {
+  cursor: default;
+}
+.chat__plus--pending:disabled:hover {
+  background: color-mix(in srgb, var(--surface) 70%, transparent);
+  color: var(--muted);
+}
+
 /* Keyboard-only focus ring on the + button. No :focus rule (pointer
    focus must not show a ring — the one-halo invariant). :focus-visible
    fires only for keyboard navigation. When the popover is active the

--- a/frontend/src/components/ChatView/ComposerPopover.jsx
+++ b/frontend/src/components/ChatView/ComposerPopover.jsx
@@ -1,6 +1,6 @@
 /**
  * ComposerPopover — the `+` button in the chat composer and the popover
- * it opens. Two sections in one popover:
+ * it opens. Three sections in one popover:
  *
  *   1. Attach files  — calls `onAttachClick` (parent owns the hidden
  *      <input type="file"> so it can clear .value after each pick).
@@ -17,6 +17,12 @@
  * remove that `position: relative` thinking `.chat__form` is the
  * anchor — the form is only relative so other absolutely-positioned
  * children (none today) could anchor to it.
+ *
+ * A draft-first New Chat uses this same component with `pending`. That
+ * renders the canonical trigger in its final geometry, but keeps it disabled
+ * and omits dialog semantics until the server-backed chat is ready. Keeping
+ * the pending state here prevents the provisional composer from maintaining a
+ * second lookalike button that can drift from the real control.
  *
  * Soft-keyboard contract: opening or using this popover preserves whether the
  * owning textarea was focused. The + trigger suppresses native button focus
@@ -67,6 +73,7 @@ export default function ComposerPopover({
   onOpenInspector,
   onOpenSummary,
   embedded = false,
+  pending = false,
 }) {
   const [open, setOpen] = useState(false)
   const wrapRef = useRef(null)
@@ -194,7 +201,9 @@ export default function ComposerPopover({
       <button
         ref={triggerRef}
         type="button"
-        className={`chat__plus${open ? ' chat__plus--active' : ''}`}
+        className={`chat__plus${pending ? ' chat__plus--pending' : ''}`
+          + `${open && !pending ? ' chat__plus--active' : ''}`}
+        disabled={pending}
         // PointerDown preventDefault stops the focus from moving off
         // the textarea — keeps the soft keyboard open when the user
         // taps `+` mid-typing. Without this, focus shifts to the
@@ -223,13 +232,15 @@ export default function ComposerPopover({
             })
           }
         }}
-        aria-label="Attach or change model"
-        aria-haspopup="dialog"
-        aria-expanded={open}
+        aria-label={pending
+          ? 'Chat options unavailable until this chat is ready'
+          : 'Attach or change model'}
+        aria-haspopup={pending ? undefined : 'dialog'}
+        aria-expanded={pending ? undefined : open}
       >
         <Plus width={26} height={26} />
       </button>
-      {open && (
+      {open && !pending && (
         <div
           className="composer-popover"
           role="dialog"

--- a/frontend/src/components/Shell/NewChatLanding.jsx
+++ b/frontend/src/components/Shell/NewChatLanding.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 
 import ChatInputBar from '../ChatView/ChatInputBar.jsx'
+import ComposerPopover from '../ChatView/ComposerPopover.jsx'
 import {
   composerDraftRevision,
   persistComposerDraft,
@@ -148,6 +149,7 @@ export default function NewChatLanding({
             submissionBlocked
             pendingFiles={attachments}
             onRemoveFile={removeAttachment}
+            leftButtons={<ComposerPopover pending />}
             attachmentsDisabled
           />
         </div>

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -1254,9 +1254,11 @@ test('round4-3: the New Chat landing renders for a null slot and reuses ChatView
   assert.match(newChatLanding,
     /focusComposerElement\(inputRef\.current\)[\s\S]*placeCaretAtTextEnd\(inputRef\.current\)/,
     'the provisional draft resumes at its text end without changing generic focus policy')
-  assert.doesNotMatch(newChatLanding,
-    /ComposerPopover|leftButtons=|attachTriggerRef/,
-    'the pre-allocation surface must not expose dead server-bound controls')
+  assert.match(newChatLanding,
+    /leftButtons=\{<ComposerPopover pending \/>\}/,
+    'the provisional composer must reuse the real options control in its inert state')
+  assert.doesNotMatch(newChatLanding, /attachTriggerRef/,
+    'the pre-allocation surface must not expose server-bound attachment behavior')
   assert.match(chatInputBar,
     /function handlePaste\(e\) \{\s*if \(attachmentsDisabled\) return/,
     'disabled attachments must leave clipboard paste to the browser')

--- a/tests/navigation.spec.mjs
+++ b/tests/navigation.spec.mjs
@@ -884,7 +884,7 @@ test.describe('Touch navigation', () => {
     await expect(page.locator('[data-chat-surface="painted"] textarea')).toBeFocused()
   })
 
-  test('New chat preserves phone focus and early typing through allocation', async ({ page }) => {
+  test('New chat keeps options geometry, phone focus, and early typing through allocation', async ({ page }) => {
     await setup(page)
     await expect.poll(() => page.evaluate(() => (
       matchMedia('(hover: none) and (pointer: coarse)').matches
@@ -916,8 +916,14 @@ test.describe('Touch navigation', () => {
 
     const presentation = page.locator('[data-new-chat-presentation]')
     const immediateComposer = presentation.getByRole('textbox', { name: 'Message Möbius…' })
+    const pendingOptions = presentation.getByRole('button', {
+      name: 'Chat options unavailable until this chat is ready',
+    })
     await expect(presentation).toBeVisible()
     await expect(presentation.getByText("What's on your mind?", { exact: true })).toBeVisible()
+    await expect(pendingOptions).toBeVisible()
+    await expect(pendingOptions).toBeDisabled()
+    const pendingOptionsBox = await pendingOptions.boundingBox()
     await expect(immediateComposer).toBeFocused()
     await page.keyboard.type('Typed while opening')
     await expect.poll(() => requestedId).toMatch(
@@ -946,6 +952,17 @@ test.describe('Touch navigation', () => {
       end: element.selectionEnd,
       length: element.value.length,
     }))).toEqual({ start: 19, end: 19, length: 19 })
+    const readyOptions = page.locator('[data-chat-surface="painted"]')
+      .getByRole('button', { name: 'Attach or change model' })
+    await expect(readyOptions).toBeVisible()
+    await expect(readyOptions).toBeEnabled()
+    const readyOptionsBox = await readyOptions.boundingBox()
+    expect(pendingOptionsBox).not.toBeNull()
+    expect(readyOptionsBox).not.toBeNull()
+    expect(readyOptionsBox.width).toBe(pendingOptionsBox.width)
+    expect(readyOptionsBox.height).toBe(pendingOptionsBox.height)
+    expect(Math.abs(readyOptionsBox.x - pendingOptionsBox.x)).toBeLessThanOrEqual(1)
+    expect(Math.abs(readyOptionsBox.y - pendingOptionsBox.y)).toBeLessThanOrEqual(1)
     await page.keyboard.type(' after allocation')
     await expect(composer).toHaveValue('Typed while opening after allocation')
   })


### PR DESCRIPTION
## Summary
- render the canonical composer options trigger on the immediate draft-first New Chat surface
- keep the trigger disabled and remove dialog semantics until the server-backed chat is ready
- protect the disabled-to-enabled handoff with phone coverage that checks visibility, focus, early typing, and unchanged geometry

This is a focused follow-up to #745. That change correctly kept server-bound capabilities unavailable before allocation, but the immediate composer omitted the trigger and added it only during handoff. This preserves the capability boundary while keeping the composer visually stable from its first frame.

## Testing
- `npm test` (2,575 passed)
- focused New Chat source regression
- production frontend watcher build
- authenticated delayed-allocation browser checks at wide and 412×915 viewports; the pending and ready controls kept identical size and position
- `git diff --check`

The isolated Playwright runner was not available inside the app container because it requires Docker. The committed browser scenario is ready for upstream CI; the equivalent delayed handoff was exercised against the live authenticated shell.