### PR TITLE
Keep mobile draft keyboards open across chat returns

### DIFF
--- a/frontend/src/components/Shell/Shell.css
+++ b/frontend/src/components/Shell/Shell.css
@@ -653,9 +653,9 @@
   white-space: nowrap;
   border: 0;
 }
-/* A real text control is required to reserve the software keyboard during the
-   async New-chat handoff. It stays mounted outside the modal drawer's inert
-   subtree and never participates in layout or pointer hit-testing. */
+/* A real text control is required to reserve the software keyboard while one
+   chat composer hands focus to another. It stays mounted outside the modal
+   drawer's inert subtree and never participates in layout or pointer input. */
 .shell__composer-focus-lease {
   position: fixed;
   left: 0;

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -98,6 +98,7 @@ import {
 } from '../ChatView/composerDraft.js'
 import {
   beginTouchComposerFocusLease,
+  composerDraftWantsKeyboard,
   releaseComposerFocusLease,
 } from './composerFocusLease.js'
 import {
@@ -201,6 +202,10 @@ export default function Shell({ onInitialVisualReady }) {
   // Navigation reads the current claimant synchronously without closing over
   // reload-controller state declared later in this component.
   const beforeNavigateRef = useRef(null)
+  // Back/Forward can reserve a draft's mobile writing session before the
+  // outgoing surface becomes inert. The callback is filled after the shared
+  // composer handoff exists below.
+  const beforeRestoreRouteRef = useRef(null)
 
   const {
     activeView,
@@ -224,6 +229,7 @@ export default function Shell({ onInitialVisualReady }) {
     replaceImplicitBootTab,
     dragActiveRef,
     beforeNavigateRef,
+    beforeRestoreRouteRef,
   })
 
   // A mobile drawer is a history-backed virtual route. A desktop sidebar is a
@@ -685,6 +691,38 @@ export default function Shell({ onInitialVisualReady }) {
   function focusDesktopChatPaneComposer(chatId) {
     if (!supportsDesktopPaneComposerFocus()) return
     requestComposer(chatId, { focus: true })
+  }
+
+  function reserveTouchDraftComposer(chatId) {
+    if (chatId == null) return false
+    const saved = readComposerDraft(chatId)
+    if (composerDraftWantsKeyboard(saved)) {
+      const leased = beginTouchComposerFocusLease(composerFocusLeaseRef.current, {
+        initialValue: saved.input,
+      })
+      if (leased) {
+        composerFocusLeaseDraftIdRef.current = String(chatId)
+        composerFocusLeaseDirtyRef.current = false
+        requestComposer(chatId, { focus: true, restoreExistingDraft: true })
+        return true
+      }
+    }
+    return false
+  }
+
+  function focusSelectedChatComposer(chatId) {
+    if (chatId == null) return false
+    if (reserveTouchDraftComposer(chatId)) return true
+    focusDesktopChatPaneComposer(chatId)
+    return true
+  }
+
+  // Browser traversal bypasses the drawer and tab selection handlers. Reserve
+  // the touch keyboard at useNavigation's validated restore boundary, before
+  // the outgoing chat or app can become inert.
+  beforeRestoreRouteRef.current = (route) => {
+    if (route?.view !== 'chat' || route.chatId == null) return
+    reserveTouchDraftComposer(route.chatId)
   }
 
   // A restored single-screen chat has no click handler to request focus. Keep
@@ -3236,7 +3274,7 @@ export default function Shell({ onInitialVisualReady }) {
       && !destinationAlreadyPainted
     clearChatAttention(id)
     navTo('chat', { chatId: id, preserveDrawerPresentation })
-    if (focusComposer) focusDesktopChatPaneComposer(id)
+    if (focusComposer) focusSelectedChatComposer(id)
   }
 
   async function deleteChat(id) {
@@ -3513,7 +3551,7 @@ export default function Shell({ onInitialVisualReady }) {
         ref={composerFocusLeaseRef}
         className="shell__composer-focus-lease"
         tabIndex={-1}
-        aria-label="New chat message"
+        aria-label="Message Möbius…"
         autoComplete="off"
         onInput={(event) => {
           const draftId = composerFocusLeaseDraftIdRef.current
@@ -3731,7 +3769,7 @@ export default function Shell({ onInitialVisualReady }) {
                 onActivate={() => {
                   const { view, opts } = tabModel.tabNavTarget(tab)
                   navTo(view, opts)
-                  if (tab.kind === 'chat') focusDesktopChatPaneComposer(tab.id)
+                  if (tab.kind === 'chat') focusSelectedChatComposer(tab.id)
                 }}
                 onClose={() => closeTab(tab)}
                 onContextMenu={(event) => openTabMenu(event, tab, null)}
@@ -4180,7 +4218,7 @@ export default function Shell({ onInitialVisualReady }) {
             onCloseTab={closeTab}
             focusedPaneViewId={focusedPaneViewId}
             onTogglePaneFocus={toggleFocusedPaneView}
-            onChatPaneSelected={focusDesktopChatPaneComposer}
+            onChatPaneSelected={focusSelectedChatComposer}
             revealKey={tabRevealRevision}
           />
         )}

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -3551,7 +3551,7 @@ export default function Shell({ onInitialVisualReady }) {
         ref={composerFocusLeaseRef}
         className="shell__composer-focus-lease"
         tabIndex={-1}
-        aria-label="Message Möbius…"
+        aria-label="Restoring message draft"
         autoComplete="off"
         onInput={(event) => {
           const draftId = composerFocusLeaseDraftIdRef.current

--- a/frontend/src/components/Shell/__tests__/chatHandoff.test.js
+++ b/frontend/src/components/Shell/__tests__/chatHandoff.test.js
@@ -322,6 +322,8 @@ test('direct chat actions hand focus to the destination composer', () => {
   assert.match(shell,
     /composerDraftWantsKeyboard\(saved\)[\s\S]*beginTouchComposerFocusLease\([\s\S]*initialValue: saved\.input[\s\S]*requestComposer\(chatId, \{ focus: true, restoreExistingDraft: true \}\)/,
     'a selected touch chat with an unsent draft must reserve the keyboard until its real composer takes focus')
+  assert.match(shell, /className="shell__composer-focus-lease"[\s\S]*aria-label="Restoring message draft"/,
+    'the hidden lease must not impersonate the visible Message Möbius composer in the accessibility tree')
   assert.match(shell,
     /beforeRestoreRouteRef\.current = \(route\) => \{[\s\S]*route\?\.view !== 'chat'[\s\S]*reserveTouchDraftComposer\(route\.chatId\)/,
     'Back and Forward must use the same draft-only touch focus handoff')

--- a/frontend/src/components/Shell/__tests__/chatHandoff.test.js
+++ b/frontend/src/components/Shell/__tests__/chatHandoff.test.js
@@ -15,6 +15,7 @@ const scrollMode = readFileSync(new URL('../../ChatView/useScrollMode.js', impor
 const detailCache = readFileSync(new URL('../../../lib/chatDetailCache.js', import.meta.url), 'utf8')
 const searchTermHighlight = readFileSync(new URL('../../../lib/searchTermHighlight.js', import.meta.url), 'utf8')
 const apiClient = readFileSync(new URL('../../../api/client.js', import.meta.url), 'utf8')
+const navigationSource = readFileSync(new URL('../../../hooks/useNavigation.js', import.meta.url), 'utf8')
 
 function ruleBody(selector, source = shellCss) {
   const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
@@ -299,7 +300,7 @@ test('direct chat actions hand focus to the destination composer', () => {
     /function selectChat\(id, \{ focusComposer = true \} = \{\}\) \{([\s\S]*?)\n  \}/,
   )?.[1] || ''
   assert.match(selectChat,
-    /navTo\('chat', \{ chatId: id, preserveDrawerPresentation \}\)[\s\S]*if \(focusComposer\) focusDesktopChatPaneComposer\(id\)/,
+    /navTo\('chat', \{ chatId: id, preserveDrawerPresentation \}\)[\s\S]*if \(focusComposer\) focusSelectedChatComposer\(id\)/,
     'drawer and settings chat selection must focus after requesting navigation')
   assert.match(shell,
     /target\.focusComposer === true[\s\S]*requestComposer\(target\.chatId, \{ focus: true \}\)/,
@@ -311,13 +312,31 @@ test('direct chat actions hand focus to the destination composer', () => {
     /flushSync\(\(\) => restoreDurableDraft\(\)\)[\s\S]*placeCaretAtTextEnd\(inputRef\.current\)/,
     'the destination composer must place the caret after its final draft re-read')
   assert.match(shell,
-    /onActivate=\{\(\) => \{[\s\S]*tabModel\.tabNavTarget\(tab\)[\s\S]*navTo\(view, opts\)[\s\S]*tab\.kind === 'chat'[\s\S]*focusDesktopChatPaneComposer\(tab\.id\)/,
+    /onActivate=\{\(\) => \{[\s\S]*tabModel\.tabNavTarget\(tab\)[\s\S]*navTo\(view, opts\)[\s\S]*tab\.kind === 'chat'[\s\S]*focusSelectedChatComposer\(tab\.id\)/,
     'the single-pane tab strip must focus a selected chat composer')
   const selectedChatHandoffs = workspaceChrome.match(
     /if \(tab\.kind === 'chat'\) onChatPaneSelected\?\.\(tab\.id\)/g,
   ) || []
   assert.equal(selectedChatHandoffs.length, 2,
     'both active-tab and tab-switch paths in a tiled pane must focus chat composers')
+  assert.match(shell,
+    /composerDraftWantsKeyboard\(saved\)[\s\S]*beginTouchComposerFocusLease\([\s\S]*initialValue: saved\.input[\s\S]*requestComposer\(chatId, \{ focus: true, restoreExistingDraft: true \}\)/,
+    'a selected touch chat with an unsent draft must reserve the keyboard until its real composer takes focus')
+  assert.match(shell,
+    /beforeRestoreRouteRef\.current = \(route\) => \{[\s\S]*route\?\.view !== 'chat'[\s\S]*reserveTouchDraftComposer\(route\.chatId\)/,
+    'Back and Forward must use the same draft-only touch focus handoff')
+  assert.match(shell, /const beforeRestoreRouteRef = useRef\(null\)/)
+  assert.match(shell, /beforeRestoreRouteRef,\s*\}\)/)
+  assert.match(
+    navigationSource,
+    /if \(itemRoute\) \{\s*beforeRestoreRouteRef\?\.current\?\.\(itemRoute\)\s*applyModeDestination\(itemRoute\)/,
+    'Back and Forward must reserve the draft keyboard before restoring the destination',
+  )
+  assert.match(
+    navigationSource,
+    /function closeDrawer[\s\S]*beforeRestoreRouteRef\?\.current\?\.\(snapshotRoute\(\)\)[\s\S]*const userBackTraversal = !drawerClosePendingRef\.current[\s\S]*if \(drawerOpenRef\.current && drawerPushedRef\.current\)[\s\S]*beforeRestoreRouteRef\?\.current\?\.\(returnRoute\)/,
+    'both explicit and Back-driven drawer closes must reserve the restored draft keyboard',
+  )
 })
 
 test('the held chat is an opaque layer above staging until the atomic swap', () => {

--- a/frontend/src/components/Shell/__tests__/composerFocusLease.test.js
+++ b/frontend/src/components/Shell/__tests__/composerFocusLease.test.js
@@ -3,8 +3,16 @@ import assert from 'node:assert/strict'
 
 import {
   beginTouchComposerFocusLease,
+  composerDraftWantsKeyboard,
   releaseComposerFocusLease,
 } from '../composerFocusLease.js'
+
+test('only a real unsent draft asks to reopen the touch keyboard', () => {
+  assert.equal(composerDraftWantsKeyboard(null), false)
+  assert.equal(composerDraftWantsKeyboard({ input: '', attachments: [] }), false)
+  assert.equal(composerDraftWantsKeyboard({ input: 'unfinished', attachments: [] }), true)
+  assert.equal(composerDraftWantsKeyboard({ input: '', attachments: [{ id: '1' }] }), true)
+})
 
 test('touch focus lease starts synchronously with a clean buffer', () => {
   const calls = []
@@ -39,6 +47,30 @@ test('touch focus lease resumes a durable draft with the caret at its end', () =
   }), true)
   assert.equal(el.value, 'draft survives')
   assert.deepEqual(selections, [[14, 14]])
+})
+
+test('an active touch lease retargets without blurring or refocusing the keyboard', () => {
+  const calls = []
+  const selections = []
+  const older = {}
+  const newer = {}
+  const el = {
+    value: 'older',
+    focus: (...args) => calls.push(args),
+    setSelectionRange: (...args) => selections.push(args),
+  }
+
+  assert.equal(beginTouchComposerFocusLease(el, {
+    matchMediaImpl: () => ({ matches: true }),
+    activeElement: el,
+    owner: newer,
+    initialValue: 'new destination',
+  }), true)
+  assert.equal(el.value, 'new destination')
+  assert.deepEqual(calls, [])
+  assert.deepEqual(selections, [[15, 15]])
+  assert.equal(releaseComposerFocusLease(el, { activeElement: el, owner: older }), false)
+  assert.equal(releaseComposerFocusLease(el, { activeElement: null, owner: newer }), true)
 })
 
 test('touch focus lease stays inert on desktop and releases failed handoffs', () => {

--- a/frontend/src/components/Shell/composerFocusLease.js
+++ b/frontend/src/components/Shell/composerFocusLease.js
@@ -6,10 +6,15 @@ import {
 const TOUCH_PRIMARY_QUERY = '(hover: none) and (pointer: coarse)'
 const leaseOwners = new WeakMap()
 
+export function composerDraftWantsKeyboard(draft) {
+  return String(draft?.input ?? '').length > 0
+    || (Array.isArray(draft?.attachments) && draft.attachments.length > 0)
+}
+
 /**
- * Keep the software keyboard open across an async New-chat allocation. The
- * lease is focused synchronously inside the owner's tap; the real composer
- * takes that focus once its chat-bound surface mounts.
+ * Keep the software keyboard open across a chat-composer handoff. The lease is
+ * focused synchronously at the navigation boundary; the real composer takes
+ * that focus once its chat-bound surface mounts.
  */
 export function beginTouchComposerFocusLease(el, {
   matchMediaImpl = globalThis.matchMedia,
@@ -17,9 +22,14 @@ export function beginTouchComposerFocusLease(el, {
   owner = null,
   initialValue = '',
 } = {}) {
-  if (!el || activeElement === el || typeof matchMediaImpl !== 'function') return false
+  if (!el || typeof matchMediaImpl !== 'function') return false
   if (matchMediaImpl(TOUCH_PRIMARY_QUERY)?.matches !== true) return false
   el.value = typeof initialValue === 'string' ? initialValue : ''
+  if (activeElement === el) {
+    leaseOwners.set(el, owner)
+    placeCaretAtTextEnd(el)
+    return true
+  }
   const focused = focusComposerElement(el)
   if (focused) leaseOwners.set(el, owner)
   return focused

--- a/frontend/src/hooks/useNavigation.js
+++ b/frontend/src/hooks/useNavigation.js
@@ -132,6 +132,8 @@ export const coldRestoredCanvasAppId =
  *   beforeNavigateRef   optional synchronous destination claimant, run after
  *                       validation/no-op detection but before history or
  *                       workspace mutation.
+ *   beforeRestoreRouteRef optional synchronous Back/Forward destination hook,
+ *                       run after validation but before workspace mutation.
  *
  * Three load-bearing pieces remain: `openDrawer` pushes one mobile sentinel;
  * `navTo` retags that sentinel or pushes one ordinary destination; every modal
@@ -148,6 +150,7 @@ export default function useNavigation({
   replaceImplicitBootTab,
   dragActiveRef,
   beforeNavigateRef,
+  beforeRestoreRouteRef,
 }) {
   // Monotonic presentation signal for re-revealing an already-active tab. The
   // semantic route remains a no-op (no history or workspace write), but a drawer
@@ -640,6 +643,7 @@ export default function useNavigation({
     // skip past the drawer's sentinel before the first traversal settles.
     if (!drawerOpenRef.current || drawerClosePendingRef.current) return
     if (drawerPushedRef.current) {
+      beforeRestoreRouteRef?.current?.(snapshotRoute())
       clearDrawerOpenAfterClose()
       drawerClosePendingRef.current = true
       drawerClosePendingAtRef.current = Date.now()
@@ -1116,6 +1120,7 @@ export default function useNavigation({
       if (chatId != null) itemRoute = { view: 'chat', chatId, appId: null, paneId: route.paneId }
     }
     if (itemRoute) {
+      beforeRestoreRouteRef?.current?.(itemRoute)
       applyModeDestination(itemRoute)
       return
     }
@@ -1139,7 +1144,13 @@ export default function useNavigation({
     }
     setSettingsOpen(false)
     settingsOpenRef.current = false
-  }, [applyModeDestination, applySettingsDestination, dispatchWorkspace, workspaceStateRef])
+  }, [
+    applyModeDestination,
+    applySettingsDestination,
+    beforeRestoreRouteRef,
+    dispatchWorkspace,
+    workspaceStateRef,
+  ])
 
   useEffect(() => {
     let bootPaneId = workspaceStateRef.current.ws.focusedPaneId
@@ -1430,7 +1441,8 @@ export default function useNavigation({
       // gesture. closeDrawer also traverses history, but that traversal is our
       // own bookkeeping: arming the same guard there made a quick post-swipe
       // iOS tap disappear when WebKit delivered click without pointerdown.
-      if (!drawerClosePendingRef.current) {
+      const userBackTraversal = !drawerClosePendingRef.current
+      if (userBackTraversal) {
         backFiredRef.current = true
         setTimeout(() => { backFiredRef.current = false }, 400)
       }
@@ -1457,6 +1469,12 @@ export default function useNavigation({
       // the drawer only — never pops navStack. Catches real back-gestures on a
       // drawer-open view AND closeDrawer's history.back().
       if (drawerOpenRef.current && drawerPushedRef.current) {
+        if (userBackTraversal) {
+          const returnRoute = isRestorableRoute(destination?.route)
+            ? destination.route
+            : snapshotRoute()
+          beforeRestoreRouteRef?.current?.(returnRoute)
+        }
         const reopenAfterClose = drawerOpenAfterCloseRef.current
         clearDrawerOpenAfterClose()
         drawerPushedRef.current = false

--- a/frontend/src/lib/__tests__/shellControllerReload.test.js
+++ b/frontend/src/lib/__tests__/shellControllerReload.test.js
@@ -54,7 +54,7 @@ test('a claimed destination runs before navigation history or view mutation', ()
 
 test('Shell connects navigation to the current reload claimant through one ref', () => {
   assert.match(shellSource, /const beforeNavigateRef = useRef\(null\)/)
-  assert.match(shellSource, /beforeNavigateRef,\s*\}\)/)
+  assert.match(shellSource, /beforeNavigateRef,\s*/)
   assert.match(
     shellSource,
     /beforeNavigateRef\.current = claimPendingShellReloadNavigation/,


### PR DESCRIPTION
## Summary
- keep the software keyboard open when returning to a mobile chat with an unsent draft
- reuse the existing composer focus lease across chat selection, Back/Forward, and drawer-close transitions
- leave empty-chat and desktop focus behavior unchanged

## Testing
- `npm test`
- `npm run lint`
- `npm run build`

Device-level soft-keyboard animation remains to be verified on iOS or Android hardware.