### PR TITLE
Converge app discovery and identity migrations

### DIFF
--- a/backend/app/install.py
+++ b/backend/app/install.py
@@ -1883,7 +1883,7 @@ class InstallTarget:
 
   existing: models.App | None
   mode: str
-  renaming: bool
+  adopting_previous_id: bool
   adopting_trusted_origin: bool
   canonical_manifest_url: str
   force_core_store_update: bool
@@ -2167,7 +2167,7 @@ def _select_install_target(
     db, source_url=source_for_key, manifest_id=manifest_id,
   )
 
-  renaming = False
+  adopting_previous_id = False
   if existing is None:
     # A rename is explicit and source-bound: previous_id is looked up under the
     # same canonical package base, never by a globally reusable slug.
@@ -2183,7 +2183,7 @@ def _select_install_target(
         .first()
       )
       if existing:
-        renaming = True
+        adopting_previous_id = True
 
   if expected_app_id is not None and (
     existing is None or existing.id != expected_app_id
@@ -2192,7 +2192,7 @@ def _select_install_target(
   return InstallTarget(
     existing=existing,
     mode="update" if existing else "install",
-    renaming=renaming,
+    adopting_previous_id=adopting_previous_id,
     adopting_trusted_origin=bool(
       existing is not None and existing.manifest_url is None
     ),
@@ -2328,7 +2328,7 @@ async def _prepare_app_row(
   manifest_id = manifest["id"]
   data_dir = Path(get_settings().data_dir)
   existing = target.existing
-  renaming = target.renaming
+  adopting_previous_id = target.adopting_previous_id
   canonical_manifest_url = target.canonical_manifest_url
 
   if existing:
@@ -2338,41 +2338,49 @@ async def _prepare_app_row(
     app.description = manifest.get("description", "")
     db.flush()
 
-    if renaming and manifest_id != app.slug:
+    if adopting_previous_id:
+      old_slug = app.slug
       old_source_dir = app.source_dir
       target_slug = manifest_id
       target_source_dir = str(data_dir / "apps" / target_slug)
-      moved = False
+      converged = False
       if old_source_dir and Path(old_source_dir).is_dir():
-        async with fs_locks.source_dir_lock(old_source_dir):
-          try:
-            _reject_if_source_dir_taken(
-              db, target_source_dir, exclude_id=app.id,
-            )
-            target_taken = False
-          except HTTPException:
-            target_taken = True
-          if not target_taken and not Path(target_source_dir).exists():
-            _unregister_cron(Path(old_source_dir))
-            os.rename(old_source_dir, target_source_dir)
-            moved = True
-            journal.rollback_actions.append(
-              _reconcile_cron_after_install_rollback
-            )
-            journal.rollback_actions.append(
-              lambda o=old_source_dir, n=target_source_dir:
-                os.rename(n, o)
-                if Path(n).is_dir() and not Path(o).exists()
-                else None
-            )
-      if moved:
+        if old_source_dir == target_source_dir:
+          converged = app.slug == target_slug
+        else:
+          async with fs_locks.source_dir_lock(old_source_dir):
+            try:
+              _reject_if_source_dir_taken(
+                db, target_source_dir, exclude_id=app.id,
+              )
+              target_taken = False
+            except HTTPException:
+              target_taken = True
+            if not target_taken and not Path(target_source_dir).exists():
+              _unregister_cron(Path(old_source_dir))
+              os.rename(old_source_dir, target_source_dir)
+              converged = True
+              journal.rollback_actions.append(
+                _reconcile_cron_after_install_rollback
+              )
+              journal.rollback_actions.append(
+                lambda o=old_source_dir, n=target_source_dir:
+                  os.rename(n, o)
+                  if Path(n).is_dir() and not Path(o).exists()
+                  else None
+              )
+      if converged:
         app.slug = target_slug
         app.source_dir = target_source_dir
         app.manifest_url = canonical_manifest_url
         db.flush()
       elif old_source_dir and Path(old_source_dir).is_dir():
         warnings.append(
-          f"could not rename slug {app.slug}->{manifest_id}: target in use"
+          f"could not rename slug {old_slug}->{manifest_id}: target in use"
+        )
+      else:
+        warnings.append(
+          f"could not rename slug {old_slug}->{manifest_id}: source missing"
         )
     return app
 

--- a/backend/scripts/list_apps.py
+++ b/backend/scripts/list_apps.py
@@ -25,6 +25,11 @@ def _args() -> argparse.Namespace:
     "--name",
     help="exact display-name search; may return multiple apps",
   )
+  parser.add_argument(
+    "--with-source-dir",
+    action="store_true",
+    help="include each app's source_dir in the compact result",
+  )
   return parser.parse_args()
 
 
@@ -63,11 +68,18 @@ def main() -> None:
   except (urllib.error.URLError, json.JSONDecodeError) as exc:
     print(f"Could not list apps: {exc}", file=sys.stderr)
     raise SystemExit(1) from exc
-  compact = [
-    {"id": app.get("id"), "name": app.get("name"), "slug": app.get("slug")}
-    for app in apps
-    if isinstance(app, dict) and _matches(app, args)
-  ]
+  compact = []
+  for app in apps:
+    if not isinstance(app, dict) or not _matches(app, args):
+      continue
+    item = {
+      "id": app.get("id"),
+      "name": app.get("name"),
+      "slug": app.get("slug"),
+    }
+    if args.with_source_dir:
+      item["source_dir"] = app.get("source_dir")
+    compact.append(item)
   print(json.dumps(compact, ensure_ascii=False, separators=(",", ":")))
 
 

--- a/backend/tests/test_apps_install.py
+++ b/backend/tests/test_apps_install.py
@@ -4170,18 +4170,45 @@ def test_rename_adopts_predecessor_row_and_moves_source_dir(
   assert r3.json()["id"] == gym_id
 
 
+def test_rename_restamps_identity_when_source_is_already_at_target(
+  client, auth, db, bypass_url_validation,
+):
+  """A partially completed rename converges instead of staying on its alias."""
+  from app import models
 
+  base = "https://rename-resume.test/repo/"
+  data_dir = Path(get_settings().data_dir)
 
+  first = _install_simple(client, auth, base, _simple_manifest("gym"))
+  assert first.status_code == 201, first.text
+  app_id = first.json()["id"]
 
+  old_source = data_dir / "apps" / "gym"
+  target_source = data_dir / "apps" / "workout"
+  os.rename(old_source, target_source)
+  row = db.query(models.App).filter_by(id=app_id).one()
+  row.slug = "workout"
+  row.source_dir = str(target_source)
+  db.commit()
 
+  resumed = _install_simple(
+    client, auth, base,
+    _simple_manifest("workout", version="2.0.0", previous_id="gym"),
+  )
 
+  assert resumed.status_code == 201, resumed.text
+  assert resumed.json()["id"] == app_id
+  row = db.query(models.App).populate_existing().filter_by(id=app_id).one()
+  assert row.slug == "workout"
+  assert row.source_dir == str(target_source)
+  assert row.manifest_url == base.rstrip("/") + "#manifest-id=workout"
+  assert not old_source.exists()
 
-
-
-
-
-
-
+  canonical = _install_simple(
+    client, auth, base, _simple_manifest("workout", version="3.0.0"),
+  )
+  assert canonical.status_code == 201, canonical.text
+  assert canonical.json()["id"] == app_id
 
 
 def test_previous_id_matching_nothing_is_a_fresh_install(

--- a/backend/tests/test_list_apps_script.py
+++ b/backend/tests/test_list_apps_script.py
@@ -63,6 +63,39 @@ def test_list_apps_prints_only_compact_identity_fields(
   }]
 
 
+def test_source_dir_is_available_only_when_explicitly_requested(
+  monkeypatch, capsys,
+):
+  module = _load()
+  monkeypatch.setattr(
+    sys,
+    "argv",
+    ["list_apps.py", "--slug", "decision-spinner", "--with-source-dir"],
+  )
+  monkeypatch.setenv("AGENT_TOKEN", "agent-token")
+  monkeypatch.setenv("API_BASE_URL", "http://mobius.test/")
+  monkeypatch.setattr(
+    module.urllib.request,
+    "urlopen",
+    lambda request, timeout: _Response([{
+      "id": 7,
+      "name": "Decision Spinner",
+      "slug": "decision-spinner",
+      "source_dir": "/data/apps/decision-spinner",
+      "permissions": {"large": "payload"},
+    }]),
+  )
+
+  module.main()
+
+  assert json.loads(capsys.readouterr().out) == [{
+    "id": 7,
+    "name": "Decision Spinner",
+    "slug": "decision-spinner",
+    "source_dir": "/data/apps/decision-spinner",
+  }]
+
+
 def test_exact_name_filter_returns_every_duplicate_name(
   monkeypatch, capsys,
 ):

--- a/backend/tests/test_memory_boot.py
+++ b/backend/tests/test_memory_boot.py
@@ -1,5 +1,7 @@
 """Base boot creates chat continuity only; graph memory belongs to its app."""
 
+import ast
+
 import hashlib
 import importlib.util
 import os
@@ -321,7 +323,17 @@ def test_boot_preserves_the_optional_memory_apps_git_repository():
 def test_install_rollback_never_executes_app_owned_cron_declarations():
   text = INSTALL.read_text(encoding="utf-8")
   assert '["bash", str(Path(o) / "init-cron.sh")]' not in text
-  assert (
-    "journal.rollback_actions.append(\n"
-    "              _reconcile_cron_after_install_rollback"
-  ) in text
+  tree = ast.parse(text)
+  assert any(
+    isinstance(node, ast.Call)
+    and isinstance(node.func, ast.Attribute)
+    and node.func.attr == "append"
+    and isinstance(node.func.value, ast.Attribute)
+    and node.func.value.attr == "rollback_actions"
+    and any(
+      isinstance(argument, ast.Name)
+      and argument.id == "_reconcile_cron_after_install_rollback"
+      for argument in node.args
+    )
+    for node in ast.walk(tree)
+  )


### PR DESCRIPTION
## Summary
- let agent-facing app discovery opt into source_dir while preserving its compact default response
- make previous_id adoption converge the canonical slug, source path, and manifest identity when a source move already completed
- name the install decision after predecessor adoption and cover partial-migration retries

## Why
Agent skills should not parse fields that their discovery helper intentionally hides. Separately, an interrupted or locally completed package rename can leave the source tree and slug at the new identity while manifest_url still names the predecessor. The old guard skipped that state, so every later update kept resolving through previous_id instead of converging on the direct canonical key.

## Integration
This builds on #792's typed source_manifest projection by ensuring a resumed rename eventually updates the identity that projection reads.

It intentionally keeps #771, #772, #785, and #788 separate: local source apply, startup readiness, storage admission, and public publication have different lifecycle owners and do not need changes to this discovery or identity-preparation boundary.

## Testing
- scripts/wt-pytest.sh tests/test_apps_install.py tests/test_apps.py tests/test_list_apps_script.py -q (194 passed)
- scripts/test.sh --fast (78 passed)
- python3 -m py_compile backend/app/install.py backend/scripts/list_apps.py