### PR TITLE
Add a shell-owned workspace-shortcuts engine (Chrome-style tab keys)

### DIFF
--- a/backend/app/app_capabilities.py
+++ b/backend/app/app_capabilities.py
@@ -214,6 +214,18 @@ def public_access_declaration_from_contract(
 # its own integer version, so adding (say) camera v2 never forces every storage
 # or microphone consumer onto a new global runtime version.
 RUNTIME_CAPABILITY_DEFINITIONS: dict[str, dict[str, Any]] = {
+  "workspace.shortcuts": {
+    "version": 1,
+    "kind": "activation",
+    "title": "Control workspace tabs with keyboard shortcuts",
+    "description": (
+      "Enable reviewed keyboard commands for the focused Möbius workspace pane."
+    ),
+    "risk": "workspace",
+    "lifecycle": "installed",
+    "default_limits": {},
+    "hard_limits": {},
+  },
   "device.asset-cache": {
     "version": 1,
     "kind": "session",

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -800,6 +800,14 @@ class App(Base):
   # Server-derived, versioned capability contract reviewed at install time.
   # Null is a legitimate legacy state for apps installed before contracts.
   capability_contract = Column(JSON, nullable=True, default=None)
+  # Owner-controlled pause state for "activation" kind runtime capabilities
+  # (e.g. workspace.shortcuts), keyed by capability id -> bool. Deliberately
+  # separate from capability_contract: a local app's contract is wholesale
+  # regenerated from its manifest on every PATCH/apply, which would silently
+  # discard a paused flag stored inside it. This column survives both. Absent
+  # or false means active; only a capability the app currently holds is
+  # meaningful here (see PATCH /api/apps/{id}).
+  paused_capabilities = Column(JSON, nullable=True, default=None)
   created_at = Column(DateTime, default=lambda: datetime.now(UTC))
   updated_at = Column(
     DateTime, default=lambda: datetime.now(UTC), onupdate=lambda: datetime.now(UTC)

--- a/backend/app/routes/apps.py
+++ b/backend/app/routes/apps.py
@@ -484,6 +484,7 @@ async def install_app(
     system_app=app.system_app,
     chat_log_access=app.chat_log_access,
     capability_contract=app.capability_contract,
+    paused_capabilities=app.paused_capabilities,
     created_at=app.created_at,
     updated_at=app.updated_at,
     mode=mode,
@@ -2191,6 +2192,25 @@ async def update_app(
           ),
         )
       app.manage_skills = body.manage_skills
+    if body.capability_pause is not None:
+      granted = ((app.capability_contract or {}).get("runtime") or {})
+      unknown = [k for k in body.capability_pause if k not in granted]
+      if unknown:
+        raise HTTPException(
+          status_code=400,
+          detail=f"App does not hold capability: {', '.join(sorted(unknown))}.",
+        )
+      not_pausable = [
+        k for k in body.capability_pause if granted[k].get("kind") != "activation"
+      ]
+      if not_pausable:
+        raise HTTPException(
+          status_code=400,
+          detail=f"Capability is not pausable: {', '.join(sorted(not_pausable))}.",
+        )
+      merged = dict(app.paused_capabilities or {})
+      merged.update({k: bool(v) for k, v in body.capability_pause.items()})
+      app.paused_capabilities = merged
     # Keep the owner-readable server-permission projection current. Runtime
     # capabilities and offline declarations still come only from reviewed
     # manifest/application flows. Store contracts must retain every other

--- a/backend/app/schema_migrations.py
+++ b/backend/app/schema_migrations.py
@@ -503,6 +503,12 @@ def _converge_legacy_schema(eng) -> None:
         "ALTER TABLE apps ADD COLUMN capability_contract JSON NULL"
       ))
       conn.commit()
+  if "paused_capabilities" not in apps_cols:
+    with eng.connect() as conn:
+      conn.execute(text(
+        "ALTER TABLE apps ADD COLUMN paused_capabilities JSON NULL"
+      ))
+      conn.commit()
   # Authority used to be an execution-policy switch in capability receipts.
   # Server-side jobs now have one owner-trusted process path, so rewrite known
   # historical receipts once rather than leaving inert policy vocabulary in

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -159,6 +159,12 @@ class AppUpdate(BaseModel):
   # their next call). Granting (True) is rejected — that path stays with the
   # reviewed manifest install.
   manage_skills: bool | None = None
+  # Pause/resume for "activation" kind runtime capabilities the app currently
+  # holds (e.g. workspace.shortcuts), keyed by capability id -> paused bool.
+  # Merged into models.App.paused_capabilities rather than replacing it, so
+  # toggling one capability never clobbers another. The route rejects any key
+  # the app does not currently hold, or whose kind is not "activation".
+  capability_pause: dict[str, bool] | None = Field(default=None, max_length=8)
 
   @field_validator("published_manifest_url")
   @classmethod
@@ -256,6 +262,10 @@ class AppOut(BaseModel):
   system_app: bool = False
   chat_log_access: ChatLogAccess = "none"
   capability_contract: dict | None = None
+  # Owner-controlled pause state for "activation" kind runtime capabilities,
+  # keyed by capability id -> bool. Absent/false means active. See
+  # models.App.paused_capabilities.
+  paused_capabilities: dict[str, bool] | None = None
   created_at: datetime
   updated_at: datetime
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -36,6 +36,14 @@ os.environ["MOBIUS_TEST_RUNTIME"] = "1"
 os.environ["MOBIUS_APP_BASE"] = f"{_tmp}/apps"
 os.environ["API_BASE_URL"] = "http://127.0.0.1:9"
 os.environ["MOEBIUS_SKIP_BOOTSTRAP"] = "1"
+# A Railway-managed instance carries real MOBIUS_SSO_* secrets in its process
+# environment. Inherited into the test process, get_settings().mobius_sso_enabled
+# reads true and every owner_token-dependent test fails setup with 403
+# "Managed sign-in is enabled for this deployment." — a real config leak, not
+# a test bug. Clear all three together so the derived property is false.
+os.environ.pop("MOBIUS_SSO_ISSUER", None)
+os.environ.pop("MOBIUS_SSO_INSTANCE_ID", None)
+os.environ.pop("MOBIUS_SSO_CLIENT_SECRET", None)
 
 # Ensure the baked static dir exists with an index.html carrying the
 # __mobius-theme__ slot BEFORE importing app.main — main.py registers the SPA

--- a/backend/tests/test_app_capabilities.py
+++ b/backend/tests/test_app_capabilities.py
@@ -107,6 +107,28 @@ def test_runtime_capability_is_independently_versioned_and_bounded():
   }
 
 
+def test_workspace_shortcuts_capability_is_installed_lifecycle_activation():
+  runtime = normalize_runtime_capabilities(_manifest(capabilities={
+    "workspace.shortcuts": {
+      "version": 1,
+      "reason": "Enable tab controls across the focused workspace pane.",
+    },
+  }))
+
+  assert runtime["workspace.shortcuts"] == {
+    "version": 1,
+    "kind": "activation",
+    "title": "Control workspace tabs with keyboard shortcuts",
+    "description": (
+      "Enable reviewed keyboard commands for the focused Möbius workspace pane."
+    ),
+    "risk": "workspace",
+    "lifecycle": "installed",
+    "reason": "Enable tab controls across the focused workspace pane.",
+    "limits": {},
+  }
+
+
 def test_device_asset_cache_is_client_only_and_reviewed_by_size():
   runtime = normalize_runtime_capabilities(_manifest(capabilities={
     "device.asset-cache": {

--- a/backend/tests/test_app_capabilities.py
+++ b/backend/tests/test_app_capabilities.py
@@ -236,6 +236,66 @@ def test_local_app_create_normalizes_runtime_capability(client, auth):
   }
 
 
+def test_capability_pause_toggles_activation_capability_and_survives_reapply(
+  client, auth,
+):
+  created = create_local_app(
+    client, auth,
+    name="Shortcut Provider",
+    capabilities={"workspace.shortcuts": {"version": 1}},
+  )
+  app_id = created["id"]
+  assert created.get("paused_capabilities") in (None, {})
+
+  paused = client.patch(
+    f"/api/apps/{app_id}", headers=auth,
+    json={"capability_pause": {"workspace.shortcuts": True}},
+  )
+  assert paused.status_code == 200, paused.text
+  assert paused.json()["paused_capabilities"] == {"workspace.shortcuts": True}
+
+  # Reapplying regenerates capability_contract from the manifest, but must
+  # not clobber the separately-stored pause state — otherwise every source
+  # edit would silently resume a paused activation capability.
+  reapplied = client.post(
+    "/api/apps/apply", headers=auth,
+    json={"source_dir": created["source_dir"]},
+  )
+  assert reapplied.status_code == 200, reapplied.text
+  assert reapplied.json()["app"]["paused_capabilities"] == {
+    "workspace.shortcuts": True,
+  }
+
+  resumed = client.patch(
+    f"/api/apps/{app_id}", headers=auth,
+    json={"capability_pause": {"workspace.shortcuts": False}},
+  )
+  assert resumed.status_code == 200, resumed.text
+  assert resumed.json()["paused_capabilities"] == {"workspace.shortcuts": False}
+
+
+def test_capability_pause_rejects_capability_the_app_does_not_hold(client, auth):
+  created = create_local_app(client, auth, name="No Capabilities")
+  response = client.patch(
+    f"/api/apps/{created['id']}", headers=auth,
+    json={"capability_pause": {"workspace.shortcuts": True}},
+  )
+  assert response.status_code == 400, response.text
+
+
+def test_capability_pause_rejects_non_activation_capability(client, auth):
+  created = create_local_app(
+    client, auth,
+    name="Recorder Two",
+    capabilities={"media.microphone.capture": {"version": 1}},
+  )
+  response = client.patch(
+    f"/api/apps/{created['id']}", headers=auth,
+    json={"capability_pause": {"media.microphone.capture": True}},
+  )
+  assert response.status_code == 400, response.text
+
+
 def test_local_app_capability_replacement_is_explicit(client, auth):
   created = create_local_app(
     client, auth, name="Recorder",

--- a/frontend/public/mobius-runtime.js
+++ b/frontend/public/mobius-runtime.js
@@ -3749,9 +3749,13 @@ function _editableShortcutTarget(target) {
 function _workspaceApplePlatform() {
 	return /Mac|iPhone|iPad|iPod/i.test(String(globalThis.navigator?.platform || ""));
 }
+function _workspaceLinuxPlatform() {
+	return /Linux/i.test(String(globalThis.navigator?.platform || ""));
+}
 function _workspaceShortcutCandidate(event) {
 	if (!event?.isTrusted || event.isComposing || event.repeat) return false;
 	const apple = _workspaceApplePlatform();
+	const linux = !apple && _workspaceLinuxPlatform();
 	const modifiersMatch = apple
 		? (event.metaKey && event.altKey && !event.ctrlKey)
 		: (event.ctrlKey && event.altKey && !event.metaKey);
@@ -3759,6 +3763,7 @@ function _workspaceShortcutCandidate(event) {
 	const key = String(event.key || "");
 	const lower = key.toLowerCase();
 	if (lower === "t") return true;
+	if (linux && lower === "n") return !event.shiftKey;
 	if (lower === "w") return !event.shiftKey;
 	if (event.shiftKey) return false;
 	if (apple) return key === "]" || key === "[" || /^[1-9]$/.test(key);

--- a/frontend/public/mobius-runtime.js
+++ b/frontend/public/mobius-runtime.js
@@ -3765,7 +3765,7 @@ function _setOnline(next) {
 }
 if (typeof window !== "undefined") {
 	window.addEventListener("message", (e) => {
-		if (e.origin !== window.location.origin) return;
+		if (e.source !== window.parent) return;
 		const msg = e.data;
 		if (!msg || typeof msg !== "object") return;
 		if (msg.type === "moebius:online-status" && typeof msg.online === "boolean") _setOnline(msg.online);

--- a/frontend/public/mobius-runtime.js
+++ b/frontend/public/mobius-runtime.js
@@ -3746,14 +3746,22 @@ function _editableShortcutTarget(target) {
 	if (target.isContentEditable) return true;
 	return typeof target.closest === "function" && !!target.closest("input, textarea, select, [contenteditable], [role=\"textbox\"]");
 }
+function _workspaceApplePlatform() {
+	return /Mac|iPhone|iPad|iPod/i.test(String(globalThis.navigator?.platform || ""));
+}
 function _workspaceShortcutCandidate(event) {
 	if (!event?.isTrusted || event.isComposing || event.repeat) return false;
-	if (!event.ctrlKey || !event.altKey || event.metaKey || event.getModifierState?.("AltGraph")) return false;
+	const apple = _workspaceApplePlatform();
+	const modifiersMatch = apple
+		? (event.metaKey && event.altKey && !event.ctrlKey)
+		: (event.ctrlKey && event.altKey && !event.metaKey);
+	if (!modifiersMatch || event.getModifierState?.("AltGraph")) return false;
 	const key = String(event.key || "");
 	const lower = key.toLowerCase();
 	if (lower === "t") return true;
 	if (lower === "w") return !event.shiftKey;
 	if (event.shiftKey) return false;
+	if (apple) return key === "]" || key === "[" || /^[1-9]$/.test(key);
 	return key === "PageDown" || key === "PageUp" || /^[1-9]$/.test(key);
 }
 function _setOnline(next) {

--- a/frontend/public/mobius-runtime.js
+++ b/frontend/public/mobius-runtime.js
@@ -3740,6 +3740,22 @@ function makeImmersive({ appId } = {}) {
 //#region src/runtime/index.js
 let _online = typeof navigator !== "undefined" ? navigator.onLine : true;
 const _onlineListeners = /* @__PURE__ */ new Set();
+let _workspaceShortcutsEnabled = false;
+function _editableShortcutTarget(target) {
+	if (!target || typeof target !== "object") return false;
+	if (target.isContentEditable) return true;
+	return typeof target.closest === "function" && !!target.closest("input, textarea, select, [contenteditable], [role=\"textbox\"]");
+}
+function _workspaceShortcutCandidate(event) {
+	if (!event?.isTrusted || event.isComposing || event.repeat) return false;
+	if (!event.ctrlKey || !event.altKey || event.metaKey || event.getModifierState?.("AltGraph")) return false;
+	const key = String(event.key || "");
+	const lower = key.toLowerCase();
+	if (lower === "t") return true;
+	if (lower === "w") return !event.shiftKey;
+	if (event.shiftKey) return false;
+	return key === "PageDown" || key === "PageUp" || /^[1-9]$/.test(key);
+}
 function _setOnline(next) {
 	if (next === _online) return;
 	_online = next;
@@ -3753,9 +3769,24 @@ if (typeof window !== "undefined") {
 		const msg = e.data;
 		if (!msg || typeof msg !== "object") return;
 		if (msg.type === "moebius:online-status" && typeof msg.online === "boolean") _setOnline(msg.online);
+		else if (msg.type === "moebius:workspace-shortcuts-status") _workspaceShortcutsEnabled = msg.enabled === true;
 	});
 	window.addEventListener("online", () => _setOnline(true));
 	window.addEventListener("offline", () => _setOnline(false));
+	window.addEventListener("keydown", (event) => {
+		if (!_workspaceShortcutsEnabled || _editableShortcutTarget(event.target)) return;
+		if (!_workspaceShortcutCandidate(event)) return;
+		event.preventDefault();
+		window.parent.postMessage({
+			type: "moebius:workspace-shortcut",
+			key: event.key,
+			ctrlKey: event.ctrlKey,
+			altKey: event.altKey,
+			shiftKey: event.shiftKey,
+			metaKey: event.metaKey,
+			editable: false
+		}, "*");
+	}, true);
 }
 let _runtimeContext = null;
 const runtimeFeatures = Object.freeze({ idleDocument: true });

--- a/frontend/src/components/AppCanvas/AppCanvas.jsx
+++ b/frontend/src/components/AppCanvas/AppCanvas.jsx
@@ -480,7 +480,10 @@ const AppCanvas = forwardRef(function AppCanvas({
   const capabilityHostRef = useRef(null)
   if (!capabilityHostRef.current) {
     capabilityHostRef.current = createCapabilityHost({
-      providers: builtInCapabilityProviders({ deviceAssets: { appId } }),
+      providers: builtInCapabilityProviders({
+        deviceAssets: { appId },
+        workspaceShortcuts: { api },
+      }),
       getDeclaration(capability) {
         return capabilityContractRef.current?.runtime?.[capability] || null
       },

--- a/frontend/src/components/AppCanvas/AppCanvas.jsx
+++ b/frontend/src/components/AppCanvas/AppCanvas.jsx
@@ -266,10 +266,11 @@ const AppCanvas = forwardRef(function AppCanvas({
   // the scrim, but compositor momentum inside its iframe must be cancelled so
   // background content cannot keep coasting beneath the drawer.
   interactive = visible,
+  workspaceShortcutsEnabled = false,
   pendingIntent = null,
   onNavPush, onNavPop, onNavReset, onNavForwardResult,
   onAppFocus, onImmersive, onIntentDelivered, onAppError, onHostRequest,
-  onMediaSession,
+  onMediaSession, onWorkspaceShortcut,
 }, hostRef) {
   const queryClient = useQueryClient()
   const [serviceSurface, setServiceSurface] = useState(null)
@@ -791,6 +792,22 @@ const AppCanvas = forwardRef(function AppCanvas({
         return
       }
 
+      if (msg.type === 'moebius:workspace-shortcut') {
+        if (!activeRef.current || !workspaceShortcutsEnabled) return
+        const key = typeof msg.key === 'string' ? msg.key : ''
+        if (!key) return
+        onWorkspaceShortcut?.({
+          key,
+          ctrlKey: msg.ctrlKey === true,
+          altKey: msg.altKey === true,
+          shiftKey: msg.shiftKey === true,
+          metaKey: msg.metaKey === true,
+          editable: msg.editable === true,
+          preventDefault() {},
+        })
+        return
+      }
+
       // Navigation outside the app belongs to its trusted host. Keep source
       // attribution and wire-format narrowing here, beside every other frame
       // request, so no host needs to rediscover iframe identity.
@@ -887,7 +904,7 @@ const AppCanvas = forwardRef(function AppCanvas({
   }, [
     appId, appSlug, onNavPush, onNavPop, onNavForwardResult,
     onAppFocus, onImmersive, onIntentDelivered, onAppError, onHostRequest,
-    queryClient,
+    onWorkspaceShortcut, workspaceShortcutsEnabled, queryClient,
   ])
 
   // Capabilities belong to a visible workspace pane, not merely the focused
@@ -1052,12 +1069,26 @@ const AppCanvas = forwardRef(function AppCanvas({
     postToFrame(v, { type: 'moebius:online-status', online })
   }
 
+  function sendWorkspaceShortcutStatus(v) {
+    postToFrame(v, {
+      type: 'moebius:workspace-shortcuts-status',
+      enabled: workspaceShortcutsEnabled,
+    })
+  }
+
   useEffect(() => {
     for (const v of framesRef.current.keys()) {
       if (loadedDocsRef.current.has(v)) sendOnlineStatus(v)
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [online])
+
+  useEffect(() => {
+    for (const v of framesRef.current.keys()) {
+      if (loadedDocsRef.current.has(v)) sendWorkspaceShortcutStatus(v)
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [workspaceShortcutsEnabled])
 
   // ── Immersive safe-area passthrough (.pm/128 follow-up) ──────────
   // Forward the device safe-area insets so an immersive (full-bleed) app can
@@ -1331,6 +1362,7 @@ const AppCanvas = forwardRef(function AppCanvas({
     loadedDocsRef.current.add(v)
     sendInit(v)
     sendOnlineStatus(v)
+    sendWorkspaceShortcutStatus(v)
     sendInsets(v)
     sendImmersiveState(v)
     // A booting incoming frame is invisible by construction and must not

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -149,6 +149,7 @@ import useWorkspaceSession from './useWorkspaceSession.js'
 import useShellReloadController from './useShellReloadController.js'
 import useAppFrameCache from './useAppFrameCache.js'
 import useShellVisualViewport from './useShellVisualViewport.js'
+import useWorkspaceShortcuts, { hasWorkspaceShortcutProvider } from './useWorkspaceShortcuts.js'
 import ShellBrand from './ShellBrand.jsx'
 import { createMediaSessionOwner } from './mediaSessionOwner.js'
 import { HistoryDismissProvider } from '../../hooks/useHistoryDismiss.jsx'
@@ -536,6 +537,10 @@ export default function Shell({ onInitialVisualReady }) {
   })
   const apps = appsQuery.data ?? EMPTY_LIST
   const chats = chatsQuery.data ?? EMPTY_LIST
+  const workspaceShortcutsEnabled = useMemo(
+    () => hasWorkspaceShortcutProvider(apps),
+    [apps],
+  )
   const appsStatus = apps.length > 0 || appsQuery.isSuccess
     ? 'success'
     : (appsQuery.isError ? 'error' : 'loading')
@@ -3216,6 +3221,15 @@ export default function Shell({ onInitialVisualReady }) {
   // Keep the latest-materialize ref current so the watcher effect (stable deps) always
   // runs this render's live closure without depending on the function's identity.
   materializeNewChatHomeRef.current = materializeNewChatHome
+  const handleWorkspaceShortcut = useWorkspaceShortcuts({
+    enabled: workspaceShortcutsEnabled,
+    workspaceStateRef,
+    dispatchWorkspace,
+    startNewChat: () => newChatRef.current?.({
+      forceNew: workspaceStateRef.current.ws.viewMode === 'panes',
+      recordHistory: true,
+    }),
+  })
 
   // Suppressing automatic repair while the explicit presentation owns the
   // null slot is safe only if retirement hands that responsibility back. A
@@ -3864,6 +3878,7 @@ export default function Shell({ onInitialVisualReady }) {
               // mode scene (cross-origin app interaction is inert throughout).
               interactive={appRuntimeVisible
                 && !coveredByNewChat && !navigationSurfaceOpen && !modeBeatActive}
+              workspaceShortcutsEnabled={workspaceShortcutsEnabled}
               version={versionForApp(id)}
               appName={app?.name}
               appSlug={app?.slug}
@@ -3883,6 +3898,7 @@ export default function Shell({ onInitialVisualReady }) {
               onAppError={handleAppError}
               onHostRequest={handleAppHostRequest}
               onMediaSession={handleMediaSession}
+              onWorkspaceShortcut={handleWorkspaceShortcut}
             />
             </ErrorBoundary>
           </div>

--- a/frontend/src/components/Shell/__tests__/workspaceShortcuts.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceShortcuts.test.js
@@ -29,13 +29,28 @@ test('workspace shortcut provider is disabled while paused', () => {
   }]), true)
 })
 
-test('Windows shortcut mapping ignores AltGraph and unrelated modifiers', () => {
+test('Windows/Linux shortcut mapping ignores AltGraph and unrelated modifiers', () => {
   assert.equal(workspaceShortcutAction({ ctrlKey: true, altKey: true, key: 't' }, 'Win32'), 'open')
   assert.equal(workspaceShortcutAction({ ctrlKey: true, altKey: true, shiftKey: true, key: 'T' }, 'Win32'), 'restore')
   assert.equal(workspaceShortcutAction({ ctrlKey: true, altKey: true, key: 'PageDown' }, 'Win32'), 'next')
   assert.equal(workspaceShortcutAction({ ctrlKey: true, altKey: true, key: '9' }, 'Win32'), 'select:9')
   assert.equal(workspaceShortcutAction({ ctrlKey: true, altKey: true, key: 't', getModifierState: k => k === 'AltGraph' }, 'Win32'), null)
+  // A Cmd-modified event should never fire the Ctrl+Alt mapping.
+  assert.equal(workspaceShortcutAction({ ctrlKey: true, altKey: true, metaKey: true, key: 't' }, 'Win32'), null)
+})
+
+test('Mac shortcut mapping uses Cmd+Option, never the VoiceOver or native-Chrome combos', () => {
+  assert.equal(workspaceShortcutAction({ metaKey: true, altKey: true, key: 't' }, 'MacIntel'), 'open')
+  assert.equal(workspaceShortcutAction({ metaKey: true, altKey: true, shiftKey: true, key: 'T' }, 'MacIntel'), 'restore')
+  assert.equal(workspaceShortcutAction({ metaKey: true, altKey: true, key: ']' }, 'MacIntel'), 'next')
+  assert.equal(workspaceShortcutAction({ metaKey: true, altKey: true, key: '[' }, 'MacIntel'), 'previous')
+  assert.equal(workspaceShortcutAction({ metaKey: true, altKey: true, key: '9' }, 'MacIntel'), 'select:9')
+  // Ctrl+Alt (Ctrl+Option) is the VoiceOver modifier on Mac — must not fire.
   assert.equal(workspaceShortcutAction({ ctrlKey: true, altKey: true, key: 't' }, 'MacIntel'), null)
+  // Cmd+Option+Left/Right is Chrome's own native tab-switcher — must not fire
+  // (it would move real browser tabs, and the page never sees it anyway).
+  assert.equal(workspaceShortcutAction({ metaKey: true, altKey: true, key: 'ArrowRight' }, 'MacIntel'), null)
+  assert.equal(workspaceShortcutAction({ metaKey: true, altKey: true, key: 't', getModifierState: k => k === 'AltGraph' }, 'MacIntel'), null)
 })
 
 test('closed tab records restore into the current workspace without replacing siblings', () => {

--- a/frontend/src/components/Shell/__tests__/workspaceShortcuts.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceShortcuts.test.js
@@ -18,6 +18,17 @@ test('workspace shortcut provider is activated only by reviewed capability v1', 
   }]), false)
 })
 
+test('workspace shortcut provider is disabled while paused', () => {
+  assert.equal(hasWorkspaceShortcutProvider([{
+    capability_contract: { runtime: { 'workspace.shortcuts': { version: 1 } } },
+    paused_capabilities: { 'workspace.shortcuts': true },
+  }]), false)
+  assert.equal(hasWorkspaceShortcutProvider([{
+    capability_contract: { runtime: { 'workspace.shortcuts': { version: 1 } } },
+    paused_capabilities: { 'workspace.shortcuts': false },
+  }]), true)
+})
+
 test('Windows shortcut mapping ignores AltGraph and unrelated modifiers', () => {
   assert.equal(workspaceShortcutAction({ ctrlKey: true, altKey: true, key: 't' }, 'Win32'), 'open')
   assert.equal(workspaceShortcutAction({ ctrlKey: true, altKey: true, shiftKey: true, key: 'T' }, 'Win32'), 'restore')

--- a/frontend/src/components/Shell/__tests__/workspaceShortcuts.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceShortcuts.test.js
@@ -29,7 +29,7 @@ test('workspace shortcut provider is disabled while paused', () => {
   }]), true)
 })
 
-test('Windows/Linux shortcut mapping ignores AltGraph and unrelated modifiers', () => {
+test('Windows shortcut mapping ignores AltGraph and unrelated modifiers', () => {
   assert.equal(workspaceShortcutAction({ ctrlKey: true, altKey: true, key: 't' }, 'Win32'), 'open')
   assert.equal(workspaceShortcutAction({ ctrlKey: true, altKey: true, shiftKey: true, key: 'T' }, 'Win32'), 'restore')
   assert.equal(workspaceShortcutAction({ ctrlKey: true, altKey: true, key: 'PageDown' }, 'Win32'), 'next')
@@ -37,6 +37,18 @@ test('Windows/Linux shortcut mapping ignores AltGraph and unrelated modifiers', 
   assert.equal(workspaceShortcutAction({ ctrlKey: true, altKey: true, key: 't', getModifierState: k => k === 'AltGraph' }, 'Win32'), null)
   // A Cmd-modified event should never fire the Ctrl+Alt mapping.
   assert.equal(workspaceShortcutAction({ ctrlKey: true, altKey: true, metaKey: true, key: 't' }, 'Win32'), null)
+})
+
+test('Linux opens a new tab with N instead of T (Ctrl+Alt+T is the desktop terminal shortcut)', () => {
+  assert.equal(workspaceShortcutAction({ ctrlKey: true, altKey: true, key: 't' }, 'Linux x86_64'), null)
+  assert.equal(workspaceShortcutAction({ ctrlKey: true, altKey: true, key: 'n' }, 'Linux x86_64'), 'open')
+  // Shift+T still restores — only the bare terminal binding is taken.
+  assert.equal(workspaceShortcutAction({ ctrlKey: true, altKey: true, shiftKey: true, key: 'T' }, 'Linux x86_64'), 'restore')
+  // Everything else stays identical to the Windows mapping.
+  assert.equal(workspaceShortcutAction({ ctrlKey: true, altKey: true, key: 'w' }, 'Linux x86_64'), 'close')
+  assert.equal(workspaceShortcutAction({ ctrlKey: true, altKey: true, key: 'PageDown' }, 'Linux x86_64'), 'next')
+  assert.equal(workspaceShortcutAction({ ctrlKey: true, altKey: true, key: 'PageUp' }, 'Linux x86_64'), 'previous')
+  assert.equal(workspaceShortcutAction({ ctrlKey: true, altKey: true, key: '1' }, 'Linux x86_64'), 'select:1')
 })
 
 test('Mac shortcut mapping uses Cmd+Option, never the VoiceOver or native-Chrome combos', () => {

--- a/frontend/src/components/Shell/__tests__/workspaceShortcuts.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceShortcuts.test.js
@@ -1,0 +1,40 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import * as paneModel from '../paneModel.js'
+import * as tabModel from '../tabModel.js'
+import {
+  hasWorkspaceShortcutProvider,
+  workspaceShortcutAction,
+} from '../useWorkspaceShortcuts.js'
+
+test('workspace shortcut provider is activated only by reviewed capability v1', () => {
+  assert.equal(hasWorkspaceShortcutProvider([]), false)
+  assert.equal(hasWorkspaceShortcutProvider([{
+    capability_contract: { runtime: { 'workspace.shortcuts': { version: 1 } } },
+  }]), true)
+  assert.equal(hasWorkspaceShortcutProvider([{
+    capability_contract: { runtime: { 'workspace.shortcuts': { version: 2 } } },
+  }]), false)
+})
+
+test('Windows shortcut mapping ignores AltGraph and unrelated modifiers', () => {
+  assert.equal(workspaceShortcutAction({ ctrlKey: true, altKey: true, key: 't' }, 'Win32'), 'open')
+  assert.equal(workspaceShortcutAction({ ctrlKey: true, altKey: true, shiftKey: true, key: 'T' }, 'Win32'), 'restore')
+  assert.equal(workspaceShortcutAction({ ctrlKey: true, altKey: true, key: 'PageDown' }, 'Win32'), 'next')
+  assert.equal(workspaceShortcutAction({ ctrlKey: true, altKey: true, key: '9' }, 'Win32'), 'select:9')
+  assert.equal(workspaceShortcutAction({ ctrlKey: true, altKey: true, key: 't', getModifierState: k => k === 'AltGraph' }, 'Win32'), null)
+  assert.equal(workspaceShortcutAction({ ctrlKey: true, altKey: true, key: 't' }, 'MacIntel'), null)
+})
+
+test('closed tab records restore into the current workspace without replacing siblings', () => {
+  const a = tabModel.makeTab('chat', 'a')
+  const b = tabModel.makeTab('app', '2')
+  const ws = { ...paneModel.seedFromFlatTabs([a, b]), viewMode: 'panes' }
+  const key = tabModel.tabKey(b)
+  const record = paneModel.closedTabRecord(ws, key)
+  const closed = paneModel.closeTab(ws, key)
+  const restored = paneModel.restoreClosedTab(closed, record)
+  assert.deepEqual(paneModel.flatten(restored), [a, b])
+  assert.equal(restored.panes[restored.focusedPaneId].activeTabKey, key)
+})

--- a/frontend/src/components/Shell/paneModel.js
+++ b/frontend/src/components/Shell/paneModel.js
@@ -860,6 +860,38 @@ export function closeTab(ws, tabKey) {
   })
 }
 
+// Capture only the source material needed to reopen a user-closed tab. The
+// session owner keeps this small record outside the persisted workspace so an
+// uninstall/delete can never resurrect a missing resource after relaunch.
+export function closedTabRecord(ws, tabKey) {
+  const pane = paneOf(ws, tabKey)
+  if (!pane) return null
+  const index = pane.tabs.findIndex(tab => tabModel.tabKey(tab) === tabKey)
+  if (index < 0) return null
+  return { tab: pane.tabs[index], tabKey, paneId: pane.id, index }
+}
+
+export function restoreClosedTab(ws, record) {
+  const clean = sanitizeTab(record?.tab)
+  if (!clean) return ws
+  const key = tabModel.tabKey(clean)
+  if (paneOf(ws, key)) return ws
+  const paneId = ws.panes[record.paneId]
+    ? record.paneId
+    : (ws.panes[ws.focusedPaneId] ? ws.focusedPaneId : paneIdsInOrder(ws)[0])
+  const pane = ws.panes[paneId]
+  if (!pane) return ws
+  const index = Math.max(0, Math.min(Number(record.index) || 0, pane.tabs.length))
+  const tabs = [...pane.tabs]
+  tabs.splice(index, 0, clean)
+  return commit(ws, {
+    ...ws,
+    viewMode: record.restoreViewMode ? 'panes' : ws.viewMode,
+    panes: { ...ws.panes, [paneId]: { ...pane, tabs, activeTabKey: key } },
+    focusedPaneId: paneId,
+  })
+}
+
 // Close a whole pane: drop every tab it holds, then normalize (the emptied pane
 // collapses and its space returns to the surviving sibling, focus follows). The
 // keyboard/menu "Close pane" affordance (design §3.6) so a multi-tab pane need
@@ -1672,6 +1704,10 @@ export function workspaceReducer(state, action) {
       const closeLabel = action.label || 'Closed tab'
       const { ws: closed, autoReturned } = completeCloseTransition(ws, next)
       return { ws: closed, undo: { ws, label: closeLabel, toast: closeLabel, restoreViewMode: autoReturned } }
+    }
+    case 'RESTORE_CLOSED_TAB_RECORD': {
+      const next = restoreClosedTab(ws, action.record)
+      return next === ws ? state : { ws: next, undo: null }
     }
     case 'CLOSE_PANE': {
       // Closing a pane closes all its tabs at once (a keyboard/menu affordance —

--- a/frontend/src/components/Shell/useWorkspaceSession.js
+++ b/frontend/src/components/Shell/useWorkspaceSession.js
@@ -45,6 +45,7 @@ export default function useWorkspaceSession({ storage, legacyStorage = null }) {
 
   const workspaceStateRef = useRef(workspaceState)
   workspaceStateRef.current = workspaceState
+  const closedTabsRef = useRef([])
   const dragActiveRef = useRef(false)
   const onWorkspaceTransitionRef = useRef(null)
   const requestEmptySingleNewChatRef = useRef(null)
@@ -62,7 +63,37 @@ export default function useWorkspaceSession({ storage, legacyStorage = null }) {
 
   const dispatchWorkspace = useCallback((action) => {
     const prev = workspaceStateRef.current
-    const next = paneModel.workspaceReducer(prev, action)
+    let resolvedAction = action
+    let restoreRecord = null
+    if (action?.type === 'RESTORE_CLOSED_TAB') {
+      while (closedTabsRef.current.length) {
+        const candidate = closedTabsRef.current[closedTabsRef.current.length - 1]
+        const candidateAction = { type: 'RESTORE_CLOSED_TAB_RECORD', record: candidate }
+        const candidateState = paneModel.workspaceReducer(prev, candidateAction)
+        closedTabsRef.current.pop()
+        if (candidateState !== prev) {
+          resolvedAction = candidateAction
+          restoreRecord = candidate
+          break
+        }
+      }
+      if (!restoreRecord) return false
+    }
+    const closedRecord = resolvedAction?.type === 'CLOSE_TAB'
+      ? paneModel.closedTabRecord(prev.ws, resolvedAction.tabKey)
+      : null
+    const next = paneModel.workspaceReducer(prev, resolvedAction)
+    if (resolvedAction?.type === 'CLOSE_TAB' && resolvedAction.reason === 'deleted') {
+      closedTabsRef.current = closedTabsRef.current.filter(
+        record => record.tabKey !== resolvedAction.tabKey,
+      )
+    } else if (closedRecord && next.ws !== prev.ws) {
+      closedTabsRef.current.push({
+        ...closedRecord,
+        restoreViewMode: prev.ws.viewMode !== next.ws.viewMode,
+      })
+      if (closedTabsRef.current.length > 20) closedTabsRef.current.shift()
+    }
     workspaceStateRef.current = next
     const enteredEmptySingle = next.ws !== prev.ws
       && enteredEmptySingleScreen(prev.ws, next.ws)
@@ -79,8 +110,9 @@ export default function useWorkspaceSession({ storage, legacyStorage = null }) {
         }
       }
     }
-    dispatchWorkspaceRaw(action)
+    dispatchWorkspaceRaw(resolvedAction)
     if (enteredEmptySingle) requestEmptySingleNewChatRef.current?.()
+    return next !== prev
   }, [setFocusedPaneViewId])
 
   const contentElRef = useRef(null)

--- a/frontend/src/components/Shell/useWorkspaceShortcuts.js
+++ b/frontend/src/components/Shell/useWorkspaceShortcuts.js
@@ -1,0 +1,96 @@
+import { useCallback, useEffect, useRef } from 'react'
+import * as tabModel from './tabModel.js'
+
+export const WORKSPACE_SHORTCUT_CAPABILITY = 'workspace.shortcuts'
+
+export function hasWorkspaceShortcutProvider(apps) {
+  return Array.isArray(apps) && apps.some(app => (
+    app?.capability_contract?.runtime?.[WORKSPACE_SHORTCUT_CAPABILITY]?.version === 1
+  ))
+}
+
+function isApplePlatform(platform) {
+  return /Mac|iPhone|iPad|iPod/i.test(String(platform || ''))
+}
+
+export function workspaceShortcutAction(event, platform = globalThis.navigator?.platform || '') {
+  if (!event || isApplePlatform(platform) || event.isComposing || event.repeat) return null
+  if (!event.ctrlKey || !event.altKey || event.metaKey) return null
+  if (event.getModifierState?.('AltGraph')) return null
+
+  const key = String(event.key || '')
+  const lower = key.toLowerCase()
+  if (lower === 't') return event.shiftKey ? 'restore' : 'open'
+  if (lower === 'w' && !event.shiftKey) return 'close'
+  if (event.shiftKey) return null
+  if (key === 'PageDown') return 'next'
+  if (key === 'PageUp') return 'previous'
+  if (/^[1-9]$/.test(key)) return `select:${key}`
+  return null
+}
+
+function editableElement(element) {
+  if (!element || typeof element !== 'object') return false
+  if (element.isContentEditable) return true
+  return typeof element.closest === 'function'
+    && !!element.closest('input, textarea, select, [contenteditable], [role="textbox"]')
+}
+
+export default function useWorkspaceShortcuts({
+  enabled,
+  workspaceStateRef,
+  dispatchWorkspace,
+  startNewChat,
+}) {
+  const actionsRef = useRef({ workspaceStateRef, dispatchWorkspace, startNewChat })
+  actionsRef.current = { workspaceStateRef, dispatchWorkspace, startNewChat }
+
+  const execute = useCallback((event, { forwarded = false } = {}) => {
+    if (!enabled) return false
+    if (forwarded ? event.editable : editableElement(document.activeElement)) return false
+    const action = workspaceShortcutAction(event)
+    if (!action) return false
+
+    const { workspaceStateRef: stateRef, dispatchWorkspace: dispatch, startNewChat: openChat } = actionsRef.current
+    const ws = stateRef.current.ws
+    const pane = ws.panes[ws.focusedPaneId]
+    let handled = false
+
+    if (action === 'open') {
+      handled = true
+      openChat?.()
+    } else if (action === 'restore') {
+      handled = dispatch({ type: 'RESTORE_CLOSED_TAB' }) !== false
+    } else if (ws.viewMode === 'panes' && pane) {
+      if (action === 'close' && pane.activeTabKey) {
+        handled = true
+        dispatch({ type: 'CLOSE_TAB', tabKey: pane.activeTabKey, label: 'Closed tab' })
+      } else if ((action === 'next' || action === 'previous') && pane.tabs.length > 1) {
+        const current = Math.max(0, pane.tabs.findIndex(tab => tabModel.tabKey(tab) === pane.activeTabKey))
+        const step = action === 'next' ? 1 : -1
+        const target = pane.tabs[(current + step + pane.tabs.length) % pane.tabs.length]
+        handled = true
+        dispatch({ type: 'SET_ACTIVE', paneId: pane.id, tabKey: tabModel.tabKey(target) })
+      } else if (action.startsWith('select:')) {
+        const number = Number(action.slice(7))
+        const index = number === 9 ? pane.tabs.length - 1 : number - 1
+        const target = pane.tabs[index]
+        if (target) {
+          handled = true
+          dispatch({ type: 'SET_ACTIVE', paneId: pane.id, tabKey: tabModel.tabKey(target) })
+        }
+      }
+    }
+
+    if (handled) event.preventDefault?.()
+    return handled
+  }, [enabled])
+
+  useEffect(() => {
+    const onKeyDown = event => execute(event)
+    window.addEventListener('keydown', onKeyDown, true)
+    return () => window.removeEventListener('keydown', onKeyDown, true)
+  }, [execute])
+
+  return useCallback(payload => execute(payload, { forwarded: true }), [execute])
+}

--- a/frontend/src/components/Shell/useWorkspaceShortcuts.js
+++ b/frontend/src/components/Shell/useWorkspaceShortcuts.js
@@ -6,6 +6,7 @@ export const WORKSPACE_SHORTCUT_CAPABILITY = 'workspace.shortcuts'
 export function hasWorkspaceShortcutProvider(apps) {
   return Array.isArray(apps) && apps.some(app => (
     app?.capability_contract?.runtime?.[WORKSPACE_SHORTCUT_CAPABILITY]?.version === 1
+    && app?.paused_capabilities?.[WORKSPACE_SHORTCUT_CAPABILITY] !== true
   ))
 }
 

--- a/frontend/src/components/Shell/useWorkspaceShortcuts.js
+++ b/frontend/src/components/Shell/useWorkspaceShortcuts.js
@@ -14,6 +14,10 @@ export function isApplePlatform(platform) {
   return /Mac|iPhone|iPad|iPod/i.test(String(platform || ''))
 }
 
+export function isLinuxPlatform(platform) {
+  return /Linux/i.test(String(platform || ''))
+}
+
 // Windows/Linux use Ctrl+Alt — never bare Ctrl, which the browser chrome
 // itself owns for T/W/Tab-switching (Ctrl+T, Ctrl+Tab, ...), so a page can
 // never intercept the unprefixed key. Mac uses Cmd+Option instead of the
@@ -27,6 +31,7 @@ export function isApplePlatform(platform) {
 export function workspaceShortcutAction(event, platform = globalThis.navigator?.platform || '') {
   if (!event || event.isComposing || event.repeat) return null
   const apple = isApplePlatform(platform)
+  const linux = !apple && isLinuxPlatform(platform)
   const modifiersMatch = apple
     ? (event.metaKey && event.altKey && !event.ctrlKey)
     : (event.ctrlKey && event.altKey && !event.metaKey)
@@ -35,7 +40,14 @@ export function workspaceShortcutAction(event, platform = globalThis.navigator?.
 
   const key = String(event.key || '')
   const lower = key.toLowerCase()
-  if (lower === 't') return event.shiftKey ? 'restore' : 'open'
+  // Ctrl+Alt+T opens a terminal on GNOME, KDE, and most other Linux desktop
+  // environments — captured by the desktop shell before any page ever sees
+  // the keypress, the same non-interceptable-shortcut problem that shaped
+  // every other platform branch here. Linux opens a new tab with N instead;
+  // Shift+T still restores everywhere (only the bare terminal binding is
+  // taken, Ctrl+Alt+Shift+T is not a known desktop shortcut).
+  if (lower === 't') return event.shiftKey ? 'restore' : (linux ? null : 'open')
+  if (linux && lower === 'n' && !event.shiftKey) return 'open'
   if (lower === 'w' && !event.shiftKey) return 'close'
   if (event.shiftKey) return null
   if (apple) {

--- a/frontend/src/components/Shell/useWorkspaceShortcuts.js
+++ b/frontend/src/components/Shell/useWorkspaceShortcuts.js
@@ -10,13 +10,27 @@ export function hasWorkspaceShortcutProvider(apps) {
   ))
 }
 
-function isApplePlatform(platform) {
+export function isApplePlatform(platform) {
   return /Mac|iPhone|iPad|iPod/i.test(String(platform || ''))
 }
 
+// Windows/Linux use Ctrl+Alt — never bare Ctrl, which the browser chrome
+// itself owns for T/W/Tab-switching (Ctrl+T, Ctrl+Tab, ...), so a page can
+// never intercept the unprefixed key. Mac uses Cmd+Option instead of the
+// naive Ctrl+Option port for two independent reasons: Control+Option is
+// macOS's own VoiceOver modifier (silently breaks for screen-reader users),
+// and Cmd+Option+Left/Right is Chrome's own native, equally uninterceptable
+// tab-switcher — using it here would move the browser's real tabs, not
+// Möbius's panes. Next/previous use bracket keys instead, mirroring the
+// pattern Chrome/Safari already use for tab-switching on Mac, just under the
+// free Cmd+Option prefix rather than the taken one.
 export function workspaceShortcutAction(event, platform = globalThis.navigator?.platform || '') {
-  if (!event || isApplePlatform(platform) || event.isComposing || event.repeat) return null
-  if (!event.ctrlKey || !event.altKey || event.metaKey) return null
+  if (!event || event.isComposing || event.repeat) return null
+  const apple = isApplePlatform(platform)
+  const modifiersMatch = apple
+    ? (event.metaKey && event.altKey && !event.ctrlKey)
+    : (event.ctrlKey && event.altKey && !event.metaKey)
+  if (!modifiersMatch) return null
   if (event.getModifierState?.('AltGraph')) return null
 
   const key = String(event.key || '')
@@ -24,8 +38,13 @@ export function workspaceShortcutAction(event, platform = globalThis.navigator?.
   if (lower === 't') return event.shiftKey ? 'restore' : 'open'
   if (lower === 'w' && !event.shiftKey) return 'close'
   if (event.shiftKey) return null
-  if (key === 'PageDown') return 'next'
-  if (key === 'PageUp') return 'previous'
+  if (apple) {
+    if (key === ']') return 'next'
+    if (key === '[') return 'previous'
+  } else {
+    if (key === 'PageDown') return 'next'
+    if (key === 'PageUp') return 'previous'
+  }
   if (/^[1-9]$/.test(key)) return `select:${key}`
   return null
 }

--- a/frontend/src/lib/capabilityProviders.js
+++ b/frontend/src/lib/capabilityProviders.js
@@ -7,6 +7,7 @@ import {
 export const MICROPHONE_CAPTURE = 'media.microphone.capture'
 export const SPEECH = 'media.speech'
 export const SPEECH_MODELS = 'device.speech-models'
+export const WORKSPACE_SHORTCUTS = 'workspace.shortcuts'
 
 export function createSpeechProvider({
   loadRuntime = () => import('./speech/speechProviderRuntime.js'),
@@ -78,6 +79,35 @@ export function createMicrophoneProvider({ startCapture = startMicrophoneCapture
   }
 }
 
+// The app that DECLARES workspace.shortcuts is also the only reasonable
+// caller of its pause/resume action (it owns the toggle UI), but the write
+// belongs entirely to the shell: an opaque app frame cannot itself call
+// PATCH /api/apps/{id} (no origin-authenticated fetch is exposed to it, by
+// design — see runtime/index.js's module doc), so this provider does the
+// authenticated update.apps.update() on the app's behalf and lets its
+// existing list-cache invalidation carry the new paused state back to
+// hasWorkspaceShortcutProvider() in useWorkspaceShortcuts.js.
+export function createWorkspaceShortcutsPauseProvider({ appId, api }) {
+  return {
+    version: 1,
+    async open({ input, channel }) {
+      const paused = input?.paused === true
+      try {
+        const response = await api.apps.update(appId, {
+          capability_pause: { [WORKSPACE_SHORTCUTS]: paused },
+        })
+        if (!response.ok) {
+          throw new Error(`Could not update shortcut state (${response.status}).`)
+        }
+        channel.result({ paused })
+      } catch (error) {
+        channel.error(error)
+      }
+      return { control() {} }
+    },
+  }
+}
+
 export function builtInCapabilityProviders(options = {}) {
   return {
     [DEVICE_ASSET_CACHE]: createDeviceAssetCacheProvider(options.deviceAssets),
@@ -86,6 +116,10 @@ export function builtInCapabilityProviders(options = {}) {
     [SPEECH_MODELS]: createSpeechModelsProvider({
       appId: options.deviceAssets?.appId,
       ...options.speechModels,
+    }),
+    [WORKSPACE_SHORTCUTS]: createWorkspaceShortcutsPauseProvider({
+      appId: options.deviceAssets?.appId,
+      ...options.workspaceShortcuts,
     }),
   }
 }

--- a/frontend/src/runtime/index.js
+++ b/frontend/src/runtime/index.js
@@ -133,7 +133,14 @@ function _setOnline(next) {
 // Listen for the probed verdict from AppCanvas.
 if (typeof window !== 'undefined') {
   window.addEventListener('message', (e) => {
-    if (e.origin !== window.location.origin) return
+    // The default mount is a sandboxed opaque-origin frame (see the module
+    // doc above), so window.location.origin here is the literal string
+    // "null" and can never equal the shell's real origin — an origin-string
+    // check silently drops every trusted message from the parent, including
+    // the online-status seed and (newly, loudly) the workspace-shortcuts
+    // enable signal. Verify sender identity instead, matching the pattern
+    // immersive.js and navigation.js already use for the same opaque frame.
+    if (e.source !== window.parent) return
     const msg = e.data
     if (!msg || typeof msg !== 'object') return
     if (msg.type === 'moebius:online-status' && typeof msg.online === 'boolean') {

--- a/frontend/src/runtime/index.js
+++ b/frontend/src/runtime/index.js
@@ -111,14 +111,27 @@ function _editableShortcutTarget(target) {
     && !!target.closest('input, textarea, select, [contenteditable], [role="textbox"]')
 }
 
+function _workspaceApplePlatform() {
+  return /Mac|iPhone|iPad|iPod/i.test(String(globalThis.navigator?.platform || ''))
+}
+
+// Mirrors workspaceShortcutAction() in useWorkspaceShortcuts.js — see that
+// file's comment for why Mac uses Cmd+Option+[/] instead of a naive
+// Ctrl+Option+PageUp/PageDown port. Kept in sync by hand rather than shared
+// via import: this runtime ships standalone into the app iframe.
 function _workspaceShortcutCandidate(event) {
   if (!event?.isTrusted || event.isComposing || event.repeat) return false
-  if (!event.ctrlKey || !event.altKey || event.metaKey || event.getModifierState?.('AltGraph')) return false
+  const apple = _workspaceApplePlatform()
+  const modifiersMatch = apple
+    ? (event.metaKey && event.altKey && !event.ctrlKey)
+    : (event.ctrlKey && event.altKey && !event.metaKey)
+  if (!modifiersMatch || event.getModifierState?.('AltGraph')) return false
   const key = String(event.key || '')
   const lower = key.toLowerCase()
   if (lower === 't') return true
   if (lower === 'w') return !event.shiftKey
   if (event.shiftKey) return false
+  if (apple) return key === ']' || key === '[' || /^[1-9]$/.test(key)
   return key === 'PageDown' || key === 'PageUp' || /^[1-9]$/.test(key)
 }
 

--- a/frontend/src/runtime/index.js
+++ b/frontend/src/runtime/index.js
@@ -102,6 +102,25 @@ export * from './immersive.js'
 // ─────────────────────────────────────────────────────────────────────────────
 let _online = typeof navigator !== 'undefined' ? navigator.onLine : true
 const _onlineListeners = new Set()
+let _workspaceShortcutsEnabled = false
+
+function _editableShortcutTarget(target) {
+  if (!target || typeof target !== 'object') return false
+  if (target.isContentEditable) return true
+  return typeof target.closest === 'function'
+    && !!target.closest('input, textarea, select, [contenteditable], [role="textbox"]')
+}
+
+function _workspaceShortcutCandidate(event) {
+  if (!event?.isTrusted || event.isComposing || event.repeat) return false
+  if (!event.ctrlKey || !event.altKey || event.metaKey || event.getModifierState?.('AltGraph')) return false
+  const key = String(event.key || '')
+  const lower = key.toLowerCase()
+  if (lower === 't') return true
+  if (lower === 'w') return !event.shiftKey
+  if (event.shiftKey) return false
+  return key === 'PageDown' || key === 'PageUp' || /^[1-9]$/.test(key)
+}
 
 function _setOnline(next) {
   if (next === _online) return
@@ -119,11 +138,27 @@ if (typeof window !== 'undefined') {
     if (!msg || typeof msg !== 'object') return
     if (msg.type === 'moebius:online-status' && typeof msg.online === 'boolean') {
       _setOnline(msg.online)
+    } else if (msg.type === 'moebius:workspace-shortcuts-status') {
+      _workspaceShortcutsEnabled = msg.enabled === true
     }
   })
   // Keep the seed roughly current before AppCanvas's first probed verdict.
   window.addEventListener('online', () => _setOnline(true))
   window.addEventListener('offline', () => _setOnline(false))
+  window.addEventListener('keydown', event => {
+    if (!_workspaceShortcutsEnabled || _editableShortcutTarget(event.target)) return
+    if (!_workspaceShortcutCandidate(event)) return
+    event.preventDefault()
+    window.parent.postMessage({
+      type: 'moebius:workspace-shortcut',
+      key: event.key,
+      ctrlKey: event.ctrlKey,
+      altKey: event.altKey,
+      shiftKey: event.shiftKey,
+      metaKey: event.metaKey,
+      editable: false,
+    }, '*')
+  }, true)
 }
 // ─────────────────────────────────────────────────────────────────────────────
 

--- a/frontend/src/runtime/index.js
+++ b/frontend/src/runtime/index.js
@@ -115,13 +115,20 @@ function _workspaceApplePlatform() {
   return /Mac|iPhone|iPad|iPod/i.test(String(globalThis.navigator?.platform || ''))
 }
 
+function _workspaceLinuxPlatform() {
+  return /Linux/i.test(String(globalThis.navigator?.platform || ''))
+}
+
 // Mirrors workspaceShortcutAction() in useWorkspaceShortcuts.js — see that
-// file's comment for why Mac uses Cmd+Option+[/] instead of a naive
-// Ctrl+Option+PageUp/PageDown port. Kept in sync by hand rather than shared
-// via import: this runtime ships standalone into the app iframe.
+// file's comments for why Mac uses Cmd+Option+[/] instead of a naive
+// Ctrl+Option+PageUp/PageDown port, and why Linux opens a new tab with N
+// instead of T (Ctrl+Alt+T is the desktop's own terminal shortcut on GNOME
+// and KDE). Kept in sync by hand rather than shared via import: this runtime
+// ships standalone into the app iframe.
 function _workspaceShortcutCandidate(event) {
   if (!event?.isTrusted || event.isComposing || event.repeat) return false
   const apple = _workspaceApplePlatform()
+  const linux = !apple && _workspaceLinuxPlatform()
   const modifiersMatch = apple
     ? (event.metaKey && event.altKey && !event.ctrlKey)
     : (event.ctrlKey && event.altKey && !event.metaKey)
@@ -129,6 +136,7 @@ function _workspaceShortcutCandidate(event) {
   const key = String(event.key || '')
   const lower = key.toLowerCase()
   if (lower === 't') return true
+  if (linux && lower === 'n') return !event.shiftKey
   if (lower === 'w') return !event.shiftKey
   if (event.shiftKey) return false
   if (apple) return key === ']' || key === '[' || /^[1-9]$/.test(key)


### PR DESCRIPTION
## Summary
Adds a small, install-scoped shell capability, `workspace.shortcuts`, that lets a reviewed mini-app activate Chrome-friendly keyboard shortcuts for the workspace (open/close/restore a tab, switch next/previous, jump to first/last), scoped to the focused pane, on Windows, Linux, and Mac. An installed App Store app (mobius-os/app-store#32, `app-workspace-shortcuts`) turns this on by declaring the capability; uninstalling it turns it back off (an in-app toggle can also pause/resume it without uninstalling).

An App Store mini-app cannot capture keystrokes while another workspace tab has focus (each app is a separate iframe), so this had to be a small shell-owned primitive rather than something the app could do alone. The app supplies the specific key mapping and UI; the shell owns the actual keyboard listener, permission, and cross-frame forwarding.

### What's included
- `backend/app/app_capabilities.py`: new `workspace.shortcuts` runtime capability definition (kind `activation`).
- `frontend/src/components/Shell/useWorkspaceShortcuts.js`: the shell-side keyboard handler, with a per-platform mapping:
  - **Windows**: `Ctrl+Alt+T/W/Shift+T/PageUp/PageDown/1-9`. Ignores `AltGr` so international layouts aren't affected. Deliberately avoids `Ctrl+Alt+Tab` (OS-owned).
  - **Linux**: identical, except `Ctrl+Alt+N` opens a new tab instead of `T` — `Ctrl+Alt+T` is the desktop's own terminal shortcut on GNOME, KDE, and most other Linux desktop environments, captured before any page ever sees the keypress. Checked against GNOME/KDE's documented defaults, not exhaustively tested across every distro/WM.
  - **Mac**: `Cmd+Option` instead of a naive `Ctrl+Option` port — `Control+Option` is macOS's own VoiceOver modifier (would silently break for screen-reader users) — with bracket keys (`⌘⌥[`/`⌘⌥]`) for next/previous instead of arrows, since `Cmd+Option+Left/Right` is Chrome's own native, equally uninterceptable tab-switcher.
  - Every platform's modifier check explicitly excludes the others (e.g. a Cmd-held event never fires the Windows/Linux branch), and every rejected combo has an explicit test.
- `frontend/src/runtime/index.js` + `frontend/public/mobius-runtime.js`: forwards a matching keydown from inside a sandboxed app iframe up to the shell, mirroring the same per-platform key matching (kept in sync by hand — this runtime ships standalone into the app iframe, no shared import).
- **Bug fix, same PR**: the message listener that receives the shell's enable/online-status broadcast inside an app iframe used `e.origin !== window.location.origin`. The default app mount is a sandboxed *opaque-origin* frame, so `window.location.origin` there is the literal string `"null"` and can never equal the shell's real origin — this receive check could never pass, silently dropping the broadcast (including, previously, the unrelated online-status signal). Fixed using the sender-identity check (`e.source === window.parent`) already established elsewhere in this runtime for the same opaque frame (see `immersive.js`).
- A real pause/resume toggle for "activation" kind capabilities: a new `paused_capabilities` column on `App` (in `schema_migrations.py`, added alongside `capability_contract` — deliberately separate from it, since that field is wholesale regenerated from the manifest on every apply/PATCH and would otherwise silently discard a paused flag), a validated `PATCH /api/apps/{id}` path (`capability_pause`, rejects any capability the app doesn't hold or whose kind isn't `activation`), and a capability-session provider (`frontend/src/lib/capabilityProviders.js`) so a sandboxed app frame can ask the shell to make the change on its behalf — the app has no direct authenticated fetch to its own app record.
- `backend/tests/conftest.py`: unrelated one-line-context fix found along the way — a Railway-managed instance carries real `MOBIUS_SSO_*` secrets in its process environment, which leaked into the test process and made every `owner_token`-dependent test fail with 403 "Managed sign-in is enabled for this deployment." Cleared alongside the existing `DATA_DIR`/`DATABASE_URL` isolation.

### Why
This is the platform half of an App Store submission (mobius-os/app-store#32) for a "Shortcuts" mini-app. The catalog entry alone can't work without this: it declares a capability the current backend doesn't recognize, so install would fail immediately with "Unknown capability" for anyone who isn't running a patched instance.

## Test plan
- [x] `backend/tests/test_app_capabilities.py` — 26/26 passing, including 3 new tests for the pause/resume path (holds-capability validation, activation-kind-only validation, survives reapply)
- [x] `frontend` full `test:lib` — 2532/2532 passing, including new tests for the Mac and Linux branches (each rejected combo asserted explicitly, not just the accepted ones)
- [x] Rebased onto current `main` and re-verified in an isolated worktree (both `schema_migrations.py`'s relocated migration block and `constants.js`/`catalog.json`'s registry-derived catalog required manual resolution after upstream refactors — re-tested clean)
- [x] Manual verification on the author's own instance: install activates the capability, the app's own UI reflects live state, pause/resume round-trips through the new PATCH path
- [ ] Real-device confirmation on Chrome for Windows 11, a Linux desktop, and macOS for the full key mapping (open/close/restore/switch/first-last, international character entry) — tracked separately, not blocking this PR's mechanism

🤖 Generated with [Claude Code](https://claude.com/claude-code)