### PR TITLE
Add one-use secure input with durable safe receipts

### DIFF
--- a/backend/app/chat.py
+++ b/backend/app/chat.py
@@ -2207,6 +2207,8 @@ async def stop_chat_for(
         "queue for reconciliation", chat_id, exc_info=True,
       )
   questions.cancel(chat_id)
+  from app import secure_inputs
+  secure_inputs.cancel_chat(chat_id)
   all_stopped = True
   escalated = False
   for handle in handles:

--- a/backend/app/chat_event_sink.py
+++ b/backend/app/chat_event_sink.py
@@ -43,6 +43,7 @@ from app.memory_recall import (
   RecallBinding, recall_from_command, settle_recall,
 )
 from app.runtime_types import ChatEvent
+from app.secure_inputs import redact_reveal_markers
 
 
 _active_sinks: dict[str, "ChatEventSink"] = {}
@@ -243,7 +244,7 @@ class ChatEventSink:
   _IMMEDIATE_SAVE_TYPES = frozenset(
     {
       "context_compacted", "tool_start", "tool_end", "task_start",
-      "task_done", "error",
+      "task_done", "secure_input_request", "secure_input_settled", "error",
     }
   )
 
@@ -550,6 +551,10 @@ class ChatEventSink:
     # contains the line that settles a recognized lookup.
     output_reduced = False
     if event_type == "tool_output":
+      # An explicit secure-input reveal reaches the provider as a tool result,
+      # but the marked envelope must not enter Möbius's live UI, transcript, or
+      # chat-side logs. Normal sealed execution never emits these markers.
+      event["content"] = redact_reveal_markers(event.get("content"))
       output_reduced = self._reduce_tool_output(event)
       if not output_reduced and event.get("output_exit_code") is None:
         exit_code = tool_output_exit_code(event.get("content"))

--- a/backend/app/chat_log_redaction.py
+++ b/backend/app/chat_log_redaction.py
@@ -44,6 +44,7 @@ from app.continuations import (
   continuation_actor_label,
   is_continuation_message,
 )
+from app.secure_inputs import redact_reveal_markers
 
 # Per-excerpt char cap for the list view, and per-message char cap for
 # the single-chat view. Excerpts are a teaser; full-message bodies in
@@ -112,6 +113,7 @@ def scrub_secrets(text: str) -> str:
   """
   if not text:
     return text
+  text = redact_reveal_markers(text)
   for pattern, repl in _SECRET_PATTERNS:
     text = pattern.sub(repl, text)
   return text

--- a/backend/app/events.py
+++ b/backend/app/events.py
@@ -72,6 +72,10 @@ EventType = Literal[
   "task_progress",
   "task_done",
   "question",
+  "secure_input_request",
+  "secure_input_filled",
+  "secure_input_consuming",
+  "secure_input_settled",
   "queued_turn_starting",
   "catch_up_done",
   "error",
@@ -241,7 +245,7 @@ def _persisted_block(block: dict) -> dict:
 # Event types that begin (or belong to) a DIFFERENT visible content block and
 # therefore legitimately END a trailing thinking run. This is EXACTLY the set of
 # branches below that APPEND a new sibling block: text, text_final, text_boundary,
-# context_compacted, tool_start, error, question.
+# context_compacted, tool_start, error, question, secure_input_request.
 #
 # Every OTHER event type must be TRANSPARENT to thinking coalescing:
 #  - Provider bookkeeping/heartbeats forwarded as "unknown_sdk_event" (a periodic
@@ -262,6 +266,7 @@ _THINKING_INTERRUPTING_TYPES: frozenset[str] = frozenset({
   "context_compacted",
   "tool_start",
   "question",
+  "secure_input_request",
   "error",
 })
 
@@ -507,6 +512,108 @@ def _process_question_event(event: dict, assistant_blocks: list) -> bool:
     return True
 
   return False
+
+
+_SECURE_INPUT_EVENT_TYPES = frozenset({
+  "secure_input_request",
+  "secure_input_filled",
+  "secure_input_consuming",
+  "secure_input_settled",
+})
+_SECURE_INPUT_TERMINAL_STATUSES = frozenset({
+  "completed", "failed", "cancelled", "expired",
+})
+_SECURE_INPUT_ACTIVE_PHASE = {"pending": 0, "filled": 1, "consuming": 2}
+
+
+def _secure_input_fields(fields) -> list[dict]:
+  """Copy only safe prompt metadata onto a durable secure-input receipt."""
+  safe: list[dict] = []
+  for raw in fields if isinstance(fields, list) else []:
+    if not isinstance(raw, dict):
+      continue
+    name = raw.get("name")
+    label = raw.get("label")
+    if not isinstance(name, str) or not name or len(name) > 48:
+      continue
+    if not isinstance(label, str) or not label or len(label) > 80:
+      continue
+    input_type = raw.get("type")
+    autocomplete = raw.get("autocomplete")
+    safe.append({
+      "name": name,
+      "label": label,
+      "type": input_type if input_type in {"text", "password"} else "password",
+      "autocomplete": (
+        autocomplete
+        if isinstance(autocomplete, str) and len(autocomplete) <= 64
+        else "off"
+      ),
+    })
+    if len(safe) >= 8:
+      break
+  return safe
+
+
+def _process_secure_input_event(event: dict, assistant_blocks: list) -> bool:
+  """Persist prompts and state while structurally excluding entered values."""
+  event_type = event.get("type")
+  request_id = event.get("request_id")
+  if not isinstance(request_id, str) or not request_id or len(request_id) > 128:
+    return False
+
+  existing = next((
+    block for block in reversed(assistant_blocks)
+    if block.get("type") == "secure_input"
+    and block.get("request_id") == request_id
+  ), None)
+
+  if event_type == "secure_input_request":
+    title = event.get("title")
+    description = event.get("description")
+    receipt = {
+      "type": "secure_input",
+      "request_id": request_id,
+      "mode": "reveal" if event.get("mode") == "reveal" else "sealed",
+      "title": title[:80] if isinstance(title, str) else "Secure input",
+      "description": (
+        description[:240] if isinstance(description, str) else ""
+      ),
+      "fields": _secure_input_fields(event.get("fields")),
+      "status": "pending",
+    }
+    if existing is None:
+      assistant_blocks.append(receipt)
+      return True
+    # A replayed request refreshes safe prompt metadata without turning a
+    # completed receipt back into a live form.
+    receipt["status"] = existing.get("status", "pending")
+    changed = any(existing.get(key) != value for key, value in receipt.items())
+    existing.update(receipt)
+    return changed
+
+  if existing is None:
+    return False
+  if event_type == "secure_input_filled":
+    status = "filled"
+  elif event_type == "secure_input_consuming":
+    status = "consuming"
+  else:
+    raw_status = event.get("status")
+    status = (
+      raw_status if raw_status in _SECURE_INPUT_TERMINAL_STATUSES else "failed"
+    )
+  current = existing.get("status", "pending")
+  if current in _SECURE_INPUT_TERMINAL_STATUSES:
+    return False
+  if (
+    status not in _SECURE_INPUT_TERMINAL_STATUSES
+    and _SECURE_INPUT_ACTIVE_PHASE.get(status, 0)
+      <= _SECURE_INPUT_ACTIVE_PHASE.get(current, 0)
+  ):
+    return False
+  existing["status"] = status
+  return True
 
 
 _SUBAGENT_EVENT_TYPES = frozenset({"task_start", "task_done"})
@@ -985,6 +1092,9 @@ def process_event(event: dict, assistant_blocks: list) -> bool:
   if event_type == "question":
     return _process_question_event(event, assistant_blocks)
 
+  if event_type in _SECURE_INPUT_EVENT_TYPES:
+    return _process_secure_input_event(event, assistant_blocks)
+
   return False
 
 
@@ -1204,3 +1314,10 @@ def finalize_blocks(assistant_blocks: list) -> None:
     if (blk.get("type") == "tool"
         and blk.get("status") == "running"):
       blk["status"] = "done"
+    if (
+      blk.get("type") == "secure_input"
+      and blk.get("status") in {"pending", "filled", "consuming"}
+    ):
+      # A finalized/recovered turn no longer has an in-memory request behind
+      # the receipt. Never persist an apparently-live form after that boundary.
+      blk["status"] = "expired"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -63,6 +63,7 @@ from app import activity, models
 from app.routes import (
   admin_router, apps_router, auth_router,
   chat_embed_router, chat_logs_router, chat_router, chats_router, chats_stream_router,
+  secure_inputs_router,
   connectors_router, connectors_public_router,
   debug_router, delegations_router, fs_router, github_router, media_router,
   local_services_router, notifications_router, notify_router, proxy_router, push_router,
@@ -614,6 +615,7 @@ app.include_router(chat_router)
 app.include_router(chat_embed_router)
 app.include_router(chats_router)
 app.include_router(chats_stream_router)
+app.include_router(secure_inputs_router)
 app.include_router(delegations_router)
 app.include_router(chat_logs_router)
 app.include_router(connectors_router)

--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -57,6 +57,7 @@ chat_router = _load("chat")
 chat_embed_router = _load("chat_embed")
 chats_router = _load("chats")
 chats_stream_router = _load("chats_stream")
+secure_inputs_router = _load("secure_inputs")
 chat_logs_router = _load("chat_logs")
 connectors_router = _load("connectors")
 try:
@@ -96,6 +97,7 @@ __all__ = [
   "chat_embed_router",
   "chats_router",
   "chats_stream_router",
+  "secure_inputs_router",
   "chat_logs_router",
   "connectors_router",
   "connectors_public_router",

--- a/backend/app/routes/chats.py
+++ b/backend/app/routes/chats.py
@@ -1793,6 +1793,8 @@ async def delete_chat(
   # the delete-ABA case — reads `we_own_gen=False` and skips finalizing onto
   # the soft-deleted row. recover_chat restores it with a strictly-newer gen.
   questions.cancel(chat_id)
+  from app import secure_inputs
+  secure_inputs.cancel_chat(chat_id)
   mark_chat_deleted(chat_id)
   # Close the chat's durable run state as part of the delete. A delete with a
   # LIVE handle stops the runner but hands durable closure to run_chat's finally,

--- a/backend/app/routes/chats_stream.py
+++ b/backend/app/routes/chats_stream.py
@@ -81,6 +81,10 @@ _SNAPSHOT_REPLAY_EVENT_TYPES = frozenset({
   "queued_turn_starting",
   "steer_delivery_failed",
   "steered_into_turn",
+  "secure_input_request",
+  "secure_input_filled",
+  "secure_input_consuming",
+  "secure_input_settled",
   "theme_updated",
 })
 

--- a/backend/app/routes/debug.py
+++ b/backend/app/routes/debug.py
@@ -38,6 +38,7 @@ from app.memory_observability import (
 from app.questions import question_memory_diagnostics
 from app.resource_pressure import resource_status
 from app.runner_registry import RunnerKind, registry
+from app.secure_inputs import secure_input_memory_diagnostics
 
 router = APIRouter(prefix="/api/debug", tags=["debug"])
 
@@ -67,6 +68,7 @@ def _runtime_memory_ownership(*, include_payloads: bool = True) -> dict:
     ),
     "writer": writer_memory_diagnostics(),
     "questions": question_memory_diagnostics(),
+    "secure_inputs": secure_input_memory_diagnostics(),
   }
   report["payload_sizing"] = {
     "included": include_payloads,

--- a/backend/app/routes/secure_inputs.py
+++ b/backend/app/routes/secure_inputs.py
@@ -1,0 +1,205 @@
+"""Trusted transient-value inputs for sealed local execution."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from sqlalchemy.orm import Session
+
+from app import models, secure_inputs
+from app.broadcast import get_broadcast
+from app.database import get_db
+from app.deps import get_current_owner, reject_cross_site
+
+
+router = APIRouter(prefix="/api/secure-inputs", tags=["secure-inputs"])
+
+
+async def _json_object(request: Request) -> dict[str, Any]:
+  """Parse a secret-bearing body without validation errors echoing its input."""
+  try:
+    payload = await request.json()
+  except Exception as exc:
+    raise HTTPException(400, detail="Invalid secure input submission.") from exc
+  if not isinstance(payload, dict):
+    raise HTTPException(400, detail="Invalid secure input submission.")
+  return payload
+
+
+def _active_owner_chat(db: Session, chat_id: str) -> models.Chat:
+  chat = db.query(models.Chat).filter(
+    models.Chat.id == chat_id,
+    models.Chat.deleted_at.is_(None),
+  ).first()
+  if chat is None:
+    raise HTTPException(404, detail="Chat not found.")
+  if chat.created_by_app_id is not None:
+    raise HTTPException(
+      403, detail="Secure input is available only in owner chats.",
+    )
+  return chat
+
+
+def _authorized_request(request_id: str, capability: Any):
+  pending = secure_inputs.authorize(request_id, capability)
+  if pending is None:
+    raise HTTPException(404, detail="Secure input request not found.")
+  return pending
+
+
+@router.post("/{chat_id}", dependencies=[Depends(reject_cross_site)])
+async def create_secure_input(
+  chat_id: str,
+  request: Request,
+  _: models.Owner = Depends(get_current_owner),
+  db: Session = Depends(get_db),
+):
+  """Create a bounded card for a running owner chat."""
+  _active_owner_chat(db, chat_id)
+  bc = get_broadcast(chat_id)
+  if bc is None or not bc.running:
+    raise HTTPException(409, detail="This chat is not running.")
+
+  payload = await _json_object(request)
+  try:
+    title, description, mode, fields = secure_inputs.validate_request_spec(
+      title=payload.get("title"),
+      description=payload.get("description", ""),
+      mode=payload.get("mode", "sealed"),
+      fields=payload.get("fields"),
+    )
+  except ValueError as exc:
+    payload.clear()
+    raise HTTPException(400, detail=str(exc)) from exc
+  payload.clear()
+  try:
+    pending, capability = secure_inputs.create_request(
+      chat_id=chat_id,
+      mode=mode,
+      title=title,
+      description=description,
+      fields=fields,
+    )
+  except ValueError as exc:
+    raise HTTPException(409, detail=str(exc)) from exc
+  except RuntimeError as exc:
+    raise HTTPException(503, detail=str(exc)) from exc
+
+  # Route through the turn's sink when present: it owns both the live event and
+  # the durable safe receipt. The event contains prompt metadata only.
+  from app.chat_event_sink import get_active_sink
+  sink = get_active_sink(chat_id)
+  if sink is not None and sink.bc is bc:
+    sink.publish(pending.public_event())
+  else:
+    bc.publish(pending.public_event())
+  return {
+    "request_id": pending.request_id,
+    "capability": capability,
+    "expires_in": secure_inputs.REQUEST_TTL_SECONDS,
+  }
+
+
+@router.post(
+  "/{chat_id}/{request_id}/submit",
+  dependencies=[Depends(reject_cross_site)],
+)
+async def submit_secure_input(
+  chat_id: str,
+  request_id: str,
+  request: Request,
+  _: models.Owner = Depends(get_current_owner),
+  db: Session = Depends(get_db),
+):
+  """Move submitted fields into process memory without logging or persistence."""
+  _active_owner_chat(db, chat_id)
+  pending = secure_inputs.get_request(request_id)
+  if pending is None or pending.chat_id != chat_id:
+    raise HTTPException(404, detail="Secure input request not found.")
+  if pending.status != "pending":
+    raise HTTPException(409, detail="Secure input request is no longer open.")
+
+  payload = await _json_object(request)
+  values_payload = payload.pop("fields", None)
+  reveal_confirmed = payload.pop("reveal_confirmed", False) is True
+  payload.clear()
+  if pending.mode == "reveal" and not reveal_confirmed:
+    if isinstance(values_payload, dict):
+      values_payload.clear()
+    raise HTTPException(
+      400,
+      detail="Confirm that these values may be sent to the AI provider.",
+    )
+  try:
+    values = secure_inputs.validate_submitted_values(pending, values_payload)
+  except ValueError as exc:
+    if isinstance(values_payload, dict):
+      values_payload.clear()
+    raise HTTPException(400, detail=str(exc)) from exc
+  if isinstance(values_payload, dict):
+    values_payload.clear()
+  secure_inputs.fill_request(pending, values)
+  return {"status": "filled"}
+
+
+@router.post("/{request_id}/wait")
+async def wait_for_secure_input(request_id: str, request: Request):
+  """Long-poll state with a one-way capability; returns no submitted values."""
+  payload = await _json_object(request)
+  capability = payload.pop("capability", None)
+  payload.clear()
+  pending = _authorized_request(request_id, capability)
+  if pending.status == "pending":
+    try:
+      await asyncio.wait_for(pending.event.wait(), timeout=25)
+    except TimeoutError:
+      pass
+  return {
+    "status": pending.status,
+    "result": pending.result if pending.status not in {"pending", "filled"} else None,
+  }
+
+
+@router.post("/{request_id}/consume")
+async def consume_secure_input(request_id: str, request: Request):
+  """Return values exactly once to the local helper holding the capability."""
+  payload = await _json_object(request)
+  capability = payload.pop("capability", None)
+  payload.clear()
+  pending = _authorized_request(request_id, capability)
+  try:
+    values = secure_inputs.consume_request(pending)
+  except ValueError as exc:
+    raise HTTPException(409, detail=str(exc)) from exc
+  # Deliberate narrow reveal: this response is capability-authenticated, read
+  # only by the local helper, and never logged. The registry already dropped
+  # its reference; the helper clears its decoded mapping after use.
+  return {"fields": values, "mode": pending.mode}
+
+
+@router.post("/{request_id}/settle")
+async def settle_secure_input(request_id: str, request: Request):
+  """Record only a bounded non-secret consumer outcome."""
+  payload = await _json_object(request)
+  capability = payload.pop("capability", None)
+  ok = payload.pop("ok", False) is True
+  message = payload.pop("message", "Secure input complete.")
+  payload.clear()
+  pending = _authorized_request(request_id, capability)
+  if pending.status != "consuming":
+    raise HTTPException(409, detail="Secure input is not being consumed.")
+  secure_inputs.settle_request(pending, ok=ok, message=message)
+  return {"status": pending.status}
+
+
+@router.post("/{request_id}/cancel")
+async def cancel_secure_input(request_id: str, request: Request):
+  """Cancel using the one-way capability when the local helper exits."""
+  payload = await _json_object(request)
+  capability = payload.pop("capability", None)
+  payload.clear()
+  pending = _authorized_request(request_id, capability)
+  secure_inputs.cancel_request(pending)
+  return {"status": pending.status}

