### PR TITLE
Keep contribution card stationary when jumping to latest

### DIFF
--- a/frontend/src/components/ChatView/ChatView.css
+++ b/frontend/src/components/ChatView/ChatView.css
@@ -350,6 +350,10 @@
   align-items: flex-start;
 }
 
+/* Event-only owner for Markdown-aware native selection copy. `contents` keeps
+   every prose/tool child in the message row's existing flex and gap geometry. */
+.chat__assistant-copy-surface { display: contents; }
+
 /* A search jump is a one-shot held position, not a new scrolling mode. The
    restrained row wash and text highlight make the destination legible without
    competing with ordinary user/assistant surfaces. */
@@ -2066,23 +2070,29 @@
 .chat__foot .composer-plus { pointer-events: auto; }
 
 /* One geometry-neutral stack for every control that floats above the measured
-   footer. Transient controls grow upward; the contribution card remains the
-   bottom anchor without changing --composer-h or the transcript scroll tail. */
+   footer. The safe default keeps transient-only controls clear of the composer.
+   When a contribution card actually renders, it becomes the lower anchor and
+   the transient lane grows upward from it without changing --composer-h or the
+   transcript scroll tail. */
 .chat__floating-actions {
   position: absolute;
   left: 12px;
   right: 12px;
-  /* Match the goal rail's close dock without putting floating actions back
-     into composer-height measurement. The second padding subtraction accounts
-     for the transparent gutter above the visible composer surface. */
-  bottom: calc(
-    100% - var(--chat-foot-pad-block) - var(--chat-foot-pad-block)
-    + var(--chat-foot-card-gap)
-  );
+  bottom: calc(100% + var(--chat-foot-card-gap));
   display: flex;
   flex-direction: column;
   gap: var(--chat-foot-card-gap);
   pointer-events: none;
+}
+
+/* Only the contribution card gets the goal-rail-like close dock. Using the
+   rendered child as the state owner avoids lowering jump/resume/open-app
+   controls when the async contribution query has nothing to show. */
+.chat__floating-actions:has(> .contrib-card-stack) {
+  bottom: calc(
+    100% - var(--chat-foot-pad-block) - var(--chat-foot-pad-block)
+    + var(--chat-foot-card-gap)
+  );
 }
 
 .chat__floating-transients {

--- a/frontend/src/components/ChatView/ChatView.css
+++ b/frontend/src/components/ChatView/ChatView.css
@@ -1992,6 +1992,7 @@
   /* Opaque footer cards need a wider physical gap to read as equally
      separated from the composer as the translucent progress rail. */
   --chat-foot-card-gap: 6px;
+  --chat-foot-pad-block: 8px;
   position: absolute;
   /* Interactive controls must stay wholly inside the device safe rectangle.
      Android Chrome paints the shell's gesture backdrop in the unsafe band;
@@ -2001,7 +2002,7 @@
   bottom: env(safe-area-inset-bottom, 0px);
   left: 0;
   right: 0;
-  padding: 8px 12px;
+  padding: var(--chat-foot-pad-block) 12px;
   background: transparent;
   pointer-events: none;
   z-index: 5;
@@ -2055,6 +2056,7 @@
 .chat__foot .queued,
 .chat__foot .connection-status,
 .chat__foot .chat__attach-tray,
+.chat__foot .chat__history-retry,
 .chat__foot .chat__question-nudge,
 .chat__foot .chat__resume-nudge,
 .chat__foot .chat__jump-latest,
@@ -2064,17 +2066,29 @@
 .chat__foot .composer-plus { pointer-events: auto; }
 
 /* One geometry-neutral stack for every control that floats above the measured
-   footer. Keeping cards and viewport cues in this same lane makes them clear
-   one another without changing --composer-h or the transcript scroll tail. */
+   footer. Transient controls grow upward; the contribution card remains the
+   bottom anchor without changing --composer-h or the transcript scroll tail. */
 .chat__floating-actions {
   position: absolute;
   left: 12px;
   right: 12px;
-  bottom: calc(100% + var(--chat-foot-card-gap));
+  /* Match the goal rail's close dock without putting floating actions back
+     into composer-height measurement. The second padding subtraction accounts
+     for the transparent gutter above the visible composer surface. */
+  bottom: calc(
+    100% - var(--chat-foot-pad-block) - var(--chat-foot-pad-block)
+    + var(--chat-foot-card-gap)
+  );
   display: flex;
   flex-direction: column;
   gap: var(--chat-foot-card-gap);
   pointer-events: none;
+}
+
+.chat__floating-transients {
+  display: flex;
+  flex-direction: column;
+  gap: var(--chat-foot-card-gap);
 }
 
 /* Embedded composer: the app sheet (not the chat) owns the device

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -4416,51 +4416,72 @@ export default function ChatView({
             composer remain in normal footer flow. The shell owns the one persistent
             offline explanation; the composer retains contextual send-failure copy. */}
         <div className="chat__floating-actions">
