### PR TITLE
Add verifiable core image provenance

### DIFF
--- a/.github/workflows/main-image.yml
+++ b/.github/workflows/main-image.yml
@@ -71,6 +71,21 @@ jobs:
             exit 1
           fi
 
+          labels="$(
+            docker buildx imagetools inspect "$SHA_IMAGE" \
+              --format '{{json .Image.Config.Labels}}'
+          )"
+          revision="$(jq -er '."org.opencontainers.image.revision"' <<<"$labels")"
+          source="$(jq -er '."org.opencontainers.image.source"' <<<"$labels")"
+          if [ "$revision" != "$GITHUB_SHA" ]; then
+            echo "Immutable SHA image reports revision $revision, expected $GITHUB_SHA." >&2
+            exit 1
+          fi
+          if [ "$source" != "https://github.com/mobius-os/mobius" ]; then
+            echo "Immutable SHA image reports unexpected source $source." >&2
+            exit 1
+          fi
+
   promote-main:
     needs: publish
     runs-on: ubuntu-latest

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -156,7 +156,7 @@ FastAPI app. `main.py` is the factory (CORS, rate limiting, routers, static serv
 | `deps.py` | FastAPI auth dependencies: `get_current_owner` (owner-only), `get_current_owner_or_app` (owner + app token), `get_principal`, `require_app_permission`, and `reject_cross_site` (CSRF) |
 | `compiler.py` | `compile_jsx()` — calls the Rolldown adapter to compile a JSX string into an ES module |
 | `providers.py` | `BaseProvider` adapters (`ClaudeProvider`, `CodexProvider`) + the `PROVIDERS` registry; identity/auth/env shaping for the SDK runners (`build_env`), and `get_skill_path()`. |
-| `claude_sdk_runner.py` | Claude SDK turn runner; passes `cli_path="/usr/local/bin/claude"` so the SDK drives the same pinned binary recovery + cron use |
+| `claude_sdk_runner.py` | Claude SDK turn runner; passes `cli_path="/usr/local/bin/claude"` so interactive chat and cron turns use the same pinned binary |
 | `codex_sdk_runner.py` | Codex SDK turn runner (Thread/TurnHandle + steer) |
 | `codex_appserver.py` | Small helper module: `codex_sdk_runner.py` imports its one surviving function, `_extract_bash_command`, which pulls the bash command string out of a shell tool item. The SDK runner does its own event/tool classification locally. |
 | `chat.py` | `run_chat()` background task: spawns the turn, publishes events, routes persistence through the actor |

--- a/Dockerfile
+++ b/Dockerfile
@@ -348,6 +348,8 @@ ENV BUILD_SHA=${BUILD_SHA}
 # deploy-prod.sh. Managed Docker builders that do not pass BUILD_DATE use
 # /app/build-info.json, written above, so Settings can still show a date.
 ENV BUILD_DATE=${BUILD_DATE}
+LABEL org.opencontainers.image.source="https://github.com/mobius-os/mobius" \
+      org.opencontainers.image.revision="${BUILD_SHA}"
 
 EXPOSE 8000
 

--- a/backend/scripts/entrypoint.sh
+++ b/backend/scripts/entrypoint.sh
@@ -670,7 +670,7 @@ if not owner:
 # AND not revoked. A "sign out everywhere" bumps owner.token_epoch, which
 # strands the on-disk service token even though it hasn't expired — so we
 # re-mint when the stored token's epoch is behind the owner's current one.
-# This restart is the documented recovery path for the service token after
+# This restart is the documented refresh path for the service token after
 # revocation (see routes/admin.py:sign_out_everywhere).
 token_file = '/data/service-token.txt'
 if os.path.exists(token_file):
@@ -961,9 +961,9 @@ find /data -regextype posix-extended -mindepth 2 -maxdepth 4 \
 # refuses cross-owner operations with "dubious ownership", so any git
 # command we run as mobius (the else branch's untrack loop) needs the
 # repo mobius-owned first. A `docker pull` plus a recreated volume can
-# leave a previously-mobius-owned /data/.git root-owned again (e.g.
-# some recovery installs bake /data/.git into the image layer); without
-# this the agent's commits also fail. No-op via `|| true` if /data/.git
+# leave a previously-mobius-owned /data/.git root-owned again (e.g. some
+# historical images or install paths bake /data/.git into the image layer);
+# without this the agent's commits also fail. No-op via `|| true` if /data/.git
 # doesn't exist yet — the fresh-init branch below creates it and
 # re-chowns in that case.
 chown -R mobius:mobius /data/.git 2>/dev/null || true

--- a/backend/tests/test_verify_test_runtime.py
+++ b/backend/tests/test_verify_test_runtime.py
@@ -578,6 +578,7 @@ def test_manual_and_pull_request_runs_cover_suites_and_main_image():
   image_workflow = (
     ROOT / ".github" / "workflows" / "main-image.yml"
   ).read_text(encoding="utf-8")
+  dockerfile = (ROOT / "Dockerfile").read_text(encoding="utf-8")
   assert not (
     ROOT / ".github" / "workflows" / "external-recovery-image.yml"
   ).exists()
@@ -618,6 +619,14 @@ def test_manual_and_pull_request_runs_cover_suites_and_main_image():
   )
   assert '--tag "$MAIN_IMAGE" "$SHA_IMAGE"' in image_workflow
   assert image_workflow.count("--format '{{json .Manifest}}'") == 2
+  assert "--format '{{json .Image.Config.Labels}}'" in image_workflow
+  assert '."org.opencontainers.image.revision"' in image_workflow
+  assert '."org.opencontainers.image.source"' in image_workflow
+  assert 'org.opencontainers.image.revision="${BUILD_SHA}"' in dockerfile
+  assert (
+    'org.opencontainers.image.source="https://github.com/mobius-os/mobius"'
+    in dockerfile
+  )
   assert image_workflow.count("for _ in $(seq 1 12)") == 2
   assert "recovery" not in image_workflow.lower()
   assert "core-releases" not in image_workflow


### PR DESCRIPTION
## Summary
- stamp standard OCI source and exact revision labels into every core image
- make the main-image workflow fail unless the immutable tag exposes the expected labels
- remove the last misleading embedded-recovery wording found in the final source-wide audit

## Verification
- focused provenance and recovery-boundary tests: 33 passed
- Dockerfile static build check: no warnings
- actionlint
- diff check