### PR TITLE
Require explicit approval for each agent-triggered restart

### DIFF
--- a/backend/scripts/seed-skills/recovery.md
+++ b/backend/scripts/seed-skills/recovery.md
@@ -4,6 +4,36 @@ How backend edits load, how to make them permanent, the SQLite migration gotcha,
 
 ---
 
+## Choose the smallest activation action
+
+Do not infer activation from the fact that a task touched platform source.
+Review the exact changed paths and use the smallest matching action:
+
+| Changed surface | Smallest activation |
+|---|---|
+| `/data/shared/theme.css` | Hot-reloads after the theme notification. No build or restart. |
+| Mini-app source under `/data/apps/<slug>/` | Run `apply_app.py`; the compiled app live-swaps. No shell rebuild or server restart. |
+| `frontend/src/` and other frontend build inputs | The watcher rebuilds the served shell, then `shell_apply_now` applies it. A normal save triggers this automatically; source arriving through Git needs a changed frontend file touched. No server restart. |
+| `backend/app/*.py` | After compile checks, tests, and commit, one server restart loads the settled backend revision. |
+| `skill/core.md` | A server restart refreshes the cached constitution for new agent sessions only; existing sessions keep their immutable prompt snapshot. Unless new sessions need the rule immediately, leave it pending for the next separately approved restart. |
+| `backend/scripts/`, tests, docs, and shared skill content | Takes effect on its next invocation or read. No server restart. An agent that already read old instructions cannot be rewritten in place. |
+| `backend/requirements.txt`, `frontend/package.json`, or `Dockerfile` | Requires a container rebuild; a server restart is insufficient. Prefer code changes when a dependency is not genuinely necessary. |
+
+### Activation preflight — before any restart question
+
+1. List the exact paths changed for the current task and whether a later owner
+   action has already activated them.
+2. Map every path through the table above. If none still requires a server
+   restart, do not offer one. Never substitute a restart for hot reload, app
+   apply, shell rebuild, or container rebuild.
+3. Batch every restart-requiring edit, test it, and commit it before asking.
+   Do not restart between iterations or request a speculative restart.
+4. In the question, name the exact change that remains inactive and why only a
+   server restart can activate it. For a constitution-only change, default to
+   leaving it pending unless the partner needs the rule in new sessions now.
+
+---
+
 ## Backend edits — restart to load, hand off persistence
 
 The live backend is `/data/platform/backend/app/*.py`. Edits there take effect
@@ -30,10 +60,32 @@ All chat-persistence writes must route through the `chat_writer` actor — never
 ### The backend-fix loop
 
 1. Edit `/data/platform/backend/app/...py` in place; `py_compile` it.
-2. If the main shell is healthy, ask the partner to open Settings -> Server and click **"Restart server"** (POSTs `/api/admin/restart`).
-3. If the edited tree fails to import, the baked shell stays available. Ask the partner to refresh and use the repair chat to diagnose `/data/platform`.
-4. Restart takes ~5–15s; the page auto-reloads when healthy.
-5. Verify the fix in the original chat (still open, full history intact).
+2. Test first, then commit only the intended platform paths.
+3. Run the activation preflight above. Only if it proves that the settled
+   backend change is not live, stop and ask through the clarifying-question
+   tool immediately before restarting. Explain that the restart interrupts
+   every active agent turn, name the current number of running turns when
+   known, and warn that service may be unavailable for tens of seconds. Then
+   offer **Restart now** and **Not now**. Approval of the task, a broad "go
+   ahead" or "fix it", "just go with your recommendations", or delegation of
+   the complete backend-fix loop does not approve a restart.
+
+   A **Restart now** answer authorizes exactly one safe restart call:
+
+   ```bash
+   curl -fsS -X POST "$API_BASE_URL/api/admin/restart" \
+     -H "Authorization: Bearer $AGENT_TOKEN" \
+     -H "Content-Type: application/json"
+   ```
+
+   The current tool call ends as the worker exits and Möbius resumes the turn.
+   A second restart, or an ambiguous outcome where you cannot prove whether the
+   call reached the server, requires a new question. A background or scheduled
+   agent cannot use the live question tool, so it must leave the restart pending
+   for the partner rather than calling this route.
+4. If the edited tree fails to import, the baked shell stays available. Ask the partner to refresh and diagnose `/data/platform` in place.
+5. Restart time varies with active work and boot time; the page auto-reloads when healthy.
+6. Verify the fix in the original chat (still open, full history intact).
 
 ---
 

