### PR TITLE
Verify local app packages before sharing

### DIFF
--- a/backend/app/app_apply.py
+++ b/backend/app/app_apply.py
@@ -301,6 +301,7 @@ async def apply_source_revision(
         app.jsx_source,
         app.compiled_path,
         app.source_commit,
+        app.share_manifest_url,
         app.icon_png,
         app.icon_override_png,
       )
@@ -349,6 +350,14 @@ async def apply_source_revision(
       # the accepted-ahead retry, ``committed`` is None and the candidate
       # parent is the already-accepted tip.
       app.source_commit = committed or candidate.parent_sha
+      if (
+        app.manifest_url is None
+        and app.source_commit != previous_state[7]
+      ):
+        # A share URL is a statement about one exact accepted package. Once
+        # local source advances, require publication verification again rather
+        # than silently offering a stale repository to other people.
+        app.share_manifest_url = None
       published = publish_staged_bundle(app.id, staged)
       staged = None
 
@@ -364,6 +373,7 @@ async def apply_source_revision(
           source,
           str(published),
           app.source_commit,
+          app.share_manifest_url,
           app.icon_png,
           app.icon_override_png,
         )

--- a/backend/app/install.py
+++ b/backend/app/install.py
@@ -1049,6 +1049,112 @@ def _install_candidate_digest(
   return digest.hexdigest()
 
 
+def package_content_digest(
+  *,
+  manifest: dict,
+  entry_bytes: bytes,
+  icon_processed: bytes | None,
+  bundled_job: bytes | None,
+  static_assets: dict[str, bytes],
+  source_files: dict[str, bytes],
+  seeds: dict[str, bytes],
+) -> str:
+  """Bind every installable package byte without binding its public URL.
+
+  Install replay deliberately includes ``raw_base`` because a moved upstream
+  is a different replay input. Publication verification has the opposite
+  requirement: compare an accepted local package with the same bytes fetched
+  from its eventual public location. Reuse the install digest with one stable
+  empty origin so future package fields cannot silently drift between those
+  two comparisons.
+  """
+  return _install_candidate_digest(
+    manifest=manifest,
+    raw_base="",
+    entry_bytes=entry_bytes,
+    icon_processed=icon_processed,
+    bundled_job=bundled_job,
+    static_assets=static_assets,
+    source_files=source_files,
+    seeds=seeds,
+  )
+
+
+class PackageContentError(ValueError):
+  """An accepted source tree cannot reproduce its declared install package."""
+
+
+def package_content_digest_from_tree(
+  tree: dict[str, bytes],
+) -> tuple[str, str]:
+  """Return manifest identity + package digest from an immutable source tree.
+
+  This is the local half of publication verification. Keep it beside the
+  fetch/install implementation so every declared package input has one owner
+  when the manifest contract grows.
+  """
+  try:
+    manifest = json.loads(tree["mobius.json"])
+    validate_manifest_contract(manifest)
+  except (
+    KeyError, UnicodeDecodeError, json.JSONDecodeError, ManifestContractError,
+  ) as exc:
+    raise PackageContentError("invalid or missing mobius.json") from exc
+
+  def required_bytes(relative: str, field: str) -> bytes:
+    try:
+      return tree[relative]
+    except KeyError as exc:
+      raise PackageContentError(
+        f"missing declared {field} file ({relative})",
+      ) from exc
+
+  entry_bytes = required_bytes(manifest["entry"], "entry")
+  source_files = {
+    relative: required_bytes(relative, "source_files")
+    for relative in manifest.get("source_files") or []
+  }
+  schedule = manifest.get("schedule")
+  job_name = schedule.get("job") if isinstance(schedule, dict) else None
+  bundled_job = required_bytes(job_name, "schedule job") if job_name else None
+
+  icon_processed = None
+  icon_name = manifest.get("icon")
+  if icon_name:
+    try:
+      icon_processed = icon_assets.normalize_icon(
+        required_bytes(icon_name, "icon"),
+      )
+    except icon_assets.InvalidIcon as exc:
+      raise PackageContentError("invalid declared icon") from exc
+
+  static_assets = {
+    destination: required_bytes(relative, "static asset")
+    for destination, relative in static_asset_entries(
+      manifest.get("static_assets") or {},
+    ).items()
+  }
+  seeds: dict[str, bytes] = {}
+  for destination, value in (manifest.get("storage_seeds") or {}).items():
+    seeds[destination] = (
+      json.dumps(
+        value, ensure_ascii=False, sort_keys=True, separators=(",", ":"),
+      ).encode("utf-8")
+      if _seed_value_is_inline(value)
+      else required_bytes(value, "storage seed")
+    )
+
+  return manifest["id"], package_content_digest(
+    manifest=manifest,
+    entry_bytes=entry_bytes,
+    icon_processed=icon_processed,
+    bundled_job=bundled_job,
+    static_assets=static_assets,
+    source_files=source_files,
+    seeds=seeds,
+  )
+
+
 def _source_review_digest(
   *,
   manifest: dict,
@@ -1758,6 +1864,19 @@ class InstallCandidate:
   source_review_digest: str
 
 
+def install_candidate_content_digest(candidate: InstallCandidate) -> str:
+  """Return the origin-independent package digest for one fetched candidate."""
+  return package_content_digest(
+    manifest=candidate.manifest,
+    entry_bytes=candidate.entry_bytes,
+    icon_processed=candidate.icon_processed,
+    bundled_job=candidate.bundled_job,
+    static_assets=candidate.static_assets,
+    source_files=candidate.source_files,
+    seeds=candidate.seeds,
+  )
+
+
 @dataclass(frozen=True)
 class InstallTarget:
   """Identity decision made before any database or filesystem mutation."""
@@ -2007,6 +2126,20 @@ async def _fetch_install_candidate(
     capability_digest=capability_digest,
     candidate_digest=candidate_digest,
     source_review_digest=source_review_digest,
+  )
+
+
+async def fetch_install_candidate(manifest_url: str) -> InstallCandidate:
+  """Fetch the exact package the installer would use, without installing it."""
+  return await _fetch_install_candidate(
+    manifest_url=manifest_url,
+    manifest=None,
+    raw_base=None,
+    reviewed_capability_digest=None,
+    reviewed_source_digest=None,
+    expected_app_id=None,
+    expected_upstream_commit=None,
+    expected_candidate_digest=None,
   )
 
 

--- a/backend/app/routes/apps.py
+++ b/backend/app/routes/apps.py
@@ -613,6 +613,45 @@ def _recorded_runtime_paths(previous_tree: dict[str, bytes]) -> set[str]:
   return paths
 
 
+def _accepted_local_share_package(app: models.App) -> tuple[str, str]:
+  """Return accepted manifest identity + origin-independent package digest.
+
+  A local worktree is a draft. Sharing must compare the public package with the
+  immutable commit that produced the live bundle, not with files an agent may
+  be editing for the next apply. The digest mirrors every installer input:
+  manifest, entry, icon, job, source modules, static assets, and storage seeds.
+  """
+  from app import install
+
+  if not app.source_commit or not app.source_dir:
+    raise HTTPException(
+      409,
+      {
+        "code": "share_source_unavailable",
+        "message": "Apply the local app source before attaching a share URL.",
+      },
+    )
+  try:
+    tree = app_git.read_ref_tree(app.source_dir, app.source_commit)
+    return install.package_content_digest_from_tree(tree)
+  except (
+    install.PackageContentError,
+    OSError,
+    RuntimeError,
+    subprocess.SubprocessError,
+  ) as exc:
+    raise HTTPException(
+      409,
+      {
+        "code": "share_source_unavailable",
+        "message": (
+          "The accepted local package could not be reproduced. Apply its "
+          "complete source again before attaching a share URL."
+        ),
+      },
+    ) from exc
+
+
 def _git_path_exists(repo: Path, name: str) -> bool:
   """Whether git reports an internal path that currently exists."""
   proc = app_git._run(repo, "rev-parse", "--git-path", name, check=False)
@@ -2045,6 +2084,27 @@ async def update_app(
   _: models.Owner = Depends(get_current_owner),
 ):
   """Update owner-controlled app metadata and narrow permission grants."""
+  from app import install
+
+  share_candidate = None
+  if body.share_manifest_url:
+    # Prove the row exists and is local before spending a network fetch. Close
+    # the request session before that I/O so a slow publisher cannot occupy a
+    # database connection or either lifecycle lock.
+    existing = live_app_or_404(db, app_id)
+    if existing.manifest_url is not None:
+      raise HTTPException(
+        409,
+        {
+          "code": "share_requires_local_app",
+          "message": "Only a local app can attach a separate share URL.",
+        },
+      )
+    db.close()
+    share_candidate = await install.fetch_install_candidate(
+      body.share_manifest_url,
+    )
+
   async with (
     fs_locks.install_uninstall_lock(),
     fs_locks.app_storage_lock(app_id),
@@ -2065,6 +2125,44 @@ async def update_app(
     if body.chat_log_access is not None:
       app.chat_log_access = body.chat_log_access
     if body.share_manifest_url is not None:
+      if share_candidate is not None:
+        if app.manifest_url is not None:
+          raise HTTPException(
+            409,
+            {
+              "code": "share_requires_local_app",
+              "message": "Only a local app can attach a separate share URL.",
+            },
+          )
+        accepted_id, accepted_digest = await asyncio.to_thread(
+          _accepted_local_share_package, app,
+        )
+        if share_candidate.manifest["id"] != accepted_id:
+          raise HTTPException(
+            409,
+            {
+              "code": "share_identity_mismatch",
+              "message": (
+                "The published manifest belongs to a different app. Publish "
+                "this app's accepted package before attaching its share URL."
+              ),
+            },
+          )
+        published_digest = install.install_candidate_content_digest(
+          share_candidate,
+        )
+        if published_digest != accepted_digest:
+          raise HTTPException(
+            409,
+            {
+              "code": "share_package_mismatch",
+              "message": (
+                "The published package does not match the app's accepted "
+                "revision. Publish the current package before attaching its "
+                "share URL."
+              ),
+            },
+          )
       app.share_manifest_url = body.share_manifest_url or None
     if body.manage_skills is not None:
       # Downgrade-only: the owner can revoke skills authority here (effective

--- a/backend/app/routes/github.py
+++ b/backend/app/routes/github.py
@@ -551,6 +551,7 @@ async def github_source_status(
     "slug": row.slug,
     "version": row.version,
     "manifest_url": row.manifest_url,
+    "share_manifest_url": row.share_manifest_url,
     "source_dir": row.source_dir,
   } for row in rows]
 

--- a/backend/app/source_status.py
+++ b/backend/app/source_status.py
@@ -616,6 +616,9 @@ def build_app_status(app: dict[str, Any]) -> dict[str, Any] | None:
     # A corrupt DB path must not turn this narrow metadata surface into an
     # arbitrary filesystem probe.
     return None
+  repository_manifest_url = (
+    app.get("manifest_url") or app.get("share_manifest_url")
+  )
   return _project_status(
     repo=source_dir,
     kind="app",
@@ -623,7 +626,9 @@ def build_app_status(app: dict[str, Any]) -> dict[str, Any] | None:
     name=str(app.get("name") or app.get("slug") or "Unnamed app"),
     slug=str(app.get("slug") or "") or None,
     version=str(app.get("version") or "") or None,
-    manifest_url=(str(app.get("manifest_url")) if app.get("manifest_url") else None),
+    manifest_url=(
+      str(repository_manifest_url) if repository_manifest_url else None
+    ),
   )
 
 

--- a/backend/tests/test_app_apply.py
+++ b/backend/tests/test_app_apply.py
@@ -416,6 +416,30 @@ def test_reapply_unchanged_source_has_no_commit_or_timestamp_change(
   assert app_git.head_sha(source, app_git.LOCAL_BRANCH) == head
 
 
+def test_local_source_revision_clears_previously_verified_share_url(
+  client, auth, db,
+):
+  source = _source()
+  created = _apply(client, auth, source)
+  app_id = created.json()["app"]["id"]
+  row = db.query(models.App).populate_existing().filter_by(id=app_id).one()
+  row.share_manifest_url = (
+    "https://raw.githubusercontent.com/example/demo/main/mobius.json"
+  )
+  db.commit()
+  (source / "index.jsx").write_text(
+    "export default function App() { return <div>second</div> }\n"
+  )
+
+  updated = _apply(client, auth, source)
+
+  assert updated.status_code == 200, updated.text
+  assert updated.json()["mode"] == "updated"
+  assert updated.json()["app"]["share_manifest_url"] is None
+  db.refresh(row)
+  assert row.share_manifest_url is None
+
+
 def test_local_manifest_identity_is_immutable(client, auth, db):
   source = _source()
   created = _apply(client, auth, source)

--- a/backend/tests/test_apps.py
+++ b/backend/tests/test_apps.py
@@ -1,10 +1,12 @@
 """App registry lifecycle tests."""
 
+import json
 from copy import deepcopy
+from dataclasses import replace
 from pathlib import Path
-from unittest.mock import call, patch
+from unittest.mock import AsyncMock, call, patch
 
-from app import models
+from app import app_git, install, models
 from app.config import get_settings
 from app.database import engine
 from sqlalchemy import event
@@ -14,6 +16,71 @@ from test_app_fixtures import create_local_app
 def _service_auth():
   token = (Path(get_settings().data_dir) / "service-token.txt").read_text()
   return {"Authorization": f"Bearer {token}"}
+
+
+def _published_candidate(row: models.App) -> install.InstallCandidate:
+  tree = app_git.read_ref_tree(row.source_dir, row.source_commit)
+  manifest = json.loads(tree["mobius.json"])
+  return install.InstallCandidate(
+    manifest=manifest,
+    raw_base="https://raw.githubusercontent.com/example/app/main/",
+    entry_bytes=tree[manifest["entry"]],
+    icon_processed=None,
+    icon_warning=None,
+    bundled_job=None,
+    static_assets={},
+    source_files={},
+    seeds={},
+    capability_contract={},
+    capability_digest="test-capabilities",
+    candidate_digest="test-candidate",
+    source_review_digest="test-source",
+  )
+
+
+def test_package_content_digest_from_tree_covers_declared_package_inputs():
+  manifest = {
+    "id": "package-digest",
+    "name": "Package digest",
+    "version": "1.0.0",
+    "description": "test",
+    "entry": "index.jsx",
+    "permissions": {},
+    "capabilities": {},
+    "source_files": ["helper.js"],
+    "schedule": {"job": "job.sh"},
+    "static_assets": {"logo.txt": "assets/logo.txt"},
+    "storage_seeds": {
+      "settings.json": {"enabled": True},
+      "prompt.md": "prompt.md",
+    },
+  }
+  tree = {
+    "mobius.json": json.dumps(manifest).encode(),
+    "index.jsx": b"export default 1\n",
+    "helper.js": b"export const helper = 1\n",
+    "job.sh": b"#!/bin/sh\n",
+    "assets/logo.txt": b"logo\n",
+    "prompt.md": b"prompt\n",
+  }
+
+  manifest_id, digest = install.package_content_digest_from_tree(tree)
+
+  assert manifest_id == "package-digest"
+  assert digest == install.package_content_digest(
+    manifest=manifest,
+    entry_bytes=tree["index.jsx"],
+    icon_processed=None,
+    bundled_job=tree["job.sh"],
+    static_assets={"logo.txt": tree["assets/logo.txt"]},
+    source_files={"helper.js": tree["helper.js"]},
+    seeds={
+      "settings.json": b'{"enabled":true}',
+      "prompt.md": tree["prompt.md"],
+    },
+  )
+  changed_tree = {**tree, "assets/logo.txt": b"different\n"}
+  assert install.package_content_digest_from_tree(changed_tree)[1] != digest
 
 
 def test_apply_app_rejects_cross_site_request(client, auth):
@@ -62,27 +129,96 @@ def test_update_app_attaches_share_url_without_changing_install_identity(
     client, auth, name="Published later", description="test",
   )
   share_url = "https://raw.githubusercontent.com/example/app/main/mobius.json"
-
-  response = client.patch(
-    f"/api/apps/{app['id']}",
-    json={"share_manifest_url": share_url},
-    headers=auth,
-  )
-
-  assert response.status_code == 200, response.text
-  assert response.json()["share_manifest_url"] == share_url
-  assert response.json()["manifest_url"] is None
   row = db.query(models.App).filter(models.App.id == app["id"]).one()
-  assert row.share_manifest_url == share_url
-  assert row.manifest_url is None
+  candidate = _published_candidate(row)
 
-  cleared = client.patch(
-    f"/api/apps/{app['id']}",
-    json={"share_manifest_url": ""},
-    headers=auth,
+  fetch = AsyncMock(return_value=candidate)
+  with patch("app.install.fetch_install_candidate", new=fetch):
+    response = client.patch(
+      f"/api/apps/{app['id']}",
+      json={"share_manifest_url": share_url},
+      headers=auth,
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["share_manifest_url"] == share_url
+    assert response.json()["manifest_url"] is None
+    db.refresh(row)
+    assert row.share_manifest_url == share_url
+    assert row.manifest_url is None
+
+    cleared = client.patch(
+      f"/api/apps/{app['id']}",
+      json={"share_manifest_url": ""},
+      headers=auth,
+    )
+    assert cleared.status_code == 200, cleared.text
+    assert cleared.json()["share_manifest_url"] is None
+  fetch.assert_awaited_once_with(share_url)
+
+
+def test_update_app_rejects_share_package_that_is_not_the_accepted_revision(
+  client, auth, db,
+):
+  app = create_local_app(
+    client, auth, name="Stale publication", description="test",
   )
-  assert cleared.status_code == 200, cleared.text
-  assert cleared.json()["share_manifest_url"] is None
+  row = db.query(models.App).filter(models.App.id == app["id"]).one()
+  candidate = _published_candidate(row)
+  candidate = replace(candidate, entry_bytes=b"export default 'stale'\n")
+
+  with patch(
+    "app.install.fetch_install_candidate",
+    new=AsyncMock(return_value=candidate),
+  ):
+    response = client.patch(
+      f"/api/apps/{app['id']}",
+      json={
+        "share_manifest_url": (
+          "https://raw.githubusercontent.com/example/app/main/mobius.json"
+        ),
+      },
+      headers=auth,
+    )
+
+  assert response.status_code == 409, response.text
+  assert response.json()["detail"]["code"] == "share_package_mismatch"
+  db.expire_all()
+  assert (
+    db.query(models.App).filter(models.App.id == app["id"]).one()
+    .share_manifest_url
+  ) is None
+
+
+def test_update_app_rejects_share_manifest_for_a_different_app(
+  client, auth, db,
+):
+  app = create_local_app(
+    client, auth, name="Identity publication", description="test",
+  )
+  row = db.query(models.App).filter(models.App.id == app["id"]).one()
+  candidate = _published_candidate(row)
+  candidate = replace(
+    candidate,
+    manifest={**candidate.manifest, "id": "another-app"},
+  )
+
+  with patch(
+    "app.install.fetch_install_candidate",
+    new=AsyncMock(return_value=candidate),
+  ):
+    response = client.patch(
+      f"/api/apps/{app['id']}",
+      json={
+        "share_manifest_url": (
+          "https://raw.githubusercontent.com/example/app/main/mobius.json"
+        ),
+      },
+      headers=auth,
+    )
+
+  assert response.status_code == 409, response.text
+  assert response.json()["detail"]["code"] == "share_identity_mismatch"
 
 
 def test_update_app_rejects_non_public_share_url(client, auth):

--- a/backend/tests/test_github_routes.py
+++ b/backend/tests/test_github_routes.py
@@ -866,6 +866,45 @@ def test_source_status_requires_github_access_for_app_tokens(
   assert allowed.status_code == 200, allowed.text
 
 
+def test_source_status_projects_local_share_manifest_identity(
+  client, owner_token, auth, monkeypatch,
+):
+  from app import models
+  from app.database import SessionLocal
+
+  app_id, _ = _app_token(client, owner_token)
+  source_dir = Path(get_settings().data_dir) / "apps" / "published-source"
+  source_dir.mkdir(parents=True, exist_ok=True)
+  share_url = (
+    "https://raw.githubusercontent.com/example/published/main/mobius.json"
+  )
+  session = SessionLocal()
+  try:
+    session.query(models.App).filter(models.App.id == app_id).update({
+      "source_dir": str(source_dir),
+      "share_manifest_url": share_url,
+    })
+    session.commit()
+  finally:
+    session.close()
+
+  monkeypatch.setattr(source_status, "build_platform_status", lambda: {
+    "key": "platform", "available": True,
+  })
+
+  def inspect(app):
+    assert app["manifest_url"] is None
+    assert app["share_manifest_url"] == share_url
+    return {"key": f"app:{app['id']}", "name": app["name"]}
+
+  monkeypatch.setattr(source_status, "build_app_status", inspect)
+
+  response = client.get("/api/github/source-status", headers=auth)
+
+  assert response.status_code == 200, response.text
+  assert response.json()["apps"][0]["key"] == f"app:{app_id}"
+
+
 def test_source_status_keeps_healthy_apps_when_one_checkout_fails(
   client, owner_token, auth, monkeypatch,
 ):

--- a/backend/tests/test_source_status.py
+++ b/backend/tests/test_source_status.py
@@ -51,6 +51,7 @@ def _app(repo: Path, *, app_id: int = 7) -> dict:
     "manifest_url": (
       "https://raw.githubusercontent.com/mobius-os/app-demo/main/mobius.json"
     ),
+    "share_manifest_url": None,
     "source_dir": str(repo),
   }
 
@@ -75,6 +76,20 @@ def test_platform_source_status_ignores_unrelated_environment(
 
   assert result["base_ref"] == "origin/main"
   assert "release_ref" not in result
+
+
+def test_local_published_app_uses_share_manifest_as_repository_identity():
+  repo = _repo("published-demo")
+  app = _app(repo)
+  app["manifest_url"] = None
+  app["share_manifest_url"] = (
+    "https://raw.githubusercontent.com/example/published-demo/main/mobius.json"
+  )
+
+  result = source_status.build_app_status(app)
+
+  assert result is not None
+  assert result["canonical_repo"] == "example/published-demo"
 
 
 def test_aligned_and_history_only_ahead_keep_tree_magnitude_zero():


### PR DESCRIPTION
## Summary
- fetch the complete published install candidate before accepting a local app share manifest
- compare its identity and installable package content with the immutable accepted local revision
- clear prior share verification whenever accepted local source advances
- use a local app share manifest as its repository identity in source status

## Testing
- `scripts/test.sh --fast`
- focused publication-verification and source-status tests