### PR TITLE
Copy assistant selections as Markdown

### DIFF
--- a/frontend/src/components/ChatView/ChatInputBar.jsx
+++ b/frontend/src/components/ChatView/ChatInputBar.jsx
@@ -91,7 +91,10 @@ import {
   composerHistoryProbeReachedBoundary,
   resolveComposerHistoryMove,
 } from './composerHistory.js'
-import { resolveComposerEnterAction } from './composerShortcuts.js'
+import {
+  isPlainTextPasteShortcut,
+  resolveComposerEnterAction,
+} from './composerShortcuts.js'
 import SlashMenu from './SlashMenu.jsx'
 import {
   applySlashCommand,
@@ -103,6 +106,10 @@ import {
 } from './slashCommands.js'
 import { filePasteNeedsDefaultPrevented, pastedFiles } from './pasteUpload.js'
 import { hasSendablePayload } from './composerSubmission.js'
+import {
+  assistantClipboardText,
+  insertClipboardText,
+} from './markdownClipboard.js'
 import {
   textareaUsesNativeSizing,
   syncComposerTallClass,
@@ -518,8 +525,9 @@ export default function ChatInputBar({
   const fileInputRef = useRef(null)
   const historyIndexRef = useRef(null)
   const historyDraftRef = useRef('')
-  const historyCaretRef = useRef(null)
+  const pendingComposerCaretRef = useRef(null)
   const historyProbeVersionRef = useRef(0)
+  const pasteAsPlainTextRef = useRef(false)
   // Captures whether the textarea was focused at the moment the file
   // picker opened. Read by `handleFileSelect` to decide whether to
   // refocus the textarea after the picker closes — refocusing
@@ -584,7 +592,7 @@ export default function ChatInputBar({
     historyProbeVersionRef.current += 1
     historyIndexRef.current = null
     historyDraftRef.current = ''
-    historyCaretRef.current = null
+    pendingComposerCaretRef.current = null
   }
 
   // Never carry a traversal or its saved draft into another chat. History
@@ -595,14 +603,14 @@ export default function ChatInputBar({
     resetMessageHistory()
   }, [chatId])
 
-  // History values arrive through the controlled composer boundary. Restore
-  // the caret after React commits that value without changing focus or scroll.
+  // Programmatic composer edits arrive through the controlled value boundary.
+  // Restore their caret after React commits without changing focus or scroll.
   useLayoutEffect(() => {
-    const pending = historyCaretRef.current
+    const pending = pendingComposerCaretRef.current
     const textarea = inputRef?.current
     if (!pending || pending.value !== input || !textarea) return
     try { textarea.setSelectionRange(pending.caret, pending.caret) } catch {}
-    historyCaretRef.current = null
+    pendingComposerCaretRef.current = null
   }, [input, inputRef])
 
   // Modern browsers size the textarea from CSS (`field-sizing: content`).
@@ -660,13 +668,35 @@ export default function ChatInputBar({
   }
 
   function handlePaste(e) {
-    if (attachmentsDisabled) return
-    const files = pastedFiles(e.clipboardData)
-    if (files.length === 0) return
-    if (filePasteNeedsDefaultPrevented(e.clipboardData, files)) {
-      e.preventDefault()
+    const preferPlainText = pasteAsPlainTextRef.current
+    pasteAsPlainTextRef.current = false
+    const files = attachmentsDisabled ? [] : pastedFiles(e.clipboardData)
+    if (files.length > 0) {
+      if (filePasteNeedsDefaultPrevented(e.clipboardData, files)) {
+        e.preventDefault()
+      }
+      onAddFiles?.(files)
+      return
     }
-    onAddFiles?.(files)
+
+    const pastedText = assistantClipboardText(
+      e.clipboardData,
+      preferPlainText,
+    )
+    if (pastedText === null) return
+
+    e.preventDefault()
+    const next = insertClipboardText(
+      input,
+      e.currentTarget.selectionStart,
+      e.currentTarget.selectionEnd,
+      pastedText,
+    )
+    resetMessageHistory()
+    pendingComposerCaretRef.current = next
+    if (listeningRef?.current) onManualVoiceEdit?.(next.value)
+    onInputChange(next.value)
+    onInputIntent?.(e.nativeEvent)
   }
 
   function acceptSlashCommand(command) {
@@ -684,6 +714,7 @@ export default function ChatInputBar({
   const canSubmit = !submissionBlocked && !questionBlocked
 
   function handleKeyDown(e) {
+    pasteAsPlainTextRef.current = isPlainTextPasteShortcut(e)
     // The menu claims Enter and the arrows while it is open — the same keys
     // that otherwise send and walk sent-message history — so it resolves
     // BEFORE both. Keys it doesn't claim fall through untouched.
@@ -704,7 +735,7 @@ export default function ChatInputBar({
     function applyHistoryMove(historyMove) {
       historyIndexRef.current = historyMove.index
       historyDraftRef.current = historyMove.draft
-      historyCaretRef.current = {
+      pendingComposerCaretRef.current = {
         value: historyMove.value,
         caret: historyMove.value.length,
       }
@@ -721,7 +752,7 @@ export default function ChatInputBar({
             historyMove.value.length,
           )
         } catch {}
-        historyCaretRef.current = null
+        pendingComposerCaretRef.current = null
       }
     }
 
@@ -854,6 +885,7 @@ export default function ChatInputBar({
               onChange={handleTextareaChange}
               onPaste={handlePaste}
               onKeyDown={handleKeyDown}
+              onKeyUp={() => { pasteAsPlainTextRef.current = false }}
               onFocus={(event) => {
                 placeCaretAtTextEnd(event.currentTarget)
                 setSlashInputFocused(true)

--- a/frontend/src/components/ChatView/ChatView.css
+++ b/frontend/src/components/ChatView/ChatView.css
@@ -350,6 +350,10 @@
   align-items: flex-start;
 }
 
+/* Event-only owner for Markdown-aware native selection copy. `contents` keeps
+   every prose/tool child in the message row's existing flex and gap geometry. */
+.chat__assistant-copy-surface { display: contents; }
+
 /* A search jump is a one-shot held position, not a new scrolling mode. The
    restrained row wash and text highlight make the destination legible without
    competing with ordinary user/assistant surfaces. */

--- a/frontend/src/components/ChatView/MsgContent.jsx
+++ b/frontend/src/components/ChatView/MsgContent.jsx
@@ -19,6 +19,7 @@ import { stripAugmentation } from './msgText.js'
 import ErrorCard from './ErrorCard.jsx'
 import ContextCompactionMarker from './ContextCompactionMarker.jsx'
 import { assistantBlockKey } from './streamPromotion.js'
+import { copyAssistantSelection } from './markdownClipboard.js'
 
 
 // Answerability is purely a function of the block + its position + live hint.
@@ -40,6 +41,28 @@ function blockAnswerable(block, { msg, isLastMsg, liveQuestionId, onQuestionAnsw
     && !block.answers
     && liveQuestionId
     && block.question_id === liveQuestionId
+  )
+}
+
+function AssistantCopySurface({ msg, markdownByIndex, children }) {
+  if (msg.role !== 'assistant') return children
+
+  function markdownForBlock(element) {
+    const index = Number(element.dataset.assistantMarkdownBlock)
+    // A supplied map is authoritative, including a missing entry. Streaming
+    // and cold-rendered blocks intentionally omit source until the whole block
+    // is visible; falling back to msg.content here would copy the hidden tail.
+    if (markdownByIndex) return markdownByIndex.get(index) ?? ''
+    return msg.content ?? ''
+  }
+
+  return (
+    <div
+      className="chat__assistant-copy-surface"
+      onCopy={(event) => copyAssistantSelection(event, markdownForBlock)}
+    >
+      {children}
+    </div>
   )
 }
 
@@ -150,6 +173,16 @@ function MsgContentInner({
     const lastEntryIdx = finalEntries.length
       ? finalEntries[finalEntries.length - 1].idx
       : -1
+    const assistantMarkdownByIndex = new Map(
+      msg.role !== 'assistant' ? [] : finalEntries.flatMap(({ item, idx }) => {
+        if (item.type !== 'text' || !item.content) return []
+        const coldFraction = Number(item._coldRenderFraction)
+        const fullyRendered = !(
+          Number.isFinite(coldFraction) && coldFraction > 0 && coldFraction < 1
+        )
+        return fullyRendered ? [[idx, item.content]] : []
+      }),
+    )
 
     // Render a stretch-breaking block by type. Activity entries (tool/thinking)
     // are folded into an ActivityStretch below; this renders only the `single`
@@ -181,7 +214,11 @@ function MsgContentInner({
           ? stripAugmentation(block.content) : block.content
         if (!text) return null
         return (
-          <div key={assistantBlockKey(block, i)} className={`chat__text chat__text--${msg.role}`}>
+          <div
+            key={assistantBlockKey(block, i)}
+            className={`chat__text chat__text--${msg.role}`}
+            data-assistant-markdown-block={msg.role === 'assistant' ? i : undefined}
+          >
             {msg.role === 'assistant'
               ? (isActiveAnswer
                   ? <ProgressiveMarkdown
@@ -345,7 +382,7 @@ function MsgContentInner({
     const nodes = groupActivityRuns(finalEntries)
 
     return (
-      <>
+      <AssistantCopySurface msg={msg} markdownByIndex={assistantMarkdownByIndex}>
         {msg.role === 'user' && <Attachments attachments={msg.attachments} chatId={chatId} />}
         {nodes.map((node, nodeIdx) => {
           if (node.group) {
@@ -391,7 +428,7 @@ function MsgContentInner({
             disclosureKey={`${messageKey}:references`}
           />
         )}
-      </>
+      </AssistantCopySurface>
     )
   }
 
@@ -399,12 +436,13 @@ function MsgContentInner({
     ? stripAugmentation(msg.content) : msg.content
 
   return (
-    <>
+    <AssistantCopySurface msg={msg}>
       {msg.role === 'user' && <Attachments attachments={msg.attachments} chatId={chatId} />}
       {text ? (
         <div
           key={isActiveAnswer ? 0 : undefined}
           className={`chat__text chat__text--${msg.role}`}
+          data-assistant-markdown-block={msg.role === 'assistant' ? 0 : undefined}
         >
           {msg.role === 'assistant'
             ? (isActiveAnswer
@@ -422,7 +460,7 @@ function MsgContentInner({
             : text}
         </div>
       ) : null}
-    </>
+    </AssistantCopySurface>
   )
 }
 

--- a/frontend/src/components/ChatView/__tests__/composerShortcuts.test.js
+++ b/frontend/src/components/ChatView/__tests__/composerShortcuts.test.js
@@ -1,7 +1,10 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
 
-import { resolveComposerEnterAction } from '../composerShortcuts.js'
+import {
+  isPlainTextPasteShortcut,
+  resolveComposerEnterAction,
+} from '../composerShortcuts.js'
 
 const enter = (overrides = {}) => ({ key: 'Enter', ...overrides })
 
@@ -134,4 +137,11 @@ test('non-Enter keys do not trigger composer shortcuts', () => {
     }),
     null,
   )
+})
+
+test('Cmd/Ctrl+Shift+V requests paste without Markdown formatting', () => {
+  assert.equal(isPlainTextPasteShortcut({ key: 'v', metaKey: true, shiftKey: true }), true)
+  assert.equal(isPlainTextPasteShortcut({ key: 'V', ctrlKey: true, shiftKey: true }), true)
+  assert.equal(isPlainTextPasteShortcut({ key: 'v', metaKey: true, shiftKey: false }), false)
+  assert.equal(isPlainTextPasteShortcut({ key: 'v', shiftKey: true }), false)
 })

--- a/frontend/src/components/ChatView/__tests__/markdownClipboard.test.js
+++ b/frontend/src/components/ChatView/__tests__/markdownClipboard.test.js
@@ -1,0 +1,166 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import {
+  assistantClipboardText,
+  insertClipboardText,
+  markdownClipboardHtml,
+  markdownFromFragment,
+  plainTextFromFragment,
+} from '../markdownClipboard.js'
+
+function text(value) {
+  return { nodeType: 3, nodeValue: value, textContent: value, parentNode: null }
+}
+
+function element(tagName, children = [], attrs = {}, classes = []) {
+  const node = {
+    nodeType: 1,
+    tagName: tagName.toUpperCase(),
+    childNodes: children,
+    parentNode: null,
+    classList: {
+      contains: name => classes.includes(name),
+      [Symbol.iterator]: function* iterate() { yield* classes },
+    },
+    getAttribute: name => attrs[name] ?? null,
+    querySelector(selector) {
+      return this.querySelectorAll(selector)[0] || null
+    },
+    querySelectorAll(selector) {
+      const wanted = selector.toLowerCase()
+      const matches = []
+      function walk(current) {
+        for (const child of current.childNodes || []) {
+          if (String(child.tagName || '').toLowerCase() === wanted) matches.push(child)
+          walk(child)
+        }
+      }
+      walk(this)
+      return matches
+    },
+  }
+  Object.defineProperty(node, 'textContent', {
+    get: () => node.childNodes.map(child => child.textContent || '').join(''),
+  })
+  for (const child of children) child.parentNode = node
+  return node
+}
+
+function fragment(children = []) {
+  const node = { nodeType: 11, childNodes: children, parentNode: null }
+  Object.defineProperty(node, 'textContent', {
+    get: () => node.childNodes.map(child => child.textContent || '').join(''),
+  })
+  for (const child of children) child.parentNode = node
+  return node
+}
+
+function clipboard(values) {
+  return { getData: type => values[type] || '' }
+}
+
+test('rendered prose serializes to Markdown while plain text drops punctuation', () => {
+  const tree = fragment([
+    element('h2', [text('Clipboard contract')]),
+    element('p', [
+      text('Keep '),
+      element('strong', [text('structure')]),
+      text(' and '),
+      element('a', [text('links')], { href: 'https://example.com' }),
+      text('.'),
+    ]),
+    element('ul', [
+      element('li', [text('First')]),
+      element('li', [text('Second')]),
+    ]),
+  ])
+
+  assert.equal(markdownFromFragment(tree), [
+    '## Clipboard contract',
+    '',
+    'Keep **structure** and [links](https://example.com).',
+    '',
+    '- First',
+    '- Second',
+  ].join('\n'))
+  assert.equal(plainTextFromFragment(tree), [
+    'Clipboard contract',
+    '',
+    'Keep structure and links.',
+    '',
+    '- First',
+    '- Second',
+  ].join('\n'))
+})
+
+test('code serialization preserves inline delimiters and fenced language', () => {
+  const inline = element('code', [text('a`b')])
+  const code = element('code', [text('const answer = 42\n')], {}, ['language-js'])
+  const tree = fragment([
+    element('p', [text('Use '), inline, text('.')]),
+    element('pre', [code]),
+  ])
+
+  assert.equal(
+    markdownFromFragment(tree),
+    'Use ``a`b``.\n\n```js\nconst answer = 42\n```',
+  )
+  assert.equal(plainTextFromFragment(tree), 'Use a`b.\n\nconst answer = 42')
+})
+
+test('partial plain text cannot turn into Markdown structure after trimming', () => {
+  const tree = element('p', [text('# heading > quote - item 1. item <tag> &copy;')])
+  assert.equal(
+    markdownFromFragment(tree),
+    '\\# heading \\> quote \\- item 1\\. item \\<tag\\> \\&copy;',
+  )
+})
+
+test('composer prefers Markdown unless paste-without-formatting was requested', () => {
+  const data = clipboard({
+    'text/markdown': '**hello**',
+    'text/plain': 'hello',
+  })
+  assert.equal(assistantClipboardText(data), '**hello**')
+  assert.equal(assistantClipboardText(data, true), 'hello')
+  assert.equal(assistantClipboardText(clipboard({ 'text/plain': 'ordinary' })), null)
+})
+
+test('HTML carrier round-trips Markdown when optional clipboard types are lost', () => {
+  const markdown = '## Café\n\n**one & two**'
+  const html = markdownClipboardHtml(markdown, 'Café\none & two')
+  assert.equal(
+    assistantClipboardText(clipboard({ 'text/html': html, 'text/plain': 'Café\none & two' })),
+    markdown,
+  )
+  assert.match(html, /Caf%C3%A9/)
+  assert.match(html, /one &amp; two/)
+})
+
+test('Markdown insertion preserves the selected caret range', () => {
+  assert.deepEqual(
+    insertClipboardText('before old after', 7, 10, '**new**'),
+    { value: 'before **new** after', caret: 14 },
+  )
+  assert.deepEqual(
+    insertClipboardText('draft', -4, 99, '!'),
+    { value: '!', caret: 1 },
+    'browser selection offsets are clamped before editing the controlled value',
+  )
+})
+
+test('assistant prose and the composer share the Markdown clipboard boundary', () => {
+  const message = readFileSync(new URL('../MsgContent.jsx', import.meta.url), 'utf8')
+  const composer = readFileSync(new URL('../ChatInputBar.jsx', import.meta.url), 'utf8')
+  assert.match(message, /onCopy=\{\(event\) => copyAssistantSelection\(event, markdownForBlock\)\}/)
+  assert.match(message, /data-assistant-markdown-block=/)
+  assert.match(message, /if \(markdownByIndex\) return markdownByIndex\.get\(index\) \?\? ''/,
+    'a partial cold render must not fall back to the hidden full message source')
+  assert.match(composer, /assistantClipboardText\(\s*e\.clipboardData,\s*preferPlainText/)
+  assert.match(composer, /pasteAsPlainTextRef\.current = isPlainTextPasteShortcut\(e\)/)
+  assert.match(composer, /pendingComposerCaretRef\.current = next/,
+    'paste and sent-message history should share the controlled caret handoff')
+  assert.doesNotMatch(composer, /setSelectionRange\(next\.caret/,
+    'paste must not introduce a second requestAnimationFrame caret path')
+})

--- a/frontend/src/components/ChatView/composerShortcuts.js
+++ b/frontend/src/components/ChatView/composerShortcuts.js
@@ -17,3 +17,14 @@ export function resolveComposerEnterAction(event, {
   if (canRequestSteer) return 'steer'
   return 'noop'
 }
+
+/** Paste-without-formatting chord. ClipboardEvent does not reliably retain
+ * keyboard modifiers, so the composer snapshots this during keydown and lets
+ * the subsequent paste event consume it. */
+export function isPlainTextPasteShortcut(event) {
+  return !!(
+    String(event?.key || '').toLowerCase() === 'v'
+    && event?.shiftKey
+    && (event?.metaKey || event?.ctrlKey)
+  )
+}

--- a/frontend/src/components/ChatView/markdownClipboard.js
+++ b/frontend/src/components/ChatView/markdownClipboard.js
@@ -1,0 +1,364 @@
+/** Clipboard contract for rendered assistant prose.
+ *
+ * Copy keeps native selection, but replaces the clipboard payload with two
+ * representations of the selected assistant text:
+ *   - text/markdown: source Markdown (or an equivalent serialization when the
+ *     selection cuts through only part of a rendered block)
+ *   - text/plain: the same selection without Markdown punctuation
+ *
+ * text/html is a small carrier for browsers that do not round-trip optional
+ * clipboard MIME types. The composer reads the carrier but never inserts its
+ * HTML. Ordinary destinations still receive readable plain text.
+ */
+
+const MARKDOWN_TYPE = 'text/markdown'
+const MARKDOWN_CARRIER_ATTR = 'data-mobius-markdown'
+
+const ELEMENT_NODE = 1
+const TEXT_NODE = 3
+const DOCUMENT_FRAGMENT_NODE = 11
+
+function childrenOf(node) {
+  return Array.from(node?.childNodes || [])
+}
+
+function classHas(node, name) {
+  return !!node?.classList?.contains?.(name)
+}
+
+function tagOf(node) {
+  return String(node?.tagName || '').toLowerCase()
+}
+
+function escapeMarkdownText(text) {
+  return String(text || '')
+    .replace(/\\/g, '\\\\')
+    .replace(/([`*_[\]~<>#+\-!|&])/g, '\\$1')
+    .replace(/(\d+)([.)])(?=\s)/g, '$1\\$2')
+}
+
+function inlineCode(text) {
+  const value = String(text || '')
+  const runs = value.match(/`+/g) || []
+  const fence = '`'.repeat(Math.max(1, ...runs.map(run => run.length + 1)))
+  const needsPadding = /^`|`$|^\s|\s$/.test(value)
+  return `${fence}${needsPadding ? ' ' : ''}${value}${needsPadding ? ' ' : ''}${fence}`
+}
+
+function codeFence(text) {
+  const runs = String(text || '').match(/`{3,}/g) || []
+  return '`'.repeat(Math.max(3, ...runs.map(run => run.length + 1)))
+}
+
+function ignoredElement(node) {
+  const tag = tagOf(node)
+  return (
+    tag === 'script'
+    || tag === 'style'
+    || tag === 'noscript'
+    || tag === 'button'
+    || node?.getAttribute?.('aria-hidden') === 'true'
+    || classHas(node, 'md-code-lang')
+    || classHas(node, 'md-code-copy')
+    || classHas(node, 'chat__cursor')
+    || classHas(node, 'katex-html')
+  )
+}
+
+function texFrom(node) {
+  const annotations = node?.querySelectorAll?.('annotation') || []
+  for (const annotation of annotations) {
+    if (annotation.getAttribute?.('encoding') === 'application/x-tex') {
+      return annotation.textContent || ''
+    }
+  }
+  return ''
+}
+
+function markdownChildren(node) {
+  return childrenOf(node).map(markdownNode).join('')
+}
+
+function listMarkdown(node, ordered) {
+  const start = ordered ? Number(node.getAttribute?.('start') || 1) : 1
+  const items = childrenOf(node).filter(child => tagOf(child) === 'li')
+  return items.map((item, index) => {
+    const marker = ordered ? `${start + index}. ` : '- '
+    const content = markdownChildren(item).trim()
+    const lines = content.split('\n')
+    return `${marker}${lines[0] || ''}${lines.slice(1).map(line => `\n  ${line}`).join('')}`
+  }).join('\n') + '\n\n'
+}
+
+function tableMarkdown(node) {
+  const rows = Array.from(node.querySelectorAll?.('tr') || [])
+  if (rows.length === 0) return ''
+  const cells = row => childrenOf(row)
+    .filter(cell => ['th', 'td'].includes(tagOf(cell)))
+    .map(cell => markdownChildren(cell).trim().replace(/\|/g, '\\|').replace(/\n/g, ' '))
+  const head = cells(rows[0])
+  if (head.length === 0) return ''
+  const body = rows.slice(1).map(cells)
+  return [
+    `| ${head.join(' | ')} |`,
+    `| ${head.map(() => '---').join(' | ')} |`,
+    ...body.map(row => `| ${row.join(' | ')} |`),
+    '',
+    '',
+  ].join('\n')
+}
+
+/** Serialize the selected rendered fragment back into equivalent Markdown. */
+export function markdownFromFragment(node) {
+  return markdownNode(node).trim()
+}
+
+function markdownNode(node) {
+  if (!node) return ''
+  if (node.nodeType === TEXT_NODE) return escapeMarkdownText(node.nodeValue ?? node.textContent)
+  if (node.nodeType === DOCUMENT_FRAGMENT_NODE) return markdownChildren(node)
+  if (node.nodeType !== ELEMENT_NODE || ignoredElement(node)) return ''
+
+  const tag = tagOf(node)
+  const childMarkdown = () => markdownChildren(node)
+  const tex = (classHas(node, 'md-math-block') || classHas(node, 'katex'))
+    ? texFrom(node)
+    : ''
+  if (tex) {
+    return classHas(node, 'md-math-block') ? `$$\n${tex}\n$$\n\n` : `$${tex}$`
+  }
+
+  if (/^h[1-6]$/.test(tag)) return `${'#'.repeat(Number(tag[1]))} ${childMarkdown().trim()}\n\n`
+  if (tag === 'p') return `${childMarkdown().trim()}\n\n`
+  if (tag === 'strong' || tag === 'b') return `**${childMarkdown()}**`
+  if (tag === 'em' || tag === 'i') return `_${childMarkdown()}_`
+  if (tag === 'del' || tag === 's') return `~~${childMarkdown()}~~`
+  if (tag === 'br') return '  \n'
+  if (tag === 'hr') return '---\n\n'
+  if (tag === 'code' && tagOf(node.parentNode) !== 'pre') return inlineCode(node.textContent)
+  if (tag === 'pre') {
+    const code = node.querySelector?.('code')
+    const value = code?.textContent ?? node.textContent ?? ''
+    const language = Array.from(code?.classList || [])
+      .find(name => name.startsWith('language-'))
+      ?.slice('language-'.length) || ''
+    const fence = codeFence(value)
+    return `${fence}${language}\n${value.replace(/\n$/, '')}\n${fence}\n\n`
+  }
+  if (tag === 'a') {
+    const label = childMarkdown()
+    const href = node.getAttribute?.('href') || ''
+    if (!href) return label
+    const title = node.getAttribute?.('title')
+    return `[${label}](${href}${title ? ` "${title.replace(/"/g, '\\"')}"` : ''})`
+  }
+  if (tag === 'img') {
+    const alt = node.getAttribute?.('alt') || ''
+    // Rendered media URLs may carry short-lived authorization. Never copy a
+    // transformed DOM URL; whole-block copies use the original source instead.
+    return alt ? escapeMarkdownText(alt) : ''
+  }
+  if (tag === 'blockquote') {
+    const value = childMarkdown().trim()
+    return `${value.split('\n').map(line => `> ${line}`).join('\n')}\n\n`
+  }
+  if (tag === 'ul') return listMarkdown(node, false)
+  if (tag === 'ol') return listMarkdown(node, true)
+  if (tag === 'table') return tableMarkdown(node)
+
+  return childMarkdown()
+}
+
+function plainChildren(node) {
+  return childrenOf(node).map(plainNode).join('')
+}
+
+function plainList(node, ordered) {
+  const start = ordered ? Number(node.getAttribute?.('start') || 1) : 1
+  const items = childrenOf(node).filter(child => tagOf(child) === 'li')
+  return items.map((item, index) => {
+    const marker = ordered ? `${start + index}. ` : '- '
+    const content = plainChildren(item).trim()
+    return `${marker}${content.replace(/\n/g, '\n  ')}`
+  }).join('\n') + '\n\n'
+}
+
+/** Serialize the same fragment as readable, formatting-free text. */
+export function plainTextFromFragment(node) {
+  return plainNode(node).trim()
+}
+
+function plainNode(node) {
+  if (!node) return ''
+  if (node.nodeType === TEXT_NODE) return String(node.nodeValue ?? node.textContent ?? '')
+  if (node.nodeType === DOCUMENT_FRAGMENT_NODE) return plainChildren(node)
+  if (node.nodeType !== ELEMENT_NODE || ignoredElement(node)) return ''
+
+  const tag = tagOf(node)
+  const children = () => plainChildren(node)
+  const tex = (classHas(node, 'md-math-block') || classHas(node, 'katex'))
+    ? texFrom(node)
+    : ''
+  if (tex) return classHas(node, 'md-math-block') ? `${tex}\n\n` : tex
+
+  if (/^h[1-6]$/.test(tag) || tag === 'p') return `${children().trim()}\n\n`
+  if (tag === 'br') return '\n'
+  if (tag === 'hr') return '—\n\n'
+  if (tag === 'pre') {
+    const code = node.querySelector?.('code')
+    return `${code?.textContent ?? node.textContent ?? ''}\n\n`
+  }
+  if (tag === 'img') return node.getAttribute?.('alt') || ''
+  if (tag === 'blockquote') {
+    return `${children().trim().split('\n').map(line => `> ${line}`).join('\n')}\n\n`
+  }
+  if (tag === 'ul') return plainList(node, false)
+  if (tag === 'ol') return plainList(node, true)
+  if (tag === 'table') {
+    const rows = Array.from(node.querySelectorAll?.('tr') || [])
+    return rows.map(row => childrenOf(row)
+      .filter(cell => ['th', 'td'].includes(tagOf(cell)))
+      .map(cell => plainChildren(cell).trim())
+      .join('\t'))
+      .join('\n') + '\n\n'
+  }
+  return children()
+}
+
+function rangeIntersectsNode(range, node) {
+  try {
+    return range.intersectsNode(node)
+  } catch {
+    return false
+  }
+}
+
+function rangeInsideNode(range, node) {
+  const nodeRange = node.ownerDocument.createRange()
+  nodeRange.selectNodeContents(node)
+  const overlap = nodeRange.cloneRange()
+
+  if (node === range.startContainer || node.contains(range.startContainer)) {
+    overlap.setStart(range.startContainer, range.startOffset)
+  }
+  if (node === range.endContainer || node.contains(range.endContainer)) {
+    overlap.setEnd(range.endContainer, range.endOffset)
+  }
+  return overlap.collapsed ? null : overlap
+}
+
+function cloneRangeWithContext(range, block) {
+  let selected = range.cloneContents()
+  let ancestor = range.commonAncestorContainer
+  if (ancestor.nodeType === TEXT_NODE) ancestor = ancestor.parentNode
+
+  // Range.cloneContents() omits a common ancestor. If a selection lives
+  // entirely inside one <strong>, link, list item, or code span, cloning only
+  // the range would therefore lose exactly the Markdown structure the user is
+  // asking to copy. Rebuild only that shallow ancestor chain; descendants stay
+  // limited to the selected range.
+  while (ancestor && ancestor !== block) {
+    const shell = ancestor.cloneNode(false)
+    shell.appendChild(selected)
+    selected = shell
+    ancestor = ancestor.parentNode
+  }
+  return selected
+}
+
+function selectedAssistantPayload(root, selection, markdownForBlock) {
+  if (!root || !selection || selection.rangeCount !== 1 || selection.isCollapsed) return null
+  const range = selection.getRangeAt(0)
+  const blocks = Array.from(root.querySelectorAll('[data-assistant-markdown-block]'))
+    .filter(block => rangeIntersectsNode(range, block))
+  if (blocks.length === 0) return null
+
+  const markdown = []
+  const plain = []
+  for (const block of blocks) {
+    const overlap = rangeInsideNode(range, block)
+    if (!overlap) continue
+    const fragment = cloneRangeWithContext(overlap, block)
+    const fullRange = block.ownerDocument.createRange()
+    fullRange.selectNodeContents(block)
+    const selectedAllRenderedText = overlap.toString() === fullRange.toString()
+    const raw = selectedAllRenderedText ? markdownForBlock(block) : ''
+    const markdownPart = raw?.trim() || markdownFromFragment(fragment)
+    const plainPart = plainTextFromFragment(fragment)
+    if (markdownPart) markdown.push(markdownPart)
+    if (plainPart) plain.push(plainPart)
+  }
+  if (markdown.length === 0 || plain.length === 0) return null
+  return { markdown: markdown.join('\n\n'), plainText: plain.join('\n\n') }
+}
+
+function escapeHtml(text) {
+  return String(text || '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+}
+
+export function markdownClipboardHtml(markdown, plainText) {
+  const encoded = encodeURIComponent(markdown)
+  return `<span ${MARKDOWN_CARRIER_ATTR}="${encoded}">${escapeHtml(plainText).replace(/\n/g, '<br>')}</span>`
+}
+
+/** React onCopy handler used by the response-level copy surface. */
+export function copyAssistantSelection(event, markdownForBlock) {
+  const selection = event.currentTarget?.ownerDocument?.getSelection?.()
+  const payload = selectedAssistantPayload(event.currentTarget, selection, markdownForBlock)
+  if (!payload || !event.clipboardData) return false
+
+  let plainWritten = false
+  try { event.clipboardData.setData(MARKDOWN_TYPE, payload.markdown) } catch { /* optional */ }
+  try {
+    event.clipboardData.setData('text/html', markdownClipboardHtml(payload.markdown, payload.plainText))
+  } catch { /* optional */ }
+  try {
+    event.clipboardData.setData('text/plain', payload.plainText)
+    plainWritten = true
+  } catch { /* native copy remains available below */ }
+
+  if (!plainWritten) return false
+  event.preventDefault()
+  return true
+}
+
+function markdownFromHtmlCarrier(html) {
+  const match = String(html || '').match(new RegExp(`${MARKDOWN_CARRIER_ATTR}="([^"]*)"`, 'i'))
+  if (!match) return ''
+  try {
+    return decodeURIComponent(match[1])
+  } catch {
+    return ''
+  }
+}
+
+/** Return null for an ordinary clipboard so native paste remains untouched. */
+export function assistantClipboardText(clipboardData, preferPlainText = false) {
+  if (!clipboardData) return null
+  const plain = clipboardData.getData?.('text/plain') || ''
+  const markdown = (
+    clipboardData.getData?.(MARKDOWN_TYPE)
+    || markdownFromHtmlCarrier(clipboardData.getData?.('text/html'))
+  )
+  if (!markdown) return null
+  return preferPlainText ? plain : markdown
+}
+
+export function insertClipboardText(value, selectionStart, selectionEnd, text) {
+  const current = String(value || '')
+  const inserted = String(text || '')
+  const start = Number.isInteger(selectionStart)
+    ? Math.max(0, Math.min(selectionStart, current.length))
+    : current.length
+  const end = Number.isInteger(selectionEnd)
+    ? Math.max(start, Math.min(selectionEnd, current.length))
+    : start
+  return {
+    value: `${current.slice(0, start)}${inserted}${current.slice(end)}`,
+    caret: start + inserted.length,
+  }
+}

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -1260,8 +1260,8 @@ test('round4-3: the New Chat landing renders for a null slot and reuses ChatView
   assert.doesNotMatch(newChatLanding, /attachTriggerRef/,
     'the pre-allocation surface must not expose server-bound attachment behavior')
   assert.match(chatInputBar,
-    /function handlePaste\(e\) \{\s*if \(attachmentsDisabled\) return/,
-    'disabled attachments must leave clipboard paste to the browser')
+    /const files = attachmentsDisabled \? \[\] : pastedFiles\(e\.clipboardData\)/,
+    'disabled attachments must suppress only pasted files, not text handling')
   assert.match(chatInputBar, /\{!attachmentsDisabled && \(\s*<input/,
     'disabled attachments must not mount a hidden file picker')
   // Seamless swap: the landing reuses ChatView's exact empty treatment.


### PR DESCRIPTION
## Summary

- Copy assistant selections as source Markdown while keeping readable plain text for ordinary destinations.
- Paste the Markdown representation with Cmd/Ctrl+V, or paste without formatting with Cmd/Ctrl+Shift+V.
- Preserve headings, emphasis, links, code, lists, tables, quotes, and math in partial selections without copying transformed media URLs or hidden response text.
- Keep native selection, file paste, voice editing, and composer scroll behavior unchanged.

## Related work

#553 explored an explicit clipboard-reader action. This change instead stays on the native copy/paste event path, avoids new clipboard permissions and UI, and adds round-trip Markdown plus paste-without-formatting behavior.

## Testing

- `npm test`
- `npm run lint`
- `npm run build`
- Authenticated browser copy/paste verification