### PR TITLE
Unify fork-safe contribution workflows

### DIFF
--- a/.github/workflows/main-image.yml
+++ b/.github/workflows/main-image.yml
@@ -15,6 +15,9 @@ env:
 
 jobs:
   publish:
+    # Forks inherit workflow files. Never allocate a runner or attempt a
+    # package write outside the one repository that owns this image channel.
+    if: github.repository == 'mobius-os/mobius'
     runs-on: ubuntu-latest
     outputs:
       digest: ${{ steps.publish.outputs.digest }}
@@ -87,6 +90,7 @@ jobs:
           fi
 
   promote-main:
+    if: github.repository == 'mobius-os/mobius'
     needs: publish
     runs-on: ubuntu-latest
     concurrency:

--- a/.github/workflows/warm-build-cache.yml
+++ b/.github/workflows/warm-build-cache.yml
@@ -29,6 +29,9 @@ concurrency:
 
 jobs:
   warm:
+    # A fork may enable Actions solely to run the allowlisted Tests workflow.
+    # It must not inherit the canonical repository's recurring cache spend.
+    if: github.repository == 'mobius-os/mobius'
     runs-on: ubuntu-latest
     # A full cold build can approach the same duration as the e2e build it feeds.
     timeout-minutes: 40

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,6 +116,23 @@ fork and manually dispatches `.github/workflows/test.yml`; it does not open a
 pull request. From another checkout whose branch is already on GitHub, the
 equivalent manual command is:
 
+Forks inherit every workflow file from upstream even though Contribute enables
+only `test.yml`. Therefore `test.yml` is the sole fork-runnable workflow: every
+job in every other workflow must carry
+`if: github.repository == 'mobius-os/mobius'`. The focused pre-PR contract test
+enforces this safe default. A future workflow may run in forks only through an
+explicit allowlist change with corresponding review; never rely on missing
+secrets, package permissions, or repository variables to fail after allocating
+a runner.
+
+Contribute has one GitHub permission contract: device flow always requests
+public-repository and workflow access together. Do not add a second
+limited-scope publication path or adapt reviewed commits onto stale fork bases;
+sync a proven-behind fork when the Tests workflow needs its current default
+branch, then push the exact reviewed commit. Existing partial credentials are
+rejected before any GitHub write so the owner can reconnect once through the
+same path.
+
 ```bash
 gh workflow run test.yml -R <your-login>/mobius --ref <branch>
 ```

--- a/backend/app/github_connection.py
+++ b/backend/app/github_connection.py
@@ -11,7 +11,6 @@ from contextlib import asynccontextmanager
 
 import httpx
 from fastapi import HTTPException, Request
-from pydantic import BaseModel
 
 from app import github_auth, models
 from app.config import get_settings
@@ -22,24 +21,20 @@ _API_BASE = "https://api.github.com"
 _GITHUB_LOGIN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9-]{0,38}$")
 _CONNECTION_LOCK_TIMEOUT = 70.0
 _device_flow_poll_lock = asyncio.Lock()
-_CLASSIC_TOKEN_URL = (
-  "https://github.com/settings/tokens/new"
-  "?scopes=public_repo&description=Mobius%20Contribute"
-)
-_CLASSIC_WORKFLOW_TOKEN_URL = (
-  "https://github.com/settings/tokens/new"
-  "?scopes=public_repo,workflow&description=Mobius%20Contribute"
-)
+_FULL_PR_SCOPES = ("public_repo", "workflow")
 
 log = logging.getLogger("moebius.github")
 
 
-class GithubTokenRequest(BaseModel):
-  token: str
-
-
-class GithubConnectStartRequest(BaseModel):
-  workflow: bool = False
+def has_full_pr_access(scopes: object) -> bool:
+  """Return whether one credential can publish every reviewed PR shape."""
+  if not isinstance(scopes, (list, tuple, set, frozenset)):
+    return False
+  granted = {str(scope) for scope in scopes}
+  return (
+    "workflow" in granted
+    and ("public_repo" in granted or "repo" in granted)
+  )
 
 
 def _bounded_provider_int(
@@ -119,7 +114,6 @@ async def _github_user(token: str) -> tuple[int, str, int | None, list[str]]:
 
 async def _start_device_attempt(
   request: Request,
-  body: GithubConnectStartRequest | None,
 ) -> dict:
   """Request and persist one device code while the connection lock is held."""
   if await request.is_disconnected():
@@ -130,12 +124,12 @@ async def _start_device_attempt(
       status_code=409,
       detail=(
         "Device flow is not configured on this instance "
-        "(GITHUB_OAUTH_CLIENT_ID is unset). Connect with a classic "
-        "personal access token instead."
+        "(GITHUB_OAUTH_CLIENT_ID is unset). Configure the Möbius GitHub "
+        "OAuth app before connecting."
       ),
     )
   try:
-    scopes = "public_repo workflow" if body and body.workflow else "public_repo"
+    scopes = " ".join(_FULL_PR_SCOPES)
     async with httpx.AsyncClient(timeout=15.0) as client:
       r = await client.post(
         _DEVICE_CODE_URL,
@@ -153,7 +147,7 @@ async def _start_device_attempt(
       status_code=409,
       detail=(
         "The configured GitHub OAuth app has the device flow disabled. "
-        "Connect with a classic personal access token instead."
+        "Enable device flow for that OAuth app before connecting."
       ),
     )
   if r.status_code != 200 or "device_code" not in payload:
@@ -212,6 +206,8 @@ def _device_attempt_result(flow: dict, *, now: float | None = None) -> dict:
   }
   if flow.get("reason"):
     response["reason"] = flow["reason"]
+  if flow.get("message"):
+    response["message"] = flow["message"]
   if flow.get("login"):
     response["login"] = flow["login"]
   if response["status"] == "waiting":
@@ -239,43 +235,3 @@ def _current_device_attempt(attempt_id: str) -> dict:
       detail="This GitHub connection attempt no longer exists.",
     )
   return flow
-
-
-async def _connect_token_locked(body: GithubTokenRequest) -> dict:
-  """Validate and install a PAT while the connection lock is held."""
-  token = body.token.strip()
-  if token.startswith("github_pat_"):
-    raise HTTPException(
-      status_code=400,
-      detail=(
-        "That's a fine-grained personal access token (github_pat_…). "
-        "Fine-grained tokens can only reach repositories you own or are "
-        "explicitly granted, so they can't push to or open pull requests "
-        "on the upstream public repos Contribute targets. Create a classic "
-        "token with the public_repo scope instead — this link pre-fills it: "
-        f"{_CLASSIC_TOKEN_URL} (or use the device flow)."
-      ),
-    )
-  if not token:
-    raise HTTPException(status_code=400, detail="Token is empty.")
-  status, login, user_id, scopes = await _github_user(token)
-  if status != 200 or not _GITHUB_LOGIN.fullmatch(login):
-    raise HTTPException(
-      status_code=400, detail="GitHub rejected the token.",
-    )
-  if "repo" not in scopes and "public_repo" not in scopes:
-    granted = ", ".join(scopes) if scopes else "none"
-    raise HTTPException(
-      status_code=400,
-      detail=(
-        "The token lacks the public_repo (or repo) scope needed to "
-        f"contribute — its scopes are: {granted}."
-      ),
-    )
-  github_auth.write_credentials(
-    token=token, login=login, user_id=user_id, scopes=scopes, source="pat",
-  )
-  # PAT success supersedes any device attempt. Clearing both disk and cache
-  # ensures an older tab cannot later complete and overwrite these credentials.
-  github_auth.set_device_flow(None)
-  return {"login": login}

