### PR TITLE
Expose installed app source manifests

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -42,6 +42,13 @@ class TokenResponse(BaseModel):
   token_type: str = "bearer"
 
 
+class AppSourceManifest(BaseModel):
+  """Fetchable manifest identity for a Store-managed installed app."""
+
+  id: str
+  url: str
+
+
 # A one-time sign-in pass handed to a mini-app being installed to the iOS home
 # screen, where the new web app gets its own empty storage container.
 class InstallPassRequest(BaseModel):
@@ -236,6 +243,20 @@ class AppOut(BaseModel):
       return None
     version = quote(self.updated_at.isoformat(), safe="")
     return f"/api/apps/{self.id}/icon?v={version}"
+
+  @computed_field
+  @property
+  def source_manifest(self) -> AppSourceManifest | None:
+    """Return the public source contract without exposing identity parsing."""
+    if not self.manifest_url:
+      return None
+    base, marker, manifest_id = self.manifest_url.rpartition("#manifest-id=")
+    if not marker or not base or not manifest_id:
+      return None
+    return AppSourceManifest(
+      id=manifest_id,
+      url=f"{base.rstrip('/')}/mobius.json",
+    )
 
   model_config = {"from_attributes": True}
 

--- a/backend/tests/test_apps.py
+++ b/backend/tests/test_apps.py
@@ -345,6 +345,33 @@ def test_list_apps_does_not_hydrate_source_or_icon_payloads(client, auth, db):
   assert "apps.icon_override_png AS apps_icon_override_png" not in projection
 
 
+def test_list_apps_exposes_one_fetchable_source_manifest_contract(
+  client, auth, db,
+):
+  app = models.App(
+    source_dir="/tmp/mobius-tests/source-manifest-contract",
+    name="Published app",
+    description="Installed from a published manifest",
+    jsx_source="export default function App() { return null }",
+    slug="published-app",
+    manifest_url=(
+      "https://raw.githubusercontent.com/example/app/main"
+      "#manifest-id=published-app"
+    ),
+  )
+  db.add(app)
+  db.commit()
+
+  response = client.get("/api/apps/", headers=auth)
+
+  assert response.status_code == 200
+  payload = next(item for item in response.json() if item["id"] == app.id)
+  assert payload["source_manifest"] == {
+    "id": "published-app",
+    "url": "https://raw.githubusercontent.com/example/app/main/mobius.json",
+  }
+
+
 def test_delete_then_purge_removes_non_slug_source_dir(client, auth, db):
   """Delete is soft (the source tree survives for recovery); the TTL purge
   removes it, using the stored source_dir rather than the display-name slug.


### PR DESCRIPTION
## Summary
- expose a typed `source_manifest` object for Store-managed installed apps
- keep canonical persistence identity internal while providing the manifest id and fetchable URL to clients
- cover the list-apps projection without hydrating source or icon payloads

## Why
The App Store needs to present and update apps installed from published links even when they are not in the curated catalog. Giving clients one explicit source contract avoids reverse-engineering the platform's internal `manifest_url` identity format.

## Testing
- `scripts/wt-pytest.sh backend/tests/test_apps.py -q` (33 passed)
- `python3 -m py_compile backend/app/schemas.py`