### PR TITLE
Add durable public app publication

### DIFF
--- a/backend/app/app_apply.py
+++ b/backend/app/app_apply.py
@@ -301,7 +301,7 @@ async def apply_source_revision(
         app.jsx_source,
         app.compiled_path,
         app.source_commit,
-        app.share_manifest_url,
+        app.published_manifest_url,
         app.icon_png,
         app.icon_override_png,
       )
@@ -333,7 +333,9 @@ async def apply_source_revision(
         if "offline_capable" in runtime_fields:
           app.offline_capable = runtime_fields["offline_capable"]
         app.capability_contract = contract_from_app_state(
-          app, capabilities=runtime_fields["capabilities"],
+          app,
+          capabilities=runtime_fields["capabilities"],
+          public_access=runtime_fields["public_access"],
         )
       if chat_id is not None:
         app.chat_id = chat_id
@@ -354,10 +356,10 @@ async def apply_source_revision(
         app.manifest_url is None
         and app.source_commit != previous_state[7]
       ):
-        # A share URL is a statement about one exact accepted package. Once
+        # A distribution manifest is a statement about one exact accepted package. Once
         # local source advances, require publication verification again rather
         # than silently offering a stale repository to other people.
-        app.share_manifest_url = None
+        app.published_manifest_url = None
       published = publish_staged_bundle(app.id, staged)
       staged = None
 
@@ -373,7 +375,7 @@ async def apply_source_revision(
           source,
           str(published),
           app.source_commit,
-          app.share_manifest_url,
+          app.published_manifest_url,
           app.icon_png,
           app.icon_override_png,
         )

--- a/backend/app/app_capabilities.py
+++ b/backend/app/app_capabilities.py
@@ -10,11 +10,199 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 from copy import deepcopy
 from typing import Any
+from urllib.parse import urlsplit
 
 
-CONTRACT_SCHEMA = 4
+CONTRACT_SCHEMA = 5
+
+_PUBLIC_NETWORK_RULE_LIMIT = 16
+_PUBLIC_QUERY_NAME = re.compile(r"^[A-Za-z0-9_.-]{1,64}$")
+
+
+def _normalize_public_query(value: Any, *, rule_index: int) -> dict[str, Any]:
+  if value is None:
+    return {}
+  if not isinstance(value, dict) or set(value) - {"allow", "exact", "sha256"}:
+    raise ValueError(
+      f"Manifest public network rule {rule_index} query must contain only "
+      "`allow`, `exact`, and `sha256`."
+    )
+  allow = value.get("allow", [])
+  exact = value.get("exact", {})
+  digests = value.get("sha256", {})
+  if not isinstance(allow, list) or not all(
+    isinstance(name, str) and _PUBLIC_QUERY_NAME.fullmatch(name)
+    for name in allow
+  ):
+    raise ValueError(
+      f"Manifest public network rule {rule_index} query.allow must be an "
+      "array of bounded parameter names."
+    )
+  if len(set(allow)) != len(allow):
+    raise ValueError(
+      f"Manifest public network rule {rule_index} query.allow contains duplicates."
+    )
+
+  def normalized_map(raw: Any, *, field: str, digest: bool) -> dict[str, list[str]]:
+    if not isinstance(raw, dict):
+      raise ValueError(
+        f"Manifest public network rule {rule_index} query.{field} must be an object."
+      )
+    result: dict[str, list[str]] = {}
+    for name in sorted(raw):
+      accepted = raw[name]
+      valid_name = isinstance(name, str) and _PUBLIC_QUERY_NAME.fullmatch(name)
+      valid_values = (
+        isinstance(accepted, list)
+        and 1 <= len(accepted) <= 8
+        and all(isinstance(item, str) for item in accepted)
+      )
+      if not valid_name or not valid_values:
+        raise ValueError(
+          f"Manifest public network rule {rule_index} query.{field} entries "
+          "must map bounded parameter names to 1-8 strings."
+        )
+      if digest:
+        if not all(re.fullmatch(r"[0-9a-f]{64}", item) for item in accepted):
+          raise ValueError(
+            f"Manifest public network rule {rule_index} query.sha256 values "
+            "must be lowercase SHA-256 digests."
+          )
+      elif not all(len(item) <= 4096 for item in accepted):
+        raise ValueError(
+          f"Manifest public network rule {rule_index} query.exact values may "
+          "contain at most 4096 characters."
+        )
+      result[name] = sorted(set(accepted))
+    return result
+
+  normalized_exact = normalized_map(exact, field="exact", digest=False)
+  normalized_digests = normalized_map(digests, field="sha256", digest=True)
+  names = set(allow) | set(normalized_exact) | set(normalized_digests)
+  if len(names) > 16:
+    raise ValueError(
+      f"Manifest public network rule {rule_index} may constrain at most 16 "
+      "query parameters."
+    )
+  if len(names) != len(allow) + len(normalized_exact) + len(normalized_digests):
+    raise ValueError(
+      f"Manifest public network rule {rule_index} query parameter names must "
+      "belong to exactly one constraint."
+    )
+  normalized: dict[str, Any] = {}
+  if allow:
+    normalized["allow"] = sorted(allow)
+  if normalized_exact:
+    normalized["exact"] = normalized_exact
+  if normalized_digests:
+    normalized["sha256"] = normalized_digests
+  return normalized
+
+
+def normalize_public_access(manifest: dict[str, Any]) -> dict[str, Any]:
+  """Normalize the network surface available to anonymous app sessions.
+
+  Publication itself is owner state and deliberately does not live in the
+  manifest. The package may only declare a bounded set of exact HTTPS origins
+  and path prefixes that the public, GET-only fetch capability may reach.
+  """
+  raw = manifest.get("public_access")
+  if raw is None:
+    return {"network": []}
+  if not isinstance(raw, dict) or set(raw) - {"network"}:
+    raise ValueError(
+      "Manifest `public_access` must be an object containing only `network`."
+    )
+  network = raw.get("network", [])
+  if not isinstance(network, list):
+    raise ValueError("Manifest `public_access.network` must be an array.")
+  if len(network) > _PUBLIC_NETWORK_RULE_LIMIT:
+    raise ValueError(
+      f"Manifest `public_access.network` may contain at most "
+      f"{_PUBLIC_NETWORK_RULE_LIMIT} rules."
+    )
+
+  normalized: list[dict[str, Any]] = []
+  seen: set[tuple[str, str, str]] = set()
+  for index, rule in enumerate(network):
+    if (
+      not isinstance(rule, dict)
+      or set(rule) - {"origin", "path_prefix", "query"}
+      or not {"origin", "path_prefix"}.issubset(rule)
+    ):
+      raise ValueError(
+        "Each `public_access.network` rule must contain `origin` and "
+        "`path_prefix`, with only an optional `query` contract."
+      )
+    origin = rule.get("origin")
+    prefix = rule.get("path_prefix")
+    if not isinstance(origin, str) or not isinstance(prefix, str):
+      raise ValueError(
+        f"Manifest public network rule {index + 1} must use string values."
+      )
+    try:
+      parsed = urlsplit(origin.strip())
+      port = parsed.port
+    except ValueError as exc:
+      raise ValueError(
+        f"Manifest public network rule {index + 1} has an invalid origin."
+      ) from exc
+    if (
+      parsed.scheme != "https"
+      or not parsed.hostname
+      or parsed.username is not None
+      or parsed.password is not None
+      or parsed.path not in ("", "/")
+      or parsed.query
+      or parsed.fragment
+    ):
+      raise ValueError(
+        f"Manifest public network rule {index + 1} origin must be an exact "
+        "HTTPS origin."
+      )
+    host = parsed.hostname.lower()
+    authority = host if port in (None, 443) else f"{host}:{port}"
+    normalized_origin = f"https://{authority}"
+    if (
+      not prefix.startswith("/")
+      or "?" in prefix
+      or "#" in prefix
+      or len(prefix) > 512
+    ):
+      raise ValueError(
+        f"Manifest public network rule {index + 1} path_prefix must be a "
+        "plain absolute path."
+      )
+    query = _normalize_public_query(rule.get("query"), rule_index=index + 1)
+    key = (
+      normalized_origin,
+      prefix,
+      json.dumps(query, sort_keys=True, separators=(",", ":")),
+    )
+    if key not in seen:
+      seen.add(key)
+      normalized_rule: dict[str, Any] = {
+        "origin": normalized_origin,
+        "path_prefix": prefix,
+      }
+      if query:
+        normalized_rule["query"] = query
+      normalized.append(normalized_rule)
+  return {"network": normalized}
+
+
+def public_access_declaration_from_contract(
+  contract: dict[str, Any] | None,
+) -> dict[str, Any]:
+  """Recover the normalized public declaration from a stored contract."""
+  value = contract.get("public") if isinstance(contract, dict) else None
+  network = value.get("network") if isinstance(value, dict) else None
+  if not isinstance(network, list):
+    return {"network": []}
+  return {"network": deepcopy(network)}
 
 
 # Host-mediated browser capabilities. These are deliberately separate from
@@ -184,7 +372,10 @@ def local_manifest_runtime_fields(manifest: dict[str, Any]) -> dict[str, Any]:
   # Validate names, versions, reasons, and limits now; callers still need the
   # author declaration rather than the host-enriched normalized contract.
   normalize_runtime_capabilities(manifest)
-  fields: dict[str, Any] = {"capabilities": capabilities}
+  fields: dict[str, Any] = {
+    "capabilities": capabilities,
+    "public_access": normalize_public_access(manifest),
+  }
   if "offline_capable" in manifest:
     offline_capable = manifest["offline_capable"]
     if not isinstance(offline_capable, bool):
@@ -257,6 +448,7 @@ def contract_from_manifest(manifest: dict[str, Any]) -> dict[str, Any]:
       "contract": manifest.get("offline") or None,
     },
     "runtime": normalize_runtime_capabilities(manifest),
+    "public": normalize_public_access(manifest),
   }
 
 
