### PR TITLE
Keep continuation markers at their completed turn boundary

### DIFF
--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -1177,7 +1177,24 @@ export default function ChatView({
     },
     onStreamEnd: ({ continues, promotedMessage } = {}) => {
       if (embedded && continues === false) setEmbeddedRunActive(false)
-      promoteStreamToMessages()
+      const continuation = continues ? queuedContinuationRef.current : null
+      queuedContinuationRef.current = null
+      const localPromoted = continuation?.rows || null
+      const continuationPinIntent = continuation?.intent || null
+      const promotedRows = continues
+        ? continuationRowsFromPromotedMessage(promotedMessage, localPromoted)
+        : []
+      // Read this before the rows become visible. Continuation markers are not
+      // owner messages, but an ordinary first queued send is.
+      const contIsFirstUser = promotedRows.length > 0
+        ? isFirstVisibleUserMessage()
+        : false
+      const pinCid = promotedRows.length > 0 ? cidOf(promotedRows[0]) : null
+      // The completed assistant and the rows starting its continuation form
+      // one transcript boundary. A restored assistant may be bridged in place
+      // above a newer local row, so committing the following rows separately
+      // at the list tail makes a restart marker flash below that newer row.
+      promoteStreamToMessages({ followingMessages: promotedRows })
       if (continues) {
         // Backend auto-promoted queued follow-ups into the next turn. Newer
         // backend code persists the visible rows separately while sending
@@ -1185,24 +1202,13 @@ export default function ChatView({
         // The local queue was already trimmed when the
         // queued_turn_starting event arrived, so a message queued after
         // that event cannot be accidentally folded into this turn here.
-        const continuation = queuedContinuationRef.current
-        queuedContinuationRef.current = null
-        const localPromoted = continuation?.rows || null
-        const continuationPinIntent = continuation?.intent || null
-        const promotedRows = continuationRowsFromPromotedMessage(
-          promotedMessage,
-          localPromoted,
-        )
         if (promotedRows.length > 0) {
           // A queued continuation is still a user send becoming the active
           // turn, so it follows the same send rule (see shouldPinSend):
           // pin only when first-or-at-physical-tail. Read the first-user check
-          // before the append. When not pinning, leave the reader where
+          // before the boundary commit. When not pinning, leave the reader where
           // the previous turn left them — the continuation just appears
           // below without moving the scroll.
-          const contIsFirstUser = isFirstVisibleUserMessage()
-          const pinCid = cidOf(promotedRows[0])
-          commitMessages(prev => appendMessageBatch(prev, promotedRows))
           promotedRef.current = false
           landSentMessage(pinCid, {
             intent: continuationPinIntent,
@@ -1219,7 +1225,6 @@ export default function ChatView({
         setSending(true)
         setServerRunningState(true)
       } else {
-        queuedContinuationRef.current = null
         setSending(false)
         sendingRef.current = false
         setServerRunningState(false)
@@ -1587,10 +1592,16 @@ export default function ChatView({
   // would duplicate the in-flight content in the final transcript.
   // APPEND otherwise (the normal first-time send path: `prev` ends in
   // a user message, the assistant message hasn't been committed yet).
-  function promoteStreamToMessages({ keepTurnOpen = false } = {}) {
-    if (promotedRef.current && !keepTurnOpen) return
+  function promoteStreamToMessages({
+    keepTurnOpen = false,
+    followingMessages = [],
+  } = {}) {
+    const following = Array.isArray(followingMessages)
+      ? followingMessages.filter(Boolean)
+      : []
+    if (promotedRef.current && !keepTurnOpen && following.length === 0) return
     const items = latestItemsRef.current
-    if (items.length === 0) return
+    if (items.length === 0 && following.length === 0) return
     // A steer can cut over before the assistant emitted any real output — the
     // only buffered item is an empty/whitespace token. Sealing it would leave a
     // stray empty assistant bubble before the steered user row (the card-166
@@ -1632,6 +1643,7 @@ export default function ChatView({
       paintedItems: streamItems,
       promotedItems: items,
       bridgeTs,
+      followingMessages: following,
       commitMessages,
     })
     // force=true bypasses sameMessageList. In the BRIDGE merge path

--- a/frontend/src/components/ChatView/__tests__/streamPromotion.test.js
+++ b/frontend/src/components/ChatView/__tests__/streamPromotion.test.js
@@ -8,6 +8,7 @@ import { assistantAnchorKey, messageKey } from '../../../lib/chatDetailCache.js'
 import {
   streamItemsToAssistantPayload,
   promoteAssistantStream,
+  promoteAssistantStreamWithFollowingMessages,
   assistantStreamCoversMessage,
   messageCoversAssistantStream,
   chooseActiveAssistantSurface,
@@ -149,6 +150,57 @@ test('promoteAssistantStream replaces mounted partial even after steered user ro
   assert.equal(next[1].ts, 2)
   assert.equal(next[1].content, 'updated live stream')
   assert.equal(next[2].content, 'fast-forwarded q2')
+})
+
+test('a restored continuation stays beside its bridged assistant, ahead of newer local rows', () => {
+  const messages = [
+    { role: 'user', ts: 1, content: 'original request' },
+    {
+      role: 'assistant',
+      ts: 2,
+      content: 'Paused for restart',
+      blocks: [{ type: 'error', message: 'Paused for restart' }],
+    },
+    { role: 'user', ts: 4, cid: 'later-owner-row', content: 'newer local request' },
+  ]
+  const marker = {
+    role: 'user',
+    ts: 3,
+    cid: 'restart-resume-run-1',
+    kind: 'continuation',
+    continuation_reason: 'restart',
+    content: 'continue',
+  }
+
+  const next = promoteAssistantStreamWithFollowingMessages(messages, {
+    bridgeTs: 2,
+    items: [{ type: 'error', message: 'Paused for restart' }],
+    followingMessages: [marker],
+  })
+
+  assert.deepEqual(next.map(message => message.ts), [1, 2, 3, 4])
+  assert.equal(next[2], marker)
+  assert.equal(next[3].content, 'newer local request')
+})
+
+test('ordinary queued rows remain after the completed assistant despite older send timestamps', () => {
+  const messages = [
+    { role: 'user', ts: 10, content: 'first request' },
+    { role: 'assistant', ts: 30, content: 'completed response' },
+  ]
+  const queued = { role: 'user', ts: 20, cid: 'queued', content: 'follow-up' }
+
+  const next = promoteAssistantStreamWithFollowingMessages(messages, {
+    items: [],
+    bridgeTs: 30,
+    followingMessages: [queued],
+  })
+
+  assert.deepEqual(next.map(message => message.content), [
+    'first request',
+    'completed response',
+    'follow-up',
+  ])
 })
 
 test('promoteAssistantStream carries persisted question answers by identity', () => {

--- a/frontend/src/components/ChatView/activeAssistantSelection.js
+++ b/frontend/src/components/ChatView/activeAssistantSelection.js
@@ -5,7 +5,7 @@ import {
   chooseActiveAssistantMirrorIndex,
   chooseActiveAssistantSurface,
   findTrailingAssistantPartialIndex,
-  promoteAssistantStream,
+  promoteAssistantStreamWithFollowingMessages,
 } from './streamPromotion.js'
 
 
@@ -99,11 +99,16 @@ export function commitAssistantPromotion({
   paintedItems,
   promotedItems,
   bridgeTs,
+  followingMessages = [],
   commitMessages,
 }) {
   retiredItemsRef.current = paintedItems
   commitMessages(
-    prev => promoteAssistantStream(prev, { items: promotedItems, bridgeTs }),
+    prev => promoteAssistantStreamWithFollowingMessages(prev, {
+      items: promotedItems,
+      bridgeTs,
+      followingMessages,
+    }),
     undefined,
     { force: true },
   )

--- a/frontend/src/components/ChatView/streamPromotion.js
+++ b/frontend/src/components/ChatView/streamPromotion.js
@@ -467,3 +467,47 @@ export function promoteAssistantStream(messages, { items, bridgeTs = null }) {
 
   return [...messages, { role: 'assistant', content, blocks }]
 }
+
+/**
+ * Promote one assistant turn and place the user/product rows that start its
+ * continuation immediately after it.
+ *
+ * A restored live turn can bridge an assistant row that is no longer the
+ * mounted transcript tail: newer local rows may already be visible while the
+ * old stream replay catches up. Appending the continuation rows after that
+ * suffix briefly tells the wrong story until the next detail refresh. Keep
+ * the whole turn boundary in one list operation instead.
+ */
+export function promoteAssistantStreamWithFollowingMessages(
+  messages,
+  { items, bridgeTs = null, followingMessages = [] },
+) {
+  const source = Array.isArray(messages) ? messages : []
+  const bridgeIdx = bridgeTs == null
+    ? -1
+    : source.findIndex(m => m?.role === 'assistant' && m.ts === bridgeTs)
+  const promoted = promoteAssistantStream(source, { items, bridgeTs })
+  const batch = Array.isArray(followingMessages)
+    ? followingMessages.filter(Boolean)
+    : []
+  if (batch.length === 0) return promoted
+
+  const seenTs = new Set(promoted.map(m => m?.ts).filter(v => v != null))
+  const unseen = batch.filter(message => {
+    if (message.ts == null) return true
+    if (seenTs.has(message.ts)) return false
+    seenTs.add(message.ts)
+    return true
+  })
+  if (unseen.length === 0) return promoted
+
+  // With no bridge, promoteAssistantStream appends the completed assistant and
+  // it is the boundary. With a bridge, preserve every newer local suffix row
+  // but place the continuation before it.
+  const insertAt = bridgeIdx >= 0 ? bridgeIdx + 1 : promoted.length
+  return [
+    ...promoted.slice(0, insertAt),
+    ...unseen,
+    ...promoted.slice(insertAt),
+  ]
+}


### PR DESCRIPTION
## Summary

- promote a completed assistant turn and the rows starting its continuation in one transcript update
- keep automatic resume markers beside the interrupted turn even when a newer local message is already visible
- preserve first-message pinning and logical queue order for ordinary queued sends

## Testing

- `node --loader=./src/lib/__tests__/vite-env-loader.mjs --test src/components/ChatView/__tests__/streamPromotion.test.js src/components/ChatView/__tests__/activeAssistantSelection.test.js`
- `npm run build`