--- a/backend/scripts/seed-skills/recovery.md
+++ b/backend/scripts/seed-skills/recovery.md
@@ -17,7 +17,31 @@ Review the exact changed paths and use the smallest matching action:
 | `backend/app/*.py` | After compile checks, tests, and commit, one server restart loads the settled backend revision. |
 | `skill/core.md` | A server restart refreshes the cached constitution for new agent sessions only; existing sessions keep their immutable prompt snapshot. Unless new sessions need the rule immediately, leave it pending for the next separately approved restart. |
 | `backend/scripts/`, tests, docs, and shared skill content | Takes effect on its next invocation or read. No server restart. An agent that already read old instructions cannot be rewritten in place. |
-| `backend/requirements.txt`, `frontend/package.json`, or `Dockerfile` | Requires a container rebuild; a server restart is insufficient. Prefer code changes when a dependency is not genuinely necessary. |
+| A package needed by the current task | Install it into the running container first when safe. A new process can use it immediately; restart the server only when the already-running backend must load it. |
+| `backend/requirements.txt`, lockfiles, `frontend/package.json`, or `Dockerfile` | These declarations make a live install reproducible after container replacement; they do not activate it and do not require an immediate rebuild. |
+
+### Dependencies — live first, durable second
+
+1. Run `sudo -n true` once. Use `sudo` for apt or other system/global install
+   locations, not for ordinary writes under `/data`, which must remain
+   partner-owned.
+2. Use the owning package manager to install only the named dependency, pinned
+   to the intended version when possible. Do not run blanket upgrades or
+   ad-hoc remote installers. Put Python packages in the active interpreter and
+   Node packages in the active runtime dependency tree; a global Node install
+   does not satisfy a project's imports. Verify the import, executable, or
+   version. New processes can use the install immediately. A long-running
+   backend needs one approved server restart only when it must load the new
+   package itself.
+3. If shipped behavior depends on the package, record the same resolution in
+   the owning manifest and lockfile, plus the Dockerfile only when image wiring
+   is needed. These declarations are durability metadata, not an activation
+   action: they let a future image/container replacement restore the live
+   install.
+4. Treat a container rebuild as a last resort, not an ordinary closeout step.
+   Require it now only when the change genuinely cannot activate live (for
+   example a base-image/ABI change or an artifact produced only by an image
+   build), or when the partner explicitly asks to validate the image.
 
 ### Activation preflight — before any restart question
 
@@ -25,7 +49,7 @@ Review the exact changed paths and use the smallest matching action:
    action has already activated them.
 2. Map every path through the table above. If none still requires a server
    restart, do not offer one. Never substitute a restart for hot reload, app
-   apply, shell rebuild, or container rebuild.
+   apply, shell rebuild, live dependency install, or container rebuild.
 3. Batch every restart-requiring edit, test it, and commit it before asking.
    Do not restart between iterations or request a speculative restart.
 4. In the question, name the exact change that remains inactive and why only a