--- a/backend/app/secure_inputs.py
+++ b/backend/app/secure_inputs.py
@@ -1,0 +1,396 @@
+"""One-use secure inputs with transient values and durable safe receipts.
+
+The ordinary path gives an agent-authored local process programmatic access to
+submitted values through stdin while keeping those values out of model context.
+The registry never writes field values to a database, file, broadcast, result,
+or diagnostic. Prompt labels and status are deliberately safe to persist as a
+chat receipt. A separately marked reveal path exists for explicit owner-led
+debugging; its tool result reaches the AI provider but is scrubbed before
+Möbius broadcasts or persists it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac
+import re
+import secrets
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+from app.broadcast import get_broadcast
+
+
+REQUEST_TTL_SECONDS = 15 * 60
+COMPLETED_TTL_SECONDS = 2 * 60
+CONSUMING_TTL_SECONDS = 2 * 60
+MAX_REQUESTS = 32
+MAX_FIELDS = 8
+MAX_FIELD_VALUE_CHARS = 16 * 1024
+MAX_TOTAL_VALUE_CHARS = 64 * 1024
+FIELD_NAME_RE = re.compile(r"^[a-z][a-z0-9_]{0,47}$")
+
+REVEAL_BEGIN = "<<<MOBIUS_SECRET_REVEAL_BEGIN:"
+REVEAL_END = "<<<MOBIUS_SECRET_REVEAL_END:"
+REVEAL_NONCE_RE = re.compile(r"[0-9a-f]{32}")
+REVEAL_REDACTION = (
+  "[Secure input revealed to the model by explicit owner request; "
+  "value omitted from Möbius chat and logs.]"
+)
+
+
+@dataclass
+class SecureInputRequest:
+  """Safe request metadata plus in-memory values and a one-way capability."""
+
+  request_id: str
+  chat_id: str
+  mode: str
+  title: str
+  description: str
+  fields: list[dict[str, Any]]
+  capability_hash: bytes
+  created_at: float
+  expires_at: float
+  status: str = "pending"
+  values: dict[str, str] | None = None
+  result: dict[str, Any] | None = None
+  consuming_at: float | None = None
+  settled_at: float | None = None
+  event: asyncio.Event = field(default_factory=asyncio.Event)
+
+  def public_event(self) -> dict[str, Any]:
+    """Browser-safe card payload. Never includes a capability or field value."""
+    return {
+      "type": "secure_input_request",
+      "request_id": self.request_id,
+      "mode": self.mode,
+      "title": self.title,
+      "description": self.description,
+      "fields": self.fields,
+      "expires_in": max(0, int(self.expires_at - time.monotonic())),
+    }
+
+
+_requests: dict[str, SecureInputRequest] = {}
+
+
+def _schedule_cleanup(delay_seconds: float, request_id: str) -> None:
+  """Arm real-time expiry; access-time cleanup remains a restart-safe fallback."""
+  try:
+    loop = asyncio.get_running_loop()
+  except RuntimeError:
+    return
+  loop.call_later(delay_seconds, _scheduled_cleanup, request_id)
+
+
+def _scheduled_cleanup(request_id: str) -> None:
+  # Keeping the id in the callback, rather than the request object, never
+  # extends the lifetime of submitted values. `_cleanup` owns every transition.
+  if request_id in _requests:
+    _cleanup()
+
+
+def validate_request_spec(
+  *, title: Any, description: Any, mode: Any, fields: Any,
+) -> tuple[str, str, str, list[dict[str, Any]]]:
+  """Return a bounded, browser-safe request spec or raise ValueError."""
+  if not isinstance(title, str) or not 1 <= len(title.strip()) <= 80:
+    raise ValueError("Secure input title must be 1–80 characters.")
+  if not isinstance(description, str) or len(description) > 240:
+    raise ValueError("Secure input description is too long.")
+  if mode not in {"sealed", "reveal"}:
+    raise ValueError("Secure input mode must be sealed or reveal.")
+  if not isinstance(fields, list) or not 1 <= len(fields) <= MAX_FIELDS:
+    raise ValueError(f"Secure input requires 1–{MAX_FIELDS} fields.")
+
+  normalized: list[dict[str, Any]] = []
+  seen: set[str] = set()
+  for raw in fields:
+    if not isinstance(raw, dict):
+      raise ValueError("Each secure input field must be an object.")
+    name = raw.get("name")
+    label = raw.get("label")
+    input_type = raw.get("type", "password")
+    autocomplete = raw.get("autocomplete", "off")
+    if not isinstance(name, str) or not FIELD_NAME_RE.fullmatch(name):
+      raise ValueError("Secure input field names must be lowercase identifiers.")
+    if name in seen:
+      raise ValueError("Secure input field names must be unique.")
+    seen.add(name)
+    if not isinstance(label, str) or not 1 <= len(label.strip()) <= 80:
+      raise ValueError("Secure input field labels must be 1–80 characters.")
+    if input_type not in {"password", "text"}:
+      raise ValueError("Secure input fields must be text or password inputs.")
+    if not isinstance(autocomplete, str) or len(autocomplete) > 64:
+      autocomplete = "off"
+    normalized.append({
+      "name": name,
+      "label": label.strip(),
+      "type": input_type,
+      "autocomplete": autocomplete,
+    })
+  return title.strip(), description.strip(), mode, normalized
+
+
+def validate_submitted_values(
+  request: SecureInputRequest, values: Any,
+) -> dict[str, str]:
+  """Validate against the request shape without reflecting any value."""
+  if not isinstance(values, dict):
+    raise ValueError("Secure input fields are required.")
+  expected = [field["name"] for field in request.fields]
+  if set(values) != set(expected):
+    raise ValueError("Secure input fields do not match this request.")
+  normalized: dict[str, str] = {}
+  total = 0
+  for name in expected:
+    value = values.get(name)
+    if not isinstance(value, str) or not value:
+      raise ValueError("Every secure input field is required.")
+    if len(value) > MAX_FIELD_VALUE_CHARS:
+      raise ValueError("A secure input value is too long.")
+    total += len(value)
+    if total > MAX_TOTAL_VALUE_CHARS:
+      raise ValueError("Secure input submission is too large.")
+    normalized[name] = value
+  return normalized
+
+
+def redact_reveal_markers(content: Any) -> Any:
+  """Scrub explicit reveal envelopes before Möbius broadcast/persistence."""
+  if not isinstance(content, str) or REVEAL_BEGIN not in content:
+    return content
+  output: list[str] = []
+  cursor = 0
+  while True:
+    start = content.find(REVEAL_BEGIN, cursor)
+    if start == -1:
+      output.append(content[cursor:])
+      break
+    nonce_start = start + len(REVEAL_BEGIN)
+    nonce_end = nonce_start + 32
+    nonce = content[nonce_start:nonce_end]
+    if (
+      not REVEAL_NONCE_RE.fullmatch(nonce)
+      or content[nonce_end:nonce_end + 3] != ">>>"
+    ):
+      # Not one of our envelopes. Preserve this prefix, then continue looking
+      # rather than letting owner-provided text manufacture a scrub boundary.
+      output.append(content[cursor:nonce_start])
+      cursor = nonce_start
+      continue
+    output.append(content[cursor:start])
+    end_token = f"{REVEAL_END}{nonce}>>>"
+    end = content.find(end_token, nonce_end + 3)
+    output.append(REVEAL_REDACTION)
+    if end == -1:
+      break
+    cursor = end + len(end_token)
+  return "".join(output)
+
+
+def build_reveal_envelope(content: str) -> str:
+  """Frame provider-visible content with an unguessable paired scrub nonce."""
+  nonce = secrets.token_hex(16)
+  return f"{REVEAL_BEGIN}{nonce}>>>{content}{REVEAL_END}{nonce}>>>"
+
+
+def _capability_digest(capability: str) -> bytes:
+  return hashlib.sha256(capability.encode("utf-8")).digest()
+
+
+def _capability_matches(request: SecureInputRequest, capability: str) -> bool:
+  if not isinstance(capability, str) or not capability:
+    return False
+  return hmac.compare_digest(
+    request.capability_hash, _capability_digest(capability),
+  )
+
+
+def _publish(request: SecureInputRequest, event_type: str) -> None:
+  bc = get_broadcast(request.chat_id)
+  if bc is not None and bc.running:
+    event = {
+      "type": event_type,
+      "request_id": request.request_id,
+      "status": request.status,
+    }
+    # The live sink owns both broadcast and chat persistence. Import lazily to
+    # avoid the module cycle: ChatEventSink imports this module's reveal scrub.
+    from app.chat_event_sink import get_active_sink
+    sink = get_active_sink(request.chat_id)
+    if sink is not None and sink.bc is bc:
+      sink.publish(event)
+    else:
+      # Defensive fallback for synthetic/tests or a teardown race. Values are
+      # still absent; the active production path always has the owning sink.
+      bc.publish(event)
+
+
+def _clear_values(request: SecureInputRequest) -> None:
+  values = request.values
+  request.values = None
+  if values is not None:
+    values.clear()
+
+
+def _settle(
+  request: SecureInputRequest,
+  status: str,
+  result: dict[str, Any],
+) -> None:
+  if request.status in {"completed", "failed", "cancelled", "expired"}:
+    return
+  _clear_values(request)
+  request.status = status
+  request.result = result
+  request.settled_at = time.monotonic()
+  request.event.set()
+  _publish(request, "secure_input_settled")
+
+
+def _cleanup() -> None:
+  now = time.monotonic()
+  for request in list(_requests.values()):
+    expired_pending = (
+      request.status in {"pending", "filled"}
+      and request.expires_at <= now
+    )
+    expired_consumer = (
+      request.status == "consuming"
+      and request.consuming_at is not None
+      and now - request.consuming_at >= CONSUMING_TTL_SECONDS
+    )
+    if expired_pending or expired_consumer:
+      _settle(
+        request,
+        "expired",
+        {"ok": False, "message": "Secure input expired before completion."},
+      )
+  for request_id, request in list(_requests.items()):
+    if (
+      request.settled_at is not None
+      and now - request.settled_at >= COMPLETED_TTL_SECONDS
+    ):
+      _requests.pop(request_id, None)
+
+
+def create_request(
+  *,
+  chat_id: str,
+  mode: str,
+  title: str,
+  description: str,
+  fields: list[dict[str, Any]],
+) -> tuple[SecureInputRequest, str]:
+  """Register one request and return it with its one-way access capability."""
+  _cleanup()
+  if any(
+    request.chat_id == chat_id
+    and request.status in {"pending", "filled", "consuming"}
+    for request in _requests.values()
+  ):
+    raise ValueError("A secure input request is already open in this chat.")
+  if len(_requests) >= MAX_REQUESTS:
+    raise RuntimeError("Too many secure input requests are active.")
+
+  capability = secrets.token_urlsafe(32)
+  now = time.monotonic()
+  request = SecureInputRequest(
+    request_id=secrets.token_urlsafe(18),
+    chat_id=chat_id,
+    mode=mode,
+    title=title,
+    description=description,
+    fields=fields,
+    capability_hash=_capability_digest(capability),
+    created_at=now,
+    expires_at=now + REQUEST_TTL_SECONDS,
+  )
+  _requests[request.request_id] = request
+  _schedule_cleanup(REQUEST_TTL_SECONDS, request.request_id)
+  return request, capability
+
+
+def get_request(request_id: str) -> SecureInputRequest | None:
+  _cleanup()
+  return _requests.get(request_id)
+
+
+def authorize(
+  request_id: str, capability: str,
+) -> SecureInputRequest | None:
+  request = get_request(request_id)
+  if request is None or not _capability_matches(request, capability):
+    return None
+  return request
+
+
+def fill_request(request: SecureInputRequest, values: dict[str, str]) -> None:
+  if request.status != "pending":
+    raise ValueError("Secure input request is no longer open.")
+  request.values = values
+  request.status = "filled"
+  request.event.set()
+  _publish(request, "secure_input_filled")
+
+
+def consume_request(request: SecureInputRequest) -> dict[str, str]:
+  """Move values out exactly once. The caller owns clearing the returned dict."""
+  if request.status != "filled" or request.values is None:
+    raise ValueError("Secure input is not ready to consume.")
+  values = request.values
+  request.values = None
+  request.status = "consuming"
+  request.consuming_at = time.monotonic()
+  request.event.clear()
+  _publish(request, "secure_input_consuming")
+  _schedule_cleanup(CONSUMING_TTL_SECONDS, request.request_id)
+  return values
+
+
+def settle_request(
+  request: SecureInputRequest, *, ok: bool, message: str,
+) -> None:
+  safe_message = str(message or "Secure input complete.")[:240]
+  _settle(
+    request,
+    "completed" if ok else "failed",
+    {"ok": bool(ok), "message": safe_message},
+  )
+  _schedule_cleanup(COMPLETED_TTL_SECONDS, request.request_id)
+
+
+def cancel_request(request: SecureInputRequest) -> None:
+  _settle(
+    request,
+    "cancelled",
+    {"ok": False, "message": "Secure input was cancelled."},
+  )
+  _schedule_cleanup(COMPLETED_TTL_SECONDS, request.request_id)
+
+
+def cancel_chat(chat_id: str) -> None:
+  """Cancel every transient request owned by a stopped/deleted chat."""
+  _cleanup()
+  for request in list(_requests.values()):
+    if (
+      request.chat_id == chat_id
+      and request.status in {"pending", "filled", "consuming"}
+    ):
+      cancel_request(request)
+
+
+def secure_input_memory_diagnostics() -> dict[str, int]:
+  """Cardinality-only diagnostics; never expose request metadata or values."""
+  _cleanup()
+  return {
+    "request_count": len(_requests),
+    "pending_count": sum(
+      r.status in {"pending", "filled", "consuming"}
+      for r in _requests.values()
+    ),
+  }

--- a/backend/scripts/agent-screenshot.sh
+++ b/backend/scripts/agent-screenshot.sh
@@ -601,7 +601,7 @@ sleep 0.3
 # read inside the page and never appears in argv or output.
 BROWSER_PHASE="authentication verification"
 AUTH_OK="$(browser_eval_retry \
-  "(async () => { const token = localStorage.getItem('token'); if (!token || document.querySelector('input[type=password]')) return false; try { const res = await fetch('/api/chats?agent-screenshot-auth=' + Date.now(), { cache: 'no-store', headers: { Authorization: 'Bearer ' + token } }); return res.status === 200 && !!localStorage.getItem('token') && !document.querySelector('input[type=password]'); } catch { return false; } })()" \
+  "(async () => { const token = localStorage.getItem('token'); const login = () => document.querySelector('[data-auth-surface=login]'); if (!token || login()) return false; try { const res = await fetch('/api/chats?agent-screenshot-auth=' + Date.now(), { cache: 'no-store', headers: { Authorization: 'Bearer ' + token } }); return res.status === 200 && !!localStorage.getItem('token') && !login(); } catch { return false; } })()" \
   || true)"
 if [ "$AUTH_OK" != "true" ]; then
   die "authentication failed; the token was rejected or the login page remained visible"

--- a/backend/scripts/secure-input.py
+++ b/backend/scripts/secure-input.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""Request transient input and consume it without exposing submitted values."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+
+BACKEND_ROOT = Path(__file__).resolve().parent.parent
+CONSUMER_TIMEOUT_SECONDS = 120
+if str(BACKEND_ROOT) not in sys.path:
+  sys.path.insert(0, str(BACKEND_ROOT))
+
+
+def _post(url: str, payload: dict, token: str | None = None) -> tuple[int, dict]:
+  headers = {"Content-Type": "application/json"}
+  if token:
+    headers["Authorization"] = f"Bearer {token}"
+  request = urllib.request.Request(
+    url,
+    data=json.dumps(payload).encode("utf-8"),
+    headers=headers,
+    method="POST",
+  )
+  try:
+    with urllib.request.urlopen(request, timeout=35) as response:
+      return response.status, json.loads(response.read() or b"{}")
+  except urllib.error.HTTPError as exc:
+    try:
+      body = json.loads(exc.read() or b"{}")
+    except Exception:
+      body = {}
+    return exc.code, body
+
+
+def _safe_error(body: dict, fallback: str) -> str:
+  detail = body.get("detail")
+  return detail if isinstance(detail, str) else fallback
+
+
+def _field(value: str) -> dict:
+  parts = value.split(":", 2)
+  if len(parts) != 3:
+    raise argparse.ArgumentTypeError("field must be name:type:label")
+  name, input_type, label = parts
+  if input_type not in {"text", "password"}:
+    raise argparse.ArgumentTypeError("field type must be text or password")
+  return {"name": name, "type": input_type, "label": label}
+
+
+def _request_and_consume(spec: dict) -> tuple[str, str, dict[str, str]]:
+  base = os.environ.get("API_BASE_URL", "").rstrip("/")
+  token = os.environ.get("AGENT_TOKEN", "")
+  chat_id = os.environ.get("CHAT_ID", "")
+  if not base or not token or not chat_id:
+    raise RuntimeError("Secure input is unavailable: chat environment is incomplete.")
+
+  status, created = _post(
+    f"{base}/api/secure-inputs/{chat_id}", spec, token,
+  )
+  if status >= 300:
+    raise RuntimeError(_safe_error(created, "Could not open secure input."))
+  request_id = created.get("request_id")
+  capability = created.get("capability")
+  if not request_id or not capability:
+    raise RuntimeError("Could not open secure input: invalid server response.")
+
+  try:
+    while True:
+      status, state = _post(
+        f"{base}/api/secure-inputs/{request_id}/wait",
+        {"capability": capability},
+      )
+      if status >= 300:
+        raise RuntimeError("Secure input became unavailable.")
+      state_status = state.get("status")
+      if state_status == "pending":
+        continue
+      if state_status != "filled":
+        result = state.get("result") or {}
+        raise RuntimeError(result.get("message") or "Secure input closed.")
+      break
+    status, consumed = _post(
+      f"{base}/api/secure-inputs/{request_id}/consume",
+      {"capability": capability},
+    )
+    if status >= 300 or not isinstance(consumed.get("fields"), dict):
+      raise RuntimeError("Secure input could not be consumed.")
+    values = {
+      key: value for key, value in consumed["fields"].items()
+      if isinstance(key, str) and isinstance(value, str)
+    }
+    consumed["fields"].clear()
+    return request_id, capability, values
+  except BaseException:
+    _post(
+      f"{base}/api/secure-inputs/{request_id}/cancel",
+      {"capability": capability},
+    )
+    raise
+
+
+def _settle(request_id: str, capability: str, *, ok: bool, message: str) -> None:
+  base = os.environ.get("API_BASE_URL", "").rstrip("/")
+  _post(
+    f"{base}/api/secure-inputs/{request_id}/settle",
+    {"capability": capability, "ok": ok, "message": message[:240]},
+  )
+
+
+def _secret_variants(value: str) -> set[str]:
+  if not value:
+    return set()
+  raw = value.encode("utf-8")
+  return {
+    value,
+    json.dumps(value, ensure_ascii=False)[1:-1],
+    urllib.parse.quote(value, safe=""),
+    urllib.parse.quote_plus(value),
+    base64.b64encode(raw).decode("ascii"),
+    base64.urlsafe_b64encode(raw).decode("ascii"),
+  }
+
+
+def _redact_output(output: str, values: dict[str, str]) -> str:
+  variants = set()
+  for value in values.values():
+    variants.update(_secret_variants(value))
+  for variant in sorted(variants, key=len, reverse=True):
+    output = output.replace(variant, "[secret]")
+  return output
+
+
+def _run_consumer(command: list[str], values: dict[str, str]) -> int:
+  if not command:
+    raise RuntimeError("A sealed consumer command is required.")
+  payload = json.dumps(values, ensure_ascii=False).encode("utf-8")
+  try:
+    completed = subprocess.run(
+      command,
+      input=payload,
+      stdout=subprocess.PIPE,
+      stderr=subprocess.STDOUT,
+      check=False,
+      timeout=CONSUMER_TIMEOUT_SECONDS,
+    )
+  except subprocess.TimeoutExpired as exc:
+    partial = exc.stdout or b""
+    if isinstance(partial, str):
+      partial = partial.encode("utf-8", errors="replace")
+    safe_output = _redact_output(
+      partial.decode("utf-8", errors="replace"), values,
+    )
+    if safe_output:
+      print(
+        safe_output[:128 * 1024],
+        end="" if safe_output.endswith("\n") else "\n",
+      )
+    print("Sealed consumer timed out; submitted values were discarded.")
+    return 124
+  output = completed.stdout.decode("utf-8", errors="replace")
+  safe_output = _redact_output(output, values)
+  if safe_output:
+    print(safe_output[:128 * 1024], end="" if safe_output.endswith("\n") else "\n")
+  return completed.returncode
+
+
+def _owner_credentials_consumer() -> list[str]:
+  return [
+    sys.executable,
+    str(Path(__file__).with_name("update-owner-credentials.py")),
+  ]
+
+
+def main() -> int:
+  parser = argparse.ArgumentParser(
+    description="Request secure input without adding values to model context.",
+  )
+  sub = parser.add_subparsers(dest="action", required=True)
+
+  owner = sub.add_parser("owner-credentials")
+  owner.set_defaults(
+    mode="sealed",
+    title="Update sign-in",
+    description=(
+      "Values go directly to a local credential updater and are not sent to "
+      "the AI provider."
+    ),
+    fields=[
+      {"name": "current_password", "type": "password", "label": "Current password", "autocomplete": "current-password"},
+      {"name": "new_username", "type": "text", "label": "New username", "autocomplete": "username"},
+      {"name": "new_password", "type": "password", "label": "New password", "autocomplete": "new-password"},
+      {"name": "confirm_password", "type": "password", "label": "Confirm new password", "autocomplete": "new-password"},
+    ],
+    command=_owner_credentials_consumer(),
+  )
+
+  run = sub.add_parser("run")
+  run.add_argument("--title", required=True)
+  run.add_argument("--description", default="")
+  run.add_argument("--field", action="append", required=True, type=_field)
+  run.add_argument("command", nargs=argparse.REMAINDER)
+
+  reveal = sub.add_parser("reveal")
+  reveal.add_argument("--title", required=True)
+  reveal.add_argument("--description", default="")
+  reveal.add_argument("--field", action="append", required=True, type=_field)
+
+  args = parser.parse_args()
+  if args.action == "run":
+    args.mode = "sealed"
+    args.fields = args.field
+    args.command = args.command[1:] if args.command[:1] == ["--"] else args.command
+  elif args.action == "reveal":
+    args.mode = "reveal"
+    args.fields = args.field
+    args.command = None
+
+  spec = {
+    "mode": args.mode,
+    "title": args.title,
+    "description": args.description,
+    "fields": args.fields,
+  }
+  request_id = capability = None
+  values: dict[str, str] = {}
+  try:
+    request_id, capability, values = _request_and_consume(spec)
+    if args.action == "reveal":
+      from app.secure_inputs import build_reveal_envelope
+      print(build_reveal_envelope(json.dumps(values, ensure_ascii=False)))
+      rc = 0
+      message = "Secure values were revealed to the model for this turn only."
+    else:
+      rc = _run_consumer(args.command, values)
+      message = (
+        "Secure input was consumed without exposing its values."
+        if rc == 0
+        else "The sealed consumer failed; submitted values were discarded."
+      )
+    _settle(request_id, capability, ok=(rc == 0), message=message)
+    return rc
+  except (KeyboardInterrupt, EOFError):
+    if request_id and capability:
+      _settle(
+        request_id,
+        capability,
+        ok=False,
+        message="Secure input was cancelled; submitted values were discarded.",
+      )
+    print("Secure input cancelled.")
+    return 130
+  except Exception as exc:
+    if request_id and capability:
+      _settle(
+        request_id,
+        capability,
+        ok=False,
+        message="The sealed consumer failed; submitted values were discarded.",
+      )
+      print("Secure input failed; submitted values were discarded.")
+    else:
+      print(str(exc))
+    return 1
+  finally:
+    values.clear()
+
+
+if __name__ == "__main__":
+  sys.exit(main())

--- a/backend/scripts/secure-input.py
+++ b/backend/scripts/secure-input.py
@@ -4,19 +4,34 @@
 from __future__ import annotations
 
 import argparse
-import base64
 import json
 import os
 from pathlib import Path
 import subprocess
 import sys
 import urllib.error
-import urllib.parse
 import urllib.request
 
 
 BACKEND_ROOT = Path(__file__).resolve().parent.parent
 CONSUMER_TIMEOUT_SECONDS = 120
+OWNER_CREDENTIAL_OUTCOMES = {
+  0: (True, 0, "Credentials changed. Sign in again with the new details."),
+  2: (False, 2, "Credential input was invalid."),
+  3: (False, 1, "Owner account was not found."),
+  4: (False, 1, "This instance uses managed sign-in."),
+  5: (False, 1, "Current password is incorrect."),
+  6: (False, 1, "Username must be 1–64 characters."),
+  7: (False, 1, "Password cannot be blank or longer than 1024 characters."),
+  8: (False, 1, "New passwords do not match."),
+  9: (False, 1, "Credentials could not be changed."),
+  10: (
+    True,
+    0,
+    "Credentials changed. Sign in again, then restart Möbius to refresh "
+    "background access.",
+  ),
+}
 if str(BACKEND_ROOT) not in sys.path:
   sys.path.insert(0, str(BACKEND_ROOT))
 
@@ -117,29 +132,6 @@ def _settle(request_id: str, capability: str, *, ok: bool, message: str) -> None
   )
 
 
-def _secret_variants(value: str) -> set[str]:
-  if not value:
-    return set()
-  raw = value.encode("utf-8")
-  return {
-    value,
-    json.dumps(value, ensure_ascii=False)[1:-1],
-    urllib.parse.quote(value, safe=""),
-    urllib.parse.quote_plus(value),
-    base64.b64encode(raw).decode("ascii"),
-    base64.urlsafe_b64encode(raw).decode("ascii"),
-  }
-
-
-def _redact_output(output: str, values: dict[str, str]) -> str:
-  variants = set()
-  for value in values.values():
-    variants.update(_secret_variants(value))
-  for variant in sorted(variants, key=len, reverse=True):
-    output = output.replace(variant, "[secret]")
-  return output
-
-
 def _run_consumer(command: list[str], values: dict[str, str]) -> int:
   if not command:
     raise RuntimeError("A sealed consumer command is required.")
@@ -148,30 +140,30 @@ def _run_consumer(command: list[str], values: dict[str, str]) -> int:
     completed = subprocess.run(
       command,
       input=payload,
-      stdout=subprocess.PIPE,
-      stderr=subprocess.STDOUT,
+      stdout=subprocess.DEVNULL,
+      stderr=subprocess.DEVNULL,
       check=False,
       timeout=CONSUMER_TIMEOUT_SECONDS,
     )
-  except subprocess.TimeoutExpired as exc:
-    partial = exc.stdout or b""
-    if isinstance(partial, str):
-      partial = partial.encode("utf-8", errors="replace")
-    safe_output = _redact_output(
-      partial.decode("utf-8", errors="replace"), values,
-    )
-    if safe_output:
-      print(
-        safe_output[:128 * 1024],
-        end="" if safe_output.endswith("\n") else "\n",
-      )
-    print("Sealed consumer timed out; submitted values were discarded.")
+  except subprocess.TimeoutExpired:
     return 124
-  output = completed.stdout.decode("utf-8", errors="replace")
-  safe_output = _redact_output(output, values)
-  if safe_output:
-    print(safe_output[:128 * 1024], end="" if safe_output.endswith("\n") else "\n")
   return completed.returncode
+
+
+def _consumer_outcome(action: str, returncode: int) -> tuple[bool, int, str]:
+  """Map process state to trusted copy without reading consumer output."""
+  if action == "owner-credentials":
+    return OWNER_CREDENTIAL_OUTCOMES.get(
+      returncode,
+      (False, 1, "Credentials could not be changed."),
+    )
+  if returncode == 0:
+    return True, 0, "Secure input was consumed without exposing its values."
+  if returncode == 124:
+    return False, 124, "Sealed consumer timed out; submitted values were discarded."
+  return False, returncode or 1, (
+    "The sealed consumer failed; submitted values were discarded."
+  )
 
 
 def _owner_credentials_consumer() -> list[str]:
@@ -239,15 +231,15 @@ def main() -> int:
       from app.secure_inputs import build_reveal_envelope
       print(build_reveal_envelope(json.dumps(values, ensure_ascii=False)))
       rc = 0
+      ok = True
       message = "Secure values were revealed to the model for this turn only."
     else:
-      rc = _run_consumer(args.command, values)
-      message = (
-        "Secure input was consumed without exposing its values."
-        if rc == 0
-        else "The sealed consumer failed; submitted values were discarded."
+      ok, rc, message = _consumer_outcome(
+        args.action,
+        _run_consumer(args.command, values),
       )
-    _settle(request_id, capability, ok=(rc == 0), message=message)
+      print(message)
+    _settle(request_id, capability, ok=ok, message=message)
     return rc
   except (KeyboardInterrupt, EOFError):
     if request_id and capability:

--- a/backend/scripts/seed-skills/secure-input.md
+++ b/backend/scripts/seed-skills/secure-input.md
@@ -1,0 +1,82 @@
+# Secure input
+
+Use this skill when the owner needs to supply a password, API key, token,
+private username, or other value that should not pass through the LLM API or
+enter the chat transcript. The trusted card is an interactive live-chat
+primitive, not a background/scheduled-agent mechanism.
+
+## Default: sealed execution
+
+Tell the owner what the local operation will do, then invoke the trusted helper:
+
+```bash
+python3 /data/platform/backend/scripts/secure-input.py owner-credentials
+```
+
+That built-in flow requests the current password, new username, new password,
+and confirmation. Möbius holds the submitted strings only in server memory
+until the helper consumes them once. The helper passes them to the credential
+updater as JSON on stdin, captures its output in memory, scrubs exact submitted
+values and common encodings, and returns only a safe outcome. The card's title,
+field prompts, and completion state remain as a safe receipt; submitted values
+do not enter chat, tool arguments, environment variables, temporary files, or
+the durable transcript.
+The helper gives a local consumer two minutes to finish; on timeout it
+terminates the process, redacts any partial output, and discards the values.
+
+For another local consumer:
+
+```bash
+python3 /data/platform/backend/scripts/secure-input.py run \
+  --title "Connect service" \
+  --description "Credentials go directly to the local connector." \
+  --field username:text:"Username" \
+  --field api_key:password:"API key" \
+  -- python3 /data/path/to/safe-consumer.py
+```
+
+The consumer reads one JSON object from stdin. Its source may be durable, but it
+must never contain submitted values. It should consume the values immediately
+and must not print, log, persist, cache, shell-expand, or copy them into another
+command's arguments or environment. Prefer a narrow operation that writes only
+the intended hashed/encrypted destination. The helper scrubs stdout/stderr as
+defense in depth, but no redactor can guarantee removal of arbitrary
+transformations or a consumer that deliberately writes elsewhere.
+
+Never call the create/consume endpoints with curl or a general HTTP tool. The
+helper keeps the one-use capability and secret response out of model-visible
+tool output. One request may be open per chat; it expires after 15 minutes and
+is cancelled on Stop.
+
+## Explicit reveal for debugging
+
+Revealing is an escalation, not the default. First explain that the AI provider
+will receive the value and may retain it in its own session even though Möbius
+will omit the marked tool result from its live UI, transcript, and chat logs.
+Proceed only after the owner explicitly asks for or approves that exposure.
+Then use:
+
+```bash
+python3 /data/platform/backend/scripts/secure-input.py reveal \
+  --title "Reveal credential for debugging" \
+  --description "These values will be sent to the AI provider for this turn." \
+  --field api_key:password:"API key"
+```
+
+The card requires a second confirmation. After reveal, do not repeat the value
+in prose, another tool call, a file, or a command. Use it only for the approved
+diagnostic and return to sealed execution for any follow-up.
+
+## Boundaries
+
+The ordinary sealed path keeps submitted values out of the LLM API and Möbius
+persistence; only safe receipt metadata persists. Values necessarily exist
+briefly in the owner's browser DOM, the authenticated request body, server RAM,
+helper RAM, and the chosen consumer process. They are cleared or become
+unreachable after submission/consumption and are never intentionally written
+to disk. A process crash lets the OS reclaim that memory; it does not create a
+recovery copy.
+
+A background or scheduled agent must not open this card: nobody may be present,
+and the transient request cannot survive a restart. Leave a declarative
+request for the next live chat instead.

--- a/backend/scripts/seed-skills/secure-input.md
+++ b/backend/scripts/seed-skills/secure-input.md
@@ -16,8 +16,8 @@ python3 /data/platform/backend/scripts/secure-input.py owner-credentials
 That built-in flow requests the current password, new username, new password,
 and confirmation. Möbius holds the submitted strings only in server memory
 until the helper consumes them once. The helper passes them to the credential
-updater as JSON on stdin, captures its output in memory, scrubs exact submitted
-values and common encodings, and returns only a safe outcome. The card's title,
+updater as JSON on stdin, discards its stdout and stderr, and maps only fixed
+outcome codes to trusted messages. The card's title,
 field prompts, and completion state remain as a safe receipt; submitted values
 do not enter chat, tool arguments, environment variables, temporary files, or
 the durable transcript.
@@ -37,11 +37,11 @@ python3 /data/platform/backend/scripts/secure-input.py run \
 
 The consumer reads one JSON object from stdin. Its source may be durable, but it
 must never contain submitted values. It should consume the values immediately
-and must not print, log, persist, cache, shell-expand, or copy them into another
+and must not log, persist, cache, shell-expand, or copy them into another
 command's arguments or environment. Prefer a narrow operation that writes only
-the intended hashed/encrypted destination. The helper scrubs stdout/stderr as
-defense in depth, but no redactor can guarantee removal of arbitrary
-transformations or a consumer that deliberately writes elsewhere.
+the intended hashed/encrypted destination. The helper discards all consumer
+stdout and stderr and reports only a predefined success, failure, or timeout;
+a consumer that deliberately writes elsewhere remains outside this boundary.
 
 Never call the create/consume endpoints with curl or a general HTTP tool. The
 helper keeps the one-use capability and secret response out of model-visible

--- a/backend/scripts/update-owner-credentials.py
+++ b/backend/scripts/update-owner-credentials.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Consume owner credentials as stdin JSON and print only a safe outcome."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+
+
+BACKEND_ROOT = Path(__file__).resolve().parent.parent
+if str(BACKEND_ROOT) not in sys.path:
+  sys.path.insert(0, str(BACKEND_ROOT))
+
+from app import auth, models
+from app.config import get_settings
+from app.database import SessionLocal
+from app.routes.auth import _write_service_token
+
+
+def main() -> int:
+  try:
+    values = json.load(sys.stdin)
+  except Exception:
+    print("Credential input was invalid.")
+    return 2
+  if not isinstance(values, dict):
+    print("Credential input was invalid.")
+    return 2
+
+  db = SessionLocal()
+  try:
+    owner = db.query(models.Owner).one_or_none()
+    if owner is None:
+      print("Owner account was not found.")
+      return 1
+    if get_settings().mobius_sso_enabled:
+      print("This instance uses managed sign-in.")
+      return 1
+
+    current_password = values.get("current_password", "")
+    new_username = values.get("new_username", "").strip()
+    new_password = values.get("new_password", "")
+    confirm_password = values.get("confirm_password", "")
+    if not auth.verify_password(current_password, owner.hashed_password):
+      print("Current password is incorrect.")
+      return 1
+    if not 1 <= len(new_username) <= 64:
+      print("Username must be 1–64 characters.")
+      return 1
+    if not new_password.strip() or len(new_password) > 1024:
+      print("Password cannot be blank or longer than 1024 characters.")
+      return 1
+    if new_password != confirm_password:
+      print("New passwords do not match.")
+      return 1
+
+    owner.username = new_username
+    owner.hashed_password = auth.hash_password(new_password)
+    owner.token_epoch += 1
+    epoch = owner.token_epoch
+    db.commit()
+  except Exception:
+    db.rollback()
+    print("Credentials could not be changed.")
+    return 1
+  finally:
+    values.clear()
+    db.close()
+
+  try:
+    _write_service_token(new_username, epoch)
+  except OSError:
+    print(
+      "Credentials changed. Sign in again, then restart Möbius to refresh "
+      "background access."
+    )
+    return 0
+  print("Credentials changed. Sign in again with the new details.")
+  return 0
+
+
+if __name__ == "__main__":
+  sys.exit(main())

--- a/backend/scripts/update-owner-credentials.py
+++ b/backend/scripts/update-owner-credentials.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Consume owner credentials as stdin JSON and print only a safe outcome."""
+"""Consume owner credentials as stdin JSON and return a fixed outcome code."""
 
 from __future__ import annotations
 
