### PR TITLE
Name chats when the first queued message resumes

### DIFF
--- a/backend/app/chat_writer.py
+++ b/backend/app/chat_writer.py
@@ -78,6 +78,12 @@ from app.events import (
 log = logging.getLogger("moebius.chat.writer")
 
 
+def _name_chat_from_first_message(chat: models.Chat, content: object) -> None:
+  """Apply the first-message fallback without overriding an owner rename."""
+  if not chat.title_locked:
+    chat.title = first_message_title(content) or "New chat"
+
+
 # Bounded wait for a strict (commit-before-ack) writer-actor command.
 # Every must-persist caller (QuestionCommit / Finalize / AnswerQuestion /
 # StartTurn / PromotePending / ...) awaits the ack before taking the next
@@ -2151,7 +2157,7 @@ class ChatWriterActor:
       "ts": next_message_ts(existing + pending),
     }
     if len(existing) == 1:
-      chat.title = first_message_title(cmd.title_source) or "New chat"
+      _name_chat_from_first_message(chat, cmd.title_source)
     started_at = datetime.now(UTC)
     chat.updated_at = datetime.now(UTC)
     # Owner-send: advance the drawer ordering key (see models.Chat.activity_at).
@@ -2569,6 +2575,11 @@ class ChatWriterActor:
     }
     started_at = datetime.now(UTC)
     chat.updated_at = datetime.now(UTC)
+    # Restart recovery can route the first send through PromotePending instead
+    # of StartTurn, but both paths share the same naming precedence.
+    if not existing and stored_messages:
+      _name_chat_from_first_message(chat, agent_pending.get("content", ""))
+      chat.activity_at = datetime.now(UTC)
     # The prior turn finished (the queue had more) and hands off to this
     # continuation. Close its run record and open the continuation's in the
     # SAME commit as the queue handoff.

--- a/backend/tests/test_chat_writer_contention.py
+++ b/backend/tests/test_chat_writer_contention.py
@@ -52,13 +52,16 @@ def _seed_chat(
   pending=None,
   session_id="sess-1",
   pending_question_id=None,
+  title="Test chat",
+  title_locked=False,
 ):
   """Insert a Chat row and return its id, committed via a throwaway session."""
   db = SessionLocal()
   try:
     chat = models.Chat(
       id=chat_id,
-      title="Test chat",
+      title=title,
+      title_locked=title_locked,
       messages=messages if messages is not None else [],
       pending_messages=pending if pending is not None else [],
       session_id=session_id,
@@ -114,6 +117,7 @@ def _load_chat(chat_id="c1"):
       "session_id": chat.session_id,
       "provider": chat.provider,
       "title": chat.title,
+      "title_locked": chat.title_locked,
       "running_status": run.status if run is not None else None,
       "running_started_at": run.started_at if run is not None else None,
     }
@@ -631,6 +635,21 @@ def test_start_turn_keeps_a_useful_first_message_title_preview(actor):
   assert _load_chat()["title"] == first_message[:80]
 
 
+def test_start_turn_preserves_an_owner_title_before_the_first_message(actor):
+  _seed_chat(messages=[], title="My chosen title", title_locked=True)
+
+  _await(actor.submit(StartTurn(
+    chat_id="c1",
+    run_token="rt-owner-title",
+    user_msg={"role": "user", "content": "First message", "ts": 5},
+    title_source="First message",
+  )))
+
+  chat = _load_chat()
+  assert chat["title"] == "My chosen title"
+  assert chat["title_locked"] is True
+
+
 def test_start_turn_retry_after_completion_is_idempotent(actor):
   """A lost response retried after the run settled must not wake the agent."""
   original = {
@@ -724,6 +743,46 @@ def test_promote_pending_collapses_all_followups(actor):
   assert [m["content"] for m in chat["messages"][-2:]] == ["first", "second"]
   assert chat["pending_messages"] == []
   assert chat["running_status"] == "running"
+
+
+def test_promote_pending_names_a_new_chat_recovered_from_the_queue(actor):
+  """A first send queued across restart keeps StartTurn's naming contract."""
+  _seed_chat(
+    messages=[],
+    pending=[{
+      "role": "user",
+      "content": "Fix steering after restart",
+      "ts": 10,
+      "cid": "queued-first",
+    }],
+    title="New chat",
+  )
+
+  _await(actor.submit(PromotePending(chat_id="c1", run_token="rt1")))
+
+  chat = _load_chat()
+  assert chat["title"] == "Fix steering after restart"
+  assert chat["messages"][0]["cid"] == "queued-first"
+
+
+def test_promote_pending_preserves_an_owner_title_on_a_new_chat(actor):
+  _seed_chat(
+    messages=[],
+    pending=[{
+      "role": "user",
+      "content": "First message",
+      "ts": 10,
+      "cid": "queued-first",
+    }],
+    title="My chosen title",
+    title_locked=True,
+  )
+
+  _await(actor.submit(PromotePending(chat_id="c1", run_token="rt1")))
+
+  chat = _load_chat()
+  assert chat["title"] == "My chosen title"
+  assert chat["title_locked"] is True
 
 
 def test_promote_pending_stops_collapse_at_hidden_boundary(actor):


### PR DESCRIPTION
## Problem

A first message received while the backend is draining for restart enters the pending queue. Startup later promotes it through `PromotePending`, which did not apply the first-message naming behavior used by `StartTurn`, leaving an otherwise healthy chat titled `New chat`.

The first-message paths also need to preserve the existing naming precedence: an owner title chosen before the first send must never be overwritten by an automatic fallback.

## Change

- centralize first-message fallback naming in one helper shared by `StartTurn` and `PromotePending`
- derive a title when restart recovery promotes the first queued message
- preserve a manually locked title in both paths

## Tests

- add restart-recovery coverage for first-message naming
- add negative coverage proving owner titles survive normal and recovered first sends
- full backend suite: 3,849 passed, 1 skipped
