### PR TITLE
Improve controls for active chat tasks

### DIFF
--- a/backend/app/chat.py
+++ b/backend/app/chat.py
@@ -3103,6 +3103,19 @@ async def _complete_turn(
     else "completed"
   )
 
+  # An intentional Stop should close in the assistant's own voice rather than
+  # leaving a partial sentence as the final, ambiguous state. Publishing into
+  # the existing sink keeps the note in the same durable assistant turn and
+  # lets the ordinary Finalize command persist it; this is not a second chat
+  # write path. Restart interruptions already carry their own resumable pause
+  # note and must not receive this user-Stop wording.
+  if stop_handoff_successor and ending_status == "stopped":
+    sink.publish({"type": "text_boundary"})
+    sink.publish({
+      "type": "text",
+      "content": "Interrupted. How would you like to continue?",
+    })
+
   try:
     await sink.finalize()
   except Exception as exc:

--- a/backend/app/chat_writer.py
+++ b/backend/app/chat_writer.py
@@ -378,7 +378,8 @@ class ReconcileStartupChat(_Command):
 # These own the read-modify-write of the chat's `messages` /
 # `pending_messages` blobs: initial-send (`StartTurn`, from
 # routes/chats_stream.py), append (`AppendPending`), cancel
-# (`CancelPending`), promote (`PromotePending`, from chat_queue.py), and
+# (`CancelPending`), edit (`UpdatePending`), promote (`PromotePending`, from
+# chat_queue.py), and
 # clear / run markers (`ClearPending`, from chat.py).  The routes/queue
 # submit these instead of mutating the row directly, so every mutation is
 # serialized on the actor thread.  Each is must-persist (commit-before-ack,
@@ -510,6 +511,21 @@ class CancelPending(_Command):
   chat_id: str = ""
   run_token: str = ""
   cid: str = ""
+
+
+@dataclass
+class UpdatePending(_Command):
+  """Replace the text of one queued message without changing its identity.
+
+  The stable ``cid``, ordering timestamp, attachments, and queue position stay
+  untouched. Returns ``{"updated", "pending"}``; ``updated`` is false when a
+  racing promotion or cancellation already removed the row.
+  """
+
+  chat_id: str = ""
+  run_token: str = ""
+  cid: str = ""
+  content: str = ""
 
 
 @dataclass