-          {/* The viewport cues and post-turn cards share one floating stack so
-              they clear each other without entering footer or scroll geometry.
-              Tail controls come first so their disappearance cannot move the
-              persistent contribution action below them. */}
-          {connectionError !== 'disconnected' && offscreenControlsVisible && (
-            <div className="chat__offscreen-nudges">
-              {olderHistoryRetryShown(olderHistoryError, offset) && (
-                <button
-                  type="button"
-                  className="chat__history-retry"
-                  onClick={() => loadOlderMessages()}
-                >
-                  Earlier messages didn’t load — retry
-                </button>
+          {/* Short-lived controls share one lane above the stable contribution
+              anchor. Adding or dismissing any transient can only grow this
+              lane upward; it cannot move the action below it. */}
+          {connectionError !== 'disconnected'
+            && (offscreenControlsVisible || openAppCtas.length > 0) && (
+            <div className="chat__floating-transients">
+              {offscreenControlsVisible && (
+                <div className="chat__offscreen-nudges">
+                  {olderHistoryRetryShown(olderHistoryError, offset) && (
+                    <button
+                      type="button"
+                      className="chat__history-retry"
+                      onClick={() => loadOlderMessages()}
+                    >
+                      Earlier messages didn’t load — retry
+                    </button>
+                  )}
+                  {questionNudgeShown && (
+                    <button
+                      type="button"
+                      className="chat__question-nudge"
+                      onClick={revealConversationTail}
+                    >
+                      Möbius asked you something — tap to answer
+                    </button>
+                  )}
+                  {resumeNudgeShown && (
+                    <button
+                      type="button"
+                      className="chat__resume-nudge"
+                      onClick={revealConversationTail}
+                    >
+                      {pendingResumeBlock?.pause?.resets_at
+                        ? 'Rate limit reached — tap to resume'
+                        : 'Turn paused — tap to resume'}
+                    </button>
+                  )}
+                  {jumpToLatestVisible && (
+                    <button
+                      type="button"
+                      className="chat__jump-latest"
+                      aria-label="Jump to the latest message"
+                      title="Jump to latest"
+                      onClick={followLatest}
+                    >
+                      <ArrowDown size={18} strokeWidth={2.25} aria-hidden="true" />
+                    </button>
+                  )}
+                </div>
               )}
-              {questionNudgeShown && (
-                <button
-                  type="button"
-                  className="chat__question-nudge"
-                  onClick={revealConversationTail}
-                >
-                  Möbius asked you something — tap to answer
-                </button>
-              )}
-              {resumeNudgeShown && (
-                <button
-                  type="button"
-                  className="chat__resume-nudge"
-                  onClick={revealConversationTail}
-                >
-                  {pendingResumeBlock?.pause?.resets_at
-                    ? 'Rate limit reached — tap to resume'
-                    : 'Turn paused — tap to resume'}
-                </button>
-              )}
-              {jumpToLatestVisible && (
-                <button
-                  type="button"
-                  className="chat__jump-latest"
-                  aria-label="Jump to the latest message"
-                  title="Jump to latest"
-                  onClick={followLatest}
-                >
-                  <ArrowDown size={18} strokeWidth={2.25} aria-hidden="true" />
-                </button>
+              {openAppCtas.length > 0 && (
+                <div className="chat__open-app">
+                  {openAppCtas.map(({ app, vm }) => {
+                    const pulsing = pulsedAppId === Number(app.id)
+                    return (
+                      <button
+                        key={app.id}
+                        className={`chat__open-app-btn${pulsing ? ' chat__open-app-btn--pulse' : ''}`}
+                        aria-label={pulsing ? `Preview updated for ${app.name || 'app'}` : vm.ariaLabel}
+                        onClick={() => onOpenApp?.(app, { final: !turnActive })}
+                      >
+                        {pulsing ? 'Preview updated ✓' : `${vm.label} →`}
+                      </button>
+                    )
+                  })}
+                </div>
               )}
             </div>
           )}
@@ -4474,24 +4495,8 @@ export default function ChatView({
               onOpenApp={onOpenApp}
             />
           )}
-          {connectionError !== 'disconnected' && openAppCtas.length > 0 && (
-            <div className="chat__open-app">
-              {openAppCtas.map(({ app, vm }) => {
-                const pulsing = pulsedAppId === Number(app.id)
-                return (
-                  <button
-                    key={app.id}
-                    className={`chat__open-app-btn${pulsing ? ' chat__open-app-btn--pulse' : ''}`}
-                    aria-label={pulsing ? `Preview updated for ${app.name || 'app'}` : vm.ariaLabel}
-                    onClick={() => onOpenApp?.(app, { final: !turnActive })}
-                  >
-                    {pulsing ? 'Preview updated ✓' : `${vm.label} →`}
-                  </button>
-                )
-              })}
-            </div>
-          )}
-        </div>        <ProgressRail
+        </div>
+        <ProgressRail
           items={progressRail}
           ariaLabel={visibleGoalObjective ? 'Goal progress' : 'Build progress'}
         />

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -4416,6 +4416,54 @@ export default function ChatView({
             composer remain in normal footer flow. The shell owns the one persistent
             offline explanation; the composer retains contextual send-failure copy. */}
         <div className="chat__floating-actions">
+          {/* The viewport cues and post-turn cards share one floating stack so
+              they clear each other without entering footer or scroll geometry.
+              Tail controls come first so their disappearance cannot move the
+              persistent contribution action below them. */}
+          {connectionError !== 'disconnected' && offscreenControlsVisible && (
+            <div className="chat__offscreen-nudges">
+              {olderHistoryRetryShown(olderHistoryError, offset) && (
+                <button
+                  type="button"
+                  className="chat__history-retry"
+                  onClick={() => loadOlderMessages()}
+                >
+                  Earlier messages didn’t load — retry
+                </button>
+              )}
+              {questionNudgeShown && (
+                <button
+                  type="button"
+                  className="chat__question-nudge"
+                  onClick={revealConversationTail}
+                >
+                  Möbius asked you something — tap to answer
+                </button>
+              )}
+              {resumeNudgeShown && (
+                <button
+                  type="button"
+                  className="chat__resume-nudge"
+                  onClick={revealConversationTail}
+                >
+                  {pendingResumeBlock?.pause?.resets_at
+                    ? 'Rate limit reached — tap to resume'
+                    : 'Turn paused — tap to resume'}
+                </button>
+              )}
+              {jumpToLatestVisible && (
+                <button
+                  type="button"
+                  className="chat__jump-latest"
+                  aria-label="Jump to the latest message"
+                  title="Jump to latest"
+                  onClick={followLatest}
+                >
+                  <ArrowDown size={18} strokeWidth={2.25} aria-hidden="true" />
+                </button>
+              )}
+            </div>
+          )}
           {/* Contribution staged from THIS chat: approve it where the work
               happened, but keep the transient card out of composer-height
               measurement so confirmation cannot move the transcript. */}
@@ -4426,72 +4474,22 @@ export default function ChatView({
               onOpenApp={onOpenApp}
             />
           )}
-          {/* The viewport cues and post-turn cards share one floating stack so
-              they clear each other without entering footer or scroll geometry. */}
-          {connectionError !== 'disconnected' && (
-            <>
-              {offscreenControlsVisible && (
-                <div className="chat__offscreen-nudges">
-                  {olderHistoryRetryShown(olderHistoryError, offset) && (
-                    <button
-                      type="button"
-                      className="chat__history-retry"
-                      onClick={() => loadOlderMessages()}
-                    >
-                      Earlier messages didn’t load — retry
-                    </button>
-                  )}
-                  {questionNudgeShown && (
-                    <button
-                      type="button"
-                      className="chat__question-nudge"
-                      onClick={revealConversationTail}
-                    >
-                      Möbius asked you something — tap to answer
-                    </button>
-                  )}
-                  {resumeNudgeShown && (
-                    <button
-                      type="button"
-                      className="chat__resume-nudge"
-                      onClick={revealConversationTail}
-                    >
-                      {pendingResumeBlock?.pause?.resets_at
-                        ? 'Rate limit reached — tap to resume'
-                        : 'Turn paused — tap to resume'}
-                    </button>
-                  )}
-                  {jumpToLatestVisible && (
-                    <button
-                      type="button"
-                      className="chat__jump-latest"
-                      aria-label="Jump to the latest message"
-                      title="Jump to latest"
-                      onClick={followLatest}
-                    >
-                      <ArrowDown size={18} strokeWidth={2.25} aria-hidden="true" />
-                    </button>
-                  )}
-                </div>
-              )}
-              {openAppCtas.length > 0 && (
-                <div className="chat__open-app">
-                  {openAppCtas.map(({ app, vm }) => {
-                    const pulsing = pulsedAppId === Number(app.id)
-                    return (
-                      <button
-                        key={app.id}
-                        className={`chat__open-app-btn${pulsing ? ' chat__open-app-btn--pulse' : ''}`}
-                        aria-label={pulsing ? `Preview updated for ${app.name || 'app'}` : vm.ariaLabel}
-                        onClick={() => onOpenApp?.(app, { final: !turnActive })}
-                      >
-                        {pulsing ? 'Preview updated ✓' : `${vm.label} →`}
-                      </button>
-                    )
-                  })}
-                </div>
-              )}
-            </>
+          {connectionError !== 'disconnected' && openAppCtas.length > 0 && (
+            <div className="chat__open-app">
+              {openAppCtas.map(({ app, vm }) => {
+                const pulsing = pulsedAppId === Number(app.id)
+                return (
+                  <button
+                    key={app.id}
+                    className={`chat__open-app-btn${pulsing ? ' chat__open-app-btn--pulse' : ''}`}
+                    aria-label={pulsing ? `Preview updated for ${app.name || 'app'}` : vm.ariaLabel}
+                    onClick={() => onOpenApp?.(app, { final: !turnActive })}
+                  >
+                    {pulsing ? 'Preview updated ✓' : `${vm.label} →`}
+                  </button>
+                )
+              })}
+            </div>
           )}
         </div>        <ProgressRail
           items={progressRail}

--- a/frontend/src/components/ChatView/__tests__/offlineFooter.test.js
+++ b/frontend/src/components/ChatView/__tests__/offlineFooter.test.js
@@ -27,25 +27,33 @@ test('floating actions precede the measured rail → connection → queued → c
   const floatingActions = foot.indexOf('className="chat__floating-actions"')
   assert.ok(floatingActions >= 0 && floatingActions < rail,
     'transient post-turn actions must render in the separate floating layer')
-  for (const notice of [
-    'className="chat__open-app"',
-    'className="chat__question-nudge"',
-    'className="chat__resume-nudge"',
-  ]) {
-    const noticeIndex = foot.indexOf(notice)
-    assert.ok(noticeIndex >= 0, `${notice} must be present in the footer`)
-    assert.ok(noticeIndex < rail,
-      `${notice} must render before the progress rail`)
-  }
+  const transientLane = foot.indexOf('className="chat__floating-transients"')
+  const offscreenNudges = foot.indexOf('className="chat__offscreen-nudges"')
+  const openApp = foot.indexOf('className="chat__open-app"')
+  const contribution = foot.indexOf('<ContributionReviewCard')
+  assert.ok(
+    transientLane > floatingActions
+      && offscreenNudges > transientLane
+      && openApp > transientLane
+      && contribution > openApp,
+    'every transient footer action must render above the stable contribution anchor',
+  )
+  assert.ok(contribution < rail,
+    'the contribution anchor must stay outside measured footer flow')
   assert.match(
     chatCss,
-    /\.chat__floating-actions\s*\{[\s\S]*?position:\s*absolute;[\s\S]*?bottom:\s*calc\(100% \+ var\(--chat-foot-card-gap\)\);[\s\S]*?pointer-events:\s*none;/,
+    /\.chat__floating-actions\s*\{[\s\S]*?position:\s*absolute;[\s\S]*?bottom:\s*calc\([\s\S]*?100% - var\(--chat-foot-pad-block\) - var\(--chat-foot-pad-block\)[\s\S]*?\+ var\(--chat-foot-card-gap\)[\s\S]*?\);[\s\S]*?pointer-events:\s*none;/,
     'open-app and contribution actions must stay outside measured footer flow',
   )
   assert.match(
-    chatView,
-    /className="chat__floating-actions"[\s\S]*?className="chat__offscreen-nudges"[\s\S]*?<ContributionReviewCard[\s\S]*?className="chat__open-app"[\s\S]*?<ProgressRail/,
-    'tail cues must stack above the contribution card so hiding them does not move it',
+    chatCss,
+    /\.chat__foot\s*\{[\s\S]*?--chat-foot-pad-block:\s*8px;[\s\S]*?padding:\s*var\(--chat-foot-pad-block\) 12px;/,
+    'floating and measured footer surfaces must share the same top-padding owner',
+  )
+  assert.match(
+    chatCss,
+    /\.chat__floating-transients\s*\{[\s\S]*?display:\s*flex;[\s\S]*?flex-direction:\s*column;[\s\S]*?gap:\s*var\(--chat-foot-card-gap\);/,
+    'transient footer actions must share one explicit stack',
   )
   assert.match(
     chatCss,

--- a/frontend/src/components/ChatView/__tests__/offlineFooter.test.js
+++ b/frontend/src/components/ChatView/__tests__/offlineFooter.test.js
@@ -44,8 +44,8 @@ test('floating actions precede the measured rail → connection → queued → c
   )
   assert.match(
     chatView,
-    /className="chat__floating-actions"[\s\S]*?<ContributionReviewCard[\s\S]*?className="chat__offscreen-nudges"[\s\S]*?className="chat__open-app"[\s\S]*?<ProgressRail/,
-    'cards and viewport cues should share one ordered overlay before measured footer content',
+    /className="chat__floating-actions"[\s\S]*?className="chat__offscreen-nudges"[\s\S]*?<ContributionReviewCard[\s\S]*?className="chat__open-app"[\s\S]*?<ProgressRail/,
+    'tail cues must stack above the contribution card so hiding them does not move it',
   )
   assert.match(
     chatCss,

--- a/frontend/src/components/ChatView/__tests__/offlineFooter.test.js
+++ b/frontend/src/components/ChatView/__tests__/offlineFooter.test.js
@@ -42,8 +42,13 @@ test('floating actions precede the measured rail → connection → queued → c
     'the contribution anchor must stay outside measured footer flow')
   assert.match(
     chatCss,
-    /\.chat__floating-actions\s*\{[\s\S]*?position:\s*absolute;[\s\S]*?bottom:\s*calc\([\s\S]*?100% - var\(--chat-foot-pad-block\) - var\(--chat-foot-pad-block\)[\s\S]*?\+ var\(--chat-foot-card-gap\)[\s\S]*?\);[\s\S]*?pointer-events:\s*none;/,
-    'open-app and contribution actions must stay outside measured footer flow',
+    /\.chat__floating-actions\s*\{[\s\S]*?position:\s*absolute;[\s\S]*?bottom:\s*calc\(100% \+ var\(--chat-foot-card-gap\)\);[\s\S]*?pointer-events:\s*none;/,
+    'transient-only actions must stay clear of the composer and outside measured footer flow',
+  )
+  assert.match(
+    chatCss,
+    /\.chat__floating-actions:has\(> \.contrib-card-stack\)\s*\{[\s\S]*?bottom:\s*calc\([\s\S]*?100% - var\(--chat-foot-pad-block\) - var\(--chat-foot-pad-block\)[\s\S]*?\+ var\(--chat-foot-card-gap\)[\s\S]*?\);/,
+    'only a rendered contribution card may activate the closer goal-rail-like dock',
   )
   assert.match(
     chatCss,

--- a/frontend/src/components/ChatView/__tests__/resumeAffordance.test.js
+++ b/frontend/src/components/ChatView/__tests__/resumeAffordance.test.js
@@ -183,8 +183,11 @@ test('viewport-derived nudges never participate in footer geometry', () => {
   const stackCss = css.match(/\.chat__floating-actions\s*\{[\s\S]*?\}/)?.[0] ?? ''
   assert.match(stackCss, /position:\s*absolute/,
     'the shared parent keeps every cue outside measured footer geometry')
-  assert.match(stackCss, /bottom:\s*calc\(100% \+ var\(--chat-foot-card-gap\)\)/,
-    'the shared stack clears every flow-owned footer control')
+  assert.match(
+    stackCss,
+    /bottom:\s*calc\(100% \+ var\(--chat-foot-card-gap\)\)/,
+    'the transient stack stays geometry-neutral and clear of the composer',
+  )
 
   const nudgeCss = css.match(
     /\.chat__question-nudge,\s*\n\.chat__resume-nudge\s*\{[\s\S]*?\}/,


### PR DESCRIPTION
## Summary

- keep the contribution review card below transient tail controls
- prevent Jump to latest from moving the pending contribution action
- preserve the ordering with a focused footer regression test

## Testing

- `node --loader=./src/lib/__tests__/vite-env-loader.mjs --test src/components/ChatView/__tests__/offlineFooter.test.js`
- authenticated browser check: the card's top and bottom positions were unchanged before and after Jump to latest