--- a/backend/scripts/seed-skills/theming.md
+++ b/backend/scripts/seed-skills/theming.md
@@ -92,7 +92,7 @@ import { ArrowUp, ChevronDown, Mic, Paperclip, X } from '@openai/apps-sdk-ui/com
 <button><ArrowUp width={20} height={20} /></button>
 ```
 
-The SDK components accept normal SVG props; set `width` and `height` explicitly at the call site when the surrounding CSS does not own the size. Keep provider logos, brand marks, progress graphics, and purpose-built state illustrations custom when the SDK has no honest semantic match. Inline path data is otherwise brittle, hard to review, and easy to size inconsistently. Dependency additions belong in the repo/image, not as runtime installs.
+The SDK components accept normal SVG props; set `width` and `height` explicitly at the call site when the surrounding CSS does not own the size. Keep provider logos, brand marks, progress graphics, and purpose-built state illustrations custom when the SDK has no honest semantic match. Inline path data is otherwise brittle, hard to review, and easy to size inconsistently. Install a needed dependency into the live runtime first when safe, and declare/lock it in the repo when shipped behavior depends on it; do not require an immediate container rebuild merely because the declaration changed.
 
 ---
 

--- a/backend/tests/test_chat_skills_context.py
+++ b/backend/tests/test_chat_skills_context.py
@@ -175,7 +175,21 @@ def test_restart_guidance_requires_activation_proof_and_fresh_approval():
   assert "## Choose the smallest activation action" in recovery
   assert "No shell rebuild or server restart" in recovery
   assert "No server restart" in recovery
-  assert "a server restart is insufficient" in recovery
+  assert "### Dependencies — live first, durable second" in recovery
+  assert "install only the named dependency" in recovery
+  assert "Do not run blanket upgrades or ad-hoc remote installers" in (
+    normalized_recovery
+  )
+  assert "a global Node install does not satisfy a project's imports" in (
+    normalized_recovery
+  )
+  assert "not for ordinary writes under `/data`" in recovery
+  assert "the owning manifest and lockfile" in recovery
+  assert "These declarations are durability metadata, not an activation action" in (
+    normalized_recovery
+  )
+  assert "Treat a container rebuild as a last resort" in recovery
+  assert "do not require an immediate rebuild" in recovery
   assert "Do not restart between iterations" in recovery
   assert "For a constitution-only change, default to leaving it pending" in (
     normalized_recovery

--- a/backend/tests/test_chat_skills_context.py
+++ b/backend/tests/test_chat_skills_context.py
@@ -157,6 +157,43 @@ def test_core_prompt_owns_freshness_and_source_policy():
   assert "Cite the supporting link close to the claim" in core
 
 
+def test_restart_guidance_requires_activation_proof_and_fresh_approval():
+  repo = Path(__file__).resolve().parents[2]
+  core = (repo / "skill" / "core.md").read_text(encoding="utf-8")
+  recovery = (
+    repo / "backend" / "scripts" / "seed-skills" / "recovery.md"
+  ).read_text(encoding="utf-8")
+  normalized_core = " ".join(core.split())
+  normalized_recovery = " ".join(recovery.split())
+
+  assert "**Server restarts**: ALWAYS ask" in core
+  assert "If no changed runtime owner requires a restart, do not offer one" in (
+    normalized_core
+  )
+  assert "immediately before each restart" in normalized_core
+  assert "authorizes one restart call only" in normalized_core
+  assert "## Choose the smallest activation action" in recovery
+  assert "No shell rebuild or server restart" in recovery
+  assert "No server restart" in recovery
+  assert "a server restart is insufficient" in recovery
+  assert "Do not restart between iterations" in recovery
+  assert "For a constitution-only change, default to leaving it pending" in (
+    normalized_recovery
+  )
+  assert (
+    "A **Restart now** answer authorizes exactly one safe restart call"
+    in recovery
+  )
+  assert "A second restart" in recovery
+  assert "service may be unavailable for tens of seconds" in normalized_recovery
+  assert "delegation of the complete backend-fix loop does not approve" in (
+    normalized_recovery
+  )
+  assert "explicitly delegated the restart or the complete backend-fix loop" not in (
+    core + recovery
+  )
+
+
 def test_owned_app_skill_summaries_expose_complete_initial_read_sets():
   repo = Path(__file__).resolve().parents[2]
   seed_dir = repo / "backend" / "scripts" / "seed-skills"

--- a/skill/core.md
+++ b/skill/core.md
@@ -43,7 +43,7 @@ that the available local tools can establish directly.
 
 Keep these boundaries always-on:
 
-- Frontend source rebuilds automatically; backend Python and this constitution require a server restart; dependency/image changes require a container rebuild.
+- Frontend source rebuilds automatically; backend Python and this constitution require a server restart. Install task dependencies into the running container when safe; declarations make them reproducible after container replacement, while an immediate container rebuild is a last resort for changes that cannot activate live.
 - Mini-app source and shared data under `/data/apps/` and `/data/shared/` are editable. Never read or write `/data/cli-auth/` or `/data/.secret-key`.
 - A broken edited platform falls back visibly to the baked shell. Ask the partner to refresh, then use a repair chat to diagnose the preserved `/data/platform` tree.
 - All writes to `Chat.messages` or `Chat.pending_messages` MUST use `chat_writer.py` domain commands; never assign either JSON column directly. Read that module's docstring before changing chat persistence.
@@ -213,7 +213,7 @@ Partner-facing messages describe what the app does and how it feels, not how it'
 - `$API_BASE_URL` — backend URL
 - `$SCRIPTS_DIR` — helper scripts directory
 - `$VIEWPORT_WIDTH` / `$VIEWPORT_HEIGHT` — the partner's actual app viewport (set when the shell sends it; required for screenshots)
-- **System packages and root work**: full in-container root is available by default, but first run `sudo -n true` and use `sudo` deliberately for the task. If it fails, do not try to bypass it; the deployment operator has disabled root and must recreate the container to re-enable it. Runtime package changes are ephemeral until declared in the image.
+- **System packages and root work**: full in-container root is available by default, but first run `sudo -n true` and use `sudo` deliberately for system-owned locations. Do not use it for ordinary writes under `/data`, which should remain partner-owned. Install needed apt packages, Python packages into the active interpreter, and Node packages into the active runtime dependency tree when safe; use `sudo` only when that target is root-owned. New processes can use the live install immediately, and it survives a server restart. If shipped behavior depends on it, also declare and lock it so a future container replacement restores it. Rebuild the container now only when the dependency cannot activate live or the partner explicitly asks to validate the image. If `sudo -n true` fails, do not try to bypass it; the deployment operator has disabled root and must recreate the container to re-enable it.
 
 ### Chat rendering
 

--- a/skill/core.md
+++ b/skill/core.md
@@ -106,16 +106,32 @@ Name key decisions, give a concrete recommendation for each. Lead with the recom
 
 > **Carve-out for reports/digests from a background or morning run.** This live-chat rule is for an *interactive* turn with the partner present. A background/scheduled/morning agent (News, Reflection) must NOT call `AskUserQuestion`: with no one watching the turn, it parks a synchronous in-memory future that a server reset orphans, freezing the run. Such agents put questions in the report **declaratively** — a `<script type="application/mobius-questions+json">` carrier in the report HTML — and the app renders tap cards whose answers persist for the agent's NEXT run. Questions there are optional: zero cards is a normal report, several are fine when they're real, and an unanswered card never blocks the next run (risky or irreversible changes still wait for an explicit yes). Never a live `AskUserQuestion` from a background agent.
 
-### 3. Wait for approval only on vibe prompts, destructive ops, and investigative questions
+### 3. Wait for approval on vibe prompts, disruptive/destructive ops, and investigative questions
 
 - **Obvious-defaults and Material-choice prompts** (specific-app): keep building.
 - **Vibe prompts**: wait for the partner to pick through the
   clarifying-question tool. Do not end with recommendations alone.
+- **Server restarts**: ALWAYS ask through the clarifying-question tool
+  immediately before each restart. Before asking, use the recovery skill's
+  activation preflight to identify the exact changed path that still requires a
+  server restart; hot reload, mini-app apply, shell rebuild, and container
+  rebuild are distinct actions, and a change that needs one of them does not
+  justify a restart. If no changed runtime owner requires a restart, do not
+  offer one. Approval of the task, a broad "go ahead" or "fix it", "just go
+  with your recommendations", or delegation of the complete backend-fix loop
+  does not approve a restart. Explain what remains inactive, that active agent
+  work will be interrupted, name the current number of running turns when
+  known, warn that service may be unavailable for tens of seconds, then offer
+  **Restart now** and **Not now**. A **Restart now** answer authorizes one
+  restart call only; a second restart or an ambiguous call outcome needs a
+  fresh question. A background or scheduled agent cannot ask synchronously, so
+  it must leave the restart pending for the partner instead of performing it.
 - **Destructive or irreversible ops**: ALWAYS wait, regardless of specificity — anything that deletes partner data, alters auth/credentials, modifies the shell in a way that needs recover to undo, notifies other people, or hits paid external APIs. "Build a confident default" applies to building, not destroying. Cleaning up your own test fixtures is fine; deleting the partner's real data is not.
 - **Investigative questions** ("why?", "what caused this?", "how should we improve this?"): answer first. Do not mutate memory notes, theme, shell, or settings unless the partner explicitly approves. A question is not an implicit go-ahead.
 - **Open-ended critique / under-determined restyle** ("what's wrong with this?", "make it feel more natural"): treat as vibe/investigative (above) — but the specific failure is a confident WRONG guess: a multi-file change + notification aimed at the wrong defect or direction, corrected twice. When the target is genuinely ambiguous, pin it down first — a deliberately minimal pass you can cheaply course-correct, or one `AskUserQuestion` with concrete options — before a full build + notify.
 
-"Just go with your recommendations" counts as approval.
+"Just go with your recommendations" counts as approval except for a server
+restart, which always needs its own immediately preceding question-card answer.
 
 ### 4. Build on the approved plan — and stay inside it
 


### PR DESCRIPTION
## Summary

- require agents to prove a server restart is the smallest necessary activation action
- distinguish hot reload, mini-app apply, shell rebuild, server restart, and container rebuild
- require a fresh, single-use question-card approval immediately before every agent-triggered restart
- leave constitution-only restarts pending by default and prevent background agents from restarting

## Tests

- `scripts/wt-pytest.sh backend/tests/test_chat_skills_context.py --tb=short -q`
- `scripts/test.sh --fast`