@@ -22,38 +22,30 @@ def main() -> int:
   try:
     values = json.load(sys.stdin)
   except Exception:
-    print("Credential input was invalid.")
     return 2
   if not isinstance(values, dict):
-    print("Credential input was invalid.")
     return 2
 
   db = SessionLocal()
   try:
     owner = db.query(models.Owner).one_or_none()
     if owner is None:
-      print("Owner account was not found.")
-      return 1
+      return 3
     if get_settings().mobius_sso_enabled:
-      print("This instance uses managed sign-in.")
-      return 1
+      return 4
 
     current_password = values.get("current_password", "")
     new_username = values.get("new_username", "").strip()
     new_password = values.get("new_password", "")
     confirm_password = values.get("confirm_password", "")
     if not auth.verify_password(current_password, owner.hashed_password):
-      print("Current password is incorrect.")
-      return 1
+      return 5
     if not 1 <= len(new_username) <= 64:
-      print("Username must be 1–64 characters.")
-      return 1
+      return 6
     if not new_password.strip() or len(new_password) > 1024:
-      print("Password cannot be blank or longer than 1024 characters.")
-      return 1
+      return 7
     if new_password != confirm_password:
-      print("New passwords do not match.")
-      return 1
+      return 8
 
     owner.username = new_username
     owner.hashed_password = auth.hash_password(new_password)