@@ -765,6 +781,7 @@ _FENCE_COMMANDS = (
   AppendSteeredUserMessage,
   PromotePending,
   CancelPending,
+  UpdatePending,
   ClearPending,
   ReplaceTranscript,
   FinishRun,
@@ -1500,6 +1517,8 @@ class ChatWriterActor:
       return self._promote_pending(db, cmd)
     if isinstance(cmd, CancelPending):
       return self._cancel_pending(db, cmd)
+    if isinstance(cmd, UpdatePending):
+      return self._update_pending(db, cmd)
     if isinstance(cmd, ClearPending):
       return self._clear_pending(db, cmd)
     if isinstance(cmd, ReplaceTranscript):
@@ -2634,6 +2653,33 @@ class ChatWriterActor:
       if not _commit_or_rollback(db):
         raise _PersistFailed("CancelPending did not persist")
     return {"pending": remaining}
+
+  def _update_pending(self, db, cmd: UpdatePending) -> dict:
+    """Edit one still-queued row while preserving every non-text field."""
+    from datetime import UTC, datetime
+
+    from app.models import Chat
+
+    chat = db.query(Chat).filter(Chat.id == cmd.chat_id).first()
+    if chat is None:
+      raise _PersistFailed("UpdatePending: chat not found")
+    pending = list(chat.pending_messages or [])
+    updated = False
+    next_pending = []
+    for message in pending:
+      if not updated and cid_of(message) == cmd.cid:
+        replacement = dict(message)
+        replacement["content"] = cmd.content
+        next_pending.append(replacement)
+        updated = True
+      else:
+        next_pending.append(message)
+    if updated:
+      chat.pending_messages = next_pending
+      chat.updated_at = datetime.now(UTC)
+      if not _commit_or_rollback(db):
+        raise _PersistFailed("UpdatePending did not persist")
+    return {"updated": updated, "pending": next_pending}
 
   def _clear_pending(self, db, cmd: ClearPending) -> dict:
     """Empty the pending queue; return the count + the cleared cids.

--- a/backend/app/routes/chats_stream.py
+++ b/backend/app/routes/chats_stream.py
@@ -8,6 +8,7 @@ from pathlib import Path as FilePath
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Request
 from fastapi.responses import JSONResponse, StreamingResponse
+from pydantic import BaseModel
 from starlette.responses import Response
 from sqlalchemy.orm import Session
 
@@ -29,6 +30,7 @@ from app.chat_writer import (
   CancelPending,
   StartTurn,
   StartTurnBlockedByPendingQuestion,
+  UpdatePending,
   alloc_run_token,
   await_ack,
   cid_of,
@@ -54,6 +56,10 @@ from app.resource_access import (
 router = APIRouter(prefix="/api/chats", tags=["chats"])
 
 log = logging.getLogger(__name__)
+
+
+class PendingMessageUpdate(BaseModel):
+  content: str
 
 def _pending_question_open_conflict() -> HTTPException:
   return HTTPException(
@@ -1175,6 +1181,37 @@ async def cancel_pending_message(
   )
   result = await await_ack(ack)
   return {"pending_messages": result["pending"]}
+
+
+@router.patch(
+  "/{chat_id}/pending/{cid}",
+  status_code=200,
+  dependencies=[Depends(reject_cross_site)],
+)
+async def update_pending_message(
+  chat_id: str,
+  cid: str,
+  body: PendingMessageUpdate,
+  principal: Principal = Depends(get_owner_or_chat_embed_principal),
+  db: Session = Depends(get_db),
+):
+  """Edit one queued message if it has not started yet."""
+  if principal.scope == "app":
+    raise HTTPException(status_code=403, detail="App token is not valid here.")
+  require_chat_embed_operation(principal, "chat:send")
+  require_active_chat_access(db, chat_id, principal)
+  content = body.content.strip()
+  if not content:
+    raise HTTPException(status_code=422, detail="Queued message cannot be empty.")
+  result = await await_ack(get_writer().submit(
+    UpdatePending(
+      chat_id=chat_id, run_token="", cid=cid, content=content,
+    )
+  ))
+  return {
+    "updated": result["updated"],
+    "pending_messages": result["pending"],
+  }
 
 
 @router.get("/{chat_id}/stream")

--- a/backend/tests/test_augmentation.py
+++ b/backend/tests/test_augmentation.py
@@ -877,6 +877,63 @@ def test_cancel_pending_message_by_cid(client, db, auth):
   assert [m["ts"] for m in c.pending_messages] == [100, 300]
 
 
+def test_update_pending_message_preserves_identity_order_and_attachments(
+  client, db, auth,
+):
+  """PATCH changes only queued text; delivery identity and files stay put."""
+  from app import models
+
+  c = models.Chat(
+    id="edit-pending",
+    title="t",
+    messages=[],
+    pending_messages=[
+      {
+        "role": "user", "content": "before", "ts": 100, "cid": "c-edit",
+        "position": 1, "attachments": [{"name": "notes.txt"}],
+      },
+      {"role": "user", "content": "second", "ts": 200, "cid": "c-next"},
+    ],
+  )
+  db.add(c)
+  db.commit()
+
+  resp = client.patch(
+    "/api/chats/edit-pending/pending/c-edit",
+    headers=auth,
+    json={"content": "  after  "},
+  )
+  assert resp.status_code == 200, resp.text
+  data = resp.json()
+  assert data["updated"] is True
+  assert [row["cid"] for row in data["pending_messages"]] == ["c-edit", "c-next"]
+  edited = data["pending_messages"][0]
+  assert edited == {
+    "role": "user", "content": "after", "ts": 100, "cid": "c-edit",
+    "position": 1, "attachments": [{"name": "notes.txt"}],
+  }
+
+  db.refresh(c)
+  assert c.pending_messages == data["pending_messages"]
+
+
+def test_update_pending_message_reports_a_racing_promotion(client, db, auth):
+  """A row that already left the queue is not recreated by a late edit."""
+  from app import models
+
+  c = models.Chat(id="edit-gone", title="t", messages=[], pending_messages=[])
+  db.add(c)
+  db.commit()
+
+  resp = client.patch(
+    "/api/chats/edit-gone/pending/c-gone",
+    headers=auth,
+    json={"content": "too late"},
+  )
+  assert resp.status_code == 200
+  assert resp.json() == {"updated": False, "pending_messages": []}
+
+
 def test_cancel_pending_row_by_backfilled_legacy_cid(client, db, auth):
   """A card-221-backfilled row carries an explicit `legacy-<ts>` cid; cancelling
   by that value removes it (the value is stored now, not derived at read time)."""

--- a/backend/tests/test_chat_writer_contention.py
+++ b/backend/tests/test_chat_writer_contention.py
@@ -41,6 +41,7 @@ from app.chat_writer import (
   ReplaceTranscript,
   StartTurn,
   StartTurnBlockedByPendingQuestion,
+  UpdatePending,
 )
 from app.database import SessionLocal
 
@@ -507,6 +508,27 @@ def test_concurrent_append_cancel_promote_preserve_order(actor):
   assert chat["pending_messages"] == []
   assert "m0" in promoted["promoted"]["content"]
   assert "m3" not in promoted["promoted"]["content"]
+
+
+def test_update_pending_preserves_non_text_fields(actor):
+  _seed_chat(pending=[
+    {
+      "role": "user", "content": "before", "ts": 10, "cid": "c-edit",
+      "position": 1, "attachments": [{"name": "notes.txt"}],
+    },
+    {"role": "user", "content": "next", "ts": 20, "cid": "c-next"},
+  ])
+  result = _await(actor.submit(UpdatePending(
+    chat_id="c1", run_token="", cid="c-edit", content="after",
+  )))
+  assert result["updated"] is True
+  assert result["pending"] == [
+    {
+      "role": "user", "content": "after", "ts": 10, "cid": "c-edit",
+      "position": 1, "attachments": [{"name": "notes.txt"}],
+    },
+    {"role": "user", "content": "next", "ts": 20, "cid": "c-next"},
+  ]
 
 
 # -- cid identity: dedup + idempotency ------------------------------------

--- a/backend/tests/test_terminal_completion.py
+++ b/backend/tests/test_terminal_completion.py
@@ -990,6 +990,53 @@ def test_stop_handoff_clear_does_not_erase_racing_fresh_start_turn_marker(
   assert chat_mod.is_chat_running("t10")
 
 
+def test_in_progress_stop_closes_partial_with_a_continuation_question():
+  """A live turn stopped after producing content ends unambiguously and asks
+  the owner what should happen next; a text boundary keeps the note separate
+  from the model's interrupted sentence."""
+  from app import broadcast as bc_mod
+
+  _seed_chat(
+    "t-stop-note",
+    messages=[{"role": "user", "content": "hi", "ts": 1}],
+    pending=[], running="running",
+  )
+  _seed_run("rt-stop-note", "t-stop-note")
+  chat_mod.mark_starting("t-stop-note")
+  gen = chat_mod.current_run_generation("t-stop-note")
+  chat_mod._clear_after_terminal_generation["t-stop-note"] = gen
+  chat_mod.bump_run_generation("t-stop-note")
+  chat_mod.discard_starting("t-stop-note")
+
+  bc = create_broadcast("t-stop-note")
+  bc_mod.set_active_broadcast(bc)
+  sink = chat_mod._ChatEventSink(
+    bc, "t-stop-note", run_token="rt-stop-note",
+    recall_binding=EMPTY_RECALL_BINDING,
+  )
+  sink.publish({"type": "text", "content": "Partial answer."})
+
+  db = SessionLocal()
+  try:
+    asyncio.run(chat_mod._complete_turn(
+      bc=bc, sink=sink, db=db, chat_id="t-stop-note", run_gen=gen,
+      provider_id="claude", cost_usd=0.0, close_browser=False,
+    ))
+    _drain_actor()
+  finally:
+    bc_mod.set_active_broadcast(None)
+
+  assistant = _load("t-stop-note")["messages"][-1]
+  assert assistant["role"] == "assistant"
+  assert assistant["blocks"] == [
+    {"type": "text", "content": "Partial answer."},
+    {
+      "type": "text",
+      "content": "Interrupted. How would you like to continue?",
+    },
+  ]
+
+
 # -- 10b. stale finalize must NOT append after a fresh turn's user msg -------
 def test_stale_dying_run_does_not_finalize_after_fresh_turn_claimed(monkeypatch):
   """The bug the corrected fix closes: a Stop-superseded dying run reaches

--- a/frontend/src/components/ChatView/ChatView.css
+++ b/frontend/src/components/ChatView/ChatView.css
@@ -3409,6 +3409,59 @@
   text-overflow: ellipsis;
 }
 
+.queued__row--editing {
+  padding: 6px;
+  background: var(--bg);
+}
+
+.queued__editor {
+  flex: 1;
+  min-width: 0;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: start;
+  gap: 4px;
+}
+
+.queued__editor-input {
+  box-sizing: border-box;
+  width: 100%;
+  min-height: 56px;
+  max-height: 160px;
+  padding: 8px 10px;
+  resize: vertical;
+  border: 1px solid var(--border);
+  border-radius: 9px;
+  outline: none;
+  background: var(--surface);
+  color: var(--text);
+  font: inherit;
+  font-size: 14px;
+  line-height: 1.4;
+}
+
+.queued__editor-input:focus {
+  border-color: color-mix(in srgb, var(--accent) 60%, var(--border));
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.queued__editor-actions {
+  display: flex;
+  align-items: flex-start;
+}
+
+.queued__edit-save:not(:disabled) {
+  color: var(--accent);
+}
+
+.queued__editor-error {
+  grid-column: 1 / -1;
+  padding: 0 4px 2px;
+  color: var(--danger);
+  font-size: 11px;
+  line-height: 1.3;
+}
+
 .queued__action {
   --queued-action-visual-shift: 0px;
   flex-shrink: 0;

--- a/frontend/src/components/ChatView/ChatView.css
+++ b/frontend/src/components/ChatView/ChatView.css
@@ -2097,6 +2097,18 @@
   gap: 0;
 }
 
+.chat__stop-hint {
+  width: fit-content;
+  max-width: calc(100% - 24px);
+  margin: 0 auto 4px;
+  color: var(--muted);
+  font-size: 10px;
+  line-height: 1.2;
+  letter-spacing: 0.01em;
+  text-align: center;
+  pointer-events: none;
+}
+
 .chat__offline-note {
   box-sizing: border-box;
   width: fit-content;

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -3096,6 +3096,29 @@ export default function ChatView({
     }
   }, [chatId, pendingQueue])
 
+  const handleUpdatePending = useCallback(async (cid, content) => {
+    const queueWrite = queuedSendRequestsRef.current.get(cid)
+    if (queueWrite) await Promise.allSettled([queueWrite])
+    try {
+      const res = await apiFetch(
+        `/chats/${chatId}/pending/${encodeURIComponent(cid)}`,
+        {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ content }),
+          timeoutMs: CHAT_FETCH_TIMEOUT_MS,
+        },
+      )
+      const data = await jsonOrThrow(res, 'Queued-message edit failed')
+      if (Array.isArray(data.pending_messages)) {
+        pendingQueue.hydrate(data.pending_messages)
+      }
+      return true
+    } catch {
+      return false
+    }
+  }, [chatId, pendingQueue])
+
   async function handleStop() {
     // Re-entry guard. Without this, two rapid Stop clicks would both
     // snapshot the same pending queue (the snapshot happens BEFORE
@@ -4534,6 +4557,7 @@ export default function ChatView({
           <QueuedMessages
             items={pendingQueue.visiblePendingMessages}
             onCancel={handleCancelPending}
+            onEdit={handleUpdatePending}
             onSteerOne={handleSteerOne}
             steerActive={turnActive && !hasPendingQuestion}
             steerBusy={steerBusy}

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -36,6 +36,7 @@ import useChatRuntimePolicy from './hooks/useChatRuntimePolicy.js'
 import useOffscreenNudge, { useNudgeTargetRef } from './hooks/useOffscreenNudge.js'
 import ChatInputBar from './ChatInputBar.jsx'
 import { hasSendablePayload } from './composerSubmission.js'
+import { resolveDoubleEscapeStop } from './composerShortcuts.js'
 import AgentContextInspector from './AgentContextInspector.jsx'
 import ChatSummaryViewer from './ChatSummaryViewer.jsx'
 import ComposerPopover from './ComposerPopover.jsx'
@@ -3593,6 +3594,31 @@ export default function ChatView({
   // (The fast-forward identity/readiness gates are computed separately below.)
   const turnActive = sending || isStreaming || serverRunning
 
+  // A quiet, discoverable keyboard counterpart to the visible Stop control.
+  // Listen only while this mounted chat owns a live turn; hidden workspace
+  // panes must never react to a shortcut intended for the active pane. The
+  // first Escape remains available to dismiss transient composer surfaces,
+  // while a second unclaimed Escape inside the short window stops the turn.
+  const lastStopEscapeAtRef = useRef(0)
+  useEffect(() => {
+    if (hidden || !turnActive) {
+      lastStopEscapeAtRef.current = 0
+      return undefined
+    }
+    function onDoubleEscape(event) {
+      const resolution = resolveDoubleEscapeStop(event, {
+        lastEscapeAt: lastStopEscapeAtRef.current,
+        now: performance.now(),
+      })
+      lastStopEscapeAtRef.current = resolution.lastEscapeAt
+      if (!resolution.stop) return
+      event.preventDefault()
+      void handleStop()
+    }
+    window.addEventListener('keydown', onDoubleEscape)
+    return () => window.removeEventListener('keydown', onDoubleEscape)
+  }, [hidden, turnActive])
+
   // Auto-dismiss the settled "Open <app>" CTA a few seconds after the turn
   // ends, so it reads as an ephemeral nudge rather than a permanent chat-foot
   // fixture. Only the settled (post-turn) CTA times out; a live in-turn preview
@@ -4512,6 +4538,11 @@ export default function ChatView({
             steerActive={turnActive && !hasPendingQuestion}
             steerBusy={steerBusy}
           />
+        )}
+        {turnActive && (
+          <div className="chat__stop-hint" role="status">
+            Double Esc to stop the current task
+          </div>
         )}
         <ChatInputBar
           chatId={chatId}

--- a/frontend/src/components/ChatView/QueuedMessages.jsx
+++ b/frontend/src/components/ChatView/QueuedMessages.jsx
@@ -1,5 +1,11 @@
 import { useRef, useState } from 'react'
-import { ChevronDown, DoubleChevronRight, X } from '@openai/apps-sdk-ui/components/Icon'
+import {
+  Check,
+  ChevronDown,
+  DoubleChevronRight,
+  Pencil,
+  X,
+} from '@openai/apps-sdk-ui/components/Icon'
 import { stripAugmentation } from './msgText.js'
 import { cidOf } from './messageIdentity.js'
 import {
@@ -25,10 +31,14 @@ const TRUNCATE_AT = 80
  * the chat list and the input form. Empty queue → nothing rendered.
  */
 export default function QueuedMessages({
-  items, onCancel, onSteerOne, steerActive, steerBusy = false,
+  items, onCancel, onEdit, onSteerOne, steerActive, steerBusy = false,
 }) {
   const [expanded, setExpanded] = useState(() => new Set())
   const [collapsed, setCollapsed] = useState(false)
+  const [editingCid, setEditingCid] = useState(null)
+  const [editDraft, setEditDraft] = useState('')
+  const [editSaving, setEditSaving] = useState(false)
+  const [editError, setEditError] = useState('')
   const pointerSelectionRef = useRef(null)
 
   if (!items || items.length === 0) return null
@@ -52,6 +62,44 @@ export default function QueuedMessages({
 
   function toggleCollapsed() {
     setCollapsed(c => !c)
+  }
+
+  function beginEdit(msg) {
+    const cid = cidOf(msg)
+    setEditingCid(cid)
+    setEditDraft(stripAugmentation(msg.content || ''))
+    setEditError('')
+    setExpanded(prev => new Set(prev).add(cid))
+  }
+
+  function cancelEdit() {
+    if (editSaving) return
+    setEditingCid(null)
+    setEditDraft('')
+    setEditError('')
+  }
+
+  async function saveEdit(msg) {
+    if (editSaving) return
+    const content = editDraft.trim()
+    if (!content) {
+      setEditError('Queued message cannot be empty.')
+      return
+    }
+    if (content === stripAugmentation(msg.content || '').trim()) {
+      cancelEdit()
+      return
+    }
+    setEditSaving(true)
+    setEditError('')
+    const saved = await onEdit?.(cidOf(msg), content)
+    setEditSaving(false)
+    if (saved) {
+      setEditingCid(null)
+      setEditDraft('')
+    } else {
+      setEditError('Couldn’t save this edit. Try again.')
+    }
   }
 
   function onHdrKeyDown(e) {
@@ -107,13 +155,67 @@ export default function QueuedMessages({
               ? firstLine.slice(0, TRUNCATE_AT) + '…'
               : firstLine + (text.includes('\n') ? ' …' : '')
             const MessageSurface = needsTruncation ? 'button' : 'div'
+            const isEditing = editingCid === key
 
             return (
               <div
                 key={key}
-                className={`queued__row${isExpanded ? ' queued__row--expanded' : ''}`}
+                className={`queued__row${isExpanded ? ' queued__row--expanded' : ''}${isEditing ? ' queued__row--editing' : ''}`}
                 role="listitem"
               >
+                {isEditing ? (
+                  <div className="queued__editor">
+                    <textarea
+                      className="queued__editor-input"
+                      value={editDraft}
+                      onChange={(event) => {
+                        setEditDraft(event.target.value)
+                        setEditError('')
+                      }}
+                      onKeyDown={(event) => {
+                        if (event.key === 'Escape') {
+                          event.preventDefault()
+                          cancelEdit()
+                        } else if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
+                          event.preventDefault()
+                          void saveEdit(msg)
+                        }
+                      }}
+                      aria-label="Edit queued message"
+                      rows={2}
+                      autoFocus
+                      disabled={editSaving}
+                    />
+                    <div className="queued__editor-actions">
+                      <button
+                        type="button"
+                        className="queued__action queued__edit-save"
+                        onClick={() => void saveEdit(msg)}
+                        aria-label="Save queued message edit"
+                        title="Save edit"
+                        disabled={editSaving || !editDraft.trim()}
+                      >
+                        <Check width={16} height={16} aria-hidden="true" />
+                      </button>
+                      <button
+                        type="button"
+                        className="queued__action queued__edit-cancel"
+                        onClick={cancelEdit}
+                        aria-label="Discard queued message edit"
+                        title="Discard edit"
+                        disabled={editSaving}
+                      >
+                        <X width={16} height={16} aria-hidden="true" />
+                      </button>
+                    </div>
+                    {editError && (
+                      <div className="queued__editor-error" role="status">
+                        {editError}
+                      </div>
+                    )}
+                  </div>
+                ) : (
+                  <>
                 <MessageSurface
                   type={needsTruncation ? 'button' : undefined}
                   className={`queued__toggle${needsTruncation ? '' : ' queued__toggle--static'}`}
@@ -149,6 +251,16 @@ export default function QueuedMessages({
                     {isExpanded ? text : preview}
                   </span>
                 </MessageSurface>
+                <button
+                  type="button"
+                  className="queued__action queued__edit"
+                  onPointerDown={(e) => e.preventDefault()}
+                  onClick={() => beginEdit(msg)}
+                  aria-label="Edit queued message"
+                  title="Edit"
+                >
+                  <Pencil width={16} height={16} aria-hidden="true" />
+                </button>
                 {steerActive && (
                   // Per-row fast-forward (owner ask, 2026-07-17): the same
                   // double-chevron as the composer's steer button, in the
@@ -183,6 +295,8 @@ export default function QueuedMessages({
                 >
                   <X width={16} height={16} aria-hidden="true" />
                 </button>
+                  </>
+                )}
               </div>
             )
           })}

--- a/frontend/src/components/ChatView/__tests__/composerShortcuts.test.js
+++ b/frontend/src/components/ChatView/__tests__/composerShortcuts.test.js
@@ -1,9 +1,45 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
 
-import { resolveComposerEnterAction } from '../composerShortcuts.js'
+import {
+  resolveComposerEnterAction,
+  resolveDoubleEscapeStop,
+} from '../composerShortcuts.js'
 
 const enter = (overrides = {}) => ({ key: 'Enter', ...overrides })
+
+test('two plain Escape presses in the hint window stop the live task', () => {
+  const first = resolveDoubleEscapeStop({ key: 'Escape' }, { now: 1000 })
+  assert.deepEqual(first, { stop: false, lastEscapeAt: 1000 })
+  assert.deepEqual(
+    resolveDoubleEscapeStop(
+      { key: 'Escape' },
+      { lastEscapeAt: first.lastEscapeAt, now: 1600 },
+    ),
+    { stop: true, lastEscapeAt: 0 },
+  )
+})
+
+test('claimed, modified, repeated, or slow Escape presses never stop a task', () => {
+  for (const event of [
+    { key: 'Escape', defaultPrevented: true },
+    { key: 'Escape', metaKey: true },
+    { key: 'Escape', repeat: true },
+    { key: 'Enter' },
+  ]) {
+    assert.equal(
+      resolveDoubleEscapeStop(event, { lastEscapeAt: 1000, now: 1200 }).stop,
+      false,
+    )
+  }
+  assert.deepEqual(
+    resolveDoubleEscapeStop(
+      { key: 'Escape' },
+      { lastEscapeAt: 1000, now: 1800 },
+    ),
+    { stop: false, lastEscapeAt: 1800 },
+  )
+})
 
 test('Cmd+Enter steers composer text when a live turn can accept it', () => {
   assert.equal(

--- a/frontend/src/components/ChatView/__tests__/composerSteerTouch.test.js
+++ b/frontend/src/components/ChatView/__tests__/composerSteerTouch.test.js
@@ -73,27 +73,6 @@ test('per-row fast-forward appears with the optimistic row and dispatches on tou
   )
 })
 
-test('queued rows expose an inline editor backed by the durable queue route', () => {
-  assert.match(
-    queuedMessages,
-    /className="queued__action queued__edit"[\s\S]*?aria-label="Edit queued message"/,
-  )
-  assert.match(
-    queuedMessages,
-    /className="queued__editor-input"[\s\S]*?aria-label="Edit queued message"/,
-  )
-  assert.match(
-    queuedMessages,
-    /onEdit\?\.\(cidOf\(msg\), content\)/,
-    'saving should retain the queued row identity',
-  )
-  assert.match(
-    chatView,
-    /const handleUpdatePending = useCallback\(async \(cid, content\)[\s\S]*?method: 'PATCH'[\s\S]*?pendingQueue\.hydrate\(data\.pending_messages\)/,
-    'the edit should reconcile from the authoritative queue response',
-  )
-})
-
 test('fast-forward preserves queue-time scroll intent through layout reflow', () => {
   const steerPath = chatView.match(
     /async function steerRowsImpl\(steerRowsList\) \{[\s\S]*?\n  \/\/ STEER \(fast-forward\): inject/,

--- a/frontend/src/components/ChatView/__tests__/composerSteerTouch.test.js
+++ b/frontend/src/components/ChatView/__tests__/composerSteerTouch.test.js
@@ -73,6 +73,27 @@ test('per-row fast-forward appears with the optimistic row and dispatches on tou
   )
 })
 
+test('queued rows expose an inline editor backed by the durable queue route', () => {
+  assert.match(
+    queuedMessages,
+    /className="queued__action queued__edit"[\s\S]*?aria-label="Edit queued message"/,
+  )
+  assert.match(
+    queuedMessages,
+    /className="queued__editor-input"[\s\S]*?aria-label="Edit queued message"/,
+  )
+  assert.match(
+    queuedMessages,
+    /onEdit\?\.\(cidOf\(msg\), content\)/,
+    'saving should retain the queued row identity',
+  )
+  assert.match(
+    chatView,
+    /const handleUpdatePending = useCallback\(async \(cid, content\)[\s\S]*?method: 'PATCH'[\s\S]*?pendingQueue\.hydrate\(data\.pending_messages\)/,
+    'the edit should reconcile from the authoritative queue response',
+  )
+})
+
 test('fast-forward preserves queue-time scroll intent through layout reflow', () => {
   const steerPath = chatView.match(
     /async function steerRowsImpl\(steerRowsList\) \{[\s\S]*?\n  \/\/ STEER \(fast-forward\): inject/,

--- a/frontend/src/components/ChatView/composerShortcuts.js
+++ b/frontend/src/components/ChatView/composerShortcuts.js
@@ -17,3 +17,25 @@ export function resolveComposerEnterAction(event, {
   if (canRequestSteer) return 'steer'
   return 'noop'
 }
+
+export const DOUBLE_ESCAPE_STOP_WINDOW_MS = 700
+
+export function resolveDoubleEscapeStop(event, {
+  lastEscapeAt = 0,
+  now = 0,
+} = {}) {
+  if (
+    !event
+    || event.defaultPrevented
+    || event.key !== 'Escape'
+    || event.repeat
+    || event.altKey
+    || event.ctrlKey
+    || event.metaKey
+    || event.shiftKey
+  ) return { stop: false, lastEscapeAt }
+
+  const stop = lastEscapeAt > 0
+    && now - lastEscapeAt <= DOUBLE_ESCAPE_STOP_WINDOW_MS
+  return { stop, lastEscapeAt: stop ? 0 : now }
+}


### PR DESCRIPTION
## Summary
- show a small Double Esc hint while a chat task is active and stop on two quick, unclaimed Escape presses
- close an intentionally interrupted partial response by asking how the owner wants to continue
- let owners edit queued follow-up messages inline without changing their order, attachments, or delivery identity
- reconcile edits safely when a queued message is promoted or cancelled during save

## Testing
- `npm test`
- `npm run lint -- --quiet`
- `pytest -q backend/tests/test_augmentation.py::test_update_pending_message_preserves_identity_order_and_attachments backend/tests/test_augmentation.py::test_update_pending_message_reports_a_racing_promotion backend/tests/test_chat_writer_contention.py::test_update_pending_preserves_non_text_fields backend/tests/test_terminal_completion.py::test_stop_handoff_clears_only_immediate_successor_marker backend/tests/test_terminal_completion.py::test_in_progress_stop_closes_partial_with_a_continuation_question`
- `python3 -m py_compile backend/app/chat.py backend/app/chat_writer.py backend/app/routes/chats_stream.py`