--- a/backend/app/github_contributions.py
+++ b/backend/app/github_contributions.py
@@ -31,10 +31,10 @@ from app import (
 )
 from app.config import get_settings
 from app.contribution_errors import ContributionSubmitError, push_rejected
+from app.github_connection import has_full_pr_access
 from app.terminal_output import readable_output
 from app.github_contribution_contract import (
   BRANCH_NAME as _BRANCH_NAME,
-  COAUTHOR_TRAILER as _COAUTHOR_TRAILER,
   GITHUB_LOGIN as _GITHUB_LOGIN,
   GITHUB_REPO as _GITHUB_REPO,
   GIT_SHA as _GIT_SHA,
@@ -1320,19 +1320,6 @@ def _existing_branch_pr(
   return merged
 
 
-def _is_workflow_scope_push_error(message: str) -> bool:
-  """Recognize GitHub's stable OAuth workflow-scope rejection."""
-  detail = str(message or "").lower()
-  return (
-    "workflow" in detail
-    and (
-      "refusing to allow" in detail
-      or ".github/workflows" in detail
-      or "oauth app" in detail
-    )
-  )
-
-
 def _is_transient_push_error(message: str) -> bool:
   """Retry transport/server failures, never deterministic push rejections."""
   detail = str(message or "").lower()
@@ -1444,18 +1431,7 @@ def _inspect_owner_fork_default_branch(
   upstream_branch: str,
   upstream_sha: str,
 ) -> dict:
-  """Inspect a reusable PR fork without mutating its default branch.
-
-  GitHub rejects an OAuth push that would introduce a new or changed Actions
-  workflow to a repository unless the token also has the broad `workflow`
-  scope. The same restriction applies to GitHub's merge-upstream endpoint, so
-  a public_repo-only connection cannot refresh a stale fork that crossed a
-  workflow change. Instead, a strictly-behind fork is handled by preparing the
-  reviewed change on its existing tip; the fork's default branch stays put.
-
-  A current fork (or one containing upstream) can receive the reviewed branch
-  normally. A diverged default branch is left untouched and stops submission.
-  """
+  """Classify a reusable PR fork's default branch without mutating it."""
   upstream_branch = _git_ops._validate_branch(upstream_branch)
   if not _GIT_SHA.match(str(upstream_sha or "")):
     raise ContributionSubmitError(
@@ -1467,7 +1443,6 @@ def _inspect_owner_fork_default_branch(
     f"{fork_slug}\0{fork_branch}\0{time.time_ns()}".encode("utf-8")
   ).hexdigest()[:24]
   fork_ref = f"refs/mobius-submit/fork-{ref_key}"
-  fork_heads_prefix = f"refs/mobius-submit/fork-heads-{ref_key}"
   patch = {
     "last_submit_fork_branch": fork_branch,
     "last_submit_upstream_branch": upstream_branch,
@@ -1523,161 +1498,19 @@ def _inspect_owner_fork_default_branch(
         record_patch={**patch, "last_submit_fork_sync": "diverged"},
       )
 
-    # GitHub's own "Update branch" action can merge current upstream into a
-    # topic branch while leaving the reusable fork's default branch stale. In
-    # that case the workflow-bearing upstream commits already exist in the
-    # fork, so a public_repo-only token may safely create another reviewed
-    # topic ref without introducing workflow history. Discover that carrier
-    # branch before asking for broader workflow access.
-    fetched_heads = _git_ops._git(
-      repo,
-      "fetch", "--no-tags", "--force",
-      fork_url,
-      f"+refs/heads/*:{fork_heads_prefix}/*",
-      check=False,
-    )
-    if fetched_heads.returncode == 0:
-      refs = _git_ops._git(
-        repo,
-        "for-each-ref", "--format=%(refname)%00%(objectname)",
-        f"{fork_heads_prefix}/",
-      ).stdout.splitlines()
-      for row in refs:
-        ref, separator, tip = row.partition("\0")
-        if not separator or not _GIT_SHA.match(tip):
-          continue
-        if is_ancestor(upstream_sha, tip):
-          carrier = ref.removeprefix(f"{fork_heads_prefix}/")
-          return {
-            **patch,
-            "last_submit_fork_sync": "contains-upstream",
-            "last_submit_fork_carrier_branch": carrier,
-            "last_submit_fork_carrier_sha": tip,
-          }
     return {**patch, "last_submit_fork_sync": "strictly-behind"}
   finally:
     _git_ops._git(repo, "update-ref", "-d", fork_ref, check=False)
-    refs = _git_ops._git(
-      repo,
-      "for-each-ref", "--format=%(refname)", f"{fork_heads_prefix}/",
-      check=False,
-    )
-    if refs.returncode == 0:
-      for ref in (refs.stdout or "").splitlines():
-        _git_ops._git(repo, "update-ref", "-d", ref, check=False)
 
 
-def _build_fork_compatible_topic_commit(
-  repo: Path,
-  *,
-  branch: str,
-  fork_sha: str,
-  upstream_sha: str,
-  diff_path: Path,
-  expected_diff: str,
-  author_name: str,
-  author_email: str,
-) -> str:
-  """Re-parent an exact reviewed change onto a strictly-behind fork tip.
-
-  The fork default branch is never changed. The temporary topic commit is
-  accepted only when merging it into current upstream produces the exact
-  reviewed source diff byte-for-byte. This avoids OAuth's workflow restriction
-  without weakening review or silently changing the contribution.
-  """
-  message = _git_ops._git(repo, "log", "-1", "--format=%B", branch).stdout
-  if _COAUTHOR_TRAILER not in message:
-    raise ContributionSubmitError(
-      "This staged commit is missing the Möbius Agent co-author trailer. "
-      "Leave feedback so your agent can prepare it again."
-    )
-
-  message_path = None
-  detached = False
-  try:
-    with tempfile.NamedTemporaryFile(
-      "w", encoding="utf-8", delete=False,
-    ) as message_file:
-      message_file.write(message)
-      message_path = message_file.name
-
-    _git_ops._git(repo, "checkout", "-q", "--detach", fork_sha)
-    detached = True
-    applied = _git_ops._git(
-      repo,
-      "apply", "--index", "--3way", "--binary", str(diff_path),
-      check=False,
-    )
-    if applied.returncode != 0:
-      raise ContributionSubmitError(
-        "The reviewed change cannot be placed safely on this stale PR fork. "
-        "Leave feedback so your agent can refresh the contribution."
-      )
-
-    workflows = _git_ops._git(
-      repo, "diff", "--cached", "--name-only", "--", ".github/workflows",
-    ).stdout.strip()
-    if workflows:
-      raise ContributionSubmitError(
-        "This reviewed contribution changes a GitHub Actions workflow. "
-        "Reconnect GitHub with a classic token granting public_repo and "
-        "workflow, then try Send again."
-      )
-
-    _git_ops._git(
-      repo,
-      "-c", f"user.name={author_name}",
-      "-c", f"user.email={author_email}",
-      "commit", "--no-gpg-sign", "-F", message_path,
-    )
-    push_sha = _git_ops._git(repo, "rev-parse", "HEAD").stdout.strip()
-    if not _GIT_SHA.match(push_sha):
-      raise ContributionSubmitError(
-        "Could not prepare the reviewed branch for this stale PR fork."
-      )
-
-    merged = _git_ops._git(
-      repo, "merge-tree", "--write-tree", upstream_sha, push_sha,
-      check=False,
-    )
-    merged_tree = (merged.stdout or "").strip().splitlines()[0:1]
-    if (
-      merged.returncode != 0
-      or not merged_tree
-      or not _GIT_SHA.match(merged_tree[0])
-    ):
-      raise ContributionSubmitError(
-        "The stale-fork branch no longer merges cleanly with upstream. Leave "
-        "feedback so your agent can refresh the contribution."
-      )
-    merged_hash = hashlib.sha256(
-      _git_ops._reviewed_branch_diff(repo, upstream_sha, merged_tree[0])
-    ).hexdigest()
-    if merged_hash != expected_diff:
-      raise ContributionSubmitError(
-        "Adapting this branch to the stale PR fork would change the reviewed "
-        "result, so Contribute stopped before pushing anything."
-      )
-    return push_sha
-  finally:
-    if message_path:
-      try:
-        os.unlink(message_path)
-      except OSError:
-        pass
-    if detached:
-      _git_ops._git(repo, "reset", "--hard", fork_sha, check=False)
-      _git_ops._git(repo, "checkout", "-q", branch, check=False)
-
-
-def _sync_owner_fork_with_workflow_scope(
+def _sync_owner_fork(
   repo: Path,
   fork_slug: str,
   *,
   upstream_branch: str,
   upstream_sha: str,
 ) -> dict:
-  """Fast-forward a proven-behind fork when the owner granted workflow scope."""
+  """Fast-forward a proven-behind fork and verify the resulting default."""
   synced = _git_ops._gh(
     repo,
     "api", "--method", "POST",
@@ -1708,92 +1541,6 @@ def _sync_owner_fork_with_workflow_scope(
   return {**verified, "last_submit_fork_sync": "fast-forwarded"}
 
 
-def _push_reviewed_topic(
-  repo: Path,
-  *,
-  branch: str,
-  fork_slug: str,
-  merge_patch: dict,
-  record_patch: dict,
-  diff_path: Path,
-  expected_diff: str,
-  author_name: str,
-  author_email: str,
-  workflow_scope: bool = False,
-) -> tuple[str, dict]:
-  """Push the reviewed topic, inspecting a stale fork only when required."""
-  push_source = "HEAD"
-  last_push_error = _push_topic_branch(repo, branch, push_source)
-  if not last_push_error:
-    return push_source, record_patch
-  if not _is_workflow_scope_push_error(last_push_error):
-    raise push_rejected(last_push_error, record_patch=record_patch)
-
-  # Most topic branches can be pushed without consulting the fork's default
-  # branch. GitHub only makes that state relevant when a public_repo-only
-  # OAuth token would introduce a workflow that landed upstream after the
-  # fork fell behind. Inspect and adapt only on that specific rejection.
-  try:
-    fork_sync_patch = _inspect_owner_fork_default_branch(
-      repo,
-      fork_slug,
-      upstream_branch=str(merge_patch["last_submit_upstream_branch"]),
-      upstream_sha=str(merge_patch["last_submit_upstream_sha"]),
-    )
-    record_patch = _git_ops._record_patch_with(record_patch, fork_sync_patch)
-  except ContributionSubmitError as exc:
-    raise _git_ops._merge_error_patch(exc, record_patch) from exc
-  if fork_sync_patch.get("last_submit_fork_sync") != "strictly-behind":
-    raise ContributionSubmitError(
-      "GitHub refused this branch because the connection does not grant "
-      "workflow access. Reconnect GitHub with a classic token granting "
-      "public_repo and workflow, then try Send again.",
-      record_patch=record_patch,
-    )
-  try:
-    push_source = _build_fork_compatible_topic_commit(
-      repo,
-      branch=branch,
-      fork_sha=str(fork_sync_patch["last_submit_fork_sha"]),
-      upstream_sha=str(merge_patch["last_submit_upstream_sha"]),
-      diff_path=diff_path,
-      expected_diff=expected_diff,
-      author_name=author_name,
-      author_email=author_email,
-    )
-    record_patch = _git_ops._record_patch_with(record_patch, {
-      "last_submit_fork_sync": "stale-base-compatible",
-      "last_submit_push_sha": push_source,
-    })
-  except ContributionSubmitError as exc:
-    if not workflow_scope:
-      raise ContributionSubmitError(
-        "This reviewed change depends on newer code in a stale PR fork. "
-        "In Contribute, enable optional workflow access, then try Send "
-        "again; Contribute will fast-forward only that fork's default "
-        "branch before pushing the reviewed topic branch.",
-        record_patch=_git_ops._record_patch_with(record_patch, {
-          "last_submit_requires_workflow_scope": True,
-          "last_submit_compatible_error": exc.message,
-        }),
-      ) from exc
-    try:
-      synced_patch = _sync_owner_fork_with_workflow_scope(
-        repo,
-        fork_slug,
-        upstream_branch=str(merge_patch["last_submit_upstream_branch"]),
-        upstream_sha=str(merge_patch["last_submit_upstream_sha"]),
-      )
-      record_patch = _git_ops._record_patch_with(record_patch, synced_patch)
-      push_source = "HEAD"
-    except ContributionSubmitError as sync_exc:
-      raise _git_ops._merge_error_patch(sync_exc, record_patch) from sync_exc
-  last_push_error = _push_topic_branch(repo, branch, push_source)
-  if last_push_error:
-    raise push_rejected(last_push_error, record_patch=record_patch)
-  return push_source, record_patch
-
-
 def _submit_prepared_pr(
   record: dict,
   diff_path: Path,
@@ -1811,6 +1558,11 @@ def _submit_prepared_pr(
   login = str(state.get("login") or "")
   if not token or not login:
     raise ContributionSubmitError("Connect GitHub before approving this PR.", 401)
+  if not has_full_pr_access(state.get("scopes")):
+    raise ContributionSubmitError(
+      "Reconnect GitHub with full PR access before approving this PR.",
+      status_code=409,
+    )
   author_name, author_email = _git_ops._connected_git_identity(state, login)
 
   plan = record.get("plan") or {}
@@ -1930,18 +1682,10 @@ def _submit_prepared_pr(
       except ContributionSubmitError as exc:
         raise _git_ops._merge_error_patch(exc, record_patch) from exc
       record_patch = _git_ops._record_patch_with(record_patch, {"head_repository": fork_slug})
-      push_source, record_patch = _push_reviewed_topic(
-        repo,
-        branch=branch,
-        fork_slug=fork_slug,
-        merge_patch=merge_patch,
-        record_patch=record_patch,
-        diff_path=diff_path,
-        expected_diff=expected_diff,
-        author_name=author_name,
-        author_email=author_email,
-        workflow_scope="workflow" in set(state.get("scopes") or []),
-      )
+      push_source = "HEAD"
+      last_push_error = _push_topic_branch(repo, branch, push_source)
+      if last_push_error:
+        raise push_rejected(last_push_error, record_patch=record_patch)
       published_repo = fork_slug
     pushed_branch_url = (
       f"https://github.com/{published_repo}/tree/{quote(branch, safe='/')}"
@@ -2091,6 +1835,11 @@ def _preflight_prepared_stack(rows: list[dict]) -> None:
   login = str(state.get("login") or "")
   if not token or not login:
     raise ContributionSubmitError("Connect GitHub before approving this PR stack.", 401)
+  if not has_full_pr_access(state.get("scopes")):
+    raise ContributionSubmitError(
+      "Reconnect GitHub with full PR access before approving this PR stack.",
+      status_code=409,
+    )
   author_name, author_email = _git_ops._connected_git_identity(state, login)
   sendable = [row for row in rows if row["record"].get("status") == "submitting"]
   if not sendable:
@@ -2236,6 +1985,11 @@ def _land_reviewed_stack(rows: list[dict]) -> tuple[str, str]:
   login = str(state.get("login") or "")
   if not token or not login:
     raise ContributionSubmitError("Connect GitHub before landing this PR stack.", 401)
+  if not has_full_pr_access(state.get("scopes")):
+    raise ContributionSubmitError(
+      "Reconnect GitHub with full PR access before landing this PR stack.",
+      status_code=409,
+    )
 
   first_record = rows[0]["record"]
   first_plan = first_record.get("plan") or {}

--- a/backend/app/github_pre_pr_checks.py
+++ b/backend/app/github_pre_pr_checks.py
@@ -16,13 +16,14 @@ from pathlib import Path
 from urllib.parse import quote
 
 from app import github_auth
-from app.contribution_errors import ContributionSubmitError
+from app.contribution_errors import ContributionSubmitError, push_rejected
 from app.github_contribution_contract import (
   GIT_SHA as _GIT_SHA,
   PRE_PR_CHECK_ACTIVE_STATES as _ACTIVE_STATES,
 )
 from app import github_contribution_git as _git_ops
 from app import github_contributions as _contrib
+from app.github_connection import has_full_pr_access
 
 
 _SUPPORTED_WORKFLOWS = {
@@ -197,10 +198,9 @@ def dispatch_pre_pr_checks(
   token = github_auth.get_token()
   state = github_auth.read_state() or {}
   login = str(state.get("login") or "")
-  scopes = set(state.get("scopes") or [])
   if not token or not login:
     raise ContributionSubmitError("Connect GitHub before running checks.", 401)
-  if "workflow" not in scopes:
+  if not has_full_pr_access(state.get("scopes")):
     raise ContributionSubmitError(
       "Reconnect GitHub with full PR access before running checks on a fork.",
       status_code=409,
@@ -280,11 +280,8 @@ def dispatch_pre_pr_checks(
       upstream_branch=str(merge_patch["last_submit_upstream_branch"]),
       upstream_sha=str(merge_patch["last_submit_upstream_sha"]),
     )
-    if (
-      fork_patch.get("last_submit_fork_sync") == "strictly-behind"
-      or fork_patch.get("last_submit_fork_carrier_branch")
-    ):
-      fork_patch = _contrib._sync_owner_fork_with_workflow_scope(
+    if fork_patch.get("last_submit_fork_sync") == "strictly-behind":
+      fork_patch = _contrib._sync_owner_fork(
         repo,
         fork_slug,
         upstream_branch=str(merge_patch["last_submit_upstream_branch"]),
@@ -292,18 +289,10 @@ def dispatch_pre_pr_checks(
       )
     record_patch = _git_ops._record_patch_with(record_patch, fork_patch)
 
-    push_source, record_patch = _contrib._push_reviewed_topic(
-      repo,
-      branch=branch,
-      fork_slug=fork_slug,
-      merge_patch=merge_patch,
-      record_patch=record_patch,
-      diff_path=diff_path,
-      expected_diff=expected_diff,
-      author_name=author_name,
-      author_email=author_email,
-      workflow_scope=True,
-    )
+    push_source = "HEAD"
+    last_push_error = _contrib._push_topic_branch(repo, branch, push_source)
+    if last_push_error:
+      raise push_rejected(last_push_error, record_patch=record_patch)
     pushed_sha = _git_ops._git(repo, "rev-parse", push_source).stdout.strip()
     if not _GIT_SHA.fullmatch(pushed_sha):
       raise ContributionSubmitError(

--- a/backend/app/routes/github.py
+++ b/backend/app/routes/github.py
@@ -1,12 +1,11 @@
-"""GitHub connection routes: device flow, PAT fallback, read surface, submit.
+"""GitHub connection routes: device flow, read surface, and reviewed writes.
 
 Connect endpoints persist a token via app.github_auth (owner OR a
 github_connect app — so the Contribute app can drive connect from its
 own UI — CSRF-guarded, rate-limited — INV4). github_connect is the
 credential-management grant: an app with it can start/complete the connect
-flow, submit a PAT, inspect connection status, and disconnect. A
-normal connect still needs the owner to authorize on github.com or
-paste their own token, but the grant itself is powerful — see the
+flow, inspect connection status, and disconnect. A normal connect still needs
+the owner to authorize on github.com, but the grant itself is powerful — see the
 get_owner_or_app_with_github_connect docstring. The separate github_access
 grant gates the remote read and reviewed-submit surface.
 (/api/{path}, /graphql) is read-only by construction (INV2): the REST
@@ -77,18 +76,14 @@ from app.database import get_db
 from app.github_connection import (
   _ACCESS_TOKEN_URL,
   _API_BASE,
-  _CLASSIC_TOKEN_URL,
-  _CLASSIC_WORKFLOW_TOKEN_URL,
   _GITHUB_LOGIN,
-  GithubConnectStartRequest,
-  GithubTokenRequest,
   _bounded_provider_int,
   _github_connection_transaction,
+  has_full_pr_access,
   _github_user,
   _start_device_attempt,
   _device_attempt_result,
   _current_device_attempt,
-  _connect_token_locked,
 )
 from app.github_checks import (
   _contributions_dir,
@@ -166,16 +161,13 @@ from app.github_contributions import (
   _apply_reviewed_pr_labels,
   _find_existing_pr,
   _existing_branch_pr,
-  _is_workflow_scope_push_error,
   _is_transient_push_error,
   _push_branch,
   _push_topic_branch,
   _github_remote_slug,
   _ensure_owner_fork_remote,
   _inspect_owner_fork_default_branch,
-  _build_fork_compatible_topic_commit,
-  _sync_owner_fork_with_workflow_scope,
-  _push_reviewed_topic,
+  _sync_owner_fork,
   _submit_prepared_pr,
   _preflight_prepared_stack,
   _push_stack_tip_with_lease,
@@ -308,15 +300,14 @@ class ContributionStackLandRequest(BaseModel):
 @_limiter.limit("3/minute")
 async def connect_start(
   request: Request,
-  body: GithubConnectStartRequest | None = None,
   _: models.Owner = Depends(get_owner_or_app_with_github_connect),
 ):
   """Starts exactly one GitHub device flow and returns its user code."""
   # All credential/attempt mutations share this lock. In particular, a start
   # cannot publish a ghost attempt after its client timed out behind an older
-  # poll, PAT connection, or Disconnect.
+  # poll or Disconnect.
   async with _github_connection_transaction():
-    return await _start_device_attempt(request, body)
+    return await _start_device_attempt(request)
 
 
 
@@ -439,6 +430,18 @@ async def connect_poll(
       flow.pop("pending_token", None)
       github_auth.set_device_flow(flow)
       return _device_attempt_result(flow, now=now)
+    if not has_full_pr_access(scopes):
+      flow.update(
+        status="failed",
+        reason="insufficient_scopes",
+        message=(
+          "GitHub did not grant the full PR access Contribute needs. "
+          "Try connecting again and approve the complete permission request."
+        ),
+      )
+      flow.pop("pending_token", None)
+      github_auth.set_device_flow(flow)
+      return _device_attempt_result(flow, now=now)
     github_auth.write_credentials(
       token=token, login=login, user_id=user_id, scopes=scopes,
       source="device",
@@ -465,21 +468,6 @@ async def connect_cancel(
       flow.pop("pending_token", None)
       github_auth.set_device_flow(flow)
     return _device_attempt_result(flow)
-
-
-
-
-@router.post("/connect/token", dependencies=[Depends(reject_cross_site)])
-@_limiter.limit("5/minute")
-async def connect_token(
-  request: Request,
-  body: GithubTokenRequest,
-  _: models.Owner = Depends(get_owner_or_app_with_github_connect),
-):
-  """Connects GitHub with a pasted classic personal access token."""
-  async with _github_connection_transaction():
-    return await _connect_token_locked(body)
-
 
 @router.get("/status")
 async def github_status(
@@ -515,8 +503,6 @@ async def github_status(
     "scopes": (state.get("scopes") or []) if connected else [],
     "token_source": state.get("token_source") if connected else None,
     "device_flow_available": bool(get_settings().github_oauth_client_id),
-    "classic_token_url": _CLASSIC_TOKEN_URL,
-    "classic_workflow_token_url": _CLASSIC_WORKFLOW_TOKEN_URL,
     "gh_version": github_auth.gh_version(),
     "active_attempt": active_attempt,
     "autopilot_available": True,

--- a/backend/tests/test_github_pre_pr_checks.py
+++ b/backend/tests/test_github_pre_pr_checks.py
@@ -2,11 +2,17 @@
 
 import json
 import subprocess
+from pathlib import Path
 
 import pytest
+import yaml
 
 from app.contribution_errors import ContributionSubmitError
-from app import github_pre_pr_checks as checks
+from app import github_auth, github_pre_pr_checks as checks
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CANONICAL_REPOSITORY_GUARD = "github.repository == 'mobius-os/mobius'"
 
 
 def _record(*, repo="mobius-os/mobius", status="prepared"):
@@ -42,6 +48,38 @@ def test_support_is_narrow_and_active_states_are_explicit():
   assert not checks.pre_pr_checks_active({"state": "completed"})
 
 
+def test_only_allowlisted_workflow_jobs_may_run_in_forks():
+  """Enabling Tests on a fork must not arm production or scheduled jobs."""
+  workflow_dir = ROOT / ".github" / "workflows"
+  paths = sorted([
+    *workflow_dir.glob("*.yml"),
+    *workflow_dir.glob("*.yaml"),
+  ])
+  allowlisted = set(checks._SUPPORTED_WORKFLOWS.values())
+  names = {path.name for path in paths}
+  assert allowlisted <= names
+
+  for path in paths:
+    payload = yaml.load(path.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+    jobs = payload.get("jobs") if isinstance(payload, dict) else None
+    assert isinstance(jobs, dict) and jobs, f"{path.name} must define jobs"
+    if path.name in allowlisted:
+      assert payload.get("permissions") == {"contents": "read"}, (
+        f"{path.name} is fork-runnable and must remain read-only"
+      )
+      assert all("permissions" not in job for job in jobs.values()), (
+        f"{path.name} jobs must not widen the fork workflow token"
+      )
+      continue
+    for job_name, job in jobs.items():
+      assert isinstance(job, dict), f"{path.name}:{job_name} must be a job"
+      condition = str(job.get("if") or "")
+      assert condition == CANONICAL_REPOSITORY_GUARD, (
+        f"{path.name}:{job_name} can run in a fork; add the canonical "
+        "repository guard or explicitly allowlist the workflow"
+      )
+
+
 def test_bootstrap_requires_manual_trigger_on_upstream(monkeypatch, tmp_path):
   calls = []
 
@@ -59,6 +97,22 @@ def test_bootstrap_requires_manual_trigger_on_upstream(monkeypatch, tmp_path):
   assert calls[0][1] == (
     "show", f"{'a' * 40}:.github/workflows/test.yml",
   )
+
+
+def test_dispatch_rejects_partial_connection_before_git(monkeypatch, tmp_path):
+  monkeypatch.setattr(github_auth, "get_token", lambda: "gh-partial")
+  monkeypatch.setattr(
+    github_auth,
+    "read_state",
+    lambda: {"login": "octocat", "scopes": ["public_repo"]},
+  )
+  monkeypatch.setattr(checks.shutil, "which", lambda name: f"/bin/{name}")
+
+  with pytest.raises(ContributionSubmitError) as failure:
+    checks.dispatch_pre_pr_checks(_record(), tmp_path / "reviewed.diff")
+
+  assert failure.value.code == "pre_pr_checks_scope"
+  assert "full PR access" in failure.value.message
 
 
 def test_dispatch_response_without_run_identity_is_uncertain(

--- a/backend/tests/test_github_routes.py
+++ b/backend/tests/test_github_routes.py
@@ -85,7 +85,7 @@ def _install_mock_transport(monkeypatch, handler):
 
 def _write_token(
   *, token="gh-tok-abc", login="octocat", user_id=42,
-  scopes=("public_repo",), source="pat",
+  scopes=("public_repo", "workflow"), source="device",
 ):
   """Writes a connected-state file directly (the get_token() read source)."""
   os.makedirs(github_auth.GH_AUTH_DIR, exist_ok=True)
@@ -176,7 +176,7 @@ async def test_disconnected_start_never_publishes_attempt():
       return True
 
   with pytest.raises(HTTPException) as caught:
-    await github_routes._start_device_attempt(GoneRequest(), None)
+    await github_routes._start_device_attempt(GoneRequest())
 
   assert getattr(caught.value, "status_code", None) == 499
   assert github_auth.get_device_flow() is None
@@ -231,7 +231,7 @@ def test_connect_start_bounds_invalid_provider_durations(
   assert github_auth.get_device_flow()["interval"] == 5
 
 
-def test_connect_start_can_explicitly_request_workflow_scope(
+def test_connect_start_always_requests_full_pr_access(
   client, auth, monkeypatch,
 ):
   _set_client_id(monkeypatch, "cid-123")
@@ -248,13 +248,29 @@ def test_connect_start_can_explicitly_request_workflow_scope(
     return _fail(request)
 
   _install_mock_transport(monkeypatch, handler)
+  # Older Contribute builds sent this selector. It is intentionally ignored:
+  # callers can no longer create a partial connection.
   r = client.post(
-    "/api/github/connect/start", headers=auth, json={"workflow": True},
+    "/api/github/connect/start", headers=auth, json={"workflow": False},
   )
 
   assert r.status_code == 200, r.text
   assert seen["scope"] == ["public_repo workflow"]
   assert r.json()["requested_scopes"] == ["public_repo", "workflow"]
+
+
+@pytest.mark.parametrize(
+  ("scopes", "expected"),
+  [
+    (("public_repo", "workflow"), True),
+    (("repo", "workflow"), True),
+    (("public_repo",), False),
+    (("workflow",), False),
+    ((), False),
+  ],
+)
+def test_full_pr_access_is_one_explicit_scope_contract(scopes, expected):
+  assert github_routes.has_full_pr_access(scopes) is expected
 
 
 def test_connect_start_app_with_github_connect(
@@ -338,7 +354,9 @@ def test_device_flow_happy_path(client, auth, monkeypatch, tmp_path):
       calls["user"] += 1
       assert request.headers.get("authorization") == "Bearer gh-secret-xyz"
       return httpx.Response(200, json={"login": "octocat", "id": 42},
-                            headers={"x-oauth-scopes": "public_repo, read:org"})
+                            headers={
+                              "x-oauth-scopes": "public_repo, workflow, read:org",
+                            })
     return _fail(request)
 
   _install_mock_transport(monkeypatch, handler)
@@ -387,7 +405,7 @@ def test_device_flow_happy_path(client, auth, monkeypatch, tmp_path):
   assert state["token"] == "gh-secret-xyz"
   assert state["login"] == "octocat"
   assert state["token_source"] == "device"
-  assert state["scopes"] == ["public_repo", "read:org"]
+  assert state["scopes"] == ["public_repo", "workflow", "read:org"]
 
   # Git identity attributes commits to the connected user.
   def _git_get(key):
@@ -424,7 +442,7 @@ def test_device_token_survives_user_lookup_retry(
       return httpx.Response(
         200,
         json={"login": "octocat", "id": 42},
-        headers={"x-oauth-scopes": "public_repo"},
+        headers={"x-oauth-scopes": "public_repo, workflow"},
       )
     return _fail(request)
 
@@ -450,6 +468,45 @@ def test_device_token_survives_user_lookup_retry(
   assert completed.json()["status"] == "complete"
   assert calls == {"token": 1, "user": 2}
   assert github_auth.read_state()["token"] == "gh-recoverable"
+  assert "pending_token" not in github_auth.get_device_flow()
+
+
+def test_device_flow_rejects_a_partial_scope_grant(
+  client, auth, monkeypatch,
+):
+  _set_client_id(monkeypatch, "cid-123")
+
+  def handler(request):
+    url = str(request.url)
+    if url == _DEVICE_CODE_URL:
+      return httpx.Response(200, json={
+        "device_code": "DEV", "user_code": "AB-12",
+        "verification_uri": "https://github.com/login/device",
+        "interval": 5, "expires_in": 900,
+      })
+    if url == _ACCESS_TOKEN_URL:
+      return httpx.Response(200, json={"access_token": "gh-partial"})
+    if url == "https://api.github.com/user":
+      return httpx.Response(
+        200,
+        json={"login": "octocat", "id": 42},
+        headers={"x-oauth-scopes": "public_repo"},
+      )
+    return _fail(request)
+
+  _install_mock_transport(monkeypatch, handler)
+  attempt_id = client.post(
+    "/api/github/connect/start", headers=auth,
+  ).json()["attempt_id"]
+  _patch_device_flow(next_poll_at=0)
+
+  result = _poll(client, auth, attempt_id)
+
+  assert result.status_code == 200
+  assert result.json()["status"] == "failed"
+  assert result.json()["reason"] == "insufficient_scopes"
+  assert "full PR access" in result.json()["message"]
+  assert github_auth.read_state() is None
   assert "pending_token" not in github_auth.get_device_flow()
 
 
@@ -601,63 +658,14 @@ def test_expired_attempt_never_calls_github(client, auth, monkeypatch):
   assert "device_code" not in github_auth.get_device_flow()
 
 
-# --- connect/token (classic PAT) --------------------------------------
+def test_legacy_pasted_token_connection_is_retired(client, auth):
+  response = client.post(
+    "/api/github/connect/token",
+    json={"token": "ghp_not_sent_anywhere"},
+    headers=auth,
+  )
 
-
-def test_connect_token_rejects_fine_grained(client, auth):
-  r = client.post("/api/github/connect/token",
-                  json={"token": "github_pat_11ABCDEF_secret"}, headers=auth)
-  assert r.status_code == 400
-  detail = r.json()["detail"]
-  assert "fine-grained" in detail
-  # The rejection is actionable: it links straight to the classic-token
-  # creation page with the required scope pre-filled, and says why.
-  assert "https://github.com/settings/tokens/new" in detail
-  assert "scopes=public_repo" in detail
-
-
-def test_connect_token_rejects_missing_scope(client, auth, monkeypatch):
-  def handler(request):
-    if str(request.url) == "https://api.github.com/user":
-      return httpx.Response(200, json={"login": "octocat", "id": 42},
-                            headers={"x-oauth-scopes": "read:user, gist"})
-    return _fail(request)
-
-  _install_mock_transport(monkeypatch, handler)
-  r = client.post("/api/github/connect/token",
-                  json={"token": "ghp_noscope"}, headers=auth)
-  assert r.status_code == 400
-  detail = r.json()["detail"]
-  # The scopes the token DID have are echoed back.
-  assert "read:user" in detail and "gist" in detail
-
-
-def test_connect_token_happy_path(client, auth, monkeypatch):
-  def handler(request):
-    if str(request.url) == "https://api.github.com/user":
-      assert request.headers.get("authorization") == "Bearer ghp_classic123"
-      return httpx.Response(200, json={"login": "octocat", "id": 42},
-                            headers={"x-oauth-scopes": "repo"})
-    return _fail(request)
-
-  _install_mock_transport(monkeypatch, handler)
-  github_auth.set_device_flow({
-    "attempt_id": "superseded-by-pat",
-    "status": "waiting",
-    "device_code": "DEV",
-  })
-  r = client.post("/api/github/connect/token",
-                  json={"token": "ghp_classic123"}, headers=auth)
-  assert r.status_code == 200, r.text
-  assert r.json() == {"login": "octocat"}
-  state = json.loads(github_auth.STATE_PATH.read_text())
-  assert state["token"] == "ghp_classic123"
-  assert state["token_source"] == "pat"
-  assert stat.S_IMODE(github_auth.STATE_PATH.stat().st_mode) == 0o600
-  hosts = github_auth.HOSTS_PATH.read_text()
-  assert 'user: "octocat"' in hosts
-  assert 'oauth_token: "ghp_classic123"' in hosts
-  assert github_auth.get_device_flow() is None
+  assert response.status_code == 404
 
 
 def test_connection_mutation_lock_is_exclusive_and_survives_disconnect():
@@ -693,7 +701,7 @@ def test_credential_state_is_committed_only_after_cli_view(
       login="octocat",
       user_id=42,
       scopes=["public_repo"],
-      source="pat",
+      source="device",
     )
 
   assert github_auth.HOSTS_PATH.exists()
@@ -714,8 +722,8 @@ def test_status_disconnected(client, auth, monkeypatch):
   assert body["scopes"] == []
   assert body["token_source"] is None
   assert body["device_flow_available"] is True
-  assert "scopes=public_repo" in body["classic_token_url"]
-  assert "workflow" in body["classic_workflow_token_url"]
+  assert "classic_token_url" not in body
+  assert "classic_workflow_token_url" not in body
   assert "gh_version" in body
   assert body["active_attempt"] is None
   assert "token" not in body
@@ -759,7 +767,7 @@ def test_status_exposes_resumable_attempt_without_secrets(client, auth):
     "next_poll_at": time.time() + 5,
     "created_at": time.time(),
     "expires_at": time.time() + 300,
-    "requested_scopes": ["public_repo"],
+    "requested_scopes": ["public_repo", "workflow"],
     "user_code": "ABCD-EFGH",
     "verification_uri": "https://github.com/login/device",
   })
@@ -786,14 +794,14 @@ def test_status_device_flow_unavailable_without_client_id(
 
 def test_status_connected_never_echoes_token(client, auth):
   secret = _write_token(token="gh-super-secret", login="octocat",
-                        scopes=("public_repo", "read:org"), source="pat")
+                        scopes=("public_repo", "read:org"), source="device")
   r = client.get("/api/github/status", headers=auth)
   assert r.status_code == 200
   body = r.json()
   assert body["connected"] is True
   assert body["login"] == "octocat"
   assert body["scopes"] == ["public_repo", "read:org"]
-  assert body["token_source"] == "pat"
+  assert body["token_source"] == "device"
   # INV1: the token never appears anywhere in the payload.
   assert "token" not in body
   assert secret not in json.dumps(body)
@@ -1765,164 +1773,6 @@ def test_push_topic_branch_briefly_retries_transient_transport_errors(
   assert sleeps == [0.5, 1.0]
 
 
-def test_workflow_scope_push_errors_are_classified_for_stale_fork_fallback():
-  from app.routes.github import _is_workflow_scope_push_error
-
-  assert _is_workflow_scope_push_error(
-    "refusing to allow an OAuth App to create or update workflow "
-    "`.github/workflows/test.yml` without `workflow` scope"
-  )
-  assert not _is_workflow_scope_push_error(
-    "remote rejected: non-fast-forward"
-  )
-
-
-def test_push_reviewed_topic_adapts_only_after_workflow_scope_rejection(
-  tmp_path, monkeypatch,
-):
-  from app.routes.github import _push_reviewed_topic
-
-  pushes = []
-  inspections = []
-  built_sha = "e" * 40
-
-  def fake_push(_repo, branch, source="HEAD"):
-    pushes.append((branch, source))
-    if len(pushes) == 1:
-      return (
-        "refusing to allow an OAuth App to create or update workflow "
-        "`.github/workflows/test.yml` without `workflow` scope"
-      )
-    return None
-
-  monkeypatch.setattr("app.github_contributions._push_topic_branch", fake_push)
-  monkeypatch.setattr(
-    "app.github_contributions._inspect_owner_fork_default_branch",
-    lambda _repo, fork, **kwargs: inspections.append((fork, kwargs)) or {
-      "last_submit_fork_sync": "strictly-behind",
-      "last_submit_fork_sha": "c" * 40,
-    },
-  )
-  monkeypatch.setattr(
-    "app.github_contributions._build_fork_compatible_topic_commit",
-    lambda *_args, **_kwargs: built_sha,
-  )
-
-  source, patch = _push_reviewed_topic(
-    tmp_path,
-    branch="fix/demo",
-    fork_slug="octocat/demo",
-    merge_patch={
-      "last_submit_upstream_branch": "main",
-      "last_submit_upstream_sha": "d" * 40,
-    },
-    record_patch={"head_repository": "octocat/demo"},
-    diff_path=tmp_path / "reviewed.diff",
-    expected_diff="f" * 64,
-    author_name="octocat",
-    author_email="42+octocat@users.noreply.github.com",
-  )
-
-  assert source == built_sha
-  assert pushes == [("fix/demo", "HEAD"), ("fix/demo", built_sha)]
-  assert len(inspections) == 1
-  assert patch["last_submit_fork_sync"] == "stale-base-compatible"
-  assert patch["last_submit_push_sha"] == built_sha
-
-
-def test_push_reviewed_topic_uses_granted_workflow_scope_only_as_fallback(
-  tmp_path, monkeypatch,
-):
-  from app.routes.github import ContributionSubmitError, _push_reviewed_topic
-
-  pushes = []
-  syncs = []
-
-  def fake_push(_repo, branch, source="HEAD"):
-    pushes.append((branch, source))
-    if len(pushes) == 1:
-      return (
-        "refusing to allow an OAuth App to create or update workflow "
-        "`.github/workflows/test.yml` without `workflow` scope"
-      )
-    return None
-
-  monkeypatch.setattr("app.github_contributions._push_topic_branch", fake_push)
-  monkeypatch.setattr(
-    "app.github_contributions._inspect_owner_fork_default_branch",
-    lambda *_args, **_kwargs: {
-      "last_submit_fork_sync": "strictly-behind",
-      "last_submit_fork_sha": "c" * 40,
-    },
-  )
-  monkeypatch.setattr(
-    "app.github_contributions._build_fork_compatible_topic_commit",
-    lambda *_args, **_kwargs: (_ for _ in ()).throw(
-      ContributionSubmitError("workflow files cannot be re-parented")
-    ),
-  )
-  monkeypatch.setattr(
-    "app.github_contributions._sync_owner_fork_with_workflow_scope",
-    lambda _repo, fork, **kwargs: syncs.append((fork, kwargs)) or {
-      "last_submit_fork_sync": "fast-forwarded",
-    },
-  )
-
-  source, patch = _push_reviewed_topic(
-    tmp_path,
-    branch="fix/workflow",
-    fork_slug="octocat/demo",
-    merge_patch={
-      "last_submit_upstream_branch": "main",
-      "last_submit_upstream_sha": "d" * 40,
-    },
-    record_patch={"head_repository": "octocat/demo"},
-    diff_path=tmp_path / "reviewed.diff",
-    expected_diff="f" * 64,
-    author_name="octocat",
-    author_email="42+octocat@users.noreply.github.com",
-    workflow_scope=True,
-  )
-
-  assert source == "HEAD"
-  assert pushes == [("fix/workflow", "HEAD"), ("fix/workflow", "HEAD")]
-  assert len(syncs) == 1
-  assert patch["last_submit_fork_sync"] == "fast-forwarded"
-
-
-def test_push_reviewed_topic_skips_fork_inspection_on_happy_path(
-  tmp_path, monkeypatch,
-):
-  from app.routes.github import _push_reviewed_topic
-
-  monkeypatch.setattr(
-    "app.github_contributions._push_topic_branch",
-    lambda _repo, _branch, _source="HEAD": None,
-  )
-  monkeypatch.setattr(
-    "app.github_contributions._inspect_owner_fork_default_branch",
-    lambda *_args, **_kwargs: pytest.fail("fork inspection is not needed"),
-  )
-
-  source, patch = _push_reviewed_topic(
-    tmp_path,
-    branch="fix/demo",
-    fork_slug="octocat/demo",
-    merge_patch={
-      "last_submit_upstream_branch": "main",
-      "last_submit_upstream_sha": "d" * 40,
-    },
-    record_patch={"head_repository": "octocat/demo"},
-    diff_path=tmp_path / "reviewed.diff",
-    expected_diff="f" * 64,
-    author_name="octocat",
-    author_email="42+octocat@users.noreply.github.com",
-  )
-
-  assert source == "HEAD"
-  assert patch == {"head_repository": "octocat/demo"}
-
-
 def test_inspect_owner_fork_reports_strictly_behind_without_mutation(
   tmp_path, monkeypatch,
 ):
@@ -1967,52 +1817,7 @@ def test_inspect_owner_fork_reports_strictly_behind_without_mutation(
   assert patch["last_submit_fork_sync"] == "strictly-behind"
   assert patch["last_submit_fork_sha"] == stale
   assert gh_calls == []
-  assert sum(call[:1] == ("fetch",) for call in git_calls) == 2
-
-
-def test_inspect_owner_fork_accepts_updated_topic_as_upstream_carrier(
-  tmp_path, monkeypatch,
-):
-  from app.routes.github import _inspect_owner_fork_default_branch
-
-  repo = tmp_path / "repo"
-  repo.mkdir()
-  stale = "c" * 40
-  upstream = "d" * 40
-  carrier_tip = "e" * 40
-
-  monkeypatch.setattr(
-    "app.github_contribution_git._upstream_default_branch",
-    lambda _repo, _slug: "main",
-  )
-
-  def fake_git(repo_path, *args, check=True):
-    if args[:2] == ("rev-parse", "--verify"):
-      return _cp(stale + "\n")
-    if args[:2] == ("merge-base", "--is-ancestor"):
-      if args[2:] == (upstream, stale):
-        return _cp(returncode=1)
-      if args[2:] == (stale, upstream):
-        return _cp(returncode=0)
-      if args[2:] == (upstream, carrier_tip):
-        return _cp(returncode=0)
-    if args[:2] == ("for-each-ref", "--format=%(refname)%00%(objectname)"):
-      prefix = args[2].rstrip("/")
-      return _cp(f"{prefix}/fix/review\x00{carrier_tip}\n")
-    return _cp("")
-
-  monkeypatch.setattr("app.github_contribution_git._git", fake_git)
-
-  patch = _inspect_owner_fork_default_branch(
-    repo,
-    "octocat/app-demo",
-    upstream_branch="main",
-    upstream_sha=upstream,
-  )
-
-  assert patch["last_submit_fork_sync"] == "contains-upstream"
-  assert patch["last_submit_fork_carrier_branch"] == "fix/review"
-  assert patch["last_submit_fork_carrier_sha"] == carrier_tip
+  assert sum(call[:1] == ("fetch",) for call in git_calls) == 1
 
 
 def test_inspect_owner_fork_leaves_diverged_default_branch_untouched(
@@ -2109,10 +1914,10 @@ def test_inspect_owner_fork_reports_current_or_ahead_branch(
   assert gh_calls == []
 
 
-def test_sync_owner_fork_with_workflow_scope_verifies_fast_forward(
+def test_sync_owner_fork_verifies_fast_forward(
   tmp_path, monkeypatch,
 ):
-  from app.routes.github import _sync_owner_fork_with_workflow_scope
+  from app.routes.github import _sync_owner_fork
 
   repo = tmp_path / "repo"
   repo.mkdir()
@@ -2132,7 +1937,7 @@ def test_sync_owner_fork_with_workflow_scope_verifies_fast_forward(
     },
   )
 
-  patch = _sync_owner_fork_with_workflow_scope(
+  patch = _sync_owner_fork(
     repo,
     "octocat/app-demo",
     upstream_branch="main",
@@ -2147,117 +1952,29 @@ def test_sync_owner_fork_with_workflow_scope_verifies_fast_forward(
   assert patch["last_submit_fork_sync"] == "fast-forwarded"
 
 
-def test_build_fork_compatible_topic_preserves_exact_reviewed_merge(tmp_path):
-  from app.routes.github import (
-    _build_fork_compatible_topic_commit,
-    _reviewed_branch_diff,
-  )
-
-  repo = tmp_path / "repo"
-  repo.mkdir()
-
-  def git(*args, input_text=None):
-    return subprocess.run(
-      ["git", "-C", str(repo), *args],
-      input=input_text,
-      capture_output=True,
-      text=True,
-      check=True,
-    ).stdout.strip()
-
-  git("init", "-b", "main")
-  (repo / ".github" / "workflows").mkdir(parents=True)
-  (repo / ".github" / "workflows" / "test.yml").write_text("old workflow\n")
-  (repo / "app.py").write_text("old\n")
-  git("add", ".")
-  git(
-    "-c", "user.name=owner", "-c", "user.email=owner@example.com",
-    "commit", "-m", "fork base",
-  )
-  fork_sha = git("rev-parse", "HEAD")
-
-  (repo / ".github" / "workflows" / "test.yml").write_text("new workflow\n")
-  git("add", ".github/workflows/test.yml")
-  git(
-    "-c", "user.name=owner", "-c", "user.email=owner@example.com",
-    "commit", "-m", "upstream workflow change",
-  )
-  upstream_sha = git("rev-parse", "HEAD")
-  git("checkout", "-b", "reviewed")
-  (repo / "app.py").write_text("reviewed\n")
-  git("add", "app.py")
-  git(
-    "-c", "user.name=owner", "-c", "user.email=owner@example.com",
-    "commit", "-m", "Reviewed fix", "-m", (
-      "Co-authored-by: Möbius Agent "
-      "<mobius-agent@users.noreply.github.com>"
+@pytest.mark.parametrize(
+  "operation",
+  [
+    lambda tmp_path: github_routes._submit_prepared_pr(
+      {}, tmp_path / "reviewed.diff",
     ),
-  )
-  reviewed_sha = git("rev-parse", "HEAD")
-  reviewed_diff = _reviewed_branch_diff(repo, upstream_sha, reviewed_sha)
-  diff_path = tmp_path / "reviewed.diff"
-  diff_path.write_bytes(reviewed_diff)
-  expected_diff = hashlib.sha256(reviewed_diff).hexdigest()
-
-  push_sha = _build_fork_compatible_topic_commit(
-    repo,
-    branch="reviewed",
-    fork_sha=fork_sha,
-    upstream_sha=upstream_sha,
-    diff_path=diff_path,
-    expected_diff=expected_diff,
-    author_name="owner",
-    author_email="owner@example.com",
-  )
-
-  assert git("rev-parse", "--abbrev-ref", "HEAD") == "reviewed"
-  assert git("rev-parse", f"{push_sha}^") == fork_sha
-  assert git("diff", "--name-only", f"{fork_sha}..{push_sha}") == "app.py"
-  merged_tree = git("merge-tree", "--write-tree", upstream_sha, push_sha)
-  assert hashlib.sha256(
-    _reviewed_branch_diff(repo, upstream_sha, merged_tree)
-  ).hexdigest() == expected_diff
-  assert git("status", "--porcelain") == ""
-
-
-def test_build_fork_compatible_topic_does_not_reset_if_detach_fails(
-  tmp_path, monkeypatch,
+    lambda _tmp_path: github_routes._preflight_prepared_stack([]),
+    lambda _tmp_path: github_routes._land_reviewed_stack([]),
+  ],
+)
+def test_reviewed_writes_reject_partial_connections_before_git(
+  tmp_path, monkeypatch, operation,
 ):
-  from app.routes.github import (
-    ContributionSubmitError,
-    _build_fork_compatible_topic_commit,
+  _write_token(scopes=("public_repo",))
+  monkeypatch.setattr(
+    "app.github_contributions.shutil.which", lambda name: f"/bin/{name}",
   )
 
-  repo = tmp_path / "repo"
-  repo.mkdir()
-  calls = []
+  with pytest.raises(ContributionSubmitError) as failure:
+    operation(tmp_path)
 
-  def fake_git(repo_path, *args, check=True):
-    calls.append(args)
-    if args[:3] == ("log", "-1", "--format=%B"):
-      return _cp(
-        "Reviewed fix\n\nCo-authored-by: Möbius Agent "
-        "<mobius-agent@users.noreply.github.com>\n"
-      )
-    if args[:3] == ("checkout", "-q", "--detach"):
-      raise ContributionSubmitError("detach failed")
-    return _cp("")
-
-  monkeypatch.setattr("app.github_contribution_git._git", fake_git)
-
-  with pytest.raises(ContributionSubmitError, match="detach failed"):
-    _build_fork_compatible_topic_commit(
-      repo,
-      branch="reviewed",
-      fork_sha="a" * 40,
-      upstream_sha="b" * 40,
-      diff_path=tmp_path / "reviewed.diff",
-      expected_diff="c" * 64,
-      author_name="owner",
-      author_email="owner@example.com",
-    )
-
-  assert not any(call[:2] == ("reset", "--hard") for call in calls)
+  assert failure.value.status_code == 409
+  assert "full PR access" in failure.value.message
 
 
 def test_safe_repo_path_accepts_durable_contribution_roots():
@@ -3134,8 +2851,8 @@ def test_submit_contribution_recovers_ambiguous_create_by_exact_pushed_head(
     lambda *_args, **_kwargs: "octocat/app-demo-1",
   )
   monkeypatch.setattr(
-    "app.github_contributions._push_reviewed_topic",
-    lambda *_args, **kwargs: ("HEAD", kwargs["record_patch"]),
+    "app.github_contributions._push_topic_branch",
+    lambda *_args, **_kwargs: None,
   )
 
   git_calls = []


### PR DESCRIPTION
## What

- keep production image and cache workflows inert in personal forks
- make full PR access the single GitHub connection contract
- publish the exact reviewed commit instead of adapting it onto stale fork history
- keep fork synchronization only where pre-PR Tests need the current default branch

## Why

Contribute enables Actions in a personal fork to run the allowlisted Tests workflow. Forks inherit every workflow file, so production-oriented jobs need an explicit canonical-repository boundary. The backend also still carried a second limited-permission publication path after the product had moved to full PR access, multiplying fork states and rewriting reviewed commits unnecessarily.

This change makes the safety policy structural and gives connection, checks, standalone PRs, stacks, and landing one shared permission contract.

## Verification

- `scripts/wt-pytest.sh backend/tests/test_github_routes.py backend/tests/test_github_pre_pr_checks.py -q` (155 passed)
- `scripts/test.sh --fast` (78 passed)
- Python compilation and diff checks