@@ -62,8 +54,7 @@ def main() -> int:
     db.commit()
   except Exception:
     db.rollback()
-    print("Credentials could not be changed.")
-    return 1
+    return 9
   finally:
     values.clear()
     db.close()
@@ -71,12 +62,7 @@ def main() -> int:
   try:
     _write_service_token(new_username, epoch)
   except OSError:
-    print(
-      "Credentials changed. Sign in again, then restart Möbius to refresh "
-      "background access."
-    )
-    return 0
-  print("Credentials changed. Sign in again with the new details.")
+    return 10
   return 0
 
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -150,11 +150,13 @@ def fresh_db():
   from app import broadcast as bc_mod
   from app import chat_queue as chat_queue_mod
   from app import questions as questions_mod
+  from app import secure_inputs as secure_inputs_mod
   from app.runner_registry import registry
   # ticket 033: pending-question registry lives in app.questions;
   # queue locks live in app.chat_queue. Reset both canonical homes.
   questions_mod._pending.clear()
   questions_mod._cancelled.clear()
+  secure_inputs_mod._requests.clear()
   registry.reset_for_tests()
   # Reset the per-chat queue-lock registry so a lock held by a leaked
   # task from a prior test can't be returned to the next test's caller.

--- a/backend/tests/test_agent_screenshot_auth.py
+++ b/backend/tests/test_agent_screenshot_auth.py
@@ -367,6 +367,13 @@ def test_helper_captures_after_authentication_is_confirmed(tmp_path: Path):
   assert all("test-token" not in command for command in commands)
 
 