@@ -289,6 +481,7 @@ def contract_from_app_state(
   app: Any,
   *,
   capabilities: dict[str, Any] | None = None,
+  public_access: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
   """Build an accurate contract for an owner-authored local app.
 
@@ -299,6 +492,10 @@ def contract_from_app_state(
   """
   if capabilities is None:
     capabilities = runtime_declaration_from_contract(
+      getattr(app, "capability_contract", None),
+    )
+  if public_access is None:
+    public_access = public_access_declaration_from_contract(
       getattr(app, "capability_contract", None),
     )
   manifest = {
@@ -319,6 +516,7 @@ def contract_from_app_state(
     "offline_capable": bool(getattr(app, "offline_capable", False)),
     "offline": getattr(app, "offline_contract", None),
     "capabilities": capabilities,
+    "public_access": public_access,
   }
   return contract_from_manifest(manifest)
 

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -110,6 +110,29 @@ def create_app_token(
   )
 
 
+def create_public_app_token(
+  app_id: int,
+  publication_nonce: str,
+  *,
+  expires_delta: timedelta = timedelta(hours=8),
+) -> str:
+  """Create a short-lived anonymous capability for one published app.
+
+  It intentionally carries no owner identity or epoch: the bearer can only
+  fetch the matching app module and its manifest-declared public GET targets.
+  The publication nonce is rechecked on every use, so stopping access or
+  publishing a new snapshot revokes every token for the previous revision.
+  """
+  return create_access_token(
+    {
+      "scope": "public_app",
+      "app_id": app_id,
+      "publication_nonce": publication_nonce,
+    },
+    expires_delta=expires_delta,
+  )
+
+
 def create_media_token(chat_id: str, owner_username: str, token_epoch: int) -> str:
   """Creates a short-lived JWT scoped to uploads and media for one chat.
 

--- a/backend/app/compiler.py
+++ b/backend/app/compiler.py
@@ -37,6 +37,9 @@ class CompileError(RuntimeError):
 
 _CONTENT_BUNDLE_RE = re.compile(r"^app-(?P<app_id>[0-9]+)-(?P<digest>[0-9a-f]{64})\.js$")
 _LEGACY_BUNDLE_RE = re.compile(r"^app-(?P<app_id>[0-9]+)\.js$")
+_PUBLIC_BUNDLE_RE = re.compile(
+  r"^public-app-(?P<app_id>[0-9]+)-(?P<digest>[0-9a-f]{64})\.js$"
+)
 
 
 def _compiled_dir() -> Path:
@@ -152,6 +155,81 @@ def unlink_app_bundle(app_id: int, path: str | Path | None) -> bool:
     return False
 
 
+def app_bundle_digest(app_id: int, path: str | Path | None) -> str | None:
+  """Return the content digest encoded by one validated immutable bundle."""
+  owned = owned_bundle_path(app_id, path)
+  if owned is None:
+    return None
+  match = _CONTENT_BUNDLE_RE.fullmatch(owned.name)
+  return match.group("digest") if match else None
+
+
+def owned_public_bundle_path(
+  app_id: int, path: str | Path | None,
+) -> Path | None:
+  """Return a validated anonymous-publication bundle owned by ``app_id``."""
+  if not path:
+    return None
+  candidate = Path(path)
+  try:
+    if candidate.parent.resolve() != _compiled_dir().resolve():
+      return None
+  except OSError:
+    return None
+  match = _PUBLIC_BUNDLE_RE.fullmatch(candidate.name)
+  if match is None or int(match.group("app_id")) != app_id:
+    return None
+  return _compiled_dir() / candidate.name
+
+
+def publish_public_bundle(app_id: int, source: str | Path) -> tuple[Path, str]:
+  """Snapshot one installed module behind a separately-owned public name.
+
+  The source bundle is immutable and content-addressed. A hard link gives the
+  hosted publication its own lifetime without duplicating bytes; unlinking a
+  later-superseded installed name cannot remove the public snapshot. The copy
+  fallback covers filesystems that do not support hard links.
+  """
+  source_path = owned_bundle_path(app_id, source)
+  if source_path is None or not source_path.is_file():
+    raise ValueError("Installed app bundle is missing or invalid.")
+  digest = _file_sha256(source_path)
+  final = _compiled_dir() / f"public-app-{app_id}-{digest}.js"
+  if final.exists():
+    try:
+      if _file_sha256(final) == digest:
+        _sync_published_bundle(final)
+        return final, digest
+    except OSError:
+      pass
+  staging = _compiled_dir() / f"public-app-{app_id}.js.staging"
+  staging.unlink(missing_ok=True)
+  try:
+    try:
+      os.link(source_path, staging)
+    except OSError:
+      shutil.copyfile(source_path, staging)
+    if _file_sha256(staging) != digest:
+      raise OSError("Public bundle snapshot changed while it was copied.")
+    os.replace(staging, final)
+    _sync_published_bundle(final)
+  finally:
+    staging.unlink(missing_ok=True)
+  return final, digest
+
+
+def unlink_public_bundle(app_id: int, path: str | Path | None) -> bool:
+  """Best-effort unlink of one validated hosted-publication bundle."""
+  owned = owned_public_bundle_path(app_id, path)
+  if owned is None:
+    return False
+  try:
+    owned.unlink(missing_ok=True)
+    return True
+  except OSError:
+    return False
+
+
 def purge_app_bundles(app_id: int) -> None:
   """Best-effort removal of every legacy/content bundle for a hard-deleted app."""
   compiled = _compiled_dir()
@@ -159,6 +237,8 @@ def purge_app_bundles(app_id: int) -> None:
     compiled / f"app-{app_id}.js",
     compiled / f"app-{app_id}.js.staging",
     *compiled.glob(f"app-{app_id}-*.js"),
+    compiled / f"public-app-{app_id}.js.staging",
+    *compiled.glob(f"public-app-{app_id}-*.js"),
   ]
   for candidate in candidates:
     if candidate.name.endswith(".staging"):
@@ -167,7 +247,10 @@ def purge_app_bundles(app_id: int) -> None:
       except OSError:
         pass
       continue
-    unlink_app_bundle(app_id, candidate)
+    if candidate.name.startswith("public-app-"):
+      unlink_public_bundle(app_id, candidate)
+    else:
+      unlink_app_bundle(app_id, candidate)
 
 
 def _entry_source_path(app, *, source_root: Path | None = None) -> Path:
@@ -520,11 +603,19 @@ def reap_orphaned_bundles(db) -> list[str]:
       referenced.add(Path(stored_path).resolve())
     except OSError:
       continue
+  for (stored_path,) in db.query(models.App.public_bundle_path).all():
+    if not stored_path:
+      continue
+    try:
+      referenced.add(Path(stored_path).resolve())
+    except OSError:
+      continue
   removed: list[str] = []
-  for candidate in _compiled_dir().glob("app-*.js"):
+  for candidate in _compiled_dir().glob("*.js"):
     if not (
       _LEGACY_BUNDLE_RE.fullmatch(candidate.name)
       or _CONTENT_BUNDLE_RE.fullmatch(candidate.name)
+      or _PUBLIC_BUNDLE_RE.fullmatch(candidate.name)
     ):
       continue
     try:

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -10,6 +10,7 @@ this module.
 import json
 import logging
 import os
+import secrets
 import threading
 import time
 import uuid
@@ -199,7 +200,7 @@ def _agent_lifecycle_width_migrations(
 
 
 def _upgrade_app_capability_contract(value):
-  """Drop the retired job-authority fields from known contract versions."""
+  """Advance known contracts and drop retired job-authority fields."""
   if isinstance(value, str):
     try:
       value = json.loads(value)
@@ -208,11 +209,11 @@ def _upgrade_app_capability_contract(value):
   if not isinstance(value, dict):
     return None
   schema = value.get("schema")
-  if type(schema) is not int or schema not in (1, 2, 3, 4):
+  if type(schema) is not int or schema not in (1, 2, 3, 4, 5):
     return None
 
   upgraded = dict(value)
-  changed = schema != 4
+  changed = schema != 5
   background = value.get("background")
   if isinstance(background, dict):
     next_background = {
@@ -222,9 +223,12 @@ def _upgrade_app_capability_contract(value):
     if next_background != background:
       upgraded["background"] = next_background
       changed = True
+  if not isinstance(value.get("public"), dict):
+    upgraded["public"] = {"network": []}
+    changed = True
   if not changed:
     return None
-  upgraded["schema"] = 4
+  upgraded["schema"] = 5
   return upgraded
 
 
@@ -1629,6 +1633,108 @@ def _add_delegation_parent_wake(eng) -> None:
       ))
 
 
+def _add_app_hosted_publication(eng) -> None:
+  """Replace the live public flag with an immutable hosted snapshot."""
+  from sqlalchemy import JSON as SAJSON, bindparam, inspect as sa_inspect, text
+  from app.app_capabilities import (
+    capability_digest,
+    public_access_declaration_from_contract,
+  )
+  from app.compiler import publish_public_bundle
+
+  inspector = sa_inspect(eng)
+  if "apps" not in inspector.get_table_names():
+    return
+  columns = {column["name"] for column in inspector.get_columns("apps")}
+  with eng.begin() as conn:
+    additions = {
+      "published_manifest_url": "VARCHAR(1024) NULL",
+      "public_name": "VARCHAR(255) NULL",
+      "public_bundle_path": "VARCHAR(512) NULL",
+      "public_bundle_digest": "VARCHAR(64) NULL",
+      "public_source_commit": "VARCHAR(64) NULL",
+      "public_access_contract": "JSON NULL",
+      "public_access_digest": "VARCHAR(64) NULL",
+      "public_token_nonce": "VARCHAR(32) NULL",
+      "public_published_at": "DATETIME NULL",
+    }
+    for name, declaration in additions.items():
+      if name not in columns:
+        conn.execute(text(f"ALTER TABLE apps ADD COLUMN {name} {declaration}"))
+        columns.add(name)
+
+    # The outbound distribution field was renamed before the hosted feature
+    # merged. Preserve local developer-instance data, then retire the old name;
+    # no runtime reads both shapes.
+    if "share_manifest_url" in columns:
+      conn.execute(text(
+        "UPDATE apps SET published_manifest_url = share_manifest_url "
+        "WHERE published_manifest_url IS NULL"
+      ))
+
+    if "capability_contract" in columns:
+      rows = conn.execute(text(
+        "SELECT id, capability_contract FROM apps "
+        "WHERE capability_contract IS NOT NULL"
+      )).fetchall()
+      update_contract = text(
+        "UPDATE apps SET capability_contract = :contract WHERE id = :app_id"
+      ).bindparams(bindparam("contract", type_=SAJSON))
+      for app_id, contract in rows:
+        upgraded = _upgrade_app_capability_contract(contract)
+        if upgraded is not None:
+          conn.execute(update_contract, {"contract": upgraded, "app_id": app_id})
+
+    # Owners who tried the unmerged boolean version keep one exact snapshot of
+    # what was live at migration time. Missing/legacy bundles fail private: a
+    # publication without executable bytes is not durable state.
+    required = {
+      "public_enabled", "compiled_path", "source_commit", "capability_contract",
+    }
+    if required.issubset(columns):
+      active = conn.execute(text(
+        "SELECT id, name, compiled_path, source_commit, capability_contract "
+        "FROM apps WHERE public_enabled = TRUE"
+      )).fetchall()
+      publish_row = text(
+        "UPDATE apps SET public_name = :public_name, "
+        "public_bundle_path = :bundle_path, "
+        "public_bundle_digest = :bundle_digest, "
+        "public_source_commit = :source_commit, "
+        "public_access_contract = :contract, "
+        "public_access_digest = :contract_digest, "
+        "public_token_nonce = :token_nonce, "
+        "public_published_at = :published_at WHERE id = :app_id"
+      ).bindparams(bindparam("contract", type_=SAJSON))
+      for app_id, name, compiled_path, source_commit, contract in active:
+        if isinstance(contract, str):
+          try:
+            contract = json.loads(contract)
+          except json.JSONDecodeError:
+            contract = {}
+        contract = contract if isinstance(contract, dict) else {}
+        try:
+          bundle_path, bundle_digest = publish_public_bundle(app_id, compiled_path)
+        except (OSError, ValueError):
+          continue
+        public_access = public_access_declaration_from_contract(contract)
+        conn.execute(publish_row, {
+          "public_name": name,
+          "bundle_path": str(bundle_path),
+          "bundle_digest": bundle_digest,
+          "source_commit": source_commit,
+          "contract": public_access,
+          "contract_digest": capability_digest(public_access),
+          "token_nonce": secrets.token_hex(16),
+          "published_at": datetime.now(UTC).replace(tzinfo=None),
+          "app_id": app_id,
+        })
+
+    for retired in ("share_manifest_url", "public_enabled"):
+      if retired in columns:
+        conn.execute(text(f"ALTER TABLE apps DROP COLUMN {retired}"))
+
+
 _SCHEMA_MIGRATIONS = (
   ("0001_legacy_schema_convergence", _converge_legacy_schema),
   ("0002_chat_run_goal_objective", _add_chat_run_goal_objective),
@@ -1642,6 +1748,7 @@ _SCHEMA_MIGRATIONS = (
   ("0010_chat_pending_question_id", _add_chat_pending_question_id),
   ("0011_delegation_parent_wake", _add_delegation_parent_wake),
   ("0012_connector_oauth_gcloud", _add_connector_oauth_gcloud_fields),
+  ("0013_app_hosted_publication", _add_app_hosted_publication),
 )
 
 

--- a/backend/app/deps.py
+++ b/backend/app/deps.py
@@ -97,6 +97,23 @@ class Principal:
   operations: frozenset[str] = frozenset()
 
 
+@dataclass(frozen=True)
+class PublicAppAccess:
+  """One live, anonymous, exact-app capability."""
+
+  app: models.App
+
+  @property
+  def app_id(self) -> int:
+    return self.app.id
+
+  @property
+  def network(self) -> list[dict]:
+    contract = self.app.public_access_contract
+    rules = contract.get("network") if isinstance(contract, dict) else None
+    return rules if isinstance(rules, list) else []
+
+
 def chat_embed_grant_is_latest_consumed(
   db: Session,
   grant: models.ChatEmbedGrant | None,
@@ -408,6 +425,47 @@ def resolve_owner_or_app(token: str, db: Session) -> models.Owner:
     raise HTTPException(status_code=403, detail="Token scope is not valid here.")
   _enforce_app_scope(payload, db)
   return owner
+
+
+def resolve_public_app_token(
+  token: str,
+  db: Session,
+  *,
+  expected_app_id: int | None = None,
+) -> PublicAppAccess:
+  """Resolve a low-privilege public token against current app state."""
+  payload = auth.decode_access_token(token)
+  if not payload or payload.get("scope") != "public_app":
+    raise HTTPException(status_code=401, detail="Valid public app token required.")
+  app_id = payload.get("app_id")
+  nonce = payload.get("publication_nonce")
+  if (
+    not isinstance(app_id, int)
+    or not isinstance(nonce, str)
+    or (expected_app_id is not None and app_id != expected_app_id)
+  ):
+    raise HTTPException(status_code=401, detail="Malformed public app token.")
+  app = (
+    db.query(models.App)
+    .filter(models.App.id == app_id, models.App.deleted_at.is_(None))
+    .first()
+  )
+  if (
+    app is None
+    or not app.public_bundle_path
+    or not app.public_token_nonce
+    or nonce != app.public_token_nonce
+  ):
+    raise HTTPException(status_code=401, detail="Public app session is no longer valid.")
+  return PublicAppAccess(app=app)
+
+
+def authorize_app_module_token(
+  token: str,
+  db: Session,
+) -> None:
+  """Authorize owner/app module reads; public snapshots use their own route."""
+  resolve_owner_or_app(token, db)
 
 
 def get_current_owner_or_app(

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -67,6 +67,7 @@ from app.routes import (
   connectors_router, connectors_public_router,
   debug_router, delegations_router, fs_router, github_router, media_router,
   local_services_router, notifications_router, notify_router, proxy_router, push_router,
+  public_apps_router,
   secrets_router, self_reminders_router, settings_router, skills_router,
   client_error_router, client_signal_router, standalone_router, storage_router,
   theme_router, uploads_router, platform_router,
@@ -178,6 +179,11 @@ async def lifespan(app):
     yield
   finally:
     record_memory_checkpoint("shutdown_begin")
+    try:
+      from app.public_app_transport import close_public_fetch_clients
+      await close_public_fetch_clients()
+    except Exception as exc:
+      _log.error("public fetch client shutdown failed: %s", exc, exc_info=True)
     # Preserve the final partial request-error windows across graceful restarts.
     # This is one bounded batch append, not one write per response.
     activity.flush_request_errors()
@@ -634,6 +640,7 @@ except Exception as _exc:  # pragma: no cover - defensive boot guard
   )
 app.include_router(notify_router)
 app.include_router(proxy_router)
+app.include_router(public_apps_router)
 app.include_router(local_services_router)
 app.include_router(client_error_router)
 app.include_router(client_signal_router)
@@ -1300,6 +1307,19 @@ if _baked_dir.is_dir() or _live_dir.is_dir():
     # Resolve which build serves THIS request (live dist if complete, else the
     # baked floor) once, up front — per request, never a module-load snapshot.
     static_dir = _resolve_static_dir()
+    # An explicitly public app owns its exact top-level slug. It still runs in
+    # the ordinary opaque sandbox, but the tiny parent host carries only a
+    # short-lived exact-app public capability — never the owner's session.
+    try:
+      from app.routes.public_apps import public_app_page_for_path
+      public_page = await run_in_threadpool(public_app_page_for_path, path)
+    except Exception:
+      logging.getLogger(__name__).exception(
+        "public app host resolution failed for path=%s", path,
+      )
+      public_page = None
+    if public_page is not None:
+      return public_page
     app_slug = await run_in_threadpool(_top_level_app_slug_alias, path)
     if app_slug:
       from fastapi.responses import RedirectResponse

--- a/backend/app/manifest_contract.py
+++ b/backend/app/manifest_contract.py
@@ -228,6 +228,11 @@ def validate_manifest_contract(manifest) -> None:
   # Runtime capabilities are normalized by the same canonical registry used
   # to build the owner-reviewable install contract. Keep a single definition
   # of names, versions, limits, and failure semantics.
+  from app.app_capabilities import normalize_public_access
+  try:
+    normalize_public_access(dict(manifest))
+  except ValueError as exc:
+    _fail(str(exc))
   from app.app_capabilities import normalize_runtime_capabilities
   try:
     normalize_runtime_capabilities(dict(manifest))

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -594,11 +594,23 @@ class App(Base):
   # between user-built apps and store-installed apps are tolerated
   # because allocate_unique_slug just picks the next free suffix.
   manifest_url = Column(String(1024), nullable=True, index=True)
-  # Public manifest URL the owner explicitly attached for sharing this app.
+  # Public manifest URL the owner explicitly attached for distributing this app.
   # Kept separate from `manifest_url`: the latter is install/update identity,
   # while a locally-built app may be published later without becoming a
   # Store-managed install or changing how its source updates are reconciled.
-  share_manifest_url = Column(String(1024), nullable=True, default=None)
+  published_manifest_url = Column(String(1024), nullable=True, default=None)
+  # Hosted anonymous use is a snapshot, not a live flag. These fields bind the
+  # exact immutable module and reviewed public network contract that the owner
+  # published. Later source/capability changes therefore remain private until
+  # the owner explicitly publishes an update.
+  public_name = Column(String(255), nullable=True, default=None)
+  public_bundle_path = Column(String(512), nullable=True, default=None)
+  public_bundle_digest = Column(String(64), nullable=True, default=None)
+  public_source_commit = Column(String(64), nullable=True, default=None)
+  public_access_contract = Column(JSON, nullable=True, default=None)
+  public_access_digest = Column(String(64), nullable=True, default=None)
+  public_token_nonce = Column(String(32), nullable=True, default=None)
+  public_published_at = Column(DateTime, nullable=True, default=None)
   # Soft-delete tombstone. Uninstall sets this instead of dropping the row, so
   # the source tree AND the id-keyed runtime storage tree survive — a reinstall
   # (matched by manifest_url) or POST /{id}/recover then revives the SAME id +

--- a/backend/app/public_app_transport.py
+++ b/backend/app/public_app_transport.py
@@ -1,0 +1,270 @@
+"""Bounded, observable transport for anonymous app network access."""
+
+from __future__ import annotations
+
+import asyncio
+from collections import OrderedDict
+from contextlib import asynccontextmanager
+from copy import deepcopy
+from dataclasses import dataclass
+from datetime import UTC, datetime
+import hashlib
+import threading
+import time
+from urllib.parse import parse_qsl, urlsplit
+
+import httpx
+from fastapi import HTTPException
+from fastapi.responses import Response
+
+from app.net_utils import validate_url_safe
+from app.routes.proxy import _capped_response
+
+
+_usage_lock = threading.Lock()
+_usage: dict[int, dict] = {}
+_transport_metrics = {
+  "clients": 0,
+  "active_requests": 0,
+  "active_limit": 64,
+  "clients_created": 0,
+  "clients_evicted": 0,
+}
+
+
+@dataclass
+class _PooledClient:
+  client: httpx.AsyncClient
+  leases: int = 0
+
+
+class _PublicFetchClientPool:
+  """Bounded, host-isolated connection reuse for anonymous upstream reads.
+
+  DNS safety pins requests to an IP while TLS still uses the declared host.
+  One global client would be unsafe because HTTPX pools by the pinned origin
+  and could reuse a TLS connection for two logical hosts sharing an IP. Keying
+  clients by Host/SNI preserves that boundary and still removes a handshake per
+  map tile or API page.
+  """
+
+  def __init__(self, max_clients: int = 64, max_active: int = 64):
+    self.max_clients = max_clients
+    self.max_active = max_active
+    self._lock = asyncio.Lock()
+    self._capacity = asyncio.BoundedSemaphore(max_active)
+    self._clients: OrderedDict[tuple[str, str], _PooledClient] = OrderedDict()
+    with _usage_lock:
+      _transport_metrics["active_limit"] = max_active
+
+  def _publish_metrics(self) -> None:
+    with _usage_lock:
+      _transport_metrics["clients"] = len(self._clients)
+      _transport_metrics["active_requests"] = sum(
+        entry.leases for entry in self._clients.values()
+      )
+
+  def _trim(self) -> list[httpx.AsyncClient]:
+    retired: list[httpx.AsyncClient] = []
+    while len(self._clients) > self.max_clients:
+      idle_key = next(
+        (key for key, entry in self._clients.items() if entry.leases == 0),
+        None,
+      )
+      if idle_key is None:
+        break
+      retired.append(self._clients.pop(idle_key).client)
+      with _usage_lock:
+        _transport_metrics["clients_evicted"] += 1
+    self._publish_metrics()
+    return retired
+
+  @asynccontextmanager
+  async def lease(self, host_header: str, sni_host: str):
+    await self._capacity.acquire()
+    try:
+      key = (host_header, sni_host)
+      retired: list[httpx.AsyncClient] = []
+      async with self._lock:
+        entry = self._clients.pop(key, None)
+        if entry is None:
+          entry = _PooledClient(httpx.AsyncClient(
+            follow_redirects=False,
+            timeout=15,
+            limits=httpx.Limits(
+              max_connections=16,
+              max_keepalive_connections=4,
+              keepalive_expiry=30,
+            ),
+          ))
+          with _usage_lock:
+            _transport_metrics["clients_created"] += 1
+        entry.leases += 1
+        self._clients[key] = entry
+        retired = self._trim()
+      try:
+        for client in retired:
+          await client.aclose()
+        yield entry.client
+      finally:
+        async with self._lock:
+          live = self._clients.get(key)
+          if live is entry:
+            live.leases = max(0, live.leases - 1)
+          retired = self._trim()
+        for client in retired:
+          await client.aclose()
+    finally:
+      self._capacity.release()
+
+  async def close(self) -> None:
+    async with self._lock:
+      clients = [entry.client for entry in self._clients.values()]
+      self._clients.clear()
+      self._publish_metrics()
+    for client in clients:
+      await client.aclose()
+
+
+_fetch_clients = _PublicFetchClientPool()
+
+
+async def close_public_fetch_clients() -> None:
+  await _fetch_clients.close()
+
+
+def _record_usage(app_id: int, *, elapsed: float, response_bytes: int, failed: bool):
+  with _usage_lock:
+    row = _usage.setdefault(app_id, {
+      "requests": 0,
+      "failures": 0,
+      "response_bytes": 0,
+      "upstream_seconds": 0.0,
+      "started_at": datetime.now(UTC).isoformat(),
+      "last_request_at": None,
+    })
+    row["requests"] += 1
+    row["failures"] += int(failed)
+    row["response_bytes"] += max(0, response_bytes)
+    row["upstream_seconds"] += max(0.0, elapsed)
+    row["last_request_at"] = datetime.now(UTC).isoformat()
+
+
+def public_app_usage_snapshot() -> dict[str, dict]:
+  """Cheap per-process counters for spotting a public app's server footprint."""
+  with _usage_lock:
+    return {
+      "apps": {str(app_id): deepcopy(row) for app_id, row in _usage.items()},
+      "transport": deepcopy(_transport_metrics),
+    }
+
+
+def _query_allowed(raw_query: str, contract: dict | None) -> bool:
+  """Apply one explicit, bounded query contract.
+
+  Prefix-only URL checks are not enough for endpoints such as GraphQL, where
+  the query string selects the operation. Rules therefore default to no query
+  parameters and may separately allow arbitrary values, exact values, or
+  SHA-256-bound values without embedding large static queries in a manifest.
+  """
+  try:
+    pairs = parse_qsl(raw_query, keep_blank_values=True, strict_parsing=True)
+  except ValueError:
+    return False
+  if len(pairs) > 16 or len({name for name, _value in pairs}) != len(pairs):
+    return False
+  if not isinstance(contract, dict):
+    contract = {}
+  allowed = contract.get("allow", [])
+  exact = contract.get("exact", {})
+  digests = contract.get("sha256", {})
+  if (
+    not isinstance(allowed, list)
+    or not isinstance(exact, dict)
+    or not isinstance(digests, dict)
+    or not all(isinstance(name, str) for name in allowed)
+    or not all(isinstance(values, list) for values in exact.values())
+    or not all(isinstance(values, list) for values in digests.values())
+  ):
+    return False
+  values = dict(pairs)
+  permitted = set(allowed) | set(exact) | set(digests)
+  if set(values) - permitted:
+    return False
+  for name, accepted in exact.items():
+    if values.get(name) not in accepted:
+      return False
+  for name, accepted in digests.items():
+    value = values.get(name)
+    if value is None or hashlib.sha256(value.encode()).hexdigest() not in accepted:
+      return False
+  return True
+
+
+def _target_allowed(url: str, rules: list[dict]) -> bool:
+  try:
+    parsed = urlsplit(url)
+    port = parsed.port
+  except ValueError:
+    return False
+  if parsed.scheme != "https" or not parsed.hostname:
+    return False
+  host = parsed.hostname.lower()
+  origin = f"https://{host if port in (None, 443) else f'{host}:{port}'}"
+  path = parsed.path or "/"
+  lowered_path = path.lower()
+  # Do not let an allowlisted prefix be escaped through a server that decodes
+  # encoded path separators/dot segments before routing the request.
+  if (
+    "\\" in path
+    or any(segment in (".", "..") for segment in path.split("/"))
+    or any(encoded in lowered_path for encoded in ("%2e", "%2f", "%5c"))
+  ):
+    return False
+  for rule in rules:
+    if not isinstance(rule, dict) or rule.get("origin") != origin:
+      continue
+    prefix = rule.get("path_prefix")
+    if not isinstance(prefix, str):
+      continue
+    if (path == prefix or prefix == "/" or (
+      prefix.endswith("/") and path.startswith(prefix)
+    ) or path.startswith(prefix + "/")) and _query_allowed(
+      parsed.query, rule.get("query"),
+    ):
+      return True
+  return False
+
+
+async def fetch_public_url(
+  app_id: int,
+  url: str,
+  rules: list[dict],
+) -> Response:
+  """Fetch one declared public URL through the bounded shared transport."""
+  if not _target_allowed(url, rules):
+    raise HTTPException(status_code=403, detail="URL is not allowed for this public app.")
+
+  pinned_url, host_header, sni_host = validate_url_safe(url)
+  started = time.monotonic()
+  try:
+    async with _fetch_clients.lease(host_header, sni_host) as client:
+      upstream = client.build_request("GET", pinned_url)
+      upstream.headers["host"] = host_header
+      upstream.extensions["sni_hostname"] = sni_host
+      response = await _capped_response(
+        client, upstream, forward_cache_headers=True,
+      )
+  except Exception:
+    _record_usage(
+      app_id, elapsed=time.monotonic() - started, response_bytes=0, failed=True,
+    )
+    raise
+  body = getattr(response, "body", b"") or b""
+  _record_usage(
+    app_id,
+    elapsed=time.monotonic() - started,
+    response_bytes=len(body),
+    failed=response.status_code >= 400,
+  )
+  return response

--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -65,6 +65,7 @@ try:
 except Exception:  # pragma: no cover - mirrors _load's stub behavior
   connectors_public_router = APIRouter()
 proxy_router = _load("proxy")
+public_apps_router = _load("public_apps")
 local_services_router = _load("local_services")
 notify_router = _load("notify")
 settings_router = _load("settings")
@@ -102,6 +103,7 @@ __all__ = [
   "connectors_router",
   "connectors_public_router",
   "proxy_router",
+  "public_apps_router",
   "local_services_router",
   "notify_router",
   "settings_router",

--- a/backend/app/routes/app_runtime.py
+++ b/backend/app/routes/app_runtime.py
@@ -15,7 +15,7 @@ from sqlalchemy.orm import Session
 from app import activity, models, theme
 from app.config import get_settings
 from app.database import get_db
-from app.deps import get_current_owner, resolve_owner_or_app
+from app.deps import authorize_app_module_token, get_current_owner
 from app.http_caching import strip_range
 from app.net_utils import validate_url_safe
 from app.resource_access import live_app, live_app_or_404
@@ -461,7 +461,7 @@ def get_module(
     raise HTTPException(
       status_code=401, detail="Valid token required."
     )
-  resolve_owner_or_app(token, db)
+  authorize_app_module_token(token, db)
   app = live_app(db, app_id)
   if not app or not app.compiled_path:
     raise HTTPException(status_code=404, detail="Module not found.")

--- a/backend/app/routes/apps.py
+++ b/backend/app/routes/apps.py
@@ -48,9 +48,12 @@ from app.storage_io import (
 from app.app_capabilities import diff_contracts
 from app.broadcast import get_system_broadcast
 from app.compiler import (
+  app_bundle_digest,
   app_bundle_uses_current_compile_contract,
   CompileError,
+  publish_public_bundle,
   recompile_app_bundle,
+  unlink_public_bundle,
 )
 from app.chat_start import start_programmatic_chat_turn
 from app.config import get_settings
@@ -465,6 +468,14 @@ async def install_app(
     filesystem_access=app.filesystem_access,
     slug=app.slug,
     manifest_url=app.manifest_url,
+    published_manifest_url=app.published_manifest_url,
+    public_name=app.public_name,
+    public_bundle_path=app.public_bundle_path,
+    public_bundle_digest=app.public_bundle_digest,
+    public_source_commit=app.public_source_commit,
+    public_access_contract=app.public_access_contract,
+    public_access_digest=app.public_access_digest,
+    public_published_at=app.public_published_at,
     theme_color=app.theme_color,
     background_color=app.background_color,
     display=app.display,
@@ -613,10 +624,10 @@ def _recorded_runtime_paths(previous_tree: dict[str, bytes]) -> set[str]:
   return paths
 
 
-def _accepted_local_share_package(app: models.App) -> tuple[str, str]:
+def _accepted_local_distribution_package(app: models.App) -> tuple[str, str]:
   """Return accepted manifest identity + origin-independent package digest.
 
-  A local worktree is a draft. Sharing must compare the public package with the
+  A local worktree is a draft. Distribution must compare the public package with the
   immutable commit that produced the live bundle, not with files an agent may
   be editing for the next apply. The digest mirrors every installer input:
   manifest, entry, icon, job, source modules, static assets, and storage seeds.
@@ -627,8 +638,10 @@ def _accepted_local_share_package(app: models.App) -> tuple[str, str]:
     raise HTTPException(
       409,
       {
-        "code": "share_source_unavailable",
-        "message": "Apply the local app source before attaching a share URL.",
+        "code": "distribution_source_unavailable",
+        "message": (
+          "Apply the local app source before attaching a distribution manifest."
+        ),
       },
     )
   try:
@@ -643,10 +656,10 @@ def _accepted_local_share_package(app: models.App) -> tuple[str, str]:
     raise HTTPException(
       409,
       {
-        "code": "share_source_unavailable",
+        "code": "distribution_source_unavailable",
         "message": (
           "The accepted local package could not be reproduced. Apply its "
-          "complete source again before attaching a share URL."
+          "complete source again before attaching a distribution manifest."
         ),
       },
     ) from exc
@@ -2086,8 +2099,8 @@ async def update_app(
   """Update owner-controlled app metadata and narrow permission grants."""
   from app import install
 
-  share_candidate = None
-  if body.share_manifest_url:
+  distribution_candidate = None
+  if body.published_manifest_url:
     # Prove the row exists and is local before spending a network fetch. Close
     # the request session before that I/O so a slow publisher cannot occupy a
     # database connection or either lifecycle lock.
@@ -2096,13 +2109,13 @@ async def update_app(
       raise HTTPException(
         409,
         {
-          "code": "share_requires_local_app",
-          "message": "Only a local app can attach a separate share URL.",
+          "code": "distribution_requires_local_app",
+          "message": "Only a local app can attach a separate distribution manifest.",
         },
       )
     db.close()
-    share_candidate = await install.fetch_install_candidate(
-      body.share_manifest_url,
+    distribution_candidate = await install.fetch_install_candidate(
+      body.published_manifest_url,
     )
 
   async with (
@@ -2124,46 +2137,47 @@ async def update_app(
       app.cross_app_access = body.cross_app_access
     if body.chat_log_access is not None:
       app.chat_log_access = body.chat_log_access
-    if body.share_manifest_url is not None:
-      if share_candidate is not None:
+    if body.published_manifest_url is not None:
+      if distribution_candidate is not None:
         if app.manifest_url is not None:
           raise HTTPException(
             409,
             {
-              "code": "share_requires_local_app",
-              "message": "Only a local app can attach a separate share URL.",
+              "code": "distribution_requires_local_app",
+              "message": "Only a local app can attach a separate distribution manifest.",
             },
           )
         accepted_id, accepted_digest = await asyncio.to_thread(
-          _accepted_local_share_package, app,
+          _accepted_local_distribution_package, app,
         )
-        if share_candidate.manifest["id"] != accepted_id:
+        if distribution_candidate.manifest["id"] != accepted_id:
           raise HTTPException(
             409,
             {
-              "code": "share_identity_mismatch",
+              "code": "distribution_identity_mismatch",
               "message": (
                 "The published manifest belongs to a different app. Publish "
-                "this app's accepted package before attaching its share URL."
+                "this app's accepted package before attaching its distribution "
+                "manifest."
               ),
             },
           )
         published_digest = install.install_candidate_content_digest(
-          share_candidate,
+          distribution_candidate,
         )
         if published_digest != accepted_digest:
           raise HTTPException(
             409,
             {
-              "code": "share_package_mismatch",
+              "code": "distribution_package_mismatch",
               "message": (
                 "The published package does not match the app's accepted "
                 "revision. Publish the current package before attaching its "
-                "share URL."
+                "distribution manifest."
               ),
             },
           )
-      app.share_manifest_url = body.share_manifest_url or None
+      app.published_manifest_url = body.published_manifest_url or None
     if body.manage_skills is not None:
       # Downgrade-only: the owner can revoke skills authority here (effective
       # on the app's next request — the gate reads the live row), but a grant
@@ -2210,7 +2224,7 @@ async def update_app(
       field is None
       for field in (
         body.name, body.description, body.chat_id, body.share_with_apps,
-        body.cross_app_access, body.chat_log_access, body.share_manifest_url,
+        body.cross_app_access, body.chat_log_access, body.published_manifest_url,
         body.manage_skills,
       )
     )
@@ -2222,6 +2236,105 @@ async def update_app(
     # query's chat_id + updated_at, so app_updated alone surfaces it in the
     # owning chat. A metadata-only PATCH still bumps updated_at; the wire carries
     # no source-only version key to gate on.
+  return app
+
+
+@router.put(
+  "/{app_id}/hosted-publication",
+  response_model=schemas.AppOut,
+  dependencies=[Depends(reject_cross_site)],
+)
+async def publish_hosted_app(
+  app_id: int,
+  db: Session = Depends(get_db),
+  _: models.Owner = Depends(get_current_owner),
+):
+  """Publish the app's exact current module and anonymous network contract."""
+  from app.app_capabilities import (
+    capability_digest,
+    public_access_declaration_from_contract,
+  )
+  from app.routes.public_apps import public_slug_is_available
+
+  new_bundle = None
+  previous_bundle = None
+  async with (
+    fs_locks.install_uninstall_lock(),
+    fs_locks.app_storage_lock(app_id),
+  ):
+    app = live_app_or_404(db, app_id, populate=True)
+    if not public_slug_is_available(app.slug):
+      raise HTTPException(
+        status_code=400,
+        detail="This app slug is reserved and cannot be published.",
+      )
+    current_digest = app_bundle_digest(app.id, app.compiled_path)
+    if current_digest is None:
+      raise HTTPException(
+        status_code=409,
+        detail="The current app build is not ready to publish.",
+      )
+    previous_bundle = app.public_bundle_path
+    try:
+      new_bundle, bundle_digest = await asyncio.to_thread(
+        publish_public_bundle, app.id, app.compiled_path,
+      )
+      if bundle_digest != current_digest:
+        raise RuntimeError("The app build changed while publication was prepared.")
+      public_access = public_access_declaration_from_contract(
+        app.capability_contract,
+      )
+      app.public_name = app.name
+      app.public_bundle_path = str(new_bundle)
+      app.public_bundle_digest = bundle_digest
+      app.public_source_commit = app.source_commit
+      app.public_access_contract = public_access
+      app.public_access_digest = capability_digest(public_access)
+      app.public_token_nonce = secrets.token_hex(16)
+      app.public_published_at = now_naive_utc()
+      db.commit()
+    except Exception:
+      db.rollback()
+      if new_bundle is not None and str(new_bundle) != previous_bundle:
+        unlink_public_bundle(app_id, new_bundle)
+      raise
+    if previous_bundle and previous_bundle != str(new_bundle):
+      unlink_public_bundle(app_id, previous_bundle)
+    db.refresh(app)
+  get_system_broadcast().publish({"type": "app_updated", "appId": str(app.id)})
+  return app
+
+
+@router.delete(
+  "/{app_id}/hosted-publication",
+  response_model=schemas.AppOut,
+  dependencies=[Depends(reject_cross_site)],
+)
+async def stop_hosted_app(
+  app_id: int,
+  db: Session = Depends(get_db),
+  _: models.Owner = Depends(get_current_owner),
+):
+  """Revoke the active anonymous snapshot and every token minted for it."""
+  previous_bundle = None
+  async with (
+    fs_locks.install_uninstall_lock(),
+    fs_locks.app_storage_lock(app_id),
+  ):
+    app = live_app_or_404(db, app_id, populate=True)
+    previous_bundle = app.public_bundle_path
+    app.public_name = None
+    app.public_bundle_path = None
+    app.public_bundle_digest = None
+    app.public_source_commit = None
+    app.public_access_contract = None
+    app.public_access_digest = None
+    app.public_token_nonce = None
+    app.public_published_at = None
+    db.commit()
+    unlink_public_bundle(app_id, previous_bundle)
+    db.refresh(app)
+  get_system_broadcast().publish({"type": "app_updated", "appId": str(app.id)})
   return app
 
 

--- a/backend/app/routes/debug.py
+++ b/backend/app/routes/debug.py
@@ -189,6 +189,11 @@ def debug_status(
     memory=memory["cgroup"],
   )
   result["runtime_memory"] = _runtime_memory_ownership(include_payloads=False)
+  try:
+    from app.public_app_transport import public_app_usage_snapshot
+    result["public_apps"] = public_app_usage_snapshot()
+  except Exception:
+    result["public_apps"] = {}
   if reconciliation_failed:
     result["reconciliation_failed"] = True
   if media_migration_failed:

--- a/backend/app/routes/github.py
+++ b/backend/app/routes/github.py
@@ -551,7 +551,7 @@ async def github_source_status(
     "slug": row.slug,
     "version": row.version,
     "manifest_url": row.manifest_url,
-    "share_manifest_url": row.share_manifest_url,
+    "published_manifest_url": row.published_manifest_url,
     "source_dir": row.source_dir,
   } for row in rows]
 

--- a/backend/app/routes/proxy.py
+++ b/backend/app/routes/proxy.py
@@ -230,7 +230,10 @@ async def _first_supported_icon(
 
 
 async def _capped_response(
-  client: httpx.AsyncClient, req: httpx.Request
+  client: httpx.AsyncClient,
+  req: httpx.Request,
+  *,
+  forward_cache_headers: bool = False,
 ) -> Response:
   """Sends `req` streaming and reads at most `_MAX_BYTES` into memory. The prior
   code read the FULL body (`r.content`) before slicing, so a huge or malicious
@@ -254,6 +257,10 @@ async def _capped_response(
       for name in _FORWARDED_RESPONSE_HEADERS
       if name in r.headers
     }
+    if forward_cache_headers:
+      for name in ("cache-control", "etag", "expires", "last-modified"):
+        if name in r.headers:
+          headers[name] = r.headers[name]
     return Response(
       content=bytes(buf),
       status_code=r.status_code,

--- a/backend/app/routes/public_apps.py
+++ b/backend/app/routes/public_apps.py
@@ -1,0 +1,290 @@
+"""Anonymous, exact-app runtime publication and bounded public fetching.
+
+Public app sessions reuse the normal opaque app frame, but their bearer has no
+owner identity and no access to owner/app APIs. The only server-mediated
+network capability is GET against the app manifest's exact reviewed allowlist.
+"""
+
+from __future__ import annotations
+
+import html
+import json
+from copy import deepcopy
+from pathlib import Path
+
+from fastapi import APIRouter, Header, HTTPException, Request
+from fastapi.responses import FileResponse, HTMLResponse
+from slowapi import Limiter
+
+from app import auth, models
+from app.compiler import owned_public_bundle_path
+from app.database import SessionLocal
+from app.deps import resolve_public_app_token
+from app.public_app_transport import fetch_public_url
+
+router = APIRouter(prefix="/api/public-apps", tags=["public-apps"])
+
+PUBLIC_APP_RESERVED_SLUGS = frozenset({
+  "api",
+  "app",
+  "app-assets",
+  "app-embeds",
+  "apps",
+  "assets",
+  "chat",
+  "index.html",
+  "manifest.webmanifest",
+  "mobius-runtime.js",
+  "recover",
+  "shell",
+  "sites",
+  "sw.js",
+  "sw-push.js",
+  "vendor",
+})
+
+
+def public_slug_is_available(slug: str) -> bool:
+  return bool(
+    slug
+    and "/" not in slug
+    and all(ch.isalnum() or ch in "-_" for ch in slug)
+    and slug not in PUBLIC_APP_RESERVED_SLUGS
+  )
+
+
+def _json_for_script(value) -> str:
+  # JSON is executable JavaScript here. Escape '<' so owner-authored app names
+  # cannot manufacture a closing script tag inside the platform-owned page.
+  return json.dumps(value, separators=(",", ":")).replace("<", "\\u003c")
+
+
+def _public_host_html(app: models.App, token: str) -> str:
+  app_id = app.id
+  frame_version = app.public_bundle_digest or "0"
+  title = html.escape(app.public_name, quote=True)
+  app_id_json = _json_for_script(app_id)
+  token_json = _json_for_script(token)
+  version_json = _json_for_script(frame_version)
+  return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover" />
+  <meta name="color-scheme" content="dark light" />
+  <title>{title}</title>
+  <style>
+    :root {{ color-scheme: dark; background: #101514; }}
+    * {{ box-sizing: border-box; }}
+    html, body, iframe {{ width: 100%; height: 100%; margin: 0; border: 0; }}
+    body {{ overflow: hidden; background: #101514; }}
+    iframe {{ display: block; background: #101514; }}
+    #status {{
+      position: fixed; inset: 0; display: grid; place-items: center;
+      padding: 24px; background: #101514; color: #d7dfdc;
+      font: 500 14px/1.5 ui-sans-serif, system-ui, sans-serif;
+      text-align: center; transition: opacity .16s ease; pointer-events: none;
+    }}
+    #status.is-ready {{ opacity: 0; }}
+    #status.is-error {{ pointer-events: auto; }}
+  </style>
+</head>
+<body>
+  <iframe id="app" title="{title}"></iframe>
+  <div id="status" role="status">Opening {title}…</div>
+  <script>
+  (() => {{
+    const APP_ID = {app_id_json};
+    const TOKEN = {token_json};
+    const VERSION = {version_json};
+    const FRAME_URL = '/api/apps/' + APP_ID + '/frame?v=' + encodeURIComponent(VERSION);
+    const frame = document.getElementById('app');
+    const status = document.getElementById('status');
+
+    function send(message, transfer) {{
+      try {{ frame.contentWindow.postMessage(message, '*', transfer || []); }} catch {{}}
+    }}
+
+    function showError(message) {{
+      status.textContent = message || 'This public app could not be opened.';
+      status.className = 'is-error';
+    }}
+
+    frame.addEventListener('load', () => send({{
+      type: 'moebius:frame-init', token: TOKEN, themeCss: '', bg: '#101514',
+      storage: {{}}, capabilityContract: null,
+    }}));
+    frame.src = FRAME_URL;
+
+    window.addEventListener('message', event => {{
+      if (event.source !== frame.contentWindow) return;
+      if (event.origin !== 'null' && event.origin !== window.location.origin) return;
+      const message = event.data;
+      if (!message || typeof message !== 'object') return;
+
+      if (message.type === 'moebius:module-request') {{
+        if (!message.requestId || String(message.appId) !== String(APP_ID)) return;
+        send({{ type: 'moebius:module-ack', requestId: message.requestId, appId: APP_ID }});
+        const retry = message.retry === 1 ? '&retry=1' : '';
+        fetch('/api/public-apps/' + APP_ID + '/module?v=' + encodeURIComponent(VERSION)
+          + retry, {{ headers: {{ Authorization: 'Bearer ' + TOKEN }} }})
+          .then(async response => {{
+            if (!response.ok) {{
+              const error = new Error('The app module returned ' + response.status + '.');
+              error.status = response.status;
+              throw error;
+            }}
+            return response.arrayBuffer();
+          }})
+          .then(bytes => send({{
+            type: 'moebius:module-result', requestId: message.requestId,
+            appId: APP_ID, ok: true, bytes,
+          }}, [bytes]))
+          .catch(error => send({{
+            type: 'moebius:module-result', requestId: message.requestId,
+            appId: APP_ID, ok: false,
+            error: {{ code: 'module-load-failed', message: error.message,
+              status: error.status || null }},
+          }}));
+        return;
+      }}
+
+      if (message.type === 'moebius:storage-rpc') {{
+        if (!message.requestId) return;
+        const method = typeof message.method === 'string' ? message.method : '';
+        const empty = method === 'list' ? []
+          : method === 'pendingCount' || method === 'pendingSignalCount' ? 0
+          : method === 'getWithVersion' ? {{ value: null, version: null }}
+          : method === 'subscribe' || method === 'unsubscribe' ? true
+          : method === 'get' || method === 'getText' || method === 'getBlob' ? null
+          : undefined;
+        if (empty !== undefined) {{
+          send({{ type: 'moebius:storage-rpc-result', requestId: message.requestId,
+            ok: true, result: empty }});
+        }} else {{
+          send({{ type: 'moebius:storage-rpc-result', requestId: message.requestId,
+            ok: false, error: {{ name: 'Error', code: 'public_storage_readonly',
+              status: 403, message: 'Public app sessions do not use owner storage.' }} }});
+        }}
+        return;
+      }}
+
+      if (message.type === 'moebius:capability-open' ||
+          message.type === 'moebius:capability-control') {{
+        if (!message.requestId) return;
+        send({{ type: 'moebius:capability-error', requestId: message.requestId,
+          code: 'public_capability_unavailable', name: 'NotAllowedError',
+          message: 'This device capability is unavailable in a public session.' }});
+        return;
+      }}
+
+      if (message.type === 'moebius:frame-mounted' &&
+          String(message.appId) === String(APP_ID)) {{
+        status.className = 'is-ready';
+        return;
+      }}
+      if (message.type === 'moebius:frame-error') {{
+        showError(message.error?.message || message.message);
+        return;
+      }}
+      if (message.type === 'moebius:token-expired' ||
+          message.type === 'moebius:token-refresh-request') {{
+        window.location.reload();
+      }}
+    }});
+  }})();
+  </script>
+</body>
+</html>"""
+
+
+def public_app_page_for_path(path: str) -> HTMLResponse | None:
+  """Return an anonymous app host for one exact published slug, if any."""
+  slug = path.strip("/")
+  if not public_slug_is_available(slug):
+    return None
+  db = SessionLocal()
+  try:
+    app = (
+      db.query(models.App)
+      .filter(
+        models.App.slug == slug,
+        models.App.deleted_at.is_(None),
+        models.App.public_name.isnot(None),
+        models.App.public_bundle_path.isnot(None),
+      )
+      .first()
+    )
+    if app is None or not app.public_token_nonce:
+      return None
+    token = auth.create_public_app_token(app.id, app.public_token_nonce)
+    body = _public_host_html(app, token)
+  finally:
+    db.close()
+  return HTMLResponse(body, headers={
+    "Cache-Control": "no-store",
+    "X-Content-Type-Options": "nosniff",
+  })
+
+
+def _public_app_key(request: Request) -> str:
+  return str(request.path_params.get("app_id", "invalid"))
+
+
+_fetch_limiter = Limiter(key_func=_public_app_key, key_style="endpoint")
+_fetch_limit = _fetch_limiter.shared_limit(
+  "3000/minute", scope="public-app-fetch",
+)
+
+
+def _bearer(authorization: str | None) -> str:
+  scheme, _, token = (authorization or "").partition(" ")
+  if scheme.lower() != "bearer" or not token:
+    raise HTTPException(status_code=401, detail="Valid public app token required.")
+  return token
+
+
+@router.get("/{app_id}/module")
+async def public_app_module(
+  app_id: int,
+  authorization: str | None = Header(default=None),
+):
+  """Serve the immutable module bound to one active hosted publication."""
+  token = _bearer(authorization)
+  db = SessionLocal()
+  try:
+    access = resolve_public_app_token(token, db, expected_app_id=app_id)
+    path = owned_public_bundle_path(app_id, access.app.public_bundle_path)
+    digest = access.app.public_bundle_digest
+  finally:
+    db.close()
+  if path is None or not path.is_file() or not digest:
+    raise HTTPException(status_code=404, detail="Published module not found.")
+  return FileResponse(
+    Path(path),
+    media_type="text/javascript; charset=utf-8",
+    headers={
+      "Cache-Control": "private, max-age=31536000, immutable",
+      "ETag": f'"{digest}"',
+      "X-Mobius-Offline": "false",
+    },
+  )
+
+
+@router.get("/{app_id}/fetch")
+@_fetch_limit
+async def public_app_fetch(
+  app_id: int,
+  request: Request,
+  url: str,
+  authorization: str | None = Header(default=None),
+):
+  """GET one app-declared public URL with exact-app anonymous authority."""
+  token = _bearer(authorization)
+  db = SessionLocal()
+  try:
+    access = resolve_public_app_token(token, db, expected_app_id=app_id)
+    rules = deepcopy(access.network)
+  finally:
+    db.close()
+  return await fetch_public_url(app_id, url, rules)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,6 +1,8 @@
 """Pydantic request and response schemas."""
 
 from datetime import UTC, datetime
+from pathlib import PurePath
+import re
 from typing import Literal
 from urllib.parse import quote, urlsplit
 
@@ -47,6 +49,21 @@ class AppSourceManifest(BaseModel):
 
   id: str
   url: str
+
+
+class AppDistributionManifest(AppSourceManifest):
+  """Install/remix handoff and the lifecycle that owns it."""
+
+  kind: Literal["published", "source"]
+
+
+class AppHostedPublication(BaseModel):
+  """Owner-visible state for one exact anonymous hosted snapshot."""
+
+  path: str
+  revision: str
+  published_at: datetime
+  has_unpublished_changes: bool
 
 
 # A one-time sign-in pass handed to a mini-app being installed to the iOS home
@@ -136,16 +153,16 @@ class AppUpdate(BaseModel):
   # Public install manifest attached after a local app is published. Empty
   # string clears it; None means omitted. This is deliberately separate from
   # App.manifest_url, which controls Store install/update identity.
-  share_manifest_url: str | None = Field(default=None, max_length=1024)
+  published_manifest_url: str | None = Field(default=None, max_length=1024)
   # Owner-only DOWNGRADE of skills authority: False revokes immediately (the
   # request gate reads the live row, so already-minted app JWTs lose access on
   # their next call). Granting (True) is rejected — that path stays with the
   # reviewed manifest install.
   manage_skills: bool | None = None
 
-  @field_validator("share_manifest_url")
+  @field_validator("published_manifest_url")
   @classmethod
-  def validate_share_manifest_url(cls, value: str | None) -> str | None:
+  def validate_published_manifest_url(cls, value: str | None) -> str | None:
     if value is None:
       return None
     value = value.strip()
@@ -158,7 +175,7 @@ class AppUpdate(BaseModel):
       or parsed.username is not None
       or parsed.password is not None
     ):
-      raise ValueError("Share manifest URL must be a public HTTPS URL.")
+      raise ValueError("Published manifest URL must be a public HTTPS URL.")
     return value
 
 
@@ -204,9 +221,16 @@ class AppOut(BaseModel):
   # POST /api/apps/install). Null for user-built apps. The install
   # endpoint matches by this for update-vs-install discrimination.
   manifest_url: str | None = None
-  # Optional public install manifest attached to a locally-built app after
-  # publication. Drawer sharing prefers this without changing Store identity.
-  share_manifest_url: str | None = None
+  # Internal publication inputs. Clients receive the typed projections below,
+  # never the nullable persistence fields or executable path.
+  published_manifest_url: str | None = Field(default=None, exclude=True)
+  public_name: str | None = Field(default=None, exclude=True)
+  public_bundle_path: str | None = Field(default=None, exclude=True)
+  public_bundle_digest: str | None = Field(default=None, exclude=True)
+  public_source_commit: str | None = Field(default=None, exclude=True)
+  public_access_contract: dict | None = Field(default=None, exclude=True)
+  public_access_digest: str | None = Field(default=None, exclude=True)
+  public_published_at: datetime | None = Field(default=None, exclude=True)
   # The manifest version currently installed (e.g. "1.7.0"). Null for
   # user-built apps and for rows installed before the column existed
   # (they backfill on their next update). The store reads this to show
@@ -256,6 +280,57 @@ class AppOut(BaseModel):
     return AppSourceManifest(
       id=manifest_id,
       url=f"{base.rstrip('/')}/mobius.json",
+    )
+
+  @computed_field
+  @property
+  def distribution_manifest(self) -> AppDistributionManifest | None:
+    """Return one install/remix handoff without leaking persistence identity."""
+    if self.published_manifest_url:
+      return AppDistributionManifest(
+        id=self.slug,
+        url=self.published_manifest_url,
+        kind="published",
+      )
+    source = self.source_manifest
+    if source is None:
+      return None
+    return AppDistributionManifest(**source.model_dump(), kind="source")
+
+  @computed_field
+  @property
+  def hosted_publication(self) -> AppHostedPublication | None:
+    """Project the active snapshot and whether a newer private draft exists."""
+    if (
+      not self.public_name
+      or not self.public_bundle_path
+      or not self.public_bundle_digest
+      or self.public_published_at is None
+    ):
+      return None
+    current_match = re.fullmatch(
+      rf"app-{self.id}-(?P<digest>[0-9a-f]{{64}})\.js",
+      PurePath(self.compiled_path).name,
+    )
+    current_bundle_digest = (
+      current_match.group("digest") if current_match is not None else None
+    )
+    from app.app_capabilities import (
+      capability_digest,
+      public_access_declaration_from_contract,
+    )
+    current_access_digest = capability_digest(
+      public_access_declaration_from_contract(self.capability_contract),
+    )
+    return AppHostedPublication(
+      path=f"/{quote(self.slug, safe='')}",
+      revision=self.public_bundle_digest[:12],
+      published_at=self.public_published_at,
+      has_unpublished_changes=(
+        self.name != self.public_name
+        or current_bundle_digest != self.public_bundle_digest
+        or current_access_digest != self.public_access_digest
+      ),
     )
 
   model_config = {"from_attributes": True}

--- a/backend/app/source_status.py
+++ b/backend/app/source_status.py
@@ -617,7 +617,7 @@ def build_app_status(app: dict[str, Any]) -> dict[str, Any] | None:
     # arbitrary filesystem probe.
     return None
   repository_manifest_url = (
-    app.get("manifest_url") or app.get("share_manifest_url")
+    app.get("manifest_url") or app.get("published_manifest_url")
   )
   return _project_status(
     repo=source_dir,

--- a/backend/scripts/agent-screenshot.sh
+++ b/backend/scripts/agent-screenshot.sh
@@ -609,13 +609,30 @@ fi
 
 # For shell routes, prove the browser loaded the same hashed entry asset that
 # exists in the currently-built dist. This turns stale screenshots into a clear
-# failure instead of misleading visual evidence. Standalone app PWAs have their
-# own entry shape, but still receive controller detachment + cache-busted
-# navigation.
+# failure instead of misleading visual evidence. Standalone PWAs and anonymous
+# public app hosts have their own entry shapes, but still receive controller
+# detachment + cache-busted navigation.
 SHELL_SETTLED_EXPR=""
+PUBLIC_APP_PAGE="$(browser_eval_retry \
+  "document.querySelector('body > iframe#app') !== null && document.querySelector('body > #status') !== null" \
+  || true)"
 case "$ROUTE" in
   /apps/*) : ;;
   *)
+    if [ "$PUBLIC_APP_PAGE" = "true" ]; then
+      CAPTURE_MIN_BYTES=8192
+      BROWSER_PHASE="public app visual readiness"
+      if ! browser_wait --fn \
+        "document.querySelector('body > iframe#app') !== null && document.querySelector('body > #status.is-ready') !== null" \
+        >/dev/null; then
+        die "public app did not reach its mounted frame before capture"
+      fi
+      if ! browser_eval_retry \
+        "new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve(true))))" \
+        >/dev/null; then
+        die "public app did not commit its mounted frame before capture"
+      fi
+    else
     # An authenticated shell frame always contains chrome/text and is far
     # larger than the ~3 KiB one-colour PNG Chromium emits before its first
     # useful compositor submission. Standalone app PWAs may intentionally be a
@@ -671,6 +688,7 @@ PY
       "new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve(true))))" \
       >/dev/null; then
       die "shell did not commit its settled frame before capture"
+    fi
     fi
     ;;
 esac

--- a/backend/tests/test_agent_screenshot_auth.py
+++ b/backend/tests/test_agent_screenshot_auth.py
@@ -115,6 +115,7 @@ def _fake_browser(tmp_path: Path) -> tuple[Path, Path]:
     "  eval)\n"
     "    if [ \"$2\" = \"--stdin\" ]; then cat > \"$FAKE_BROWSER_STDIN_LOG\"; exit 0; fi\n"
     "    case \"$2\" in\n"
+    "      *body\\ \\>\\ iframe#app*) printf '%s\\n' \"${FAKE_PUBLIC_APP:-false}\" ;;\n"
     "      *src.split*) printf '%s\\n' \"${FAKE_LOADED_ASSET:-none}\" ;;\n"
     "      *serviceWorker*) printf '%s\\n' true ;;\n"
     "      *) printf '%s\\n' \"${FAKE_AUTH_OK:-false}\" ;;\n"
@@ -177,6 +178,7 @@ def _run_helper(
   wait_error: bool = False,
   timeout_eval_mode: str = "",
   bootstrap_intercept_once: bool = False,
+  public_app: bool = False,
   existing_output: bytes | None = None,
   profile_locked: bool = False,
   subprocess_timeout: float | None = None,
@@ -243,6 +245,7 @@ def _run_helper(
     "FAKE_TIMEOUT_EVAL_MARKER": str(tmp_path / "timeout-eval-once"),
     "FAKE_BOOTSTRAP_INTERCEPT_ONCE": "1" if bootstrap_intercept_once else "0",
     "FAKE_BOOTSTRAP_INTERCEPT_MARKER": str(tmp_path / "bootstrap-intercepted"),
+    "FAKE_PUBLIC_APP": "true" if public_app else "false",
   }
   args = ["bash", str(script)]
   if content_only:
@@ -521,6 +524,23 @@ def test_stale_shell_fails_instead_of_capturing_misleading_evidence(tmp_path: Pa
   assert "stale shell loaded" in result.stderr
   assert not output.exists()
   assert not marker.exists()
+
+
+def test_public_app_host_uses_its_mounted_frame_readiness_contract(tmp_path: Path):
+  result, output, marker, browser_log = _run_helper(
+    tmp_path,
+    auth_ok=True,
+    route="/published-map",
+    public_app=True,
+    loaded_asset="index-stale.js",
+  )
+
+  assert result.returncode == 0, result.stderr
+  assert output.exists()
+  assert marker.exists()
+  commands = browser_log.read_text(encoding="utf-8").splitlines()
+  assert not any("src.split" in command for command in commands)
+  assert any("#status.is-ready" in command for command in commands)
 
 
 def test_preserve_cache_mode_is_explicit_and_skips_freshness_reset(tmp_path: Path):

--- a/backend/tests/test_app_apply.py
+++ b/backend/tests/test_app_apply.py
@@ -416,14 +416,14 @@ def test_reapply_unchanged_source_has_no_commit_or_timestamp_change(
   assert app_git.head_sha(source, app_git.LOCAL_BRANCH) == head
 
 
-def test_local_source_revision_clears_previously_verified_share_url(
+def test_local_source_revision_clears_previously_verified_distribution_manifest(
   client, auth, db,
 ):
   source = _source()
   created = _apply(client, auth, source)
   app_id = created.json()["app"]["id"]
   row = db.query(models.App).populate_existing().filter_by(id=app_id).one()
-  row.share_manifest_url = (
+  row.published_manifest_url = (
     "https://raw.githubusercontent.com/example/demo/main/mobius.json"
   )
   db.commit()
@@ -435,9 +435,9 @@ def test_local_source_revision_clears_previously_verified_share_url(
 
   assert updated.status_code == 200, updated.text
   assert updated.json()["mode"] == "updated"
-  assert updated.json()["app"]["share_manifest_url"] is None
+  assert updated.json()["app"]["distribution_manifest"] is None
   db.refresh(row)
-  assert row.share_manifest_url is None
+  assert row.published_manifest_url is None
 
 
 def test_local_manifest_identity_is_immutable(client, auth, db):

--- a/backend/tests/test_app_capabilities.py
+++ b/backend/tests/test_app_capabilities.py
@@ -79,8 +79,9 @@ def test_preview_returns_server_derived_contract_and_digest(
     "user_configurable": False,
     "initialize_on_install": True,
   }
-  assert body["capability_contract"]["schema"] == 4
+  assert body["capability_contract"]["schema"] == 5
   assert body["capability_contract"]["runtime"] == {}
+  assert body["capability_contract"]["public"] == {"network": []}
 
 
 def test_runtime_capability_is_independently_versioned_and_bounded():

--- a/backend/tests/test_apps.py
+++ b/backend/tests/test_apps.py
@@ -122,13 +122,13 @@ def test_update_app_rejects_cross_site_request(client, auth):
   assert cross.status_code == 403
 
 
-def test_update_app_attaches_share_url_without_changing_install_identity(
+def test_update_app_attaches_distribution_manifest_without_changing_install_identity(
   client, auth, db,
 ):
   app = create_local_app(
     client, auth, name="Published later", description="test",
   )
-  share_url = "https://raw.githubusercontent.com/example/app/main/mobius.json"
+  distribution_url = "https://raw.githubusercontent.com/example/app/main/mobius.json"
   row = db.query(models.App).filter(models.App.id == app["id"]).one()
   candidate = _published_candidate(row)
 
@@ -136,28 +136,30 @@ def test_update_app_attaches_share_url_without_changing_install_identity(
   with patch("app.install.fetch_install_candidate", new=fetch):
     response = client.patch(
       f"/api/apps/{app['id']}",
-      json={"share_manifest_url": share_url},
+      json={"published_manifest_url": distribution_url},
       headers=auth,
     )
 
     assert response.status_code == 200, response.text
-    assert response.json()["share_manifest_url"] == share_url
+    assert response.json()["distribution_manifest"] == {
+      "id": app["slug"], "url": distribution_url, "kind": "published",
+    }
     assert response.json()["manifest_url"] is None
     db.refresh(row)
-    assert row.share_manifest_url == share_url
+    assert row.published_manifest_url == distribution_url
     assert row.manifest_url is None
 
     cleared = client.patch(
       f"/api/apps/{app['id']}",
-      json={"share_manifest_url": ""},
+      json={"published_manifest_url": ""},
       headers=auth,
     )
     assert cleared.status_code == 200, cleared.text
-    assert cleared.json()["share_manifest_url"] is None
-  fetch.assert_awaited_once_with(share_url)
+    assert cleared.json()["distribution_manifest"] is None
+  fetch.assert_awaited_once_with(distribution_url)
 
 
-def test_update_app_rejects_share_package_that_is_not_the_accepted_revision(
+def test_update_app_rejects_distribution_package_that_is_not_the_accepted_revision(
   client, auth, db,
 ):
   app = create_local_app(
@@ -174,7 +176,7 @@ def test_update_app_rejects_share_package_that_is_not_the_accepted_revision(
     response = client.patch(
       f"/api/apps/{app['id']}",
       json={
-        "share_manifest_url": (
+        "published_manifest_url": (
           "https://raw.githubusercontent.com/example/app/main/mobius.json"
         ),
       },
@@ -182,15 +184,15 @@ def test_update_app_rejects_share_package_that_is_not_the_accepted_revision(
     )
 
   assert response.status_code == 409, response.text
-  assert response.json()["detail"]["code"] == "share_package_mismatch"
+  assert response.json()["detail"]["code"] == "distribution_package_mismatch"
   db.expire_all()
   assert (
     db.query(models.App).filter(models.App.id == app["id"]).one()
-    .share_manifest_url
+    .published_manifest_url
   ) is None
 
 
-def test_update_app_rejects_share_manifest_for_a_different_app(
+def test_update_app_rejects_distribution_manifest_for_a_different_app(
   client, auth, db,
 ):
   app = create_local_app(
@@ -210,7 +212,7 @@ def test_update_app_rejects_share_manifest_for_a_different_app(
     response = client.patch(
       f"/api/apps/{app['id']}",
       json={
-        "share_manifest_url": (
+        "published_manifest_url": (
           "https://raw.githubusercontent.com/example/app/main/mobius.json"
         ),
       },
@@ -218,16 +220,16 @@ def test_update_app_rejects_share_manifest_for_a_different_app(
     )
 
   assert response.status_code == 409, response.text
-  assert response.json()["detail"]["code"] == "share_identity_mismatch"
+  assert response.json()["detail"]["code"] == "distribution_identity_mismatch"
 
 
-def test_update_app_rejects_non_public_share_url(client, auth):
+def test_update_app_rejects_non_public_distribution_manifest(client, auth):
   app = create_local_app(
     client, auth, name="Private share", description="test",
   )
   response = client.patch(
     f"/api/apps/{app['id']}",
-    json={"share_manifest_url": "http://localhost/mobius.json"},
+    json={"published_manifest_url": "http://localhost/mobius.json"},
     headers=auth,
   )
   assert response.status_code == 422

--- a/backend/tests/test_db_migrations.py
+++ b/backend/tests/test_db_migrations.py
@@ -78,12 +78,13 @@ def test_run_migrations_removes_retired_job_authority_receipts(
   with Session(eng) as session:
     contract = session.get(models.App, app_id).capability_contract
   assert contract == {
-    "schema": 4,
+    "schema": 5,
     "data": {"shared_memory": "write"},
     "background": {
       "job": "fetch.sh",
       "mode": "scheduled",
     },
+    "public": {"network": []},
   }
 
 
@@ -110,7 +111,7 @@ def test_run_migrations_adds_manifest_url_to_existing_apps_table(tmp_path):
   indexes = {i["name"] for i in inspector.get_indexes("apps")}
 
   assert "manifest_url" in cols
-  assert "share_manifest_url" in cols
+  assert "published_manifest_url" in cols
   assert "ix_apps_manifest_url" in indexes
   # Reversible-uninstall tombstone column is added on an existing apps table
   # (feature 110) — the path that runs on a real prod boot, not create_all.
@@ -1016,6 +1017,7 @@ def test_run_migrations_records_an_inspectable_append_only_history(tmp_path):
     "0010_chat_pending_question_id",
     "0011_delegation_parent_wake",
     "0012_connector_oauth_gcloud",
+    "0013_app_hosted_publication",
   ]
   assert second == first
 
@@ -1117,6 +1119,115 @@ def test_connections_manage_reaches_a_ledgered_database(tmp_path):
   assert "0009_app_connections_manage" in {
     entry["version"] for entry in schema_migration_history(eng)
   }
+
+
+def test_hosted_publication_reaches_a_fully_ledgered_private_app(tmp_path):
+  """0013 adds snapshot fields and a closed public contract to old rows."""
+  eng = create_engine(f"sqlite:///{tmp_path / 'ledgered-public-apps.db'}")
+  with eng.begin() as conn:
+    conn.execute(text(
+      "CREATE TABLE apps ("
+      "id INTEGER PRIMARY KEY, name VARCHAR(255), slug VARCHAR(128), "
+      "token_nonce VARCHAR(32), capability_contract JSON)"
+    ))
+    conn.execute(text(
+      "INSERT INTO apps VALUES "
+      "(1, 'Old app', 'old-app', 'nonce', :contract)"
+    ), {"contract": json.dumps({"schema": 4, "runtime": {}})})
+    conn.execute(text(
+      "CREATE TABLE schema_migrations ("
+      "version VARCHAR(128) PRIMARY KEY, applied_at TIMESTAMP NOT NULL)"
+    ))
+    for version, _migration in database._SCHEMA_MIGRATIONS[:-1]:
+      conn.execute(text(
+        "INSERT INTO schema_migrations (version, applied_at) "
+        "VALUES (:version, '2026-08-15 00:00:00')"
+      ), {"version": version})
+
+  run_migrations(eng)
+  columns = {c["name"] for c in inspect(eng).get_columns("apps")}
+  assert "public_enabled" not in columns
+  assert "public_bundle_path" in columns
+  with eng.connect() as conn:
+    public_bundle, raw_contract = conn.execute(text(
+      "SELECT public_bundle_path, capability_contract FROM apps WHERE id = 1"
+    )).one()
+  contract = json.loads(raw_contract) if isinstance(raw_contract, str) else raw_contract
+  assert public_bundle is None
+  assert contract["schema"] == 5
+  assert contract["public"] == {"network": []}
+  assert "0013_app_hosted_publication" in {
+    entry["version"] for entry in schema_migration_history(eng)
+  }
+
+
+def test_hosted_publication_migrates_the_unmerged_live_flag_to_a_snapshot(
+  tmp_path, monkeypatch,
+):
+  monkeypatch.setattr(get_settings(), "data_dir", str(tmp_path))
+  compiled = tmp_path / "compiled"
+  compiled.mkdir()
+  module = b"export default function App(){return null}\n"
+  digest = hashlib.sha256(module).hexdigest()
+  installed_bundle = compiled / f"app-1-{digest}.js"
+  installed_bundle.write_bytes(module)
+  eng = create_engine(f"sqlite:///{tmp_path / 'flag-to-snapshot.db'}")
+  contract = {"schema": 5, "public": {"network": []}}
+  with eng.begin() as conn:
+    conn.execute(text(
+      "CREATE TABLE apps ("
+      "id INTEGER PRIMARY KEY, name VARCHAR(255), slug VARCHAR(128), "
+      "token_nonce VARCHAR(32), compiled_path VARCHAR(512), "
+      "source_commit VARCHAR(64), capability_contract JSON, "
+      "share_manifest_url VARCHAR(1024), "
+      "public_enabled BOOLEAN NOT NULL DEFAULT FALSE)"
+    ))
+    conn.execute(text(
+      "INSERT INTO apps VALUES "
+      "(1, 'Live app', 'live-app', 'nonce', :bundle, :commit, :contract, "
+      ":manifest, TRUE)"
+    ), {
+      "bundle": str(installed_bundle),
+      "commit": "a" * 40,
+      "contract": json.dumps(contract),
+      "manifest": "https://example.test/live-app/mobius.json",
+    })
+    conn.execute(text(
+      "CREATE TABLE schema_migrations ("
+      "version VARCHAR(128) PRIMARY KEY, applied_at TIMESTAMP NOT NULL)"
+    ))
+    for version, _migration in database._SCHEMA_MIGRATIONS[:-1]:
+      conn.execute(text(
+        "INSERT INTO schema_migrations (version, applied_at) "
+        "VALUES (:version, '2026-08-15 00:00:00')"
+      ), {"version": version})
+
+  run_migrations(eng)
+
+  columns = {c["name"] for c in inspect(eng).get_columns("apps")}
+  assert "public_enabled" not in columns
+  assert "share_manifest_url" not in columns
+  with eng.connect() as conn:
+    row = conn.execute(text(
+      "SELECT published_manifest_url, public_bundle_path, "
+      "public_name, public_bundle_digest, public_source_commit, "
+      "public_access_contract, "
+      "public_token_nonce "
+      "FROM apps WHERE id = 1"
+    )).one()
+  assert row.published_manifest_url == "https://example.test/live-app/mobius.json"
+  assert row.public_name == "Live app"
+  assert Path(row.public_bundle_path).read_bytes() == module
+  assert Path(row.public_bundle_path) != installed_bundle
+  assert row.public_bundle_digest == digest
+  assert row.public_source_commit == "a" * 40
+  public_access = (
+    json.loads(row.public_access_contract)
+    if isinstance(row.public_access_contract, str)
+    else row.public_access_contract
+  )
+  assert public_access == {"network": []}
+  assert len(row.public_token_nonce) == 32
 
 
 def test_connector_oauth_gcloud_migration_upgrades_legacy_rows_idempotently(

--- a/backend/tests/test_debug_status.py
+++ b/backend/tests/test_debug_status.py
@@ -69,6 +69,15 @@ def test_debug_status_shape_matches_golden(client, auth):
     "omitted": True,
     "detail_url": "/api/debug/memory",
   }
+  public_apps = payload.pop("public_apps")
+  assert set(public_apps) == {"apps", "transport"}
+  assert all(str(app_id).isdigit() for app_id in public_apps["apps"])
+  assert set(public_apps["transport"]) == {
+    "clients", "active_requests", "active_limit", "clients_created",
+    "clients_evicted",
+  }
+  assert public_apps["transport"]["active_limit"] > 0
+  assert all(value >= 0 for value in public_apps["transport"].values())
   golden_path = Path(__file__).with_name("golden_debug_status.json")
   expected = json.loads(golden_path.read_text(encoding="utf-8"))
   assert payload == expected

--- a/backend/tests/test_github_routes.py
+++ b/backend/tests/test_github_routes.py
@@ -866,7 +866,7 @@ def test_source_status_requires_github_access_for_app_tokens(
   assert allowed.status_code == 200, allowed.text
 
 
-def test_source_status_projects_local_share_manifest_identity(
+def test_source_status_projects_local_distribution_manifest_identity(
   client, owner_token, auth, monkeypatch,
 ):
   from app import models
@@ -875,14 +875,14 @@ def test_source_status_projects_local_share_manifest_identity(
   app_id, _ = _app_token(client, owner_token)
   source_dir = Path(get_settings().data_dir) / "apps" / "published-source"
   source_dir.mkdir(parents=True, exist_ok=True)
-  share_url = (
+  distribution_url = (
     "https://raw.githubusercontent.com/example/published/main/mobius.json"
   )
   session = SessionLocal()
   try:
     session.query(models.App).filter(models.App.id == app_id).update({
       "source_dir": str(source_dir),
-      "share_manifest_url": share_url,
+      "published_manifest_url": distribution_url,
     })
     session.commit()
   finally:
@@ -894,7 +894,7 @@ def test_source_status_projects_local_share_manifest_identity(
 
   def inspect(app):
     assert app["manifest_url"] is None
-    assert app["share_manifest_url"] == share_url
+    assert app["published_manifest_url"] == distribution_url
     return {"key": f"app:{app['id']}", "name": app["name"]}
 
   monkeypatch.setattr(source_status, "build_app_status", inspect)

--- a/backend/tests/test_public_apps.py
+++ b/backend/tests/test_public_apps.py
@@ -1,0 +1,294 @@
+"""Hosted app publication stays snapshotted, exact-app, and revocable."""
+
+import hashlib
+import json
+from pathlib import Path
+import re
+
+from fastapi.responses import Response
+
+from app import auth as token_auth, models
+from app.config import get_settings
+from app.database import SessionLocal
+from test_app_fixtures import create_local_app
+
+
+PUBLIC_ACCESS = {
+  "network": [{
+    "origin": "https://example.com",
+    "path_prefix": "/events",
+    "query": {"allow": ["city"]},
+  }],
+}
+
+
+def _create(
+  client, auth, name="Public test", public_access=PUBLIC_ACCESS, **kwargs,
+):
+  return create_local_app(
+    client,
+    auth,
+    name=name,
+    manifest_extra={"public_access": public_access},
+    **kwargs,
+  )
+
+
+def _publish(client, headers, app_id):
+  return client.put(f"/api/apps/{app_id}/hosted-publication", headers=headers)
+
+
+def _public_token_from_html(html: str) -> str:
+  match = re.search(r"const TOKEN = (\"[^\"]+\");", html)
+  assert match, html[:1000]
+  return json.loads(match.group(1))
+
+
+def _public_module(client, app_id: int, token: str):
+  return client.get(
+    f"/api/public-apps/{app_id}/module",
+    headers={"Authorization": f"Bearer {token}"},
+  )
+
+
+def test_app_is_private_by_default_and_top_level_alias_stays_owner_only(
+  client, auth,
+):
+  app = _create(client, auth)
+  assert app["hosted_publication"] is None
+  assert app["capability_contract"]["public"] == PUBLIC_ACCESS
+
+  response = client.get(f"/{app['slug']}", follow_redirects=False)
+  assert response.status_code == 307
+  assert response.headers["location"] == f"/apps/{app['slug']}/"
+
+
+def test_owner_publishes_exact_snapshot_without_exposing_an_owner_token(
+  client, auth,
+):
+  app = _create(client, auth)
+  published = _publish(client, auth, app["id"])
+  assert published.status_code == 200, published.text
+  state = published.json()["hosted_publication"]
+  assert state["path"] == f"/{app['slug']}"
+  assert state["has_unpublished_changes"] is False
+
+  response = client.get(f"/{app['slug']}", follow_redirects=False)
+  assert response.status_code == 200
+  assert response.headers["cache-control"] == "no-store"
+  assert "moebius:frame-init" in response.text
+  assert "/module?token=" not in response.text
+  token = _public_token_from_html(response.text)
+  claims = token_auth.decode_access_token(token)
+  assert claims["scope"] == "public_app"
+  assert claims["app_id"] == app["id"]
+  assert "sub" not in claims
+  assert "epoch" not in claims
+
+  module = _public_module(client, app["id"], token)
+  assert module.status_code == 200
+  assert client.get(
+    f"/api/public-apps/{app['id']}/module", params={"token": token},
+  ).status_code == 401
+  # Public tokens never enter the owner/app module route.
+  assert client.get(
+    f"/api/apps/{app['id']}/module", params={"token": token},
+  ).status_code in (401, 403)
+
+
+def test_private_edit_does_not_change_live_snapshot_until_publish_update(
+  client, auth,
+):
+  app = _create(client, auth, jsx_source=(
+    "export default function App() { return <div>first</div> }\n"
+  ))
+  assert _publish(client, auth, app["id"]).status_code == 200
+  first_page = client.get(f"/{app['slug']}")
+  first_token = _public_token_from_html(first_page.text)
+  first_module = _public_module(client, app["id"], first_token).content
+
+  source = Path(app["source_dir"])
+  (source / "index.jsx").write_text(
+    "export default function App() { return <div>second</div> }\n"
+  )
+  applied = client.post(
+    "/api/apps/apply",
+    json={"source_dir": str(source)},
+    headers=auth,
+  )
+  assert applied.status_code == 200, applied.text
+  assert applied.json()["app"]["hosted_publication"][
+    "has_unpublished_changes"
+  ] is True
+  assert _public_module(client, app["id"], first_token).content == first_module
+
+  republished = _publish(client, auth, app["id"])
+  assert republished.status_code == 200, republished.text
+  assert republished.json()["hosted_publication"][
+    "has_unpublished_changes"
+  ] is False
+  assert _public_module(client, app["id"], first_token).status_code == 401
+  second_token = _public_token_from_html(client.get(f"/{app['slug']}").text)
+  second_module = _public_module(client, app["id"], second_token).content
+  assert second_module != first_module
+
+
+def test_private_name_edit_does_not_change_public_metadata_until_republish(
+  client, auth,
+):
+  app = _create(client, auth, name="Original public name")
+  assert _publish(client, auth, app["id"]).status_code == 200
+
+  renamed = client.patch(
+    f"/api/apps/{app['id']}",
+    json={"name": "Private draft name"},
+    headers=auth,
+  )
+  assert renamed.status_code == 200, renamed.text
+  assert renamed.json()["hosted_publication"]["has_unpublished_changes"] is True
+  public_page = client.get(f"/{app['slug']}")
+  assert "<title>Original public name</title>" in public_page.text
+  assert "Private draft name" not in public_page.text
+
+  assert _publish(client, auth, app["id"]).status_code == 200
+  updated_page = client.get(f"/{app['slug']}")
+  assert "<title>Private draft name</title>" in updated_page.text
+
+
+def test_public_token_is_exact_app_and_rejected_by_private_surfaces(
+  client, auth,
+):
+  first = _create(client, auth, "First public")
+  second = _create(client, auth, "Second private")
+  _publish(client, auth, first["id"])
+  token = _public_token_from_html(client.get(f"/{first['slug']}").text)
+  bearer = {"Authorization": f"Bearer {token}"}
+
+  assert _public_module(client, second["id"], token).status_code == 401
+  assert client.get(
+    f"/api/storage/apps/{first['id']}/private.json", headers=bearer,
+  ).status_code in (401, 403)
+  assert client.get(
+    "/api/proxy?url=https%3A%2F%2Fexample.com%2Fevents", headers=bearer,
+  ).status_code in (401, 403)
+  assert client.get("/api/settings", headers=bearer).status_code in (401, 403)
+
+
+def test_public_fetch_enforces_path_query_contract_and_exact_app_token(
+  client, auth, monkeypatch,
+):
+  from app import public_app_transport as public_transport
+
+  app = _create(client, auth)
+  other = _create(client, auth, "Other app")
+  _publish(client, auth, app["id"])
+  token = _public_token_from_html(client.get(f"/{app['slug']}").text)
+  bearer = {"Authorization": f"Bearer {token}"}
+
+  monkeypatch.setattr(
+    public_transport,
+    "validate_url_safe",
+    lambda url: (url, "example.com", "example.com"),
+  )
+
+  clients = []
+
+  async def fake_response(_client, _request, **_kwargs):
+    clients.append(_client)
+    return Response(
+      b"ok", media_type="text/plain", headers={"Cache-Control": "max-age=60"},
+    )
+
+  monkeypatch.setattr(public_transport, "_capped_response", fake_response)
+  allowed = client.get(
+    f"/api/public-apps/{app['id']}/fetch",
+    params={"url": "https://example.com/events/today?city=london"},
+    headers=bearer,
+  )
+  assert allowed.status_code == 200
+  assert allowed.text == "ok"
+  assert allowed.headers["cache-control"] == "max-age=60"
+  repeated = client.get(
+    f"/api/public-apps/{app['id']}/fetch",
+    params={"url": "https://example.com/events/today?city=berlin"},
+    headers=bearer,
+  )
+  assert repeated.status_code == 200
+  assert clients[0] is clients[1]
+
+  for denied_url in (
+    "https://example.com/account",
+    "https://example.com/events?admin=true",
+    "https://example.com/events?city=london&city=berlin",
+  ):
+    denied = client.get(
+      f"/api/public-apps/{app['id']}/fetch",
+      params={"url": denied_url},
+      headers=bearer,
+    )
+    assert denied.status_code == 403
+  denied_app = client.get(
+    f"/api/public-apps/{other['id']}/fetch",
+    params={"url": "https://example.com/events"},
+    headers=bearer,
+  )
+  assert denied_app.status_code == 401
+
+
+def test_public_query_contract_can_bind_large_operation_text_by_digest():
+  from app.public_app_transport import _target_allowed
+
+  query = "query LIST($city: String!) { events(city: $city) { id } }"
+  rules = [{
+    "origin": "https://example.com",
+    "path_prefix": "/graphql",
+    "query": {
+      "allow": ["variables"],
+      "sha256": {"query": [hashlib.sha256(query.encode()).hexdigest()]},
+    },
+  }]
+  from urllib.parse import urlencode
+  allowed = "https://example.com/graphql?" + urlencode({
+    "query": query, "variables": '{"city":"London"}',
+  })
+  denied = "https://example.com/graphql?" + urlencode({
+    "query": "query ADMIN { users { password } }",
+    "variables": "{}",
+  })
+
+  assert _target_allowed(allowed, rules) is True
+  assert _target_allowed(denied, rules) is False
+
+
+def test_stop_revokes_existing_session_and_restores_private_alias(client, auth):
+  app = _create(client, auth)
+  _publish(client, auth, app["id"])
+  token = _public_token_from_html(client.get(f"/{app['slug']}").text)
+
+  stopped = client.delete(
+    f"/api/apps/{app['id']}/hosted-publication", headers=auth,
+  )
+  assert stopped.status_code == 200
+  assert stopped.json()["hosted_publication"] is None
+  assert _public_module(client, app["id"], token).status_code == 401
+  root = client.get(f"/{app['slug']}", follow_redirects=False)
+  assert root.status_code == 307
+  assert root.headers["location"] == f"/apps/{app['slug']}/"
+
+
+def test_reserved_root_slug_cannot_be_published(client, auth):
+  app = create_local_app(
+    client,
+    auth,
+    name="Reserved shell",
+    source_dir=f"{get_settings().data_dir}/apps/reserved-shell",
+  )
+  db = SessionLocal()
+  try:
+    row = db.get(models.App, app["id"])
+    row.slug = "shell"
+    db.commit()
+  finally:
+    db.close()
+  response = _publish(client, auth, app["id"])
+  assert response.status_code == 400

--- a/backend/tests/test_source_status.py
+++ b/backend/tests/test_source_status.py
@@ -51,7 +51,7 @@ def _app(repo: Path, *, app_id: int = 7) -> dict:
     "manifest_url": (
       "https://raw.githubusercontent.com/mobius-os/app-demo/main/mobius.json"
     ),
-    "share_manifest_url": None,
+    "published_manifest_url": None,
     "source_dir": str(repo),
   }
 
@@ -78,11 +78,11 @@ def test_platform_source_status_ignores_unrelated_environment(
   assert "release_ref" not in result
 
 
-def test_local_published_app_uses_share_manifest_as_repository_identity():
+def test_local_published_app_uses_distribution_manifest_as_repository_identity():
   repo = _repo("published-demo")
   app = _app(repo)
   app["manifest_url"] = None
-  app["share_manifest_url"] = (
+  app["published_manifest_url"] = (
     "https://raw.githubusercontent.com/example/published-demo/main/mobius.json"
   )
 

--- a/backend/tests/test_storage.py
+++ b/backend/tests/test_storage.py
@@ -1273,11 +1273,15 @@ def test_reap_orphaned_bundles_keeps_live_and_tombstoned_rows(
   client, owner_token, db,
 ):
   """Startup cleanup removes crash leftovers, never recoverable app bundles."""
-  from app.compiler import reap_orphaned_bundles
+  from app.compiler import publish_public_bundle, reap_orphaned_bundles
   live_id = _make_app(client, owner_token)
   tombstoned_id = _make_app(client, owner_token)
   live = _bundle_path(db, live_id)
   tombstoned = _bundle_path(db, tombstoned_id)
+  live_row = db.query(models.App).filter(models.App.id == live_id).first()
+  public_live, public_digest = publish_public_bundle(live_id, live)
+  live_row.public_bundle_path = str(public_live)
+  live_row.public_bundle_digest = public_digest
   row = db.query(models.App).filter(models.App.id == tombstoned_id).first()
   row.deleted_at = __import__(
     "app.timeutil", fromlist=["now_naive_utc"],
@@ -1286,19 +1290,24 @@ def test_reap_orphaned_bundles_keeps_live_and_tombstoned_rows(
   compiled = live.parent
   orphan_legacy = compiled / "app-999.js"
   orphan_content = compiled / ("app-999-" + "a" * 64 + ".js")
+  orphan_public = compiled / ("public-app-999-" + "b" * 64 + ".js")
   unrelated = compiled / "app-helper.js"
   orphan_legacy.write_text("legacy", encoding="utf-8")
   orphan_content.write_text("orphan", encoding="utf-8")
+  orphan_public.write_text("orphan public", encoding="utf-8")
   unrelated.write_text("not an app bundle", encoding="utf-8")
 
   removed = set(reap_orphaned_bundles(db))
 
   assert live.is_file()
+  assert public_live.is_file()
   assert tombstoned.is_file()
   assert str(orphan_legacy) in removed
   assert str(orphan_content) in removed
+  assert str(orphan_public) in removed
   assert not orphan_legacy.exists()
   assert not orphan_content.exists()
+  assert not orphan_public.exists()
   assert unrelated.is_file()
 
 
@@ -1306,11 +1315,13 @@ def test_purge_app_bundles_is_scoped_to_exact_numeric_id(
   client, owner_token, db,
 ):
   """Hard-delete cleanup removes every generation without matching id prefixes."""
-  from app.compiler import purge_app_bundles
+  from app.compiler import publish_public_bundle, purge_app_bundles
   first_id = _make_app(client, owner_token)
   second_id = _make_app(client, owner_token)
   first = _bundle_path(db, first_id)
   second = _bundle_path(db, second_id)
+  first_public, _ = publish_public_bundle(first_id, first)
+  second_public, _ = publish_public_bundle(second_id, second)
   legacy = first.parent / f"app-{first_id}.js"
   extra = first.parent / f"app-{first_id}-{'b' * 64}.js"
   legacy.write_text("legacy", encoding="utf-8")
@@ -1321,7 +1332,9 @@ def test_purge_app_bundles_is_scoped_to_exact_numeric_id(
   assert not first.exists()
   assert not legacy.exists()
   assert not extra.exists()
+  assert not first_public.exists()
   assert second.is_file()
+  assert second_public.is_file()
 
 
 def test_owned_bundle_path_canonicalizes_equivalent_stored_path(

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -488,6 +488,12 @@ export const api = {
       method: 'PATCH',
       body: JSON.stringify(payload),
     }),
+    publishHosted: (appId) => listAffectingMutation(
+      'apps', `/apps/${appId}/hosted-publication`, { method: 'PUT' },
+    ),
+    stopHosted: (appId) => listAffectingMutation(
+      'apps', `/apps/${appId}/hosted-publication`, { method: 'DELETE' },
+    ),
     remove: (appId) => listAffectingMutation(
       'apps', `/apps/${appId}`, { method: 'DELETE' },
     ),

--- a/frontend/src/components/ChatView/__tests__/accessibilityHardening.test.js
+++ b/frontend/src/components/ChatView/__tests__/accessibilityHardening.test.js
@@ -28,6 +28,19 @@ test('ShareAppSheet uses the shared modal focus contract', () => {
   assert.match(source, /aria-labelledby="sas-title"/)
 })
 
+test('ShareAppSheet presents hosted use and installable copies as separate lifecycles', () => {
+  const source = read('../../Drawer/ShareAppSheet.jsx')
+  const client = read('../../../api/client.js')
+  assert.match(source, /app\.hosted_publication/)
+  assert.match(source, /onPublish\?\.\(app\.id\)/)
+  assert.match(source, /onStop\?\.\(app\.id\)/)
+  assert.match(source, />Install or remix</)
+  assert.match(source, /editable copy/)
+  assert.doesNotMatch(source, /public_enabled|onSetPublic/)
+  assert.match(client, /\/hosted-publication.*method: 'PUT'/)
+  assert.match(client, /\/hosted-publication.*method: 'DELETE'/)
+})
+
 test('full-screen dialogs share one focus, inerting, and Escape contract', () => {
   const dialogs = [
     read('../../ui/ModelSheet.jsx'),

--- a/frontend/src/components/Drawer/Drawer.jsx
+++ b/frontend/src/components/Drawer/Drawer.jsx
@@ -518,6 +518,38 @@ export default function Drawer({
     if (res.ok) refreshApps()
   }
 
+  async function publishHostedApp(id) {
+    const res = await api.apps.publishHosted(id)
+    if (!res.ok) {
+      let message = 'Could not update public access.'
+      try {
+        const payload = await res.json()
+        if (typeof payload?.detail === 'string') message = payload.detail
+      } catch {}
+      throw new Error(message)
+    }
+    const updated = await res.json()
+    setSharingApp(updated)
+    refreshApps()
+    return updated
+  }
+
+  async function stopHostedApp(id) {
+    const res = await api.apps.stopHosted(id)
+    if (!res.ok) {
+      let message = 'Could not stop public access.'
+      try {
+        const payload = await res.json()
+        if (typeof payload?.detail === 'string') message = payload.detail
+      } catch {}
+      throw new Error(message)
+    }
+    const updated = await res.json()
+    setSharingApp(updated)
+    refreshApps()
+    return updated
+  }
+
   async function pinChat(id, pinned) {
     // Optimistic: stamp/clear pinned_at locally so the row reorders the
     // instant you tap — the sort and the row's pin badge both key off
@@ -1243,6 +1275,8 @@ export default function Drawer({
           app={sharingApp}
           apps={apps}
           onOpenApp={onApp}
+          onPublish={publishHostedApp}
+          onStop={stopHostedApp}
           onClose={() => setSharingApp(null)}
         />
       )}

--- a/frontend/src/components/Drawer/ShareAppSheet.css
+++ b/frontend/src/components/Drawer/ShareAppSheet.css
@@ -24,6 +24,8 @@
   color: var(--text, #d4d4d8);
   box-shadow: 0 16px 42px rgba(0, 0, 0, 0.36);
   animation: sas-pop 0.18s cubic-bezier(0.2, 0.7, 0.2, 1);
+  max-height: min(760px, calc(100dvh - 32px));
+  overflow-y: auto;
 }
 
 @keyframes sas-pop {
@@ -67,6 +69,47 @@
   color: var(--muted, #9ca3af);
   font-size: 13px;
   line-height: 1.55;
+}
+
+.sas__section {
+  margin-top: 18px;
+  padding-top: 18px;
+  border-top: 1px solid var(--border, #252b36);
+}
+
+.sas__section--install {
+  margin-top: 20px;
+}
+
+.sas__section-title {
+  margin: 0;
+  color: var(--text, #d4d4d8);
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1.35;
+}
+
+.sas__section .sas__body {
+  margin-top: 7px;
+}
+
+.sas__confirm {
+  margin-top: 14px;
+  padding: 12px;
+  border: 1px solid color-mix(in srgb, #ef4444 42%, var(--border, #252b36));
+  border-radius: 9px;
+  background: color-mix(in srgb, #ef4444 8%, transparent);
+}
+
+.sas__confirm p {
+  margin: 0;
+  color: var(--text, #d4d4d8);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.sas__confirm .sas__actions {
+  margin-top: 12px;
 }
 
 .sas__url {
@@ -143,6 +186,24 @@
   border-color: var(--border, #252b36);
   background: transparent;
   color: var(--text, #d4d4d8);
+}
+
+.sas__btn--quiet {
+  flex: 0 0 auto;
+  border-color: transparent;
+  background: transparent;
+  color: var(--muted, #9ca3af);
+}
+
+.sas__btn--danger {
+  border-color: #ef4444;
+  background: #ef4444;
+  color: #fff;
+}
+
+.sas__btn:disabled {
+  cursor: wait;
+  opacity: 0.65;
 }
 
 .sas__status {

--- a/frontend/src/components/Drawer/ShareAppSheet.jsx
+++ b/frontend/src/components/Drawer/ShareAppSheet.jsx
@@ -1,5 +1,4 @@
-/* Drawer Smart Share sheet for public install links and local-app publishing
-   handoffs through Contribute. */
+/* One publication surface for hosted use and independently installable copies. */
 
 import { useMemo, useRef, useState } from 'react'
 import useDialogFocus from '../../hooks/useDialogFocus.js'
@@ -19,13 +18,68 @@ async function copyText(value) {
   }
 }
 
-export default function ShareAppSheet({ app, apps, onOpenApp, onClose }) {
+export default function ShareAppSheet({
+  app, apps, onOpenApp, onPublish, onStop, onClose,
+}) {
   const cardRef = useRef(null)
   const primaryFocusRef = useRef(null)
   const [status, setStatus] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [confirmStop, setConfirmStop] = useState(false)
   const state = useMemo(() => appShareState(app, apps), [app, apps])
+  const publication = app.hosted_publication
+  const hasUnpublishedChanges = !!publication?.has_unpublished_changes
   const canNativeShare = typeof navigator !== 'undefined' &&
     typeof navigator.share === 'function'
+  const publicUrl = typeof window !== 'undefined'
+    ? `${window.location.origin}${publication?.path || `/${encodeURIComponent(app.slug)}`}`
+    : publication?.path || `/${encodeURIComponent(app.slug)}`
+
+  async function publishHosted() {
+    setBusy(true)
+    setStatus('')
+    try {
+      await onPublish?.(app.id)
+      setConfirmStop(false)
+      setStatus(hasUnpublishedChanges ? 'Published version updated.' : 'Public link is live.')
+    } catch (error) {
+      setStatus(error?.message || 'Could not update public access.')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function stopHosted() {
+    setBusy(true)
+    setStatus('')
+    try {
+      await onStop?.(app.id)
+      setConfirmStop(false)
+      setStatus('Public access stopped.')
+    } catch (error) {
+      setStatus(error?.message || 'Could not stop public access.')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function copyPublicLink() {
+    const copied = await copyText(publicUrl)
+    setStatus(copied
+      ? 'Public link copied.'
+      : "Couldn't copy automatically. Press and hold the link to copy it.")
+  }
+
+  async function sharePublicLink() {
+    setStatus('')
+    try {
+      await navigator.share({ title: app.name, url: publicUrl })
+    } catch (error) {
+      if (error?.name !== 'AbortError') {
+        setStatus("That share didn't open. You can copy the public link instead.")
+      }
+    }
+  }
 
   useDialogFocus({
     containerRef: cardRef,
@@ -59,7 +113,7 @@ export default function ShareAppSheet({ app, apps, onOpenApp, onClose }) {
     onOpenApp?.(id)
   }
 
-  const published = state.kind === 'published'
+  const installPublished = state.kind === 'published'
   const hasTarget = !!state.targetApp
   const targetIsContribute = state.kind === 'open-contribute'
 
@@ -81,24 +135,121 @@ export default function ShareAppSheet({ app, apps, onOpenApp, onClose }) {
             alt=""
           />
           <div>
-            <p className="sas__eyebrow">{published ? 'Ready to install' : 'Local app'}</p>
+            <p className="sas__eyebrow">
+              {publication ? 'Hosted publicly' : 'Private app'}
+            </p>
             <h2 id="sas-title" className="sas__title">
-              {published ? `Share ${app.name}` : `Publish ${app.name} first`}
+              Share {app.name}
             </h2>
           </div>
         </div>
 
-        {published ? (
+        <section className="sas__section" aria-labelledby="sas-public-title">
+          <h3 id="sas-public-title" className="sas__section-title">
+            {publication
+              ? hasUnpublishedChanges ? 'Published version has an update' : 'Public use is on'
+              : 'Private to you'}
+          </h3>
+          <p className="sas__body">
+            {publication
+              ? hasUnpublishedChanges
+                ? 'The existing public version is still live. Publish the update when you are ready; private edits never go live by accident.'
+                : 'Anyone with this link can use this exact published version without signing in. They cannot access your chats, files, or app data.'
+              : 'Turn on public use to give people a durable link. The app stays sandboxed and your personal data remains private.'}
+          </p>
+          {publication && (
+            <div className="sas__url" tabIndex={0}>{publicUrl}</div>
+          )}
+          {confirmStop ? (
+            <div className="sas__confirm" role="group" aria-label="Confirm stopping public access">
+              <p>Existing public sessions will stop working immediately.</p>
+              <div className="sas__actions">
+                <button
+                  type="button"
+                  className="sas__btn sas__btn--secondary"
+                  onClick={() => setConfirmStop(false)}
+                  disabled={busy}
+                >
+                  Keep public
+                </button>
+                <button
+                  type="button"
+                  className="sas__btn sas__btn--danger"
+                  onClick={stopHosted}
+                  disabled={busy}
+                >
+                  {busy ? 'Stopping…' : 'Stop public access'}
+                </button>
+              </div>
+            </div>
+          ) : (
+            <div className="sas__actions">
+              {publication ? (
+                <>
+                  {hasUnpublishedChanges && (
+                    <button
+                      ref={primaryFocusRef}
+                      type="button"
+                      className="sas__btn sas__btn--primary"
+                      onClick={publishHosted}
+                      disabled={busy}
+                    >
+                      {busy ? 'Publishing…' : 'Publish update'}
+                    </button>
+                  )}
+                  {canNativeShare && (
+                    <button
+                      ref={hasUnpublishedChanges ? undefined : primaryFocusRef}
+                      type="button"
+                      className="sas__btn sas__btn--primary"
+                      onClick={sharePublicLink}
+                    >
+                      Share link
+                    </button>
+                  )}
+                  <button
+                    ref={canNativeShare || hasUnpublishedChanges ? undefined : primaryFocusRef}
+                    type="button"
+                    className={`sas__btn ${canNativeShare ? 'sas__btn--secondary' : 'sas__btn--primary'}`}
+                    onClick={copyPublicLink}
+                  >
+                    Copy link
+                  </button>
+                  <button
+                    type="button"
+                    className="sas__btn sas__btn--quiet"
+                    onClick={() => setConfirmStop(true)}
+                  >
+                    Stop
+                  </button>
+                </>
+              ) : (
+                <button
+                  ref={primaryFocusRef}
+                  type="button"
+                  className="sas__btn sas__btn--primary"
+                  onClick={publishHosted}
+                  disabled={busy}
+                >
+                  {busy ? 'Making public…' : 'Make public'}
+                </button>
+              )}
+            </div>
+          )}
+        </section>
+
+        <section className="sas__section sas__section--install" aria-labelledby="sas-install-title">
+          <h3 id="sas-install-title" className="sas__section-title">Install or remix</h3>
+        {installPublished ? (
           <>
             <p className="sas__body">
-              Send this install link to someone who uses Möbius. Their own data
-              starts fresh.
+              Send this to another Möbius owner. They get an editable copy of
+              the app with fresh data of their own.
             </p>
             <div className="sas__url" tabIndex={0}>{state.installUrl}</div>
             <div className="sas__actions">
               {canNativeShare && (
                 <button
-                  ref={primaryFocusRef}
                   type="button"
                   className="sas__btn sas__btn--primary"
                   onClick={shareInstallLink}
@@ -107,7 +258,6 @@ export default function ShareAppSheet({ app, apps, onOpenApp, onClose }) {
                 </button>
               )}
               <button
-                ref={canNativeShare ? undefined : primaryFocusRef}
                 type="button"
                 className={`sas__btn ${canNativeShare ? 'sas__btn--secondary' : 'sas__btn--primary'}`}
                 onClick={copyInstallLink}
@@ -135,7 +285,6 @@ export default function ShareAppSheet({ app, apps, onOpenApp, onClose }) {
             <div className="sas__actions">
               {hasTarget ? (
                 <button
-                  ref={primaryFocusRef}
                   type="button"
                   className="sas__btn sas__btn--primary"
                   onClick={openTarget}
@@ -144,7 +293,6 @@ export default function ShareAppSheet({ app, apps, onOpenApp, onClose }) {
                 </button>
               ) : (
                 <button
-                  ref={primaryFocusRef}
                   type="button"
                   className="sas__btn sas__btn--secondary"
                   onClick={() => onClose?.()}
@@ -155,6 +303,7 @@ export default function ShareAppSheet({ app, apps, onOpenApp, onClose }) {
             </div>
           </>
         )}
+        </section>
 
         {status && (
           <p className="sas__status" role="status">{status}</p>

--- a/frontend/src/components/Drawer/appShareState.js
+++ b/frontend/src/components/Drawer/appShareState.js
@@ -1,5 +1,5 @@
-/* Pure Smart Share state: published apps expose an install URL; local apps
-   route through Contribute, or the App Store when Contribute is absent. */
+/* Pure publication state: hosted use is independent; install/remix handoffs
+   use a typed distribution manifest or route through Contribute. */
 
 const CONTRIBUTE_SLUG = 'contribute'
 const APP_STORE_SLUG = 'app-store'
@@ -8,15 +8,14 @@ function appBySlug(apps, slug) {
   return (apps || []).find(app => app?.slug === slug) || null
 }
 
-// Store-installed apps are already discoverable in App Store, so the drawer
-// only offers Share for locally-built apps. A local app stays eligible after
-// the owner attaches a public share manifest.
+// Every app can be shared for anonymous use, independently from whether its
+// package also has an install link.
 export function isDrawerAppShareEligible(app) {
-  return !app?.manifest_url
+  return !!app
 }
 
 export function appInstallManifestUrl(app) {
-  const value = app?.share_manifest_url || app?.manifest_url
+  const value = app?.distribution_manifest?.url
   return typeof value === 'string' && value.trim() ? value.trim() : null
 }
 

--- a/frontend/src/components/Shell/__tests__/appShareState.test.js
+++ b/frontend/src/components/Shell/__tests__/appShareState.test.js
@@ -9,31 +9,37 @@ import {
   isDrawerAppShareEligible,
 } from '../../Drawer/appShareState.js'
 
-test('explicit share manifest publishes a local app without changing install identity', () => {
+test('typed distribution manifest publishes a local app without exposing storage fields', () => {
   const app = {
     name: 'Published later',
-    manifest_url: null,
-    share_manifest_url: 'https://raw.example/published-later/mobius.json',
+    distribution_manifest: {
+      kind: 'published',
+      url: 'https://raw.example/published-later/mobius.json',
+    },
   }
-  assert.equal(appInstallManifestUrl(app), app.share_manifest_url)
+  assert.equal(appInstallManifestUrl(app), app.distribution_manifest.url)
   assert.deepEqual(appShareState(app, []), {
     kind: 'published',
-    installUrl: app.share_manifest_url,
+    installUrl: app.distribution_manifest.url,
   })
 })
 
-test('store-installed apps are omitted from drawer sharing', () => {
+test('every installed app can expose its independent public-use control', () => {
   const app = {
     name: 'News',
-    manifest_url: 'https://raw.example/news/mobius.json#manifest-id=news',
+    distribution_manifest: {
+      kind: 'source',
+      url: 'https://raw.example/news/mobius.json',
+    },
   }
-  assert.equal(isDrawerAppShareEligible(app), false)
-  assert.equal(appInstallManifestUrl(app), app.manifest_url)
-  assert.equal(isDrawerAppShareEligible({ manifest_url: null }), true)
+  assert.equal(isDrawerAppShareEligible(app), true)
+  assert.equal(appInstallManifestUrl(app), app.distribution_manifest.url)
+  assert.equal(isDrawerAppShareEligible({ distribution_manifest: null }), true)
   assert.equal(
-    isDrawerAppShareEligible({ share_manifest_url: 'https://raw.example/app' }),
+    isDrawerAppShareEligible({ distribution_manifest: { url: 'https://raw.example/app' } }),
     true,
   )
+  assert.equal(isDrawerAppShareEligible(null), false)
 })
 
 test('local apps route through installed Contribute before the App Store', () => {


### PR DESCRIPTION
## Summary

- separate anonymous hosted publication from install/remix distribution
- publish an immutable snapshot of code, display name, and reviewed anonymous network authority; later private edits require an explicit Publish update
- replace the mutable boolean and legacy share fields with intent-named endpoints and typed source/distribution projections
- constrain public GETs with exact query contracts, SSRF and response bounds, rate and concurrency limits, pooled transport, and diagnostics
- add responsive owner controls for public use and independently installable copies

## Integration

- builds on #792's `source_manifest` contract
- pairs with mobius-os/app-store#33 as the App Store consumer
- keeps #771 and #785 independent because Store apply boundaries and storage admission have different lifecycle owners

## Testing

- focused backend publication, capability, migration, security, diagnostics, and screenshot-helper suites
- backend fast contract suite
- frontend unit suite and production build
- App Store consumer suite
- authenticated desktop and mobile rendered previews
