### PR TITLE
Show working state beside chat titles

### DIFF
--- a/frontend/src/components/ChatView/__tests__/framePipelineQuiescence.test.js
+++ b/frontend/src/components/ChatView/__tests__/framePipelineQuiescence.test.js
@@ -114,10 +114,9 @@ function ruleBody(selector) {
   return rule[1].trim()
 }
 
-test('always-mounted streaming chrome has no infinite animation', () => {
+test('the retired drawer pulse does not return', () => {
   assert.doesNotMatch(ruleBody('.drawer__streaming-dot'), /animation\s*:/)
   assert.doesNotMatch(drawerCss, /@keyframes\s+drawer-streaming-pulse/)
-  assert.doesNotMatch(drawerCss, /animation[^;}]*\binfinite\b/)
 })
 
 test('streaming and attention rows stay tellable apart without motion', () => {

--- a/frontend/src/components/Drawer/Drawer.css
+++ b/frontend/src/components/Drawer/Drawer.css
@@ -770,24 +770,18 @@
 
 /* ── Row status dots ───────────────────────────────── */
 
-/* 6px accent dot in front of a row label. Marks chats whose agent
+/* Shared animated mark in front of a row label. Marks chats whose agent
    is mid-turn so a user switching to another chat still sees the
-   background build progressing in the drawer.
+   background work progressing in the drawer. The shared indicator animates
+   only while a real chat turn is active and falls back to a static ring for
+   reduced-motion users. */
+.drawer__working-indicator {
+  flex-shrink: 0;
+  margin-right: 2px;
+}
 
-   Deliberately static. This dot used to pulse on a 1.5s infinite loop,
-   but the drawer is always mounted and a long-running agent keeps its
-   row on screen for hours, so the animation never ended — which kept
-   the compositor producing 60 frames a second even with the app fully
-   idle, and every one of those frames paid for the composer's
-   backdrop-filter. Measured: disabling this animation (with the tab
-   title marquee) took DrawFrame, BeginFrame and render passes to zero
-   at idle. The reduced-motion path below already settled that a steady
-   dot is an acceptable representation and that "streaming" surfaces via
-   aria-label + presence; this generalises that decision to everyone.
-
-   If motion is ever wanted back here, it must be bounded — a few
-   iterations re-armed when the row's status CHANGES, never `infinite`
-   on always-mounted chrome. */
+/* App-building rows retain their compact static dot; chat work uses the
+   more explicit shared indicator above. */
 .drawer__streaming-dot {
   flex-shrink: 0;
   width: 6px;

--- a/frontend/src/components/Drawer/Drawer.jsx
+++ b/frontend/src/components/Drawer/Drawer.jsx
@@ -12,6 +12,7 @@ import {
   SettingsNavIcon,
 } from '../navigationIcons.js'
 import AppIcon from '../AppIcon.jsx'
+import ChatWorkingIndicator from '../ui/ChatWorkingIndicator.jsx'
 import { preloadAppIcons } from '../appIcon.js'
 import {
   computePinnedDrag,
@@ -1889,15 +1890,11 @@ const DrawerRow = memo(function DrawerRow({
         {kind === 'app' && (
           <AppIcon item={item} label={label} className="drawer__app-icon" />
         )}
-        {/* Status dot. Sits before the text so the user's eye
+        {/* Status mark. Sits before the text so the user's eye
             picks it up alongside the label rather than at the row's
             edge (where the pin lives). aria-label exposes the state. */}
         {streaming ? (
-          <span
-            className="drawer__streaming-dot"
-            aria-label="Currently streaming"
-            title="Currently streaming"
-          />
+          <ChatWorkingIndicator className="drawer__working-indicator" />
         ) : building ? (
           <span
             className="drawer__streaming-dot"

--- a/frontend/src/components/Shell/PaneStrip.jsx
+++ b/frontend/src/components/Shell/PaneStrip.jsx
@@ -3,6 +3,7 @@ import { CollapseSm, ExpandSm, X } from '@openai/apps-sdk-ui/components/Icon'
 import * as tabModel from './tabModel.js'
 import { STRIP_H } from './paneModel.js'
 import { captureLayoutSpace, clientLengthToLayout } from '../../lib/layoutSpace.js'
+import ChatWorkingIndicator from '../ui/ChatWorkingIndicator.jsx'
 
 // Each direction owns 40% of the one-shot cycle, so 1000/12 ms per clipped pixel
 // keeps travel at a readable 30px/s. The cycle runs once, returns to the beginning,
@@ -78,6 +79,7 @@ export function scrollStripWheel(e) {
 // (tabIndex 0); the rest and every close button are reached via stripKeyDown.
 export function PaneTab({
   tab, label, active, focused = true, revealKey = 0,
+  working = false,
   tabIndex, dragKey, role, tabId, controlsId,
   onActivate, onClose, onContextMenu,
 }) {
@@ -161,6 +163,7 @@ export function PaneTab({
         <span ref={titleRef} className="shell__tab-text">
           <span className="shell__tab-text-inner">{label}</span>
         </span>
+        {working && <ChatWorkingIndicator className="shell__tab-working" />}
       </button>
       <button
         type="button"
@@ -197,6 +200,7 @@ export function PaneFocusButton({ paneId, focused, onToggle }) {
 // before navTo snapshots the source route (see WorkspaceChrome.activateTab).
 export function PaneStrip({
   pane, paneRect, focused, labelForTab,
+  workingChatIds,
   onActivate, onClose, onFocus, onTabContextMenu,
   viewTransitionStyle = null,
   canFocusPane = false, paneFocused = false, onTogglePaneFocus,
@@ -231,6 +235,7 @@ export function PaneStrip({
             key={key}
             tab={tab}
             label={labelForTab(tab)}
+            working={tab.kind === 'chat' && workingChatIds?.has(String(tab.id))}
             active={active}
             focused={focused}
             revealKey={revealKey}

--- a/frontend/src/components/Shell/Shell.css
+++ b/frontend/src/components/Shell/Shell.css
@@ -447,6 +447,9 @@
   display: inline-block;
   min-width: max-content;
 }
+.shell__tab-working {
+  margin-left: 6px;
+}
 /* Only the newly-active title in the focused strip makes one bounded reveal.
    It rests at the beginning, travels far enough to expose the tail, rests there,
    then returns to the beginning and stays idle. Other panes never start competing

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -1585,6 +1585,19 @@ export default function Shell({ onInitialVisualReady }) {
     }
     return next
   }, [localStreamingChatIds, chats])
+  // A parked question still owns a durable runner, but Möbius is waiting for
+  // the owner rather than thinking. Keep that runtime fact for reload policy
+  // while withholding the animated "working" promise from title surfaces.
+  const workingChatIds = useMemo(() => new Set(
+    [...streamingChatIds].filter(id => {
+      const chat = chatById.get(String(id))
+      return !chat || chat.pending_question_id == null
+    }),
+  ), [streamingChatIds, chatById])
+  const workingChatIdStrings = useMemo(
+    () => new Set([...workingChatIds].map(id => String(id))),
+    [workingChatIds],
+  )
   const streamingChatIdsRef = useRef(streamingChatIds)
   useEffect(() => { streamingChatIdsRef.current = streamingChatIds }, [streamingChatIds])
   // Whether the chat the owner is looking at is parked on an AskUserQuestion
@@ -3620,7 +3633,7 @@ export default function Shell({ onInitialVisualReady }) {
         nowPlaying={nowPlaying}
         onNowPlayingOpen={handleNowPlayingOpen}
         onNowPlayingControl={handleNowPlayingControl}
-        streamingChatIds={streamingChatIds}
+        streamingChatIds={workingChatIds}
         attentionChatIds={attentionChatIds}
         newAppIds={appAttentionSet}
         settingsWarning={providerAuth.needsAttention}
@@ -3697,6 +3710,7 @@ export default function Shell({ onInitialVisualReady }) {
                 key={key}
                 tab={tab}
                 label={labelForTab(tab)}
+                working={tab.kind === 'chat' && workingChatIdStrings.has(String(tab.id))}
                 active={active}
                 revealKey={tabRevealRevision}
                 tabIndex={active ? 0 : -1}
@@ -4146,6 +4160,7 @@ export default function Shell({ onInitialVisualReady }) {
             dispatchWorkspace={dispatchWorkspace}
             navTo={navTo}
             labelForTab={labelForTab}
+            workingChatIds={workingChatIdStrings}
             onTabContextMenu={openTabMenu}
             // The ONE shared user-close action — WorkspaceChrome owns no private
             // close dispatcher or transition timing.

--- a/frontend/src/components/Shell/WorkspaceChrome.jsx
+++ b/frontend/src/components/Shell/WorkspaceChrome.jsx
@@ -88,6 +88,7 @@ export default function WorkspaceChrome({
   dispatchWorkspace,
   navTo,
   labelForTab,
+  workingChatIds,
   onTabContextMenu,
   // The ONE shared user-close action (INV 13) — Shell owns it, this layer no longer
   // dispatches CLOSE_TAB itself. Called with a tab object.
@@ -266,6 +267,7 @@ export default function WorkspaceChrome({
             paneRect={rect}
             focused={paneId === workspace.focusedPaneId}
             labelForTab={labelForTab}
+            workingChatIds={workingChatIds}
             onActivate={activateTab}
             onClose={onCloseTab}
             onFocus={focusPane}

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -24,6 +24,14 @@ const workspaceViewSrc = readFileSync(new URL('../workspaceView.js', import.meta
 const modeViewTransitionSrc = readFileSync(new URL('../useModeViewTransition.js', import.meta.url), 'utf8')
 const modeControllerSrc = readFileSync(new URL('../useModeController.js', import.meta.url), 'utf8')
 const drawer = readFileSync(new URL('../../Drawer/Drawer.jsx', import.meta.url), 'utf8')
+const workingIndicator = readFileSync(
+  new URL('../../ui/ChatWorkingIndicator.jsx', import.meta.url),
+  'utf8',
+)
+const workingIndicatorCss = readFileSync(
+  new URL('../../ui/ChatWorkingIndicator.css', import.meta.url),
+  'utf8',
+)
 const drawerItemActionMenu = readFileSync(
   new URL('../../Drawer/DrawerItemActionMenu.jsx', import.meta.url),
   'utf8',
@@ -858,7 +866,7 @@ test('opening navigation is presentation-only and never refetches whole lists', 
     'a run started in another live client must still advance drawer recency')
 })
 
-test('chat drawer dots distinguish active work from unseen completion', () => {
+test('chat titles distinguish active work from unseen completion', () => {
   assert.match(
     shell,
     /ev\.type === 'chat_run_started'[\s\S]*?markStreamingStart\(ev\.chatId\)/,
@@ -876,8 +884,26 @@ test('chat drawer dots distinguish active work from unseen completion', () => {
   )
   assert.match(
     drawer,
-    /streaming \? \([\s\S]*?drawer__streaming-dot[\s\S]*?: attention \? \([\s\S]*?drawer__attention-dot/,
+    /streaming \? \([\s\S]*?ChatWorkingIndicator[\s\S]*?: building \? \([\s\S]*?: attention \? \([\s\S]*?drawer__attention-dot/,
     'active work must take precedence over unseen completion in a row',
+  )
+  assert.match(workingIndicator, /aria-label="Möbius is working"/)
+  assert.match(workingIndicatorCss, /animation:\s*chat-working-orbit[^;]*infinite/)
+  assert.match(workingIndicatorCss, /prefers-reduced-motion:[\s\S]*?animation:\s*none/)
+  assert.match(
+    paneStrip,
+    /\{working && <ChatWorkingIndicator className="shell__tab-working" \/>\}/,
+    'the shared working mark must sit beside the main-panel tab title',
+  )
+  assert.match(
+    shell,
+    /working=\{tab\.kind === 'chat' && workingChatIdStrings\.has\(String\(tab\.id\)\)\}/,
+    'single-pane tabs must derive the mark from the shell working set',
+  )
+  assert.match(
+    paneStrip,
+    /working=\{tab\.kind === 'chat' && workingChatIds\?\.has\(String\(tab\.id\)\)\}/,
+    'tiled-pane tabs must derive the same mark from the same working set',
   )
   assert.match(drawerCss, /\.drawer__streaming-dot\s*\{[\s\S]*?background:\s*var\(--accent\)/)
   assert.match(drawerCss, /\.drawer__attention-dot\s*\{[\s\S]*?border:\s*1\.5px solid var\(--green\)/)

--- a/frontend/src/components/ui/ChatWorkingIndicator.css
+++ b/frontend/src/components/ui/ChatWorkingIndicator.css
@@ -1,0 +1,34 @@
+/* ChatWorkingIndicator uses one compositor-only orbit to show an active chat turn. */
+.chat-working-indicator {
+  position: relative;
+  display: inline-block;
+  flex: 0 0 auto;
+  box-sizing: border-box;
+  width: 11px;
+  height: 11px;
+  border: 1.5px solid color-mix(in srgb, var(--accent) 32%, transparent);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: chat-working-orbit 1.05s linear infinite;
+}
+
+.chat-working-indicator::after {
+  content: '';
+  position: absolute;
+  width: 3px;
+  height: 3px;
+  top: -2px;
+  left: 2.5px;
+  border-radius: 50%;
+  background: var(--accent);
+}
+
+@keyframes chat-working-orbit {
+  to { transform: rotate(360deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .chat-working-indicator {
+    animation: none;
+  }
+}

--- a/frontend/src/components/ui/ChatWorkingIndicator.jsx
+++ b/frontend/src/components/ui/ChatWorkingIndicator.jsx
@@ -1,0 +1,13 @@
+/* ChatWorkingIndicator is the shared, accessible in-progress mark for chat titles. */
+import './ChatWorkingIndicator.css'
+
+export default function ChatWorkingIndicator({ className = '' }) {
+  return (
+    <span
+      className={`chat-working-indicator${className ? ` ${className}` : ''}`}
+      role="img"
+      aria-label="Möbius is working"
+      title="Möbius is working…"
+    />
+  )
+}


### PR DESCRIPTION
## Summary

- show a small animated working indicator beside active chat titles in navigation and workspace tabs
- derive both surfaces from the existing chat run state while leaving owner-question waits visually idle
- provide an accessible label and a reduced-motion fallback

## Testing

- focused shell UI and frame-quiescence unit tests
- rendered verification in the authenticated shell