+def test_auth_check_targets_login_surface_not_unrelated_password_fields():
+  source = SCRIPT.read_text(encoding="utf-8")
+
+  assert "[data-auth-surface=login]" in source
+  assert "input[type=password]" not in source
+
+
 def test_helper_accepts_a_stable_canonical_shell_route(tmp_path: Path):
   result, output, marker, browser_log = _run_helper(
     tmp_path,

--- a/backend/tests/test_secure_inputs.py
+++ b/backend/tests/test_secure_inputs.py
@@ -1,0 +1,504 @@
+"""Security contract for transient-value input and sealed consumption."""
+
+import asyncio
+import importlib.util
+import io
+import json
+from pathlib import Path
+import sys
+
+
+def _create_request(client, auth, chat, *, mode="sealed"):
+  from app.broadcast import create_broadcast
+
+  bc = create_broadcast(chat.id)
+  response = client.post(
+    f"/api/secure-inputs/{chat.id}",
+    headers=auth,
+    json={
+      "mode": mode,
+      "title": "Private connection",
+      "description": "Values bypass model context.",
+      "fields": [
+        {"name": "username", "label": "Username", "type": "text"},
+        {"name": "password", "label": "Password", "type": "password"},
+      ],
+    },
+  )
+  assert response.status_code == 200
+  return bc, response.json()
+
+
+def test_sealed_values_never_enter_events_status_or_chat(
+  client, auth, chat, db,
+):
+  from app import secure_inputs
+
+  username = "private-owner@example.test"
+  password = "Correct Horse Battery Staple 779!"
+  bc, created = _create_request(client, auth, chat)
+  request_id = created["request_id"]
+  capability = created["capability"]
+
+  public_wire = json.dumps(bc.event_log)
+  assert username not in public_wire
+  assert password not in public_wire
+  assert "capability" not in public_wire
+  assert bc.event_log[-1]["fields"] == [
+    {"name": "username", "label": "Username", "type": "text", "autocomplete": "off"},
+    {"name": "password", "label": "Password", "type": "password", "autocomplete": "off"},
+  ]
+
+  submitted = client.post(
+    f"/api/secure-inputs/{chat.id}/{request_id}/submit",
+    headers=auth,
+    json={"fields": {"username": username, "password": password}},
+  )
+  assert submitted.status_code == 200
+  pending = secure_inputs.get_request(request_id)
+  assert pending.status == "filled"
+
+  wrong = client.post(
+    f"/api/secure-inputs/{request_id}/wait",
+    json={"capability": "wrong-capability"},
+  )
+  assert wrong.status_code == 404
+  ready = client.post(
+    f"/api/secure-inputs/{request_id}/wait",
+    json={"capability": capability},
+  )
+  assert ready.json() == {"status": "filled", "result": None}
+  assert username not in ready.text
+  assert password not in ready.text
+
+  consumed = client.post(
+    f"/api/secure-inputs/{request_id}/consume",
+    json={"capability": capability},
+  )
+  assert consumed.status_code == 200
+  assert consumed.json()["fields"] == {
+    "username": username,
+    "password": password,
+  }
+  assert secure_inputs.get_request(request_id).values is None
+  second = client.post(
+    f"/api/secure-inputs/{request_id}/consume",
+    json={"capability": capability},
+  )
+  assert second.status_code == 409
+  assert username not in second.text
+  assert password not in second.text
+
+  settled = client.post(
+    f"/api/secure-inputs/{request_id}/settle",
+    json={
+      "capability": capability,
+      "ok": True,
+      "message": "Connection updated.",
+    },
+  )
+  assert settled.status_code == 200
+  assert username not in json.dumps(bc.event_log)
+  assert password not in json.dumps(bc.event_log)
+  db.refresh(chat)
+  assert chat.messages == []
+  assert chat.pending_messages == []
+
+
+def test_sink_builds_a_persistable_prompt_only_receipt(client, auth, chat):
+  from app.broadcast import create_broadcast
+  from app.chat_event_sink import (
+    ChatEventSink, register_active_sink, unregister_active_sink,
+  )
+  from app.events import build_assistant_message
+  from app.memory_recall import EMPTY_RECALL_BINDING
+
+  username = "receipt-private-owner@example.test"
+  password = "receipt-private-password-8831"
+  bc = create_broadcast(chat.id)
+  sink = ChatEventSink(
+    bc, chat.id, recall_binding=EMPTY_RECALL_BINDING,
+  )
+  register_active_sink(chat.id, sink)
+  try:
+    response = client.post(
+      f"/api/secure-inputs/{chat.id}",
+      headers=auth,
+      json={
+        "mode": "sealed",
+        "title": "Update sign-in",
+        "description": "Values bypass model context.",
+        "fields": [
+          {"name": "username", "label": "Username", "type": "text"},
+          {"name": "password", "label": "Password", "type": "password"},
+        ],
+      },
+    )
+    assert response.status_code == 200
+    created = response.json()
+    request_id = created["request_id"]
+
+    submitted = client.post(
+      f"/api/secure-inputs/{chat.id}/{request_id}/submit",
+      headers=auth,
+      json={"fields": {"username": username, "password": password}},
+    )
+    assert submitted.status_code == 200
+    consumed = client.post(
+      f"/api/secure-inputs/{request_id}/consume",
+      json={"capability": created["capability"]},
+    )
+    assert consumed.status_code == 200
+    consumed.json()["fields"].clear()
+    settled = client.post(
+      f"/api/secure-inputs/{request_id}/settle",
+      json={
+        "capability": created["capability"],
+        "ok": True,
+        "message": "Sign-in updated.",
+      },
+    )
+    assert settled.status_code == 200
+
+    message = build_assistant_message(sink.assistant_blocks)
+    wire = json.dumps(message)
+    assert username not in wire
+    assert password not in wire
+    assert created["capability"] not in wire
+    receipt = next(
+      block for block in message["blocks"]
+      if block.get("type") == "secure_input"
+    )
+    assert receipt == {
+      "type": "secure_input",
+      "request_id": request_id,
+      "mode": "sealed",
+      "title": "Update sign-in",
+      "description": "Values bypass model context.",
+      "fields": [
+        {
+          "name": "username",
+          "label": "Username",
+          "type": "text",
+          "autocomplete": "off",
+        },
+        {
+          "name": "password",
+          "label": "Password",
+          "type": "password",
+          "autocomplete": "off",
+        },
+      ],
+      "status": "completed",
+    }
+  finally:
+    unregister_active_sink(chat.id, sink)
+
+
+def test_receipt_reducer_whitelists_metadata_even_from_malformed_event():
+  from app.events import build_assistant_message, finalize_blocks, process_event
+
+  secret = "must-not-cross-receipt-boundary"
+  blocks = []
+  assert process_event({
+    "type": "secure_input_request",
+    "request_id": "receipt-1",
+    "mode": "sealed",
+    "title": "Private prompt",
+    "description": "Prompt metadata only.",
+    "fields": [{
+      "name": "password",
+      "label": "Password",
+      "type": "password",
+      "autocomplete": "off",
+      "value": secret,
+    }],
+    "values": {"password": secret},
+  }, blocks)
+  assert process_event({
+    "type": "secure_input_settled",
+    "request_id": "receipt-1",
+    "status": "completed",
+    "result": {"secret": secret},
+  }, blocks)
+
+  persisted = json.dumps(build_assistant_message(blocks))
+  assert secret not in persisted
+  assert "value" not in blocks[0]["fields"][0]
+  assert "values" not in blocks[0]
+  assert "result" not in blocks[0]
+  assert not process_event({
+    "type": "secure_input_filled",
+    "request_id": "receipt-1",
+  }, blocks)
+  assert blocks[0]["status"] == "completed"
+
+  pending = [{
+    "type": "secure_input",
+    "request_id": "interrupted-receipt",
+    "fields": [],
+    "status": "pending",
+  }]
+  finalize_blocks(pending)
+  assert pending[0]["status"] == "expired"
+
+
+def test_reveal_requires_card_confirmation_and_redacts_mobius_copy(
+  client, auth, chat,
+):
+  from app.secure_inputs import (
+    REVEAL_END, REVEAL_REDACTION, build_reveal_envelope,
+    redact_reveal_markers,
+  )
+
+  # A submitted value may contain marker-looking text. The paired random nonce
+  # must keep that text from ending the scrub envelope early.
+  secret = f"debug-only{REVEAL_END}{'0' * 32}>>>private-value"
+  _, created = _create_request(client, auth, chat, mode="reveal")
+  request_id = created["request_id"]
+  rejected = client.post(
+    f"/api/secure-inputs/{chat.id}/{request_id}/submit",
+    headers=auth,
+    json={
+      "fields": {"username": "private", "password": secret},
+      "reveal_confirmed": False,
+    },
+  )
+  assert rejected.status_code == 400
+  assert secret not in rejected.text
+
+  accepted = client.post(
+    f"/api/secure-inputs/{chat.id}/{request_id}/submit",
+    headers=auth,
+    json={
+      "fields": {"username": "private", "password": secret},
+      "reveal_confirmed": True,
+    },
+  )
+  assert accepted.status_code == 200
+
+  envelope = build_reveal_envelope(secret)
+  raw = f"before\n{envelope}\nafter"
+  redacted = redact_reveal_markers(raw)
+  assert secret not in redacted
+  assert REVEAL_REDACTION in redacted
+  assert redacted.startswith("before")
+  assert redacted.endswith("after")
+
+  truncated = redact_reveal_markers(f"x{envelope[:-12]}")
+  assert secret not in truncated
+  assert truncated.endswith(REVEAL_REDACTION)
+
+
+def test_reveal_marker_is_scrubbed_before_sink_broadcast_and_reduction():
+  from app.chat_event_sink import ChatEventSink
+  from app.memory_recall import EMPTY_RECALL_BINDING
+  from app.secure_inputs import REVEAL_REDACTION, build_reveal_envelope
+
+  class Bus:
+    def __init__(self):
+      self.events = []
+
+    def publish(self, event):
+      self.events.append(dict(event))
+
+  secret = "provider-only-debug-value"
+  bus = Bus()
+  sink = ChatEventSink(
+    bus, "", recall_binding=EMPTY_RECALL_BINDING,
+  )
+  sink.publish({
+    "type": "tool_start",
+    "tool": "Bash",
+    "tool_use_id": "secure-reveal",
+  })
+  event = {
+    "type": "tool_output",
+    "content": build_reveal_envelope(secret),
+    "tool_use_id": "secure-reveal",
+  }
+  sink.publish(event)
+
+  wire = json.dumps(bus.events, ensure_ascii=False)
+  blocks = json.dumps(sink.assistant_blocks, ensure_ascii=False)
+  assert secret not in wire
+  assert secret not in blocks
+  assert REVEAL_REDACTION in wire
+  assert REVEAL_REDACTION in blocks
+
+
+def test_invalid_submission_never_reflects_secret(client, auth, chat):
+  secret = "must-not-echo-even-on-error"
+  _, created = _create_request(client, auth, chat)
+  response = client.post(
+    f"/api/secure-inputs/{chat.id}/{created['request_id']}/submit",
+    headers=auth,
+    json={"fields": {"unexpected": secret}},
+  )
+  assert response.status_code == 400
+  assert secret not in response.text
+
+
+def test_cancel_clears_memory_values(client, auth, chat):
+  from app import secure_inputs
+
+  _, created = _create_request(client, auth, chat)
+  request_id = created["request_id"]
+  client.post(
+    f"/api/secure-inputs/{chat.id}/{request_id}/submit",
+    headers=auth,
+    json={"fields": {"username": "u", "password": "p"}},
+  )
+  assert secure_inputs.get_request(request_id).values is not None
+  cancelled = client.post(
+    f"/api/secure-inputs/{request_id}/cancel",
+    json={"capability": created["capability"]},
+  )
+  assert cancelled.status_code == 200
+  pending = secure_inputs.get_request(request_id)
+  assert pending.status == "cancelled"
+  assert pending.values is None
+
+
+def test_filled_values_expire_without_another_request(monkeypatch):
+  from app import secure_inputs
+
+  monkeypatch.setattr(secure_inputs, "REQUEST_TTL_SECONDS", 0.01)
+
+  async def scenario():
+    pending, _ = secure_inputs.create_request(
+      chat_id="expiry-chat",
+      mode="sealed",
+      title="Short lived",
+      description="",
+      fields=[{
+        "name": "password",
+        "label": "Password",
+        "type": "password",
+        "autocomplete": "off",
+      }],
+    )
+    secure_inputs.fill_request(pending, {"password": "transient-canary"})
+    await asyncio.sleep(0.03)
+    assert pending.status == "expired"
+    assert pending.values is None
+
+  asyncio.run(scenario())
+
+
+def test_sealed_consumer_scrubs_raw_and_encoded_values(capsys):
+  script_path = (
+    Path(__file__).resolve().parents[1] / "scripts" / "secure-input.py"
+  )
+  spec = importlib.util.spec_from_file_location("secure_input_helper", script_path)
+  helper = importlib.util.module_from_spec(spec)
+  spec.loader.exec_module(helper)
+
+  secret = "private value+/with spaces"
+  values = {"password": secret}
+  command = [
+    sys.executable,
+    "-c",
+    (
+      "import base64,json,sys,urllib.parse; "
+      "v=json.load(sys.stdin)['password']; "
+      "print(v); print(urllib.parse.quote(v,safe='')); "
+      "print(base64.b64encode(v.encode()).decode())"
+    ),
+  ]
+  assert helper._run_consumer(command, values) == 0
+  output = capsys.readouterr().out
+  assert secret not in output
+  assert "private%20value" not in output
+  assert "cHJpdmF0ZSB2YWx1Z" not in output
+  assert output.count("[secret]") == 3
+
+
+def test_sealed_consumer_exception_settles_without_reflecting_values(
+  monkeypatch, capsys,
+):
+  script_path = (
+    Path(__file__).resolve().parents[1] / "scripts" / "secure-input.py"
+  )
+  spec = importlib.util.spec_from_file_location("secure_input_helper", script_path)
+  helper = importlib.util.module_from_spec(spec)
+  spec.loader.exec_module(helper)
+
+  secret = "consumer-exception-secret"
+  monkeypatch.setattr(sys, "argv", [
+    "secure-input.py",
+    "run",
+    "--title", "Private connection",
+    "--field", "password:password:Password",
+    "--", "consumer",
+  ])
+  monkeypatch.setattr(
+    helper,
+    "_request_and_consume",
+    lambda _spec: ("request-id", "capability", {"password": secret}),
+  )
+
+  def fail_consumer(_command, _values):
+    raise RuntimeError(f"consumer failed with {secret}")
+
+  settled = []
+  monkeypatch.setattr(helper, "_run_consumer", fail_consumer)
+  monkeypatch.setattr(
+    helper,
+    "_settle",
+    lambda request_id, capability, **outcome: settled.append(
+      (request_id, capability, outcome),
+    ),
+  )
+
+  assert helper.main() == 1
+  output = capsys.readouterr().out
+  assert secret not in output
+  assert output == "Secure input failed; submitted values were discarded.\n"
+  assert settled == [(
+    "request-id",
+    "capability",
+    {
+      "ok": False,
+      "message": "The sealed consumer failed; submitted values were discarded.",
+    },
+  )]
+
+
+def test_owner_credentials_consumer_changes_login_without_printing_values(
+  owner_token, db, monkeypatch, capsys,
+):
+  from app import auth, models
+
+  script_path = (
+    Path(__file__).resolve().parents[1]
+    / "scripts"
+    / "update-owner-credentials.py"
+  )
+  spec = importlib.util.spec_from_file_location(
+    "update_owner_credentials", script_path,
+  )
+  consumer = importlib.util.module_from_spec(spec)
+  spec.loader.exec_module(consumer)
+
+  new_username = "safer-owner"
+  new_password = "a private replacement passphrase"
+  monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps({
+    "current_password": "testpassword123",
+    "new_username": new_username,
+    "new_password": new_password,
+    "confirm_password": new_password,
+  })))
+
+  assert consumer.main() == 0
+  output = capsys.readouterr().out
+  assert new_username not in output
+  assert new_password not in output
+  assert "Credentials changed" in output
+
+  db.expire_all()
+  owner = db.query(models.Owner).one()
+  assert owner.username == new_username
+  assert owner.token_epoch == 1
+  assert auth.verify_password(new_password, owner.hashed_password)
+  assert not auth.verify_password("testpassword123", owner.hashed_password)

