### PR TITLE
Restore physical-tail chat autoscroll semantics

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -524,7 +524,7 @@ installing Möbius.
 
 ## Chat scroll + steer contract
 
-**Owner-authoritative contract — v1.18 (2026-08-04).** This section is the
+**Owner-authoritative contract — v1.20 (2026-08-15).** This section is the
 canonical source of truth for how a chat scrolls and steers. When implementation,
 comments, and this contract disagree, the implementation/comments are the bug:
 fix behavior to match this contract. If a real case is unspecified or the desired
@@ -575,14 +575,18 @@ and attaches their rule ids to new diagnostic chats. The Playwright lock-in spec
   mode before a keyboard or other viewport resize is laid out.
 - **R2 — One send rule everywhere.** The first visible user message always pins to
   the viewport top. Every subsequent direct, queued, promoted, or steered message
-  pins when its submit-time DOM snapshot is at the real-content tail. Geometry is
-  authoritative because `ScrollMode` can lag an input/layout frame; requiring both
-  made identical bottom sends behave inconsistently. A real user scroll after
-  submission invalidates an automatic delayed queue promotion (a tap without
-  scrolling does not). Explicit fast-forward reuses that snapshot through tray
-  reflow while its reader generation remains current; after a real scroll it
-  captures current geometry instead. Another scroll during the request invalidates
-  that snapshot. Missing delayed intent degrades to hold, never to an inferred pin.
+  pins only when its submit-time DOM snapshot is at the one physical
+  tail. Reserved reply spacer remains part of that distance: once the reader moves
+  upward through it—even while the latest user message remains visible—the chat is
+  in hold and the next send must leave the viewport untouched. Subtracting spacer
+  from the send decision creates a false second bottom and is forbidden. Physical
+  geometry is authoritative for the send snapshot while `ScrollMode` settlement may
+  trail a gesture or layout by a frame. A real user scroll after submission
+  invalidates an automatic delayed queue promotion (a tap without scrolling does
+  not). Explicit fast-forward reuses that snapshot through tray reflow while its
+  reader generation remains current; after a real scroll it captures current
+  physical geometry instead. Another scroll during the request invalidates that
+  snapshot. Missing delayed intent degrades to hold, never to an inferred pin.
 - **R3 — Pin holds until the reservation is filled.** A legitimate live pin
   transitions to `PIN_USER_MSG`, not immediately to `FOLLOW_BOTTOM`; the response
   first grows below the prompt without moving it. Exactly when the streaming reply
@@ -645,7 +649,10 @@ and attaches their rule ids to new diagnostic chats. The Playwright lock-in spec
   control activation are not reader scroll intent. Pointer/touch release handles taps,
   while scrolling-key input that produces no scroll releases on the next frame. Wheel
   input gets that early release only when its direction is exactly clamped at the
-  matching scroll edge. An elapsed frame is not evidence that an in-range wheel was a
+  matching scroll edge. An end-directed wheel or scroll-key input already clamped at
+  the physical tail claims `FOLLOW_BOTTOM` before that no-scroll release; otherwise
+  the browser's missing `scroll` event would discard explicit follow intent. An
+  elapsed frame is not evidence that an in-range wheel was a
   no-op: renderer/compositor load can update geometry before the main-thread `scroll`
   handler runs. A meaningful touch swipe toward the end may enter `FOLLOW_BOTTOM`
   once even when the browser is already clamped at the physical tail and therefore
@@ -692,11 +699,13 @@ and attaches their rule ids to new diagnostic chats. The Playwright lock-in spec
   viewport intersection alone cannot detect that the absolutely-positioned
   composer is covering the target. The floating jump-to-latest control
   (owner ask, 2026-08-04) is the same explicit one-shot action through the
-  identical controller tail reveal, with the same settled `ANCHOR_AT` outcome.
-  Its visibility is a pure geometry read outside the controller's ownership
-  gates: it renders only while the reader holds a position away from the
-  content tail, where reserved spacer room is phantom per R2's send-snapshot
-  bottom rule — so a fresh live-send reservation never summons it. It yields
+  controller's physical-tail reveal and explicitly resumes `FOLLOW_BOTTOM` so
+  subsequent output remains visible.
+  Its visibility is a pure physical-tail geometry read outside the controller's
+  ownership gates: it renders only while the reader holds a position away from
+  the physical tail, including after an upward move through reserved room. A fresh
+  live-send reservation does not summon it because a correctly pinned row rests at
+  that same physical clamp. It yields
   to a visible attention nudge, which navigates to the same tail with strictly
   more context.
 - **R5b — One keyboard geometry signal; reservation-responsive resize.** Shell alone
@@ -758,7 +767,7 @@ path means routing it through the same entries rather than inventing another rul
 | Event | Before | After | Scroll write |
 |---|---|---|---|
 | First direct/queued/steered user row becomes visible | any | `PIN_USER_MSG` | New row to top |
-| Later send submitted at real-content tail (mode may be one frame stale) | any | `PIN_USER_MSG` | New row to top |
+| Later send submitted at the physical autoscroll tail (mode may be one frame stale) | any | `PIN_USER_MSG` | New row to top |
 | Later send submitted anywhere else | hold or stale follow | `ANCHOR_AT`/existing hold | None |
 | Reader reaches or explicitly swipes toward physical bottom | any | `FOLLOW_BOTTOM` | User-owned; follow the one physical tail, including remaining reservation |
 | Reader scrolls manually away from bottom | any | `ANCHOR_AT` | User-owned |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -537,13 +537,14 @@ and attaches their rule ids to new diagnostic chats. The Playwright lock-in spec
 (`tests/send-rule`, `spacer`, `second-send-pin`, `steer-queued`, `stream-reconnect`,
 `backend/tests/test_chats_stream_steer`) encode this:
 
-- **R0 — Two modes; two explicit auto-scroll entrances.** A chat is either in **auto-scroll**
+- **R0 — Two modes; explicit auto-scroll entrances.** A chat is either in **auto-scroll**
   (`FOLLOW_BOTTOM`, following the physical scroll tail as the reply streams) or **hold**
   (`PIN_USER_MSG` or `ANCHOR_AT`, staying at a pinned prompt or frozen reading
-  position). Auto-scroll engages only through (a) the gesture-gated scroll handler
+  position). Auto-scroll engages only through (a) the gesture-gated reader path
   after the user manually reaches or explicitly swipes toward the physical bottom,
-  or (b) the live-send pin handoff when the streaming reply has consumed its exact
-  reserved room. Only a send may create `PIN_USER_MSG`. Reservation does not create
+  (b) a composer press or edit that begins at that physical bottom, or (c) the
+  live-send pin handoff when the streaming reply has consumed its exact reserved
+  room. Only a send may create `PIN_USER_MSG`. Reservation does not create
   a second kind of bottom: when `FOLLOW_BOTTOM` is active, it follows the physical
   tail including any remaining room. Real output first consumes that room without
   advancing the tail; after the room reaches zero, the same tail advances with the
@@ -646,7 +647,10 @@ and attaches their rule ids to new diagnostic chats. The Playwright lock-in spec
   Never replace the input-to-first-scroll handoff with a fixed short window: under
   rendering load the browser may deliver that scroll later. Ownership begins only for
   inputs whose default action can scroll the transcript; ordinary typing, Enter, and
-  control activation are not reader scroll intent. Pointer/touch release handles taps,
+  control activation are not reader scroll intent. Editing controls retain their own
+  navigation keys. A nested vertical surface marked `data-chat-scroll-region` retains
+  wheel and touch input while it can scroll in that direction; only a gesture at its
+  matching edge may chain to the transcript. Pointer/touch release handles taps,
   while scrolling-key input that produces no scroll releases on the next frame. Wheel
   input gets that early release only when its direction is exactly clamped at the
   matching scroll edge. An end-directed wheel or scroll-key input already clamped at
@@ -678,6 +682,9 @@ and attaches their rule ids to new diagnostic chats. The Playwright lock-in spec
   newer gesture is rejected; once that gesture settles, the controller adopts the
   current semantic location and performs one fresh geometry reconciliation. Waiting
   for the timing gate to expire never gives stale work its authority back.
+  An end-directed input already clamped at the tail may enter `FOLLOW_BOTTOM`
+  without advancing that generation: no scroll occurred, so a delayed queued send
+  retains the submit-time pin decision that the generation protects.
   A marked Q&A custom-answer field is the deliberate exception to "ordinary
   typing cannot scroll": changing its value can grow the field and cause the
   browser to move the transcript to keep the native caret visible. Only an
@@ -754,13 +761,6 @@ and attaches their rule ids to new diagnostic chats. The Playwright lock-in spec
   text block in event order, without hiding, duplicating, or reordering them. Only a
   recovered answer whose POST returns `started` creates a new hidden continuation.
   Switching sources preserves the active row's anchor identity and writes no scroll.
-- **R4a — Attention nudges reveal the usable tail.** Tapping an offscreen question or
-  paused-turn nudge lands at the physical tail, including composer-clearance padding,
-  so the real Submit or Resume action is visible above the overlaid composer. This is
-  a settled `ANCHOR_AT` hold, not `FOLLOW_BOTTOM`; one-shot navigation must not create
-  live-follow intent for later content. It routes through the scroll owner rather than
-  `scrollIntoView`, whose viewport intersection cannot detect composer coverage.
-
 The transition table is intentionally exhaustive; adding a new send or lifecycle
 path means routing it through the same entries rather than inventing another rule:
 
@@ -770,6 +770,7 @@ path means routing it through the same entries rather than inventing another rul
 | Later send submitted at the physical autoscroll tail (mode may be one frame stale) | any | `PIN_USER_MSG` | New row to top |
 | Later send submitted anywhere else | hold or stale follow | `ANCHOR_AT`/existing hold | None |
 | Reader reaches or explicitly swipes toward physical bottom | any | `FOLLOW_BOTTOM` | User-owned; follow the one physical tail, including remaining reservation |
+| Composer press or edit begins at physical bottom | any hold | `FOLLOW_BOTTOM` | No immediate write; the next owned layout follows the existing physical tail |
 | Reader scrolls manually away from bottom | any | `ANCHOR_AT` | User-owned |
 | Reply grows while an armed live pin still has reserved room | pin hold | same pin hold | Keep prompt fixed |
 | Streaming reply consumes the armed pin reservation | pin hold | `FOLLOW_BOTTOM` | Follow physical tail |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,9 +100,10 @@ ordinary unit behavior.
 **Chat scroll contract.** Before changing `ChatView`, read `ARCHITECTURE.md`
 "Chat scroll + steer contract" and run the send/spacer browser specs. The first
 visible user message always pins. A later direct, queued, promoted, or steered
-message pins only when it was submitted from gesture-entered auto-scroll at the
-real-content tail; every pin returns to hold until the user manually reaches the
-bottom again. Every visible user message gets a persistent reply-space
+message pins only when it was submitted at the one physical autoscroll tail;
+reserved reply room remains part of that distance, so any upward reader escape
+must keep the next send at the current reading position. Every pin returns to
+hold until the user manually reaches the bottom again. Every visible user message gets a persistent reply-space
 reservation, even after a short reply finishes or the chat remounts. Leaving or
 returning always preserves the exact visible anchor and never restores
 auto-scroll to a newer tail. New send and lifecycle paths must use the shared

--- a/frontend/src/components/ChatView/ChatView.css
+++ b/frontend/src/components/ChatView/ChatView.css
@@ -2428,9 +2428,9 @@
 
 /* Jump-to-latest: a round, mostly-transparent control floating in the same
    slot above the composer, shown once the reader has scrolled away from the
-   content tail (ChatView renders it only then). Tapping routes through the
-   controller's tail reveal — contract R5a's one-shot navigation, never
-   live-follow. Kept quieter than the attention nudges: neutral surface tint
+   physical tail (ChatView renders it only then). Tapping routes through the
+   controller's tail reveal and resumes live follow. Kept quieter than the
+   attention nudges: neutral surface tint
    at low opacity over blur, no accent, because it is a convenience, not an
    attention request. */
 .chat__jump-latest {

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -16,7 +16,7 @@ import { chatMessagesQueryKey } from '../../hooks/queries.js'
 import useStreamConnection from './useStreamConnection.js'
 import useScrollMode, {
   FOLLOW_STICK_BAND_PX,
-  isNearContentBottom,
+  isNearPhysicalBottom,
   olderHistoryRetryShown,
   olderHistoryShouldLoad,
   remapSavedReadingAnchor,
@@ -173,13 +173,11 @@ const MESSAGE_META_VISIBLE_MS = 5000
 // auto-dismisses itself (a durable "final" acknowledgement). An ephemeral nudge,
 // not a permanent chat-foot fixture.
 const OPEN_APP_CTA_AUTO_DISMISS_MS = 8000
-// The floating jump-to-latest control is driven by follow-state, not a raw
-// pixel distance (use-stick-to-bottom's `!isAtBottom`): it shows whenever the
-// reader is NOT following AND sits beyond the shared follow-stick band above the
-// CONTENT tail (reserved spacer room is phantom, per the send-snapshot bottom
-// rule). Using the SAME band the controller sticks within removes the old dead
-// zone where a dropped follow left the reader with neither autoscroll nor a
-// button between the band and the previous 200px threshold.
+// The floating jump-to-latest control is driven by follow-state plus physical
+// tail distance. Reserved reply room remains part of that range, so an upward
+// reader escape can reveal the control even while the latest row is visible.
+// Using the same band the controller sticks within removes the old dead zone
+// where a dropped follow left the reader with neither autoscroll nor a button.
 
 function delay(ms) {
   return new Promise(resolve => setTimeout(resolve, ms))
@@ -1198,7 +1196,7 @@ export default function ChatView({
         if (promotedRows.length > 0) {
           // A queued continuation is still a user send becoming the active
           // turn, so it follows the same send rule (see shouldPinSend):
-          // pin only when first-or-at-bottom. Read the first-user check
+          // pin only when first-or-at-physical-tail. Read the first-user check
           // before the append. When not pinning, leave the reader where
           // the previous turn left them — the continuation just appears
           // below without moving the scroll.
@@ -2205,7 +2203,7 @@ export default function ChatView({
   const [awayFromLatest, setAwayFromLatest] = useState(false)
   const updateJumpToLatest = useCallback(() => {
     const el = scrollRef.current
-    const away = !!el && !isNearContentBottom(el, FOLLOW_STICK_BAND_PX)
+    const away = !!el && !isNearPhysicalBottom(el, FOLLOW_STICK_BAND_PX)
     setAwayFromLatest(prev => (prev === away ? prev : away))
   }, [])
   useLayoutEffect(updateJumpToLatest)
@@ -2225,8 +2223,8 @@ export default function ChatView({
 
 
   // `opts.pin` allows the shared submit-time rule to pin the message. Normal
-  // user sends opt in, but still pin only when first-or-already-following at
-  // the bottom. Pass `pin: false` from synthetic-send paths where pinning
+  // user sends opt in, but still pin only when first-or-at-physical-tail.
+  // Pass `pin: false` from synthetic-send paths where pinning
   // would be surprising:
   //   - handleStop's queue-collapse: the user clicked Stop, not Send;
   //     pinning the auto-generated combined message would yank the
@@ -2272,7 +2270,7 @@ export default function ChatView({
     if (listeningRef.current) stopVoiceRef.current?.()
 
     // Resolve the ONE direct/queued/steered pin rule BEFORE blurring the
-    // textarea. The real-content geometry is authoritative; mode can lag a
+    // textarea. Physical-tail geometry is authoritative; mode can lag a
     // gesture/layout by a frame. Mobile blur can resize/clamp the viewport, so
     // capture the complete decision before it.
     const isFirstUserMsgAtSubmit = isFirstVisibleUserMessage()
@@ -2569,7 +2567,7 @@ export default function ChatView({
           // Apply the shared send-intent rule before appending. A message that
           // raced into a started turn
           // is still a new send becoming the active turn, so it pins only
-          // when first-or-at-bottom. The decision was captured at send time.
+          // when first-or-at-physical-tail. The decision was captured at send time.
           const startedMessages = startedMessagesFromResponse(result)
           commitMessages(prev => {
             if (startedMessages) return appendMessageBatch(prev, startedMessages)

--- a/frontend/src/components/ChatView/MarkerCard.jsx
+++ b/frontend/src/components/ChatView/MarkerCard.jsx
@@ -62,7 +62,7 @@ export default function MarkerCard({ icon, title, subtitle, children }) {
         </div>
       )}
       {collapsible && open && (
-        <div className="chat__marker-body">{children}</div>
+        <div className="chat__marker-body" data-chat-scroll-region>{children}</div>
       )}
     </div>
   )

--- a/frontend/src/components/ChatView/QuestionCard.jsx
+++ b/frontend/src/components/ChatView/QuestionCard.jsx
@@ -77,6 +77,7 @@ function CustomAnswerArea({
     <textarea
       ref={textareaRef}
       className={`qcard__input${active ? ' qcard__input--active' : ''}`}
+      data-chat-scroll-region
       aria-label={`Custom answer for: ${question}`}
       placeholder={answered ? 'No custom answer' : 'Or type your own answer…'}
       autoComplete="off"

--- a/frontend/src/components/ChatView/ToolBlock.jsx
+++ b/frontend/src/components/ChatView/ToolBlock.jsx
@@ -494,6 +494,7 @@ function GenericToolBlock({ t, chatId, compact = false, disclosureKey }) {
           className={`chat__tool-detail${
             editPreview ? ' chat__tool-detail--edit' : ''
           }`}
+          data-chat-scroll-region
           role="region"
           aria-labelledby={headerId}
           tabIndex={open ? 0 : undefined}

--- a/frontend/src/components/ChatView/__tests__/chatContract.test.js
+++ b/frontend/src/components/ChatView/__tests__/chatContract.test.js
@@ -49,9 +49,10 @@ test('follow registry summary keeps clamped input separate from send pinning', (
   const rule = CHAT_CONTRACT.find(entry => entry.id === 'follow-at-physical-tail')
   assert.ok(rule)
   assert.equal(rule.summary,
-    'An end-directed wheel, scroll key, or touch gesture at the physical '
-    + 'tail enters FOLLOW_BOTTOM even when the browser is already clamped '
-    + 'and emits no scroll event.')
+    'Nested controls keep input they can consume. Otherwise an end-directed '
+    + 'wheel, scroll key, or touch gesture at the physical tail enters '
+    + 'FOLLOW_BOTTOM even when no scroll event fires, without invalidating '
+    + 'a delayed send decision.')
 })
 
 test('snapshotChatUX derives the geometry fields from a clean pinned frame', () => {

--- a/frontend/src/components/ChatView/__tests__/chatContract.test.js
+++ b/frontend/src/components/ChatView/__tests__/chatContract.test.js
@@ -1,6 +1,5 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
-import { readFileSync } from 'node:fs'
 
 import {
   CHAT_CONTRACT,
@@ -36,84 +35,23 @@ const pinnedEnv = {
   lastUserMsgEl: userEl(1000),
 }
 
-test('pin registry summary matches owner-authoritative R2 geometry', () => {
+test('pin registry summary matches owner-authoritative R2 send contract', () => {
   const rule = CHAT_CONTRACT.find(entry => entry.id === 'pin-on-send')
   assert.ok(rule)
-  assert.match(rule.summary, /DOM snapshot.*real-content tail/)
-  assert.doesNotMatch(rule.summary, /gesture-entered auto-scroll/)
+  assert.equal(rule.summary,
+    'The first user message always pins. A subsequent direct, queued, or '
+    + 'steered message pins only from the physical tail. Reserved '
+    + 'reply room remains part of that distance, so any upward reader escape '
+    + 'keeps the next send at the current reading position.')
 })
 
-test('ChatView only consumes methods returned by the scroll controller', () => {
-  const chatView = readFileSync(new URL('../ChatView.jsx', import.meta.url), 'utf8')
-  const scrollController = readFileSync(new URL('../useScrollMode.js', import.meta.url), 'utf8')
-
-  const useEnd = chatView.indexOf('} = useScrollMode({')
-  const useStart = chatView.lastIndexOf('const {', useEnd)
-  assert.ok(useStart >= 0 && useEnd > useStart, 'ChatView useScrollMode destructure exists')
-
-  const returnStart = scrollController.lastIndexOf('\n  return {')
-  const returnEnd = scrollController.indexOf('\n  }', returnStart)
-  assert.ok(returnStart >= 0 && returnEnd > returnStart,
-    'useScrollMode has a final returned controller object')
-
-  const identifiers = source => [...source.matchAll(/^\s*([A-Za-z_$][\w$]*)\s*,?\s*$/gm)]
-    .map(match => match[1])
-  const consumed = identifiers(chatView.slice(useStart + 'const {'.length, useEnd))
-  const returned = new Set(identifiers(scrollController.slice(returnStart, returnEnd)))
-  const missing = consumed.filter(name => !returned.has(name))
-
-  assert.deepEqual(missing, [],
-    `ChatView consumes missing useScrollMode members: ${missing.join(', ')}`)
-})
-
-test('owner contract freezes question answers without locking keyboard movement', () => {
-  const architecture = readFileSync(
-    new URL('../../../../../ARCHITECTURE.md', import.meta.url),
-    'utf8',
-  )
-  assert.match(architecture, /Owner-authoritative contract — v1\.18 \(2026-08-04\)/)
-  assert.match(
-    architecture,
-    /In-process question is answered \| any \| transient `ANCHOR_AT` over the prior mode; same active assistant row/,
-    'question submission must freeze the reader while preserving the R6 row',
-  )
-  assert.match(
-    architecture,
-    /question-submit hold is the sole calculation exception: it may reserve only the\s+exact tail deficit required for a stable card handoff while the viewport size is\s+unchanged/,
-    'question submission may reserve only its same-viewport reachability deficit',
-  )
-  assert.match(
-    architecture,
-    /Viewport\/keyboard changes after question submission \| transient question anchor \| pre-submit unanswered-card mode/,
-    'keyboard movement must return to the unanswered card baseline',
-  )
-  assert.match(
-    architecture,
-    /Focused Q&A custom answer grows or its keyboard viewport changes \| ordinary hold \| current caret-visible `ANCHOR_AT`/,
-    'editing may adopt native caret movement without weakening stronger scroll modes',
-  )
-  assert.match(
-    architecture,
-    /One keyboard geometry signal; reservation-responsive resize/,
-    'keyboard layout must flow from Shell into the actual chat scroll box once',
-  )
-})
-
-test('an empty chat initializes scroll identity before its first transcript mounts', () => {
-  const scrollController = readFileSync(new URL('../useScrollMode.js', import.meta.url), 'utf8')
-  const layoutOwner = scrollController.indexOf('// Single layout effect:')
-  const identityReset = scrollController.indexOf(
-    'if (modeChatIdRef.current !== chatId)',
-    layoutOwner,
-  )
-  const missingSurfaceReturn = scrollController.indexOf(
-    'if (!scrollEl || !spacerEl) return',
-    layoutOwner,
-  )
-
-  assert.ok(layoutOwner >= 0 && identityReset > layoutOwner)
-  assert.ok(identityReset < missingSurfaceReturn,
-    'the empty-state early return must not defer chat identity until after the first send arms its pin')
+test('follow registry summary keeps clamped input separate from send pinning', () => {
+  const rule = CHAT_CONTRACT.find(entry => entry.id === 'follow-at-physical-tail')
+  assert.ok(rule)
+  assert.equal(rule.summary,
+    'An end-directed wheel, scroll key, or touch gesture at the physical '
+    + 'tail enters FOLLOW_BOTTOM even when the browser is already clamped '
+    + 'and emits no scroll event.')
 })
 
 test('snapshotChatUX derives the geometry fields from a clean pinned frame', () => {
@@ -359,36 +297,6 @@ test('checkContract fails closed on an empty check list', () => {
   const r = checkContract([])
   assert.equal(r.ok, false)
   assert.equal(r.violations[0].id, 'contract-no-evidence')
-})
-
-test('mirrored constants stay in sync with useScrollMode.js (sync obligation)', () => {
-  // Read as TEXT, never import — importing useScrollMode.js would drag React
-  // and its module-load sessionStorage read into this suite.
-  const src = readFileSync(new URL('../useScrollMode.js', import.meta.url), 'utf8')
-  assert.ok(
-    src.includes(`PIN_OFFSET = ${PIN_OFFSET}`),
-    `useScrollMode.js no longer declares PIN_OFFSET = ${PIN_OFFSET}. The value `
-    + 'is mirrored in chatContract.js (see its header CONSTANTS-SYNC note) — '
-    + 'update BOTH files together.',
-  )
-  assert.ok(
-    src.includes(`PIN_BOTTOM_ROOM = ${PIN_BOTTOM_ROOM}`),
-    `useScrollMode.js no longer declares PIN_BOTTOM_ROOM = ${PIN_BOTTOM_ROOM}. `
-    + 'The value is mirrored in chatContract.js (see its header CONSTANTS-SYNC '
-    + 'note) — update BOTH files together.',
-  )
-})
-
-test('the transcript reveal safety deadline cannot be reset by message churn', () => {
-  const src = readFileSync(new URL('../useScrollMode.js', import.meta.url), 'utf8')
-  const deadline = src.indexOf('Absolute reveal deadline for this mounted chat')
-  const messagesEffect = src.indexOf('Single layout effect: spacer sizing')
-  assert.ok(deadline >= 0 && deadline < messagesEffect,
-    'the safety deadline is owned outside the messages-dependent layout effect')
-  assert.match(src.slice(deadline, messagesEffect), /\}, \[chatId\]\)/,
-    'the safety deadline resets only when the mounted chat changes')
-  assert.doesNotMatch(src.slice(messagesEffect), /clearTimeout\(safetyReveal\)/,
-    'message/layout cleanup cannot cancel and restart the absolute deadline')
 })
 
 test('every predicate id is registered in CHAT_CONTRACT (registry is the map)', () => {

--- a/frontend/src/components/ChatView/__tests__/chatContractStructure.test.js
+++ b/frontend/src/components/ChatView/__tests__/chatContractStructure.test.js
@@ -1,0 +1,109 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+import { PIN_BOTTOM_ROOM, PIN_OFFSET } from '../chatContract.js'
+
+
+test('ChatView only consumes methods returned by the scroll controller', () => {
+  const chatView = readFileSync(new URL('../ChatView.jsx', import.meta.url), 'utf8')
+  const scrollController = readFileSync(new URL('../useScrollMode.js', import.meta.url), 'utf8')
+
+  const useEnd = chatView.indexOf('} = useScrollMode({')
+  const useStart = chatView.lastIndexOf('const {', useEnd)
+  assert.ok(useStart >= 0 && useEnd > useStart, 'ChatView useScrollMode destructure exists')
+
+  const returnStart = scrollController.lastIndexOf('\n  return {')
+  const returnEnd = scrollController.indexOf('\n  }', returnStart)
+  assert.ok(returnStart >= 0 && returnEnd > returnStart,
+    'useScrollMode has a final returned controller object')
+
+  const identifiers = source => [...source.matchAll(/^\s*([A-Za-z_$][\w$]*)\s*,?\s*$/gm)]
+    .map(match => match[1])
+  const consumed = identifiers(chatView.slice(useStart + 'const {'.length, useEnd))
+  const returned = new Set(identifiers(scrollController.slice(returnStart, returnEnd)))
+  const missing = consumed.filter(name => !returned.has(name))
+
+  assert.deepEqual(missing, [],
+    `ChatView consumes missing useScrollMode members: ${missing.join(', ')}`)
+})
+
+test('owner contract freezes question answers without locking keyboard movement', () => {
+  const architecture = readFileSync(
+    new URL('../../../../../ARCHITECTURE.md', import.meta.url),
+    'utf8',
+  )
+  assert.match(architecture, /Owner-authoritative contract — v1\.20 \(2026-08-15\)/)
+  assert.match(
+    architecture,
+    /In-process question is answered \| any \| transient `ANCHOR_AT` over the prior mode; same active assistant row/,
+    'question submission must freeze the reader while preserving the R6 row',
+  )
+  assert.match(
+    architecture,
+    /question-submit hold is the sole calculation exception: it may reserve only the\s+exact tail deficit required for a stable card handoff while the viewport size is\s+unchanged/,
+    'question submission may reserve only its same-viewport reachability deficit',
+  )
+  assert.match(
+    architecture,
+    /Viewport\/keyboard changes after question submission \| transient question anchor \| pre-submit unanswered-card mode/,
+    'keyboard movement must return to the unanswered card baseline',
+  )
+  assert.match(
+    architecture,
+    /Focused Q&A custom answer grows or its keyboard viewport changes \| ordinary hold \| current caret-visible `ANCHOR_AT`/,
+    'editing may adopt native caret movement without weakening stronger scroll modes',
+  )
+  assert.match(
+    architecture,
+    /One keyboard geometry signal; reservation-responsive resize/,
+    'keyboard layout must flow from Shell into the actual chat scroll box once',
+  )
+})
+
+test('an empty chat initializes scroll identity before its first transcript mounts', () => {
+  const scrollController = readFileSync(new URL('../useScrollMode.js', import.meta.url), 'utf8')
+  const layoutOwner = scrollController.indexOf('// Single layout effect:')
+  const identityReset = scrollController.indexOf(
+    'if (modeChatIdRef.current !== chatId)',
+    layoutOwner,
+  )
+  const missingSurfaceReturn = scrollController.indexOf(
+    'if (!scrollEl || !spacerEl) return',
+    layoutOwner,
+  )
+
+  assert.ok(layoutOwner >= 0 && identityReset > layoutOwner)
+  assert.ok(identityReset < missingSurfaceReturn,
+    'the empty-state early return must not defer chat identity until after the first send arms its pin')
+})
+
+test('mirrored constants stay in sync with useScrollMode.js (sync obligation)', () => {
+  // Read as TEXT, never import — importing useScrollMode.js would drag React
+  // and its module-load sessionStorage read into this suite.
+  const src = readFileSync(new URL('../useScrollMode.js', import.meta.url), 'utf8')
+  assert.ok(
+    src.includes(`PIN_OFFSET = ${PIN_OFFSET}`),
+    `useScrollMode.js no longer declares PIN_OFFSET = ${PIN_OFFSET}. The value `
+    + 'is mirrored in chatContract.js (see its header CONSTANTS-SYNC note) — '
+    + 'update BOTH files together.',
+  )
+  assert.ok(
+    src.includes(`PIN_BOTTOM_ROOM = ${PIN_BOTTOM_ROOM}`),
+    `useScrollMode.js no longer declares PIN_BOTTOM_ROOM = ${PIN_BOTTOM_ROOM}. `
+    + 'The value is mirrored in chatContract.js (see its header CONSTANTS-SYNC '
+    + 'note) — update BOTH files together.',
+  )
+})
+
+test('the transcript reveal safety deadline cannot be reset by message churn', () => {
+  const src = readFileSync(new URL('../useScrollMode.js', import.meta.url), 'utf8')
+  const deadline = src.indexOf('Absolute reveal deadline for this mounted chat')
+  const messagesEffect = src.indexOf('Single layout effect: spacer sizing')
+  assert.ok(deadline >= 0 && deadline < messagesEffect,
+    'the safety deadline is owned outside the messages-dependent layout effect')
+  assert.match(src.slice(deadline, messagesEffect), /\}, \[chatId\]\)/,
+    'the safety deadline resets only when the mounted chat changes')
+  assert.doesNotMatch(src.slice(messagesEffect), /clearTimeout\(safetyReveal\)/,
+    'message/layout cleanup cannot cancel and restart the absolute deadline')
+})

--- a/frontend/src/components/ChatView/__tests__/chatRuntimeState.test.js
+++ b/frontend/src/components/ChatView/__tests__/chatRuntimeState.test.js
@@ -28,8 +28,8 @@ import {
 } from '../chatRuntimeState.js'
 import { mergeRecentMessagesIntoLoadedWindow } from '../../../lib/chatDetailCache.js'
 
-test('R5a: jump-to-latest shows only away from the tail and yields to attention nudges', () => {
-  // At the content tail there is nothing to jump to.
+test('R5a: jump-to-latest shows only away from the physical tail and yields to attention nudges', () => {
+  // At the physical tail there is nothing to jump to.
   assert.equal(jumpToLatestShown({ awayFromTail: false }), false)
   // Scrolled up with no competing nudge: show.
   assert.equal(jumpToLatestShown({ awayFromTail: true }), true)

--- a/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
+++ b/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
@@ -17,7 +17,7 @@ import {
   composerTailIntentRequestsFollow,
   delayedSendWillPin,
   gestureLayoutRetryDelay,
-  isNearContentBottom,
+  isNearPhysicalBottom,
   layoutMayOwnScroll,
   modeForChatExit,
   modeForDisclosureToggle,
@@ -28,6 +28,7 @@ import {
   modeAfterSpacerResize,
   modeAfterTerminalLayout,
   physicalBottomAnchorModeFromScroll,
+  readerInputClaimsPhysicalTail,
   readerInputEscapeDirection,
   readerInputActivatesDisclosure,
   readerInputMayScroll,
@@ -78,18 +79,6 @@ test('shouldPinSend trusts actual scroll position over stale FOLLOW_BOTTOM mode'
   }), false)
 })
 
-test('shouldPinSend can use a complete pre-blur auto-scroll snapshot on mobile submit', () => {
-  // Mobile send blurs the textarea, which can resize/clamp the viewport before
-  // the pin decision runs. A true pre-blur bottom snapshot must win over the
-  // post-blur geometry so send-at-bottom still pins the new user row.
-  assert.equal(shouldPinSend({
-    scrollEl: makeScrollEl({ scrollHeight: 2000, scrollTop: 0, clientHeight: 500 }),
-    mode: { kind: 'ANCHOR_AT', key: 'old', offset: 0 },
-    isFirstUserMsg: false,
-    wasAtContentBottom: true,
-  }), true)
-})
-
 test('shouldPinSend uses FOLLOW_BOTTOM only when no scroll element is available', () => {
   assert.equal(shouldPinSend({
     scrollEl: null,
@@ -98,20 +87,10 @@ test('shouldPinSend uses FOLLOW_BOTTOM only when no scroll element is available'
   }), true)
 })
 
-test('shouldPinSend holds delayed insertion when submit-time intent is unavailable', () => {
-  assert.equal(shouldPinSend({
-    scrollEl: makeScrollEl({ scrollHeight: 2000, scrollTop: 0, clientHeight: 500 }),
-    mode: { kind: 'FOLLOW_BOTTOM' },
-    isFirstUserMsg: false,
-    wasAtContentBottom: false,
-  }), false)
-})
-
-test('shouldPinSend pins a following reader at the real-content bottom, ignoring dynamic spacer', () => {
-  // Raw gap is 440px, but 400px is phantom spacer left by a previous pin.
-  // Real content gap is 40px: visually, the reader is at the conversation
-  // tail. The next send should pin to the top even though the physical scroll
-  // bottom includes empty reserved room below the messages.
+test('shouldPinSend does not mistake reserved reply room for autoscroll after an upward escape', () => {
+  // Raw physical gap is 440px. The old rule subtracted the 400px spacer,
+  // misclassified this as a 40px bottom gap, and yanked the next message to the
+  // top even though the reader had moved the latest user row into mid-screen.
   const scrollEl = makeScrollEl({
     scrollHeight: 2000,
     scrollTop: 1000,
@@ -120,12 +99,12 @@ test('shouldPinSend pins a following reader at the real-content bottom, ignoring
   })
   assert.equal(shouldPinSend({
     scrollEl,
-    mode: { kind: 'FOLLOW_BOTTOM' },
+    mode: { kind: 'ANCHOR_AT', key: 'reader-row', offset: -280 },
     isFirstUserMsg: false,
-  }), true)
+  }), false)
 })
 
-test('shouldPinSend still refuses to pin when real content gap is large', () => {
+test('shouldPinSend still refuses to pin when the physical bottom gap is large', () => {
   const scrollEl = makeScrollEl({
     scrollHeight: 2000,
     scrollTop: 800,
@@ -139,10 +118,10 @@ test('shouldPinSend still refuses to pin when real content gap is large', () => 
   }), false)
 })
 
-test('shouldPinSend trusts bottom geometry even when mode is a stale hold', () => {
+test('shouldPinSend trusts the exact physical bottom even when mode is a stale hold', () => {
   const scrollEl = makeScrollEl({
     scrollHeight: 2000,
-    scrollTop: 1000,
+    scrollTop: 1440,
     clientHeight: 560,
     spacerHeight: 400,
   })
@@ -536,18 +515,16 @@ test('queued submission anchors before the active assistant shell that steer wil
   )
 })
 
-test('isNearContentBottom uses the same phantom-spacer bottom contract', () => {
+test('isNearPhysicalBottom keeps reserved room in the reader distance', () => {
   const scrollEl = makeScrollEl({
     scrollHeight: 2000,
     scrollTop: 1000,
     clientHeight: 560,
     spacerHeight: 400,
   })
-  assert.equal(isNearContentBottom(scrollEl), true)
-  assert.ok(
-    scrollEl.scrollHeight - scrollEl.scrollTop - scrollEl.clientHeight > 50,
-    'the meaningful content tail does not require traversing reserved room',
-  )
+  assert.equal(isNearPhysicalBottom(scrollEl), false)
+  scrollEl.scrollTop = 1440
+  assert.equal(isNearPhysicalBottom(scrollEl), true)
 })
 
 test('pin reapply is needed when the first pin was clamped but spacer now makes the target reachable', () => {
@@ -828,6 +805,19 @@ test('reader settlement follows the physical tail even while reservation remains
   assert.equal(readerInputEscapeDirection('keydown', { key: 'Tab' }), null)
   assert.equal(readerInputEscapeDirection('pointerdown', {}), null)
 }
+
+test('end-directed input at the physical clamp follows without a scroll event', () => {
+  assert.equal(readerInputClaimsPhysicalTail('down', 0), true,
+    'a downward input at the clamp is explicit follow intent')
+  assert.equal(readerInputClaimsPhysicalTail('down', 3.5), true,
+    'subpixel browser rounding at the clamp remains physical-tail intent')
+  assert.equal(readerInputClaimsPhysicalTail('down', 4), false,
+    'near the tail is not enough when no scroll event proves arrival')
+  assert.equal(readerInputClaimsPhysicalTail('up', 0), false,
+    'an upward input at the tail must escape rather than follow')
+  assert.equal(readerInputClaimsPhysicalTail(null, 0), false,
+    'directionless input cannot manufacture follow intent')
+})
 
 {
   assert.equal(readerScrollEscapeDirection(1400, 1200), 'up')

--- a/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
+++ b/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
@@ -27,6 +27,7 @@ import {
   modeAfterReaderGesture,
   modeAfterSpacerResize,
   modeAfterTerminalLayout,
+  nestedReaderTargetOwnsInput,
   physicalBottomAnchorModeFromScroll,
   readerInputClaimsPhysicalTail,
   readerInputEscapeDirection,
@@ -186,6 +187,44 @@ test('only scrolling keys claim reader ownership', () => {
   assert.equal(readerInputMayScroll('keydown', 'Tab'), true)
   assert.equal(readerInputMayScroll('wheel'), true)
   assert.equal(readerInputMayScroll('touchmove'), true)
+})
+
+test('nested controls keep their own keys and available scroll range', () => {
+  const editor = {
+    closest: selector => selector.startsWith('textarea,') ? editor : null,
+  }
+  const button = {
+    closest: selector => selector.startsWith('button,') ? button : null,
+  }
+  assert.equal(nestedReaderTargetOwnsInput({
+    type: 'keydown', key: 'End', target: editor,
+  }), true, 'caret navigation in a textarea is not transcript intent')
+  assert.equal(nestedReaderTargetOwnsInput({
+    type: 'keydown', key: ' ', target: button,
+  }), true, 'Space activates the focused control instead of scrolling the chat')
+  assert.equal(nestedReaderTargetOwnsInput({
+    type: 'keydown', key: 'End', target: button,
+  }), false, 'an unconsumed scroll key may still belong to the transcript')
+
+  const scrollEl = { contains: node => node === nested }
+  const nested = {
+    scrollTop: 20,
+    scrollHeight: 200,
+    clientHeight: 80,
+    closest: selector => selector === '[data-chat-scroll-region], .chat__scroll'
+      ? nested
+      : null,
+  }
+  assert.equal(nestedReaderTargetOwnsInput({
+    type: 'wheel', target: nested, scrollEl, direction: 'down',
+  }), true)
+  nested.scrollTop = 120
+  assert.equal(nestedReaderTargetOwnsInput({
+    type: 'wheel', target: nested, scrollEl, direction: 'down',
+  }), false, 'a clamped nested surface may chain the gesture to the transcript')
+  assert.equal(nestedReaderTargetOwnsInput({
+    type: 'wheel', target: nested, scrollEl, direction: 'up',
+  }), true)
 })
 
 test('a composer press or direct edit requests follow only at the physical tail', () => {

--- a/frontend/src/components/ChatView/chatContract.js
+++ b/frontend/src/components/ChatView/chatContract.js
@@ -64,9 +64,10 @@ export const CHAT_CONTRACT = [
     id: 'follow-at-physical-tail',
     title: 'Re-engage follow at the physical tail',
     summary:
-      'An end-directed wheel, scroll key, or touch gesture at the physical '
-      + 'tail enters FOLLOW_BOTTOM even when the browser is already clamped '
-      + 'and emits no scroll event.',
+      'Nested controls keep input they can consume. Otherwise an end-directed '
+      + 'wheel, scroll key, or touch gesture at the physical tail enters '
+      + 'FOLLOW_BOTTOM even when no scroll event fires, without invalidating '
+      + 'a delayed send decision.',
   },
   {
     id: 'pin-holds-streaming',

--- a/frontend/src/components/ChatView/chatContract.js
+++ b/frontend/src/components/ChatView/chatContract.js
@@ -19,8 +19,8 @@
  * module). Individual functions are NOT serializable through a bare
  * page.evaluate(fn) — they close over module scope (constants, helpers).
  *
- * PREDICATE SELECTION is the caller's job, keyed on submit-time intent: an
- * at-bottom send is judged by pinLanded/pinHeld; a not-at-bottom send or
+ * PREDICATE SELECTION is the caller's job, keyed on submit-time intent: a
+ * physical-tail send is judged by pinLanded/pinHeld; a reader-held send or
  * steer by scrollUnmoved. pinLanded deliberately cannot know whether a given
  * send SHOULD have pinned — the caller captures that at submit time.
  *
@@ -45,9 +45,10 @@ export const PIN_OFFSET = 4
 export const PIN_BOTTOM_ROOM = 0
 
 /**
- * The geometry-checkable subset of the architecture contract. Each id is the
- * `id` a predicate stamps on its result, so a violation is traceable back to
- * the owner law it broke.
+ * Machine-readable owner rules from the architecture contract. Geometry
+ * predicates stamp their rule's `id` on results; interaction-only rules are
+ * enforced by focused policy and browser tests instead of duplicating their
+ * state machine here.
  */
 export const CHAT_CONTRACT = [
   {
@@ -55,8 +56,17 @@ export const CHAT_CONTRACT = [
     title: 'Pin eligible sends to top',
     summary:
       'The first user message always pins. A subsequent direct, queued, or '
-      + 'steered message pins when its action-time DOM snapshot is at the '
-      + 'real-content tail; stale internal mode never overrides geometry.',
+      + 'steered message pins only from the physical tail. Reserved '
+      + 'reply room remains part of that distance, so any upward reader escape '
+      + 'keeps the next send at the current reading position.',
+  },
+  {
+    id: 'follow-at-physical-tail',
+    title: 'Re-engage follow at the physical tail',
+    summary:
+      'An end-directed wheel, scroll key, or touch gesture at the physical '
+      + 'tail enters FOLLOW_BOTTOM even when the browser is already clamped '
+      + 'and emits no scroll event.',
   },
   {
     id: 'pin-holds-streaming',

--- a/frontend/src/components/ChatView/chatRuntimeState.js
+++ b/frontend/src/components/ChatView/chatRuntimeState.js
@@ -65,7 +65,7 @@ export function serverSnapshotBehindLocal(serverMsgs, localMsgs) {
 }
 
 /** The floating jump-to-latest control (contract R5a) shows only while the
- * reader holds a position away from the content tail, and yields to any
+ * reader holds a position away from the physical tail, and yields to any
  * visible attention nudge — a nudge navigates to the same tail with strictly
  * more context, so stacking both would be two controls for one action. */
 export function jumpToLatestShown({

--- a/frontend/src/components/ChatView/useScrollMode.js
+++ b/frontend/src/components/ChatView/useScrollMode.js
@@ -24,9 +24,11 @@
  *                                    position at one viewport size
  *
  * Send pinning has one rule for direct, queued, and steered messages: the
- * first visible user message always pins; every later message pins when the
- * reader is at the real-content tail at submit time. DOM geometry is the
- * authority; ScrollMode is only a fallback when no scroll element exists.
+ * first visible user message always pins; every later message pins only at the
+ * physical bottom/autoscroll tail at submit time. Reserved reply room is real
+ * scroll distance for this decision: once the reader moves upward into it,
+ * their next send must hold the exact reading position. ScrollMode is only a
+ * fallback when no scroll element exists.
  * A live pin leaves FOLLOW_BOTTOM while its dynamic spacer is being consumed,
  * then hands off to FOLLOW_BOTTOM exactly when that reservation reaches zero.
  * A short reply never reaches the handoff and remains pinned after settle.
@@ -87,10 +89,10 @@ const GESTURE_SETTLE_MS = 250
 // cannot run until that same thread is available again.
 const PENDING_GESTURE_CAP_MS = 2000
 
-// Physical-bottom transitions are exact reader intent, not the broader
-// "near real-content tail" send heuristic. Allow only subpixel/browser
-// rounding at the scroll extent. Used for the explicit "swipe/press at the very
-// clamp" follow claims, NOT for retaining follow once engaged.
+// Physical-bottom transitions and later-send pin eligibility use the same
+// exact tail. Allow only subpixel/browser rounding at the scroll extent. This
+// prevents reserved reply room from disguising an upward reader escape as
+// autoscroll intent.
 const PHYSICAL_BOTTOM_EPSILON_PX = 4
 
 // Start the next bounded history read before the loaded-page boundary can
@@ -837,28 +839,25 @@ export function _computeSpacerH(
 }
 
 
-// "Near the bottom" tolerance for the submit-time real-content snapshot.
-const NEAR_BOTTOM_PX = 50
-
 /** The single submit-time rule used by direct, queued, and steered user rows.
  *  A row moves to the top (PIN_USER_MSG) only when it was the first visible
- *  user message, or the reader was at the real-content tail when submitted.
+ *  user message, or the reader was at the physical autoscroll tail when
+ *  submitted.
  *
- *  The dynamic spacer is excluded from that geometry because it is reserved
- *  reply room, not content. This deliberately does not consult ScrollMode when
- *  the DOM exists: mode transitions lag input/layout by a frame, which made an
- *  identical bottom send pin only sometimes. The measured reader position is
- *  the single submit-time authority. ScrollMode is a DOM-less fallback only.
+ *  Dynamic spacer remains part of this geometry. It is reserved reply room,
+ *  but it is also the range through which a reader moves upward after leaving
+ *  autoscroll. Subtracting it made a message sitting mid-screen look like a
+ *  bottom send and yanked the reader back to the top. Exact physical geometry
+ *  remains synchronous even while ScrollMode settlement trails by a frame;
+ *  ScrollMode is a DOM-less fallback only.
  */
 export function shouldPinSend({
   scrollEl,
   mode,
   isFirstUserMsg,
-  wasAtContentBottom = null,
 }) {
   if (isFirstUserMsg) return true
-  if (typeof wasAtContentBottom === 'boolean') return wasAtContentBottom
-  if (scrollEl) return isNearContentBottom(scrollEl)
+  if (scrollEl) return isNearPhysicalBottom(scrollEl)
   return mode?.kind === 'FOLLOW_BOTTOM'
 }
 
@@ -877,13 +876,15 @@ export function delayedSendWillPin({
 }
 
 
-/** Position-based bottom check that treats the dynamic pin spacer as phantom
- *  room, not real content. Send snapshots use the conversation tail because a
- *  new send should not require traversing reserved reply room first. */
-export function isNearContentBottom(scrollEl, threshold = NEAR_BOTTOM_PX) {
+/** Position-based check against the one physical tail. Reserved spacer stays
+ * in the range: scrolling upward through it is an explicit exit from
+ * autoscroll, not a second kind of bottom. */
+export function isNearPhysicalBottom(
+  scrollEl,
+  threshold = PHYSICAL_BOTTOM_EPSILON_PX,
+) {
   if (!scrollEl) return false
-  const spacerH = scrollEl.querySelector('.spacer-dynamic')?.offsetHeight || 0
-  const gap = scrollEl.scrollHeight - spacerH - scrollEl.scrollTop - scrollEl.clientHeight
+  const gap = scrollEl.scrollHeight - scrollEl.scrollTop - scrollEl.clientHeight
   return gap < threshold
 }
 
@@ -964,6 +965,21 @@ export function readerInputEscapeDirection(
 }
 
 
+/** An end-directed input at the physical tail is meaningful even when the
+ * browser is already clamped and therefore cannot emit a `scroll` event.
+ * Wheel/keyboard and touch all use this predicate before claiming FOLLOW_BOTTOM
+ * so a repeated "keep going" gesture has one semantic meaning on every input
+ * path. */
+export function readerInputClaimsPhysicalTail(
+  escapeDirection,
+  distanceToBottom,
+) {
+  return escapeDirection === 'down'
+    && Number.isFinite(distanceToBottom)
+    && distanceToBottom < PHYSICAL_BOTTOM_EPSILON_PX
+}
+
+
 /** Infer the same escape/re-engage direction from an actual scroll position.
  * Wheel, keyboard, and touch inputs expose direction before scrolling, but a
  * mouse scrollbar drag does not. Comparing consecutive owned positions keeps
@@ -995,8 +1011,7 @@ export function composerTailIntentRequestsFollow(event, scrollEl) {
   if ((!primaryPress && !directEdit)
       || !event?.target?.matches?.('textarea.chat__input')
       || !scrollEl) return false
-  return scrollEl.scrollHeight - scrollEl.scrollTop - scrollEl.clientHeight
-    < PHYSICAL_BOTTOM_EPSILON_PX
+  return isNearPhysicalBottom(scrollEl)
 }
 
 
@@ -2466,6 +2481,13 @@ export default function useScrollMode({
         releasePendingGesture(sequence)
       })
     }
+    const claimPhysicalTailFollow = () => {
+      if (modeRef.current?.kind === 'FOLLOW_BOTTOM') return
+      readerIntentVersionRef.current += 1
+      readerLocationExplicitRef.current = true
+      transitionMode({ kind: 'FOLLOW_BOTTOM' }, 'reader:scroll-bottom')
+      persistMode()
+    }
     const onUserInput = (event) => {
       const activatesDisclosure = readerInputActivatesDisclosure(
         event?.type,
@@ -2480,6 +2502,24 @@ export default function useScrollMode({
         // preceding gesture's actual location; otherwise a stale FOLLOW_BOTTOM
         // can be latched before the disclosure changes layout.
         settleReaderScroll()
+      }
+      // Wheel and scroll-key paths need the same geometry again for their
+      // no-scroll release decision. Memoize it inside this one input so the
+      // clamped-tail follow check does not force a second transcript layout.
+      let inputGeometry = null
+      const readInputGeometry = () => {
+        if (inputGeometry) return inputGeometry
+        const scrollTop = scrollEl.scrollTop
+        const scrollHeight = scrollEl.scrollHeight
+        const clientHeight = scrollEl.clientHeight
+        inputGeometry = {
+          deltaY: event?.deltaY,
+          scrollTop,
+          scrollHeight,
+          clientHeight,
+          distanceToBottom: scrollHeight - scrollTop - clientHeight,
+        }
+        return inputGeometry
       }
       const readerAlreadyOwns = !layoutMayOwnScroll(
         gestureWindowUntilRef.current,
@@ -2504,6 +2544,15 @@ export default function useScrollMode({
         })
         if (escapeDir === 'up') readerGestureEscaped = true
         else if (escapeDir === 'down') readerGestureEscaped = false
+        // A downward wheel/key press at the physical clamp cannot produce the
+        // scroll event that normally commits FOLLOW_BOTTOM. Claim the same
+        // semantic tail intent here instead of silently releasing it next frame.
+        if (escapeDir === 'down' && readerInputClaimsPhysicalTail(
+          escapeDir,
+          readInputGeometry().distanceToBottom,
+        )) {
+          claimPhysicalTailFollow()
+        }
       }
       if (!readerAlreadyOwns || activatesDisclosure) {
         recordTrace('events', `reader:input-${event?.type || 'unknown'}`, {
@@ -2545,12 +2594,7 @@ export default function useScrollMode({
       const keyboardDisclosure = activatesDisclosure && event?.type === 'keydown'
       if (keyboardDisclosure || readerInputNeedsFrameRelease(
           event?.type,
-          () => ({
-            deltaY: event?.deltaY,
-            scrollTop: scrollEl.scrollTop,
-            scrollHeight: scrollEl.scrollHeight,
-            clientHeight: scrollEl.clientHeight,
-          }),
+          readInputGeometry,
           event?.key,
           event?.shiftKey,
         )) {
@@ -2598,11 +2642,8 @@ export default function useScrollMode({
         const distanceToBottom = scrollEl.scrollHeight
           - scrollEl.scrollTop
           - scrollEl.clientHeight
-        if (distanceToBottom < PHYSICAL_BOTTOM_EPSILON_PX) {
-          readerIntentVersionRef.current += 1
-          readerLocationExplicitRef.current = true
-          transitionMode({ kind: 'FOLLOW_BOTTOM' }, 'reader:scroll-bottom')
-          persistMode()
+        if (readerInputClaimsPhysicalTail('down', distanceToBottom)) {
+          claimPhysicalTailFollow()
         }
       }
       // Re-arm the safety gate if a deliberately long (>2s) stationary touch

--- a/frontend/src/components/ChatView/useScrollMode.js
+++ b/frontend/src/components/ChatView/useScrollMode.js
@@ -1145,6 +1145,48 @@ export function readerInputMayScroll(type, key = '') {
 }
 
 
+/** Nested controls keep the keys and scroll range they can consume. Once an
+ * explicitly marked nested scroller reaches its matching edge, native scroll
+ * chaining may hand the same wheel/swipe to the transcript. */
+export function nestedReaderTargetOwnsInput({
+  type,
+  key = '',
+  target = null,
+  scrollEl = null,
+  direction = null,
+} = {}) {
+  if (type === 'keydown') {
+    const editingControl = target?.closest?.(
+      'textarea, input, select, [contenteditable]:not([contenteditable="false"]), '
+      + '[role="textbox"], [role="searchbox"], [role="combobox"], '
+      + '[role="listbox"], [role="spinbutton"], [role="slider"]',
+    )
+    if (editingControl) return true
+    if ([' ', 'Spacebar'].includes(key)) {
+      return !!target?.closest?.(
+        'button, a[href], summary, [role="button"], [role="menuitem"], [role="option"]',
+      )
+    }
+    return false
+  }
+
+  if (!['wheel', 'pointermove', 'touchmove'].includes(type)
+      || !['up', 'down'].includes(direction)) return false
+  const nested = target?.closest?.('[data-chat-scroll-region], .chat__scroll')
+  if (!nested || nested === scrollEl) return false
+
+  const scrollTop = Number(nested.scrollTop)
+  const scrollHeight = Number(nested.scrollHeight)
+  const clientHeight = Number(nested.clientHeight)
+  if (![scrollTop, scrollHeight, clientHeight].every(Number.isFinite)) return false
+  const maxScrollTop = Math.max(0, scrollHeight - clientHeight)
+  if (maxScrollTop <= 0.5) return false
+  return direction === 'up'
+    ? scrollTop > 0.5
+    : scrollTop < maxScrollTop - 0.5
+}
+
+
 /** A disclosure activation is a reading action even when it produces no native
  * scroll event. Snapshotting the current message anchor before its body changes
  * prevents a stale FOLLOW_BOTTOM mode from replaying after pointerup and
@@ -2483,7 +2525,9 @@ export default function useScrollMode({
     }
     const claimPhysicalTailFollow = () => {
       if (modeRef.current?.kind === 'FOLLOW_BOTTOM') return
-      readerIntentVersionRef.current += 1
+      // This gesture expressed tail intent but produced no scroll. Keep the
+      // generation captured by a queued send: only an actual reader scroll may
+      // supersede that send-time decision.
       readerLocationExplicitRef.current = true
       transitionMode({ kind: 'FOLLOW_BOTTOM' }, 'reader:scroll-bottom')
       persistMode()
@@ -2497,6 +2541,18 @@ export default function useScrollMode({
       )
       if (!activatesDisclosure
           && !readerInputMayScroll(event?.type, event?.key)) return
+      const inputDirection = readerInputEscapeDirection(event?.type, {
+        deltaY: event?.deltaY,
+        key: event?.key,
+        shiftKey: event?.shiftKey,
+      })
+      if (!activatesDisclosure && nestedReaderTargetOwnsInput({
+        type: event?.type,
+        key: event?.key,
+        target: event?.target,
+        scrollEl,
+        direction: inputDirection,
+      })) return
       if (activatesDisclosure && readerScrollDirty) {
         // A disclosure is a newer semantic reading action. First commit the
         // preceding gesture's actual location; otherwise a stale FOLLOW_BOTTOM
@@ -2537,18 +2593,13 @@ export default function useScrollMode({
         // scrollbar pointerdown, whose later scroll event is the first place
         // the browser reveals which way the reader moved.
         readerGestureLastScrollTop = scrollEl.scrollTop
-        const escapeDir = readerInputEscapeDirection(event?.type, {
-          deltaY: event?.deltaY,
-          key: event?.key,
-          shiftKey: event?.shiftKey,
-        })
-        if (escapeDir === 'up') readerGestureEscaped = true
-        else if (escapeDir === 'down') readerGestureEscaped = false
+        if (inputDirection === 'up') readerGestureEscaped = true
+        else if (inputDirection === 'down') readerGestureEscaped = false
         // A downward wheel/key press at the physical clamp cannot produce the
         // scroll event that normally commits FOLLOW_BOTTOM. Claim the same
         // semantic tail intent here instead of silently releasing it next frame.
-        if (escapeDir === 'down' && readerInputClaimsPhysicalTail(
-          escapeDir,
+        if (inputDirection === 'down' && readerInputClaimsPhysicalTail(
+          inputDirection,
           readInputGeometry().distanceToBottom,
         )) {
           claimPhysicalTailFollow()
@@ -2614,10 +2665,12 @@ export default function useScrollMode({
     // scroll event, so the recorded value is exactly the gap a reader feels.
     let pendingGestureStart = 0
     let touchStartY = null
+    let touchStartTarget = null
     let touchEndChecked = false
     const onPointerDownInput = (event) => {
       if (event.pointerType === 'touch') {
         touchStartY = Number.isFinite(event.clientY) ? event.clientY : null
+        touchStartTarget = event.target
         touchEndChecked = false
         if (isPerfProbeEnabled()) {
           pendingGestureStart = performance.now()
@@ -2634,10 +2687,20 @@ export default function useScrollMode({
     // follow before the reserved reply room has been consumed.
     const onPointerMoveInput = (event) => {
       if (event.pointerType !== 'touch') return
+      const fingerDelta = touchStartY == null ? 0 : touchStartY - event.clientY
+      const touchDirection = fingerDelta >= 12
+        ? 'down'
+        : fingerDelta <= -12 ? 'up' : null
+      if (touchDirection && nestedReaderTargetOwnsInput({
+        type: 'pointermove',
+        target: touchStartTarget || event.target,
+        scrollEl,
+        direction: touchDirection,
+      })) return
       if (!touchEndChecked
           && !readerScrollDirty
           && touchStartY != null
-          && touchStartY - event.clientY >= 12) {
+          && touchDirection === 'down') {
         touchEndChecked = true
         const distanceToBottom = scrollEl.scrollHeight
           - scrollEl.scrollTop
@@ -2654,15 +2717,13 @@ export default function useScrollMode({
       // that is scrolling DOWN, which re-engages follow; a finger moving down is
       // scrolling UP and escapes. Applied last so the stationary-touch re-arm
       // above (a fresh onUserInput claim) cannot clobber the direction.
-      if (touchStartY != null) {
-        const fingerDelta = touchStartY - event.clientY
-        if (fingerDelta >= 12) readerGestureEscaped = false
-        else if (fingerDelta <= -12) readerGestureEscaped = true
-      }
+      if (touchDirection === 'down') readerGestureEscaped = false
+      else if (touchDirection === 'up') readerGestureEscaped = true
     }
     const onPointerUpInput = () => {
       if (!readerScrollDirty) pendingGestureStart = 0
       touchStartY = null
+      touchStartTarget = null
       touchEndChecked = false
       scheduleNoScrollRelease()
     }

--- a/frontend/src/lib/__tests__/useScrollModeLifecycle.test.js
+++ b/frontend/src/lib/__tests__/useScrollModeLifecycle.test.js
@@ -69,6 +69,66 @@ function installBrowserEnvironment({ observers = [], frames = null } = {}) {
   return () => Object.assign(globalThis, previous)
 }
 
+function mountTailController(chatId) {
+  const listeners = new Map()
+  const lastUser = fakeElement({
+    dataset: { cid: 'user-1', key: 'user-1' },
+    offsetTop: 0,
+    offsetHeight: 40,
+  })
+  const assistant = fakeElement({
+    dataset: { key: 'assistant-tail' },
+    offsetTop: 100,
+    offsetHeight: 300,
+  })
+  const list = fakeElement({ offsetHeight: 400 })
+  const scroll = fakeElement({
+    scrollTop: 400,
+    scrollHeight: 900,
+    clientHeight: 500,
+    addEventListener(type, listener) { listeners.set(type, listener) },
+    removeEventListener(type, listener) {
+      if (listeners.get(type) === listener) listeners.delete(type)
+    },
+    contains(node) {
+      for (let current = node; current; current = current.parentElement) {
+        if (current === this) return true
+      }
+      return false
+    },
+    querySelector(selector) {
+      if (selector === '.chat__list') return list
+      if (selector.includes('data-key="assistant-tail"')) return assistant
+      if (selector.includes('data-cid="user-1"')) return lastUser
+      return null
+    },
+    querySelectorAll(selector) {
+      if (selector === '.chat__msg[data-key]') return [assistant]
+      if (selector === '.chat__msg--user[data-cid]') return [lastUser]
+      return []
+    },
+  })
+  scroll.parentElement = fakeElement()
+  const messages = [
+    { role: 'user', cid: 'user-1', content: 'Question' },
+    { role: 'assistant', cid: 'assistant-tail', content: 'Answer' },
+  ]
+  const hook = renderHook(useScrollMode, {
+    chatId,
+    scrollRef: { current: scroll },
+    spacerRef: { current: fakeElement() },
+    lastUserMsgRef: { current: lastUser },
+    chatRef: { current: fakeElement() },
+    footRef: { current: fakeElement({ offsetHeight: 80 }) },
+    messages,
+    messagesRef: { current: messages },
+    loadingOlderRef: { current: false },
+    initialEntryPhase: 'ready',
+    ownsReadingPosition: true,
+  })
+  return { hook, listeners, scroll }
+}
+
 
 test('transcript changes keep one scroll owner after the first row mounts', () => {
   const observers = []
@@ -121,6 +181,71 @@ test('transcript changes keep one scroll owner after the first row mounts', () =
     assert.equal(observers.length, 2,
       'adding a transcript row may reinstall the DOM lifecycle')
     assert.equal(observers[0].disconnected, true)
+    hook.unmount()
+  } finally {
+    restoreBrowser()
+  }
+})
+
+test('nested controls cannot relatch the transcript while they own the input', () => {
+  const restoreBrowser = installBrowserEnvironment()
+  try {
+    const { hook, listeners, scroll } = mountTailController('nested-input-owner')
+    assert.equal(scroll.dataset.scrollMode, 'ANCHOR_AT')
+
+    const editor = {
+      parentElement: scroll,
+      closest(selector) { return selector.startsWith('textarea,') ? this : null },
+    }
+    listeners.get('keydown')({
+      type: 'keydown', key: 'End', shiftKey: false, target: editor,
+    })
+    assert.equal(scroll.dataset.scrollMode, 'ANCHOR_AT',
+      'End moves the inline caret, not the outer conversation')
+
+    const nested = {
+      parentElement: scroll,
+      scrollTop: 10,
+      scrollHeight: 180,
+      clientHeight: 60,
+      closest(selector) {
+        return selector === '[data-chat-scroll-region], .chat__scroll' ? this : null
+      },
+    }
+    listeners.get('wheel')({
+      type: 'wheel', deltaY: 80, shiftKey: false, target: nested,
+    })
+    assert.equal(scroll.dataset.scrollMode, 'ANCHOR_AT',
+      'a nested vertical surface keeps the wheel while it can move')
+
+    nested.scrollTop = 120
+    listeners.get('wheel')({
+      type: 'wheel', deltaY: 80, shiftKey: false, target: nested,
+    })
+    assert.equal(scroll.dataset.scrollMode, 'FOLLOW_BOTTOM',
+      'the same gesture may chain to the transcript at the nested edge')
+    hook.unmount()
+  } finally {
+    restoreBrowser()
+  }
+})
+
+test('a no-scroll tail relatch preserves the queued send-time pin decision', () => {
+  const restoreBrowser = installBrowserEnvironment()
+  try {
+    const { hook, listeners, scroll } = mountTailController('queued-pin-owner')
+    const intent = hook.result.current.captureSendIntent({ isFirstUserMsg: false })
+    assert.equal(intent.willPin, true)
+
+    listeners.get('wheel')({
+      type: 'wheel', deltaY: 80, shiftKey: false,
+      target: { parentElement: scroll, closest: () => null },
+    })
+    assert.equal(scroll.dataset.scrollMode, 'FOLLOW_BOTTOM')
+
+    hook.result.current.commitSendIntent({ cid: 'queued-user-2', intent })
+    assert.equal(scroll.dataset.scrollMode, 'PIN_USER_MSG',
+      'a clamped gesture expresses follow but is not a newer scroll generation')
     hook.unmount()
   } finally {
     restoreBrowser()

--- a/tests/attention-nudges.spec.mjs
+++ b/tests/attention-nudges.spec.mjs
@@ -221,11 +221,10 @@ for (const scenario of SCENARIOS) {
   })
 }
 
-// R5a jump-to-latest (contract v1.18): the floating control renders only while
-// the reader holds a position away from the content tail; tapping it is the
-// same one-shot controller tail reveal as the nudges and lands a settled
-// ANCHOR_AT hold — never live-follow — after which the control retires itself.
-test('jump-to-latest appears only away from the tail and lands a settled hold', async ({ page }) => {
+// R5a jump-to-latest (contract v1.20): the floating control renders only while
+// the reader holds a position away from the physical tail; tapping it explicitly
+// re-enters FOLLOW_BOTTOM, after which the control retires itself.
+test('jump-to-latest appears only away from the physical tail and resumes follow', async ({ page }) => {
   await page.setViewportSize({ width: 1512, height: 861 })
   await page.goto(BASE, { waitUntil: 'domcontentloaded' })
   await page.waitForFunction(

--- a/tests/chat-redesign.spec.mjs
+++ b/tests/chat-redesign.spec.mjs
@@ -375,6 +375,73 @@ test.describe('Bug 1: AskUserQuestion', () => {
   })
 
 
+  test('a nested answer editor keeps its keys and wheel from relatching the transcript', async ({ page }) => {
+    const streamBody = [
+      `data: ${JSON.stringify({
+        type: 'text',
+        content: 'Earlier context keeps the transcript scrollable. '.repeat(180),
+      })}\n\n`,
+      `data: ${JSON.stringify({
+        type: 'question',
+        question_id: 'q-nested-input-owner',
+        questions: [{
+          question: 'Write the detailed answer',
+          header: 'Details',
+          multiSelect: false,
+          options: [{ label: 'Skip writing' }],
+        }],
+      })}\n\n`,
+      'data: {"type":"done"}\n\n',
+    ].join('')
+    await setupWithStreamMock(page, streamBody, { width: 426, height: 510 })
+    await mockPendingQuestionState(page, 'q-nested-input-owner')
+    await newChat(page)
+    await sendMessage(page, 'Ask for a detailed answer')
+
+    const scroll = page.locator('[data-chat-surface="painted"] .chat__scroll')
+    const customAnswer = page.getByRole('textbox', {
+      name: 'Custom answer for: Write the detailed answer',
+    })
+    await expect(customAnswer).toBeVisible({ timeout: 5000 })
+    await customAnswer.fill(
+      Array.from({ length: 24 }, (_, index) => `Detail line ${index + 1}`).join('\n'),
+    )
+    await expect.poll(() => customAnswer.evaluate(
+      el => el.scrollHeight - el.clientHeight,
+    )).toBeGreaterThan(20)
+
+    // Establish a genuine reader hold, then move its DOM coordinate to the
+    // physical clamp without granting follow. This is the exact state in which
+    // a bubbled End/wheel used to relatch the outer transcript.
+    await scroll.evaluate(el => {
+      el.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, button: 0 }))
+      el.scrollTop = Math.max(0, el.scrollHeight - el.clientHeight - 160)
+      el.dispatchEvent(new Event('scroll'))
+      el.dispatchEvent(new Event('scrollend'))
+    })
+    await expect(scroll).toHaveAttribute('data-scroll-mode', 'ANCHOR_AT')
+    await scroll.evaluate(el => { el.scrollTop = el.scrollHeight })
+    await page.evaluate(() => new Promise(resolve => (
+      requestAnimationFrame(() => requestAnimationFrame(resolve))
+    )))
+    await expect(scroll).toHaveAttribute('data-scroll-mode', 'ANCHOR_AT')
+
+    await customAnswer.focus()
+    await customAnswer.press('End')
+    await expect(scroll).toHaveAttribute('data-scroll-mode', 'ANCHOR_AT')
+
+    await customAnswer.evaluate(el => { el.scrollTop = 0 })
+    const outerBefore = await scroll.evaluate(el => el.scrollTop)
+    await customAnswer.hover()
+    await page.mouse.wheel(0, 120)
+    await expect.poll(() => customAnswer.evaluate(el => el.scrollTop))
+      .toBeGreaterThan(0)
+    await expect(scroll).toHaveAttribute('data-scroll-mode', 'ANCHOR_AT')
+    const outerAfter = await scroll.evaluate(el => el.scrollTop)
+    expect(Math.abs(outerAfter - outerBefore)).toBeLessThanOrEqual(1)
+  })
+
+
   test('partial question + text token + full question for same id renders ONE card', async ({ page }) => {
     // The user-visible duplicate-card bug from the klix chat: the
     // SDK's --include-partial-messages can deliver two `question`
@@ -683,7 +750,7 @@ test.describe('Q&A atomic write', () => {
         row => row.event === 'send:question-freeze',
       )
       return transitions.slice(freezeIndex + 1).some(
-        row => row.event === 'reader:physical-bottom',
+        row => row.event === 'reader:scroll-bottom',
       )
     })
     expect(laterReaderBottom).toBe(false)

--- a/tests/send-rule.spec.mjs
+++ b/tests/send-rule.spec.mjs
@@ -1,12 +1,12 @@
 /**
  * The send-scroll rule (owner's words):
  *
- *   "The first message always pins. Later messages pin when the reader is
- *    actually at the real-content bottom; every pin returns to hold."
+ *   "The first message always goes to the top. Later messages go to the top
+ *    only in autoscroll mode — i.e. at the physical bottom."
  *
  * Direct, queued, and steered rows share that submit-time rule. The pre-append
- * real-content geometry is authoritative; internal mode can lag input/layout
- * by a frame and must not make an identical bottom send intermittent.
+ * physical-tail geometry is authoritative while mode settles. Reserved reply
+ * room is part of that range: scrolling upward through it exits autoscroll.
  *
  * Mirrors the route-mock SSE flow of second-send-pin.spec.mjs.
  *
@@ -172,6 +172,7 @@ async function measure(page) {
       clientH: scroll.clientHeight,
       scrollH: scroll.scrollHeight,
       spacerH: parseInt(spacer?.style.height) || 0,
+      mode: scroll.dataset.scrollMode || null,
       lastUserVisualTop: lr ? Math.round(lr.top - sr.top) : null,
       lastUserText: textEl?.textContent?.trim() ?? '',
       userMsgCount: users.length,
@@ -371,24 +372,87 @@ test('Send while scrolled up preserves the exact reading position', async ({ pag
   expect(after.spacerH).toBeGreaterThanOrEqual(0)
 })
 
+test('Scrolling upward inside reserved reply room keeps the next send in place', async ({ page }) => {
+  await setup(page)
+  await newChat(page)
+
+  // Build real history so a later pinned row can move from the top into the
+  // middle while the latest-turn reservation still remains below it.
+  await routeStream(page, [
+    { type: 'catch_up_done' },
+    { type: 'text', content: 'Long first response. '.repeat(150) },
+    { type: 'done' },
+  ])
+  await sendMessage(page, 'First user message')
+  await waitStreamDone(page)
+  await gestureToBottom(page)
+
+  await routeStream(page, [
+    { type: 'catch_up_done' },
+    { type: 'text', content: 'Short second reply.' },
+    { type: 'done' },
+  ])
+  await sendMessage(page, 'Second message pins from autoscroll')
+  await waitStreamDone(page)
+
+  const pinned = await measure(page)
+  expect(pinned.lastUserVisualTop).toBeGreaterThanOrEqual(-2)
+  expect(pinned.lastUserVisualTop).toBeLessThanOrEqual(10)
+  expect(pinned.spacerH).toBeGreaterThan(100)
+
+  // This is the owner-reported failure: move upward only inside the reserved
+  // range, leaving the latest user row around mid-screen. The old send rule
+  // subtracted spacerH and still called this "at the bottom."
+  await page.evaluate(() => {
+    const s = document.querySelector('[data-chat-surface="painted"] .chat__scroll')
+    if (!s) return
+    s.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }))
+    s.scrollTop = Math.max(0, s.scrollTop - Math.round(s.clientHeight * 0.45))
+  })
+  await page.evaluate(() => new Promise(r => setTimeout(r, 350)))
+
+  const before = await measure(page)
+  expect(before.mode).toBe('ANCHOR_AT')
+  expect(before.lastUserVisualTop).toBeGreaterThan(before.clientH * 0.25)
+  expect(before.lastUserVisualTop).toBeLessThan(before.clientH * 0.7)
+  const physicalGap = before.scrollH - before.scrollTop - before.clientH
+  const oldSpacerExcludedGap = physicalGap - before.spacerH
+  expect(physicalGap).toBeGreaterThan(100)
+  expect(oldSpacerExcludedGap).toBeLessThan(50)
+  const savedTop = before.scrollTop
+
+  await routeStream(page, [
+    { type: 'catch_up_done' },
+    { type: 'text', content: 'Third reply stays below the reader.' },
+    { type: 'done' },
+  ])
+  await sendMessage(page, 'Third message while reading reserved range')
+  await page.evaluate(() => new Promise(r =>
+    requestAnimationFrame(() => requestAnimationFrame(() => setTimeout(r, 120)))))
+
+  const after = await measure(page)
+  expect(after.lastUserText).toBe('Third message while reading reserved range')
+  expect(Math.abs(after.scrollTop - savedTop)).toBeLessThanOrEqual(8)
+})
+
 // ───────────────────────────────────────────────────────────────────
-// Short chat at its real-content tail — the second send pins too
+// Short chat already at the one physical tail — the second send pins too
 // ───────────────────────────────────────────────────────────────────
 
-test('Short chat at the real-content tail pins the next send', async ({ page }) => {
+test('Short chat at the physical tail pins the next send', async ({ page }) => {
   await setup(page)
   await newChat(page)
 
   // The first send pins and its short reply leaves a permanent reservation.
-  // The content itself still fits: the reader is at its real-content tail.
+  // The exact spacer keeps that pin at the one physical clamp.
   await routeStream(page, [{ type: 'catch_up_done' }, { type: 'text', content: 'Short reply.' }, { type: 'done' }])
   await sendMessage(page, 'First short')
   await waitStreamDone(page)
 
-  // The chat fits the viewport, so its real-content bottom is already visible.
+  // The chat fits the viewport and already rests at the physical bottom.
   const fits = await measure(page)
   const fitsGap = fits.scrollH - fits.scrollTop - fits.clientH
-  expect(fitsGap).toBeLessThan(50)
+  expect(Math.abs(fitsGap)).toBeLessThanOrEqual(4)
 
   await routeStream(page, [{ type: 'catch_up_done' }, { type: 'text', content: 'Another short.' }, { type: 'done' }])
   await sendMessage(page, 'Second short')

--- a/tests/spacer.spec.mjs
+++ b/tests/spacer.spec.mjs
@@ -256,7 +256,7 @@ test.describe('Spacer mechanics', () => {
     assertSpacerReasonable(m)
   })
 
-  test('2. Second message at the content tail retargets the spacer and pins', async ({ page }) => {
+  test('2. Second message at the physical tail retargets the spacer and pins', async ({ page }) => {
     await setup(page)
     await newChat(page)
     await sendMessage(page, 'First message')
@@ -281,7 +281,7 @@ test.describe('Spacer mechanics', () => {
     assertSpacerReasonable(m)
   })
 
-  test('3. Repeated messages at the content tail pin deterministically', async ({ page }) => {
+  test('3. Repeated messages at the physical tail pin deterministically', async ({ page }) => {
     await setup(page)
     await newChat(page)
     await sendMessage(page, 'First')
@@ -472,7 +472,7 @@ test.describe('Short responses', () => {
     // Let spacer recalculation settle before next send.
     await page.evaluate(() => new Promise(r => setTimeout(r, 300)))
 
-    // The short transcript is still at its real-content tail, so the next
+    // The short transcript is still at its physical tail, so the next
     // send follows the same geometry rule as every other send: retarget the
     // permanent reservation and pin the new user row.
     await sendMessage(page, 'Follow-up question')
@@ -1239,6 +1239,45 @@ test.describe('Scroll edge cases', () => {
       return s ? s.scrollHeight - s.scrollTop - s.clientHeight : 0
     })
     expect(afterGap).toBeLessThan(50)
+  })
+
+  test('24b. A downward wheel at the clamp re-engages follow without a scroll event', async ({ page }) => {
+    await setup(page)
+    await newChat(page)
+    await sendMessage(page, 'Clamped wheel re-engage test')
+    await injectContent(page, 'Existing streamed content. ', 140)
+
+    const scroll = page.locator('[data-chat-surface="painted"] .chat__scroll')
+    const box = await scroll.boundingBox()
+    expect(box).not.toBeNull()
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2)
+
+    // First establish a genuine reader hold away from the tail.
+    await page.mouse.wheel(0, -500)
+    await expect(scroll).toHaveAttribute('data-scroll-mode', 'ANCHOR_AT', {
+      timeout: 3000,
+    })
+
+    // Browser/app layout may put a held coordinate exactly at the physical
+    // clamp without granting follow. A further downward wheel then emits no
+    // scroll event, but it is still an explicit request to follow the tail.
+    await page.evaluate(() => {
+      const s = document.querySelector('[data-chat-surface="painted"] .chat__scroll')
+      if (s) s.scrollTop = s.scrollHeight
+    })
+    await page.evaluate(() => new Promise(r => requestAnimationFrame(r)))
+    await expect(scroll).toHaveAttribute('data-scroll-mode', 'ANCHOR_AT')
+
+    await page.mouse.wheel(0, 500)
+    await expect(scroll).toHaveAttribute('data-scroll-mode', 'FOLLOW_BOTTOM', {
+      timeout: 3000,
+    })
+
+    await injectContent(page, 'Content after the clamped gesture. ', 20)
+    await expect.poll(async () => page.evaluate(() => {
+      const s = document.querySelector('[data-chat-surface="painted"] .chat__scroll')
+      return s ? s.scrollHeight - s.scrollTop - s.clientHeight : Infinity
+    })).toBeLessThan(50)
   })
 
   test('26. Fresh second send while scrolled up preserves the reading anchor', async ({ page }) => {

--- a/tests/spacer.spec.mjs
+++ b/tests/spacer.spec.mjs
@@ -1265,13 +1265,24 @@ test.describe('Scroll edge cases', () => {
       const s = document.querySelector('[data-chat-surface="painted"] .chat__scroll')
       if (s) s.scrollTop = s.scrollHeight
     })
-    await page.evaluate(() => new Promise(r => requestAnimationFrame(r)))
+    await page.evaluate(() => new Promise(resolve => (
+      requestAnimationFrame(() => requestAnimationFrame(resolve))
+    )))
     await expect(scroll).toHaveAttribute('data-scroll-mode', 'ANCHOR_AT')
+
+    await page.evaluate(() => {
+      const s = document.querySelector('[data-chat-surface="painted"] .chat__scroll')
+      window.__clampedWheelScrollEvents = 0
+      s?.addEventListener('scroll', () => {
+        window.__clampedWheelScrollEvents += 1
+      }, { once: true })
+    })
 
     await page.mouse.wheel(0, 500)
     await expect(scroll).toHaveAttribute('data-scroll-mode', 'FOLLOW_BOTTOM', {
       timeout: 3000,
     })
+    expect(await page.evaluate(() => window.__clampedWheelScrollEvents)).toBe(0)
 
     await injectContent(page, 'Content after the clamped gesture. ', 20)
     await expect.poll(async () => page.evaluate(() => {

--- a/tests/steer-queued.spec.mjs
+++ b/tests/steer-queued.spec.mjs
@@ -727,7 +727,7 @@ test.describe('Steer queued messages (fast-forward into the live turn)', () => {
     expect(pinIndex, JSON.stringify(result.transitions)).toBeGreaterThanOrEqual(0)
     expect(
       result.transitions.slice(pinIndex + 1).some(
-        row => row.event === 'reader:physical-bottom',
+        row => row.event === 'reader:scroll-bottom',
       ),
       JSON.stringify(result.transitions),
     ).toBe(false)


### PR DESCRIPTION
## Summary

- Use the physical scroll tail as the sole pin-on-send boundary for later messages, keeping reserved reply room in the reader distance.
- Re-engage bottom following for end-directed wheel and keyboard input at a clamped tail even when the browser emits no scroll event.
- Align jump-to-latest with the same geometry and add regression coverage for scrolling upward inside reserved reply room.

## Testing

- 2,496 frontend library tests passed on the integrated live source.
- 152 focused ChatView contract tests passed on the staged upstream branch.
- Production frontend build passed on both the live source and staged branch.
- The exact reserved-room send sequence was exercised in an authenticated live shell and preserved `scrollTop` exactly.
- Browser specs are included; their disposable Docker runner is unavailable in the app container, so comprehensive Playwright execution is left to hosted CI.