--- a/backend/tests/test_secure_inputs.py
+++ b/backend/tests/test_secure_inputs.py
@@ -386,7 +386,7 @@ def test_filled_values_expire_without_another_request(monkeypatch):
   asyncio.run(scenario())
 
 
-def test_sealed_consumer_scrubs_raw_and_encoded_values(capsys):
+def test_sealed_consumer_discards_stdout_and_stderr(capsys):
   script_path = (
     Path(__file__).resolve().parents[1] / "scripts" / "secure-input.py"
   )
@@ -403,15 +403,36 @@ def test_sealed_consumer_scrubs_raw_and_encoded_values(capsys):
       "import base64,json,sys,urllib.parse; "
       "v=json.load(sys.stdin)['password']; "
       "print(v); print(urllib.parse.quote(v,safe='')); "
-      "print(base64.b64encode(v.encode()).decode())"
+      "print(base64.b64encode(v.encode()).decode()); "
+      "print(v, file=sys.stderr)"
     ),
   ]
   assert helper._run_consumer(command, values) == 0
-  output = capsys.readouterr().out
-  assert secret not in output
-  assert "private%20value" not in output
-  assert "cHJpdmF0ZSB2YWx1Z" not in output
-  assert output.count("[secret]") == 3
+  captured = capsys.readouterr()
+  assert captured.out == ""
+  assert captured.err == ""
+
+
+def test_consumer_outcomes_are_predefined():
+  script_path = (
+    Path(__file__).resolve().parents[1] / "scripts" / "secure-input.py"
+  )
+  spec = importlib.util.spec_from_file_location("secure_input_helper", script_path)
+  helper = importlib.util.module_from_spec(spec)
+  spec.loader.exec_module(helper)
+
+  assert helper._consumer_outcome("run", 0) == (
+    True, 0, "Secure input was consumed without exposing its values.",
+  )
+  assert helper._consumer_outcome("run", 19) == (
+    False, 19, "The sealed consumer failed; submitted values were discarded.",
+  )
+  assert helper._consumer_outcome("owner-credentials", 5) == (
+    False, 1, "Current password is incorrect.",
+  )
+  assert helper._consumer_outcome("owner-credentials", 73) == (
+    False, 1, "Credentials could not be changed.",
+  )
 
 
 def test_sealed_consumer_exception_settles_without_reflecting_values(
@@ -494,7 +515,7 @@ def test_owner_credentials_consumer_changes_login_without_printing_values(
   output = capsys.readouterr().out
   assert new_username not in output
   assert new_password not in output
-  assert "Credentials changed" in output
+  assert output == ""
 
   db.expire_all()
   owner = db.query(models.Owner).one()

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -465,6 +465,12 @@ export const api = {
       'chats', `/chats/${chatId}/recover`, { method: 'POST' },
     ),
   },
+  secureInputs: {
+    submit: (chatId, requestId, payload) => apiFetch(
+      `/secure-inputs/${encodeURIComponent(chatId)}/${encodeURIComponent(requestId)}/submit`,
+      { method: 'POST', body: JSON.stringify(payload) },
+    ),
+  },
   apps: {
     list: () => apiFetch('/apps/'),
     markOpened: (appId) => apiFetch(`/apps/${appId}/opened`, {

--- a/frontend/src/components/ChatView/MsgContent.jsx
+++ b/frontend/src/components/ChatView/MsgContent.jsx
@@ -4,6 +4,7 @@ import { ProgressiveMarkdown, StandardMarkdown } from './markdown/BlockRenderer.
 import ActivityStretch from './ActivityStretch.jsx'
 import { groupActivityRuns, coalesceThinkingEntries } from './groupBlocks.js'
 import QuestionCard from './QuestionCard.jsx'
+import SecureInputCard from './SecureInputCard.jsx'
 import MessageSources from './MessageSources.jsx'
 import Attachments from './Attachments.jsx'
 import CompactionCard from './CompactionCard.jsx'
@@ -240,6 +241,16 @@ function MsgContentInner({
               pendingCardRef={answerable ? pendingQuestionRef : undefined}
             />
           </div>
+        )
+      }
+      if (block.type === 'secure_input') {
+        return (
+          <SecureInputCard
+            key={block.request_id || `secure-input-${i}`}
+            block={block}
+            chatId={chatId}
+            interactive={isActiveAnswer && isStreaming}
+          />
         )
       }
       if (block.type === 'error') {

--- a/frontend/src/components/ChatView/SecureInputCard.css
+++ b/frontend/src/components/ChatView/SecureInputCard.css
@@ -1,0 +1,88 @@
+/* The secure-input block mirrors QuestionCard's calm inline geometry. */
+
+.secure-card {
+  box-sizing: border-box;
+  width: min(100%, 640px);
+  margin: 10px auto;
+  padding: 16px;
+  border: 1px solid color-mix(in srgb, var(--green) 34%, var(--border));
+  border-radius: 14px;
+  background: linear-gradient(145deg, color-mix(in srgb, var(--green) 7%, var(--surface)) 0%, var(--surface) 64%);
+}
+.secure-card--reveal {
+  border-color: color-mix(in srgb, var(--danger) 32%, var(--border));
+  background: linear-gradient(145deg, color-mix(in srgb, var(--danger) 6%, var(--surface)) 0%, var(--surface) 64%);
+}
+.secure-card__head { display: flex; align-items: center; gap: 11px; }
+.secure-card__lock {
+  position: relative;
+  flex: none;
+  width: 30px;
+  height: 30px;
+  border: 1px solid color-mix(in srgb, var(--green) 42%, var(--border));
+  border-radius: 9px;
+  background: color-mix(in srgb, var(--green) 11%, var(--surface2));
+}
+.secure-card__lock::before {
+  content: '';
+  position: absolute;
+  left: 9px;
+  top: 6px;
+  width: 10px;
+  height: 9px;
+  border: 2px solid var(--green);
+  border-bottom: 0;
+  border-radius: 7px 7px 0 0;
+}
+.secure-card__lock::after {
+  content: '';
+  position: absolute;
+  left: 7px;
+  top: 14px;
+  width: 14px;
+  height: 10px;
+  border-radius: 3px;
+  background: var(--green);
+}
+.secure-card--reveal .secure-card__lock { border-color: color-mix(in srgb, var(--danger) 42%, var(--border)); background: color-mix(in srgb, var(--danger) 10%, var(--surface2)); }
+.secure-card--reveal .secure-card__lock::before { border-color: var(--danger); }
+.secure-card--reveal .secure-card__lock::after { background: var(--danger); }
+.secure-card__title { margin: 0; color: var(--text); font-size: 15px; font-weight: 650; line-height: 1.25; }
+.secure-card__description { margin: 12px 0 14px; color: var(--muted); font-size: 12.5px; line-height: 1.45; }
+.secure-card__form { display: grid; gap: 11px; }
+.secure-card__field { display: grid; gap: 5px; color: var(--text); font-size: 12px; font-weight: 600; }
+.secure-card__field input {
+  box-sizing: border-box;
+  width: 100%;
+  min-height: 42px;
+  padding: 9px 11px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  outline: none;
+  background: var(--surface2, rgba(128,128,128,.1));
+  color: var(--text);
+  font: inherit;
+  font-size: 14px;
+  font-weight: 400;
+}
+.secure-card__field input:focus-visible { border-color: var(--green); box-shadow: 0 0 0 3px color-mix(in srgb, var(--green) 16%, transparent); }
+.secure-card--reveal .secure-card__field input:focus-visible { border-color: var(--danger); box-shadow: 0 0 0 3px color-mix(in srgb, var(--danger) 14%, transparent); }
+.secure-card__consent { display: flex; align-items: flex-start; gap: 9px; padding: 10px; border: 1px solid color-mix(in srgb, var(--danger) 25%, var(--border)); border-radius: 8px; color: var(--muted); font-size: 11.5px; line-height: 1.4; }
+.secure-card__consent input { flex: none; margin-top: 2px; accent-color: var(--danger); }
+.secure-card__error { margin: 0; padding: 9px 10px; border: 1px solid color-mix(in srgb, var(--danger) 28%, var(--border)); border-radius: 8px; background: color-mix(in srgb, var(--danger) 7%, var(--surface)); color: color-mix(in srgb, var(--danger) 82%, var(--text)); font-size: 12px; line-height: 1.4; }
+.secure-card__submit { width: 100%; min-height: 42px; padding: 9px 12px; border: 0; border-radius: 8px; background: var(--green); color: var(--accent-fg, #fff); font-size: 13.5px; font-weight: 650; cursor: pointer; }
+.secure-card--reveal .secure-card__submit { background: var(--danger); }
+.secure-card__submit:focus-visible { outline: 2px solid var(--green); outline-offset: 2px; }
+.secure-card--reveal .secure-card__submit:focus-visible { outline-color: var(--danger); }
+.secure-card__submit:disabled { cursor: default; opacity: .55; }
+.secure-card__receipts { display: grid; gap: 7px; }
+.secure-card__receipt { display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: center; gap: 12px; min-height: 34px; padding: 8px 10px; border: 1px solid var(--border-light, var(--border)); border-radius: 8px; background: color-mix(in srgb, var(--green) 6%, var(--surface2)); color: var(--text); font-size: 12px; line-height: 1.35; }
+.secure-card__receipt-prompt { display: flex; align-items: center; min-width: 0; gap: 7px; }
+.secure-card__receipt-lock { position: relative; flex: none; width: 12px; height: 10px; border-radius: 2px; background: color-mix(in srgb, var(--green) 78%, var(--text)); }
+.secure-card__receipt-lock::before { content: ''; position: absolute; left: 3px; top: -5px; width: 6px; height: 6px; box-sizing: border-box; border: 1.5px solid color-mix(in srgb, var(--green) 78%, var(--text)); border-bottom: 0; border-radius: 5px 5px 0 0; }
+.secure-card__receipt strong { color: var(--green); font-size: 11px; font-weight: 650; white-space: nowrap; }
+.secure-card--reveal .secure-card__receipt { background: color-mix(in srgb, var(--danger) 5%, var(--surface2)); }
+.secure-card--reveal .secure-card__receipt-lock { background: color-mix(in srgb, var(--danger) 78%, var(--text)); }
+.secure-card--reveal .secure-card__receipt-lock::before { border-color: color-mix(in srgb, var(--danger) 78%, var(--text)); }
+.secure-card--reveal .secure-card__receipt strong { color: var(--danger); }
+.secure-card__foot { margin: 12px 0 0; color: var(--muted); font-size: 10.5px; line-height: 1.35; }

--- a/frontend/src/components/ChatView/SecureInputCard.jsx
+++ b/frontend/src/components/ChatView/SecureInputCard.jsx
@@ -1,0 +1,158 @@
+/* One-use secure input with a durable prompt-only receipt. */
+
+import { useEffect, useRef, useState } from 'react'
+import { api, jsonOrThrow } from '../../api/client.js'
+import './SecureInputCard.css'
+
+
+function settledLabel(status) {
+  if (status === 'filled') return 'Provided'
+  if (status === 'consuming') return 'Using securely…'
+  if (status === 'completed') return 'Provided securely'
+  if (status === 'failed') return 'Not used'
+  if (status === 'cancelled' || status === 'expired') return 'Not provided'
+  return ''
+}
+
+
+export default function SecureInputCard({ block, chatId, interactive = false }) {
+  const formRef = useRef(null)
+  const [localStatus, setLocalStatus] = useState(block.status || 'pending')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState('')
+  const reveal = block.mode === 'reveal'
+  const blockStatus = block.status || 'pending'
+  const status = blockStatus === 'pending' ? localStatus : blockStatus
+  const open = status === 'pending' && interactive
+
+  useEffect(() => {
+    if (block.status && block.status !== 'pending') {
+      setLocalStatus(block.status)
+    }
+  }, [block.status])
+
+  async function submit(event) {
+    event.preventDefault()
+    if (!open || submitting) return
+    const form = formRef.current
+    if (!form?.reportValidity()) return
+
+    const data = new FormData(form)
+    const fields = {}
+    for (const field of block.fields || []) {
+      fields[field.name] = String(data.get(field.name) || '')
+    }
+    if (reveal && data.get('reveal_confirmed') !== 'yes') {
+      setError('Confirm that these values may be sent to the AI provider.')
+      return
+    }
+
+    setError('')
+    setSubmitting(true)
+    const revealConfirmed = reveal && data.get('reveal_confirmed') === 'yes'
+    try {
+      await jsonOrThrow(
+        await api.secureInputs.submit(chatId, block.request_id, {
+          fields,
+          reveal_confirmed: revealConfirmed,
+        }),
+        'Secure input failed',
+      )
+      // Remove values from the live DOM as soon as Möbius acknowledges its
+      // transient server copy. Nothing is mirrored into React state or browser
+      // storage; the visible card retains names + status only.
+      form.reset()
+      setLocalStatus('filled')
+    } catch (submitError) {
+      setError(submitError?.message || 'Secure input failed. Please try again.')
+    } finally {
+      // FormData/fields are ordinary JS memory and become unreachable here.
+      for (const key of Object.keys(fields)) fields[key] = ''
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <section
+      className={`secure-card${reveal ? ' secure-card--reveal' : ''}`}
+      aria-label={block.title || 'Secure input'}
+    >
+      <header className="secure-card__head">
+        <span className="secure-card__lock" aria-hidden="true" />
+        <div>
+          <h3 className="secure-card__title">{block.title || 'Secure input'}</h3>
+        </div>
+      </header>
+
+      <p className="secure-card__description">
+        {block.description || (
+          reveal
+            ? 'These values will be sent to the AI provider for this turn.'
+            : 'These values go directly to a local process and bypass the AI provider.'
+        )}
+      </p>
+
+      {open ? (
+        <form ref={formRef} className="secure-card__form" onSubmit={submit}>
+          {(block.fields || []).map(field => (
+            <label className="secure-card__field" key={field.name}>
+              <span>{field.label}</span>
+              <input
+                name={field.name}
+                type={field.type === 'text' ? 'text' : 'password'}
+                autoComplete={field.autocomplete || 'off'}
+                required
+                disabled={submitting}
+                data-chat-inline-editor="secure-input"
+              />
+            </label>
+          ))}
+
+          {reveal && (
+            <label className="secure-card__consent">
+              <input
+                type="checkbox"
+                name="reveal_confirmed"
+                value="yes"
+                disabled={submitting}
+              />
+              <span>
+                I understand these values will be sent to the AI provider.
+                Möbius will omit them from its own chat and logs.
+              </span>
+            </label>
+          )}
+
+          {error && <p className="secure-card__error" role="alert">{error}</p>}
+          <button className="secure-card__submit" type="submit" disabled={submitting}>
+            {submitting
+              ? 'Entering…'
+              : reveal ? 'Reveal for this turn' : 'Enter securely'}
+          </button>
+        </form>
+      ) : (
+        <div className="secure-card__receipts" role="status">
+          {(block.fields || []).map(field => (
+            <div className="secure-card__receipt" key={field.name}>
+              <span className="secure-card__receipt-prompt">
+                <span className="secure-card__receipt-lock" aria-hidden="true" />
+                <span>{field.label}</span>
+              </span>
+              <strong>{settledLabel(status) || 'Not provided'}</strong>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <p className="secure-card__foot">
+        {reveal
+          ? (open
+              ? 'Explicit reveal sends values to AI; Möbius omits them from its transcript.'
+              : 'Receipt saved · revealed values omitted from the Möbius transcript')
+          : (open
+              ? 'One-time entry · values bypass the chat and AI'
+              : 'Receipt saved · entered values omitted')}
+      </p>
+    </section>
+  )
+}

--- a/frontend/src/components/ChatView/__tests__/secureInputCard.test.js
+++ b/frontend/src/components/ChatView/__tests__/secureInputCard.test.js
@@ -1,41 +1,90 @@
-import { readFileSync } from 'node:fs'
-import { test } from 'node:test'
 import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
 
-const component = readFileSync(new URL('../SecureInputCard.jsx', import.meta.url), 'utf8')
-const stream = readFileSync(new URL('../useStreamConnection.js', import.meta.url), 'utf8')
-const backend = readFileSync(
-  new URL('../../../../../backend/app/routes/secure_inputs.py', import.meta.url),
-  'utf8',
-)
+import SecureInputCard from '../SecureInputCard.jsx'
 
-test('secure inputs are uncontrolled and never use browser persistence', () => {
-  assert.match(component, /const formRef = useRef/)
-  assert.doesNotMatch(component, /value=\{|setFields|localStorage|sessionStorage|indexedDB/)
-  assert.match(component, /form\.reset\(\)/)
-  assert.match(component, /for \(const key of Object\.keys\(fields\)\) fields\[key\] = ''/)
+
+const fields = [
+  {
+    name: 'username',
+    label: 'Username',
+    type: 'text',
+    autocomplete: 'username',
+  },
+  {
+    name: 'password',
+    label: 'Password',
+    type: 'password',
+    autocomplete: 'current-password',
+  },
+]
+
+
+function renderCard(overrides = {}, interactive = false) {
+  const block = {
+    type: 'secure_input',
+    request_id: 'request-1',
+    mode: 'sealed',
+    title: 'Private connection',
+    description: 'Values bypass model context.',
+    fields,
+    status: 'pending',
+    ...overrides,
+  }
+  return renderToStaticMarkup(createElement(SecureInputCard, {
+    block,
+    chatId: 'chat-1',
+    interactive,
+  }))
+}
+
+
+test('pending secure input renders one uncontrolled field per prompt', () => {
+  const html = renderCard({}, true)
+
+  assert.equal((html.match(/<input/g) || []).length, 2)
+  assert.match(html, /name="username"/)
+  assert.match(html, /name="password"/)
+  assert.match(html, /type="password"/)
+  assert.match(html, /data-chat-inline-editor="secure-input"/)
+  assert.match(html, />Enter securely</)
+  assert.match(html, /values bypass the chat and AI/)
+  assert.doesNotMatch(html, /value=/)
 })
 
-test('secure input events contain metadata and status only', () => {
-  assert.match(stream, /event\.type === 'secure_input_request'/)
-  assert.match(stream, /fields: Array\.isArray\(event\.fields\)/)
-  assert.doesNotMatch(stream, /event\.values|event\.secrets/)
-  assert.doesNotMatch(stream, /item\.type !== 'secure_input'/)
-  assert.doesNotMatch(stream, /item\.type === 'secure_input'[\s\S]{0,180}item\.status/)
-  assert.match(component, /secure-card__receipt-lock/)
-  assert.match(component, /Receipt saved · entered values omitted/)
-  assert.doesNotMatch(component, /Memory only/)
+
+test('settled secure input renders locked prompt receipts without fields', () => {
+  const html = renderCard({ status: 'completed' })
+
+  assert.match(html, />Private connection</)
+  assert.match(html, />Username</)
+  assert.match(html, />Password</)
+  assert.equal((html.match(/Provided securely/g) || []).length, 2)
+  assert.equal((html.match(/secure-card__receipt-lock/g) || []).length, 2)
+  assert.match(html, /Receipt saved · entered values omitted/)
+  assert.doesNotMatch(html, /<input/)
 })
 
-test('secret-bearing request parsing avoids schema reflection', () => {
-  assert.match(backend, /await request\.json\(\)/)
-  assert.match(backend, /Invalid secure input submission\./)
-  assert.doesNotMatch(backend, /BaseModel|response_model/)
+
+test('failed and expired receipts use non-success status copy', () => {
+  assert.equal(
+    (renderCard({ status: 'failed' }).match(/Not used/g) || []).length,
+    2,
+  )
+  assert.equal(
+    (renderCard({ status: 'expired' }).match(/Not provided/g) || []).length,
+    2,
+  )
 })
 
-test('reveal is visibly distinct and needs explicit confirmation', () => {
-  assert.match(component, /secure-card--reveal/)
-  assert.match(component, /Reveal for this turn/)
-  assert.match(component, /reveal_confirmed/)
-  assert.match(component, /sent to the AI provider/)
+
+test('reveal mode is visually distinct and requires explicit confirmation', () => {
+  const html = renderCard({ mode: 'reveal' }, true)
+
+  assert.match(html, /secure-card--reveal/)
+  assert.match(html, /name="reveal_confirmed"/)
+  assert.match(html, /sent to the AI provider/)
+  assert.match(html, />Reveal for this turn</)
 })

--- a/frontend/src/components/ChatView/__tests__/secureInputCard.test.js
+++ b/frontend/src/components/ChatView/__tests__/secureInputCard.test.js
@@ -1,0 +1,41 @@
+import { readFileSync } from 'node:fs'
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+const component = readFileSync(new URL('../SecureInputCard.jsx', import.meta.url), 'utf8')
+const stream = readFileSync(new URL('../useStreamConnection.js', import.meta.url), 'utf8')
+const backend = readFileSync(
+  new URL('../../../../../backend/app/routes/secure_inputs.py', import.meta.url),
+  'utf8',
+)
+
+test('secure inputs are uncontrolled and never use browser persistence', () => {
+  assert.match(component, /const formRef = useRef/)
+  assert.doesNotMatch(component, /value=\{|setFields|localStorage|sessionStorage|indexedDB/)
+  assert.match(component, /form\.reset\(\)/)
+  assert.match(component, /for \(const key of Object\.keys\(fields\)\) fields\[key\] = ''/)
+})
+
+test('secure input events contain metadata and status only', () => {
+  assert.match(stream, /event\.type === 'secure_input_request'/)
+  assert.match(stream, /fields: Array\.isArray\(event\.fields\)/)
+  assert.doesNotMatch(stream, /event\.values|event\.secrets/)
+  assert.doesNotMatch(stream, /item\.type !== 'secure_input'/)
+  assert.doesNotMatch(stream, /item\.type === 'secure_input'[\s\S]{0,180}item\.status/)
+  assert.match(component, /secure-card__receipt-lock/)
+  assert.match(component, /Receipt saved · entered values omitted/)
+  assert.doesNotMatch(component, /Memory only/)
+})
+
+test('secret-bearing request parsing avoids schema reflection', () => {
+  assert.match(backend, /await request\.json\(\)/)
+  assert.match(backend, /Invalid secure input submission\./)
+  assert.doesNotMatch(backend, /BaseModel|response_model/)
+})
+
+test('reveal is visibly distinct and needs explicit confirmation', () => {
+  assert.match(component, /secure-card--reveal/)
+  assert.match(component, /Reveal for this turn/)
+  assert.match(component, /reveal_confirmed/)
+  assert.match(component, /sent to the AI provider/)
+})

--- a/frontend/src/components/ChatView/streamPromotion.js
+++ b/frontend/src/components/ChatView/streamPromotion.js
@@ -39,6 +39,7 @@ export function streamItemToBlock(item, { finalize = true } = {}) {
       ...(item.answers ? { answers: item.answers } : {}),
     }
   }
+  if (item.type === 'secure_input') return { ...item }
   if (item.type === 'error') {
     // Carry the whitelisted extras (resumable drives the one-tap Resume; the
     // single `pause` descriptor — {kind, resets_at?} — drives the calm "Paused"

--- a/frontend/src/components/ChatView/useStreamConnection.js
+++ b/frontend/src/components/ChatView/useStreamConnection.js
@@ -135,6 +135,8 @@ const BROADCAST_REGISTRATION_WINDOW_MS = 1500
  *                         { question_id, questions: [...] }. Renders a
  *                         card, absorbing the call's own tool_start
  *                         block in place (see streamReducers.js).
+ *   secure_input_request  Trusted one-use input card. Prompt labels and status
+ *                         persist; submitted values never ride SSE or chat.
  *   context_compacted     Provider condensed its native context window.
  *                         Appends a quiet, standalone timeline marker; this
  *                         is not tool activity or a handoff summary.
@@ -1037,6 +1039,40 @@ export default function useStreamConnection(chatId, {
               onLiveQuestionRef.current?.(event.question_id || null)
               applyStreamItems(prev => upsertQuestionItem(prev, incoming))
             }
+          } else if (event.type === 'secure_input_request') {
+            flushBuffer()
+            const incoming = {
+              type: 'secure_input',
+              request_id: event.request_id,
+              mode: event.mode || 'sealed',
+              title: event.title || 'Secure input',
+              description: event.description || '',
+              fields: Array.isArray(event.fields) ? event.fields : [],
+              status: 'pending',
+            }
+            applyStreamItems(prev => [
+              ...prev.filter(item => !(
+                item.type === 'secure_input'
+                && item.request_id === incoming.request_id
+              )),
+              incoming,
+            ])
+          } else if (
+            event.type === 'secure_input_filled'
+            || event.type === 'secure_input_consuming'
+            || event.type === 'secure_input_settled'
+          ) {
+            const status = event.type === 'secure_input_filled'
+              ? 'filled'
+              : event.type === 'secure_input_consuming'
+                ? 'consuming'
+                : (event.status || 'completed')
+            applyStreamItems(prev => prev.map(item => (
+              item.type === 'secure_input'
+              && item.request_id === event.request_id
+                ? { ...item, status }
+                : item
+            )))
           } else if (event.type === 'answers_applied') {
             // The question was answered (by this tab, another tab, or the
             // in-process answer delivery). Patch the in-flight card to

--- a/frontend/src/components/LoginForm/LoginForm.jsx
+++ b/frontend/src/components/LoginForm/LoginForm.jsx
@@ -48,7 +48,7 @@ export default function LoginForm({ onLogin }) {
   }
 
   return (
-    <div className="login">
+    <div className="login" data-auth-surface="login">
       <div className="login__card">
         <img src="/moebius.png" alt="Möbius" className="login__logo" />
         <h1 className="login__title">Möbius</h1>


### PR DESCRIPTION
## Summary

- add trusted one-use chat inputs for passwords, tokens, private usernames, and similar values
- discard sealed consumer stdout and stderr, mapping only fixed outcomes to trusted messages
- keep sealed values out of model context and durable chat storage while passing them exactly once to a bounded local consumer
- persist only whitelisted prompt metadata and safe completion state as locked receipts
- provide an explicitly confirmed reveal path for owner-led debugging, with the marked result omitted from Möbius UI, transcript, and chat logs
- include an owner credential updater and keep authenticated screenshots compatible with password fields inside chats

## Security boundary

Sealed values exist transiently in the browser, authenticated request, server, helper, and chosen local consumer. They are never intentionally written to disk, chat storage, model-visible tool arguments, environment variables, broadcasts, or diagnostics. Safe receipt persistence is built from an explicit metadata whitelist rather than by deleting secret-shaped fields after the fact.

The reveal path is separate, visually distinct, and requires an additional confirmation that the AI provider will receive the values. Möbius redacts the marked result before its own UI, transcript, and chat logs.

## Verification

- 170 focused backend tests passed
- 77 fast platform contract tests passed
- 38 focused frontend tests passed
- production frontend build passed
