### PR TITLE
Restore on-device speech across WebKit generations

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -965,6 +965,15 @@ def _resolve_asset_file(asset_path: str) -> Path | None:
 # site below.
 _SERVICE_WORKER_SCRIPTS = frozenset({"sw.js", "sw-push.js"})
 
+# Small, same-origin worker scripts that are deliberately NOT precached (mirrors
+# the frontend precache-policy.mjs UNPRECACHED_WORKERS list). A worker runs under
+# the Content-Security-Policy of its OWN response, so — exactly like sw.js — it
+# must revalidate on every load. Without this the browser caches the worker by
+# HTTP heuristic freshness, and a device that fetched it under an earlier policy
+# keeps executing under that stale CSP: this is how on-device Pocket TTS stayed
+# WebAssembly-blocked even after shell_csp restored the 'wasm-unsafe-eval' source.
+_UNPRECACHED_WORKER_SCRIPTS = frozenset({"speech/pocket-tts-worker.js"})
+
 # The push worker's scope. It exists only to name a URL prefix inside the
 # shell's PWA scope, and must never resolve to a document — a page here would
 # be controlled by a worker with no fetch handler, so it would boot the shell
@@ -1379,7 +1388,7 @@ if _baked_dir.is_dir() or _live_dir.is_dir():
       # If-None-Match on every request, so a 304 keeps the
       # download cheap when nothing changed.
       headers = _public_static_headers(path)
-      if path in _SERVICE_WORKER_SCRIPTS:
+      if path in _SERVICE_WORKER_SCRIPTS or path in _UNPRECACHED_WORKER_SCRIPTS:
         headers["Cache-Control"] = "no-cache, must-revalidate"
         # A worker script is a REVALIDATING response (no-cache + the mtime ETag
         # FileResponse sets), so it must never answer a 206. A

--- a/backend/app/response_policy.py
+++ b/backend/app/response_policy.py
@@ -67,7 +67,14 @@ def app_frame_csp(
     "allow-popups-to-escape-sandbox "
     "allow-top-navigation-by-user-activation; "
     f"default-src {origin}; "
-    f"script-src {origin} 'unsafe-inline' 'wasm-unsafe-eval' "
+    # `'wasm-unsafe-eval'` is the narrow modern source for WebAssembly, but older
+    # WebKit-based installed apps (older iOS Safari / installed-PWA engines)
+    # ignore it and still gate WebAssembly compilation on `'unsafe-eval'`.
+    # On-device Pocket TTS runs as Wasm inside these opaque, sandboxed mini-app
+    # frames, so both sources are required for it to start on those browsers.
+    # The permission stays confined to the isolated app-frame policy; the shell
+    # and other documents keep only the narrow modern source.
+    f"script-src {origin} 'unsafe-inline' 'wasm-unsafe-eval' 'unsafe-eval' "
     "blob: https://esm.sh; "
     f"style-src {origin} 'unsafe-inline' https://fonts.googleapis.com; "
     f"font-src {origin} https://fonts.gstatic.com https://cdn.openai.com; "
@@ -79,14 +86,22 @@ def app_frame_csp(
 
 
 def shell_csp(gateway_origin: str = "") -> str:
-  """Policy for ordinary shell/API documents, independent of proxy syntax."""
+  """Policy for ordinary shell/API documents, independent of proxy syntax.
+
+  ``'wasm-unsafe-eval'`` permits WebAssembly and nothing else, rather than the
+  general ``'unsafe-eval'``. On-device Pocket TTS runs as Wasm in a same-origin
+  shell-owned worker, which cannot compile without it. ``worker-src 'self'``
+  keeps that worker restricted to the real same-origin asset rather than a
+  generated or third-party worker.
+  """
   frame_sources = ["'self'"]
   gateway = absolute_csp_origin(gateway_origin)
   if gateway is not None:
     frame_sources.append(gateway)
   return (
     "default-src 'self'; "
-    "script-src 'self' 'unsafe-inline' https://esm.sh; "
+    "script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' https://esm.sh; "
+    "worker-src 'self'; "
     "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "
     "font-src 'self' https://fonts.gstatic.com https://cdn.openai.com; "
     "connect-src 'self'; "

--- a/backend/tests/test_security_headers.py
+++ b/backend/tests/test_security_headers.py
@@ -72,6 +72,28 @@ def test_bundled_caddy_does_not_override_published_site_sandbox():
   assert "default-src" not in _PUBLISHED_SITE_CSP
 
 
+def test_speech_worker_revalidates_so_its_csp_cannot_go_stale():
+  # A worker runs under the CSP of its OWN response. The speech worker carries
+  # shell_csp (now with 'wasm-unsafe-eval'); if the browser cached it under
+  # heuristic freshness, a device that fetched it before the WASM policy was
+  # restored would keep running the stale, WASM-blocked policy. Force revalidation
+  # like sw.js so the current CSP always applies.
+  import os
+
+  # The runtime serves this from the live Vite dist; the test floor is the baked
+  # stub dir conftest seeds. Provide the worker there so the serving path — not a
+  # 404 — is exercised.
+  static = Path(os.environ["MOBIUS_BAKED_STATIC_DIR"])
+  worker = static / "speech" / "pocket-tts-worker.js"
+  worker.parent.mkdir(parents=True, exist_ok=True)
+  if not worker.exists():
+    worker.write_text("// test stub speech worker\n", encoding="utf-8")
+  r = TestClient(app).get("/speech/pocket-tts-worker.js")
+  assert r.status_code == 200
+  assert r.headers.get("cache-control") == "no-cache, must-revalidate"
+  assert "'wasm-unsafe-eval'" in (r.headers.get("content-security-policy") or "")
+
+
 def test_standard_security_headers_present():
   h = _headers()
   assert h.get("x-content-type-options") == "nosniff"
@@ -86,7 +108,9 @@ def test_direct_shell_response_receives_the_origin_owned_policy():
   assert policy == _SHELL_CSP
   assert "https://esm.sh" in policy
   assert "img-src 'self' data: blob:" in policy
-  assert "'wasm-unsafe-eval'" not in policy
+  assert "'wasm-unsafe-eval'" in policy
+  assert " 'unsafe-eval'" not in policy
+  assert "worker-src 'self';" in policy
   assert "cross-origin-opener-policy" not in _headers()
   assert "cross-origin-embedder-policy" not in _headers()
 
@@ -181,7 +205,10 @@ def test_backend_owns_complete_app_frame_policy():
   assert "allow-popups-to-escape-sandbox" in policy
   assert "allow-same-origin" not in policy
   assert "'wasm-unsafe-eval'" in policy
-  assert " 'unsafe-eval'" not in policy
+  # Older WebKit-based installed apps ignore 'wasm-unsafe-eval' and gate Wasm on
+  # 'unsafe-eval'; the isolated app-frame policy carries both so on-device speech
+  # (Pocket TTS) can compile on those engines.
+  assert "'unsafe-eval'" in policy
   assert f"frame-src {origin} {gateway}" in policy
 
   # The frame's origin is opaque, so 'self' matches nothing in fetch

--- a/frontend/src/lib/__tests__/swCachePolicy.test.js
+++ b/frontend/src/lib/__tests__/swCachePolicy.test.js
@@ -55,6 +55,10 @@ test('runtime cache cleanup evicts old offline app caches', () => {
   // Those response headers must not keep blocking Wasm compilation after the
   // server policy changes.
   assert.equal(isStaleRuntimeCache('mobius-offline-apps-v5'), true)
+  // v6/v7 predate the WebAssembly-frame delivery; they must be evicted so a
+  // device does not keep serving a cached frame whose CSP blocks Wasm.
+  assert.equal(isStaleRuntimeCache('mobius-offline-apps-v6'), true)
+  assert.equal(isStaleRuntimeCache('mobius-offline-apps-v7'), true)
   assert.equal(isStaleRuntimeCache(OFFLINE_APPS_CACHE), false)
   assert.equal(isStaleRuntimeCache('mobius-standalone'), true)
   assert.equal(isStaleRuntimeCache('mobius-standalone-v1'), true)

--- a/frontend/src/sw-cache-policy.js
+++ b/frontend/src/sw-cache-policy.js
@@ -48,7 +48,13 @@ export const SHELL_DATA_CACHE = 'mobius-shell-data'
 // holding it never sees a new window.mobius capability even after the app is
 // recompiled and the shell restarts. Activation evicts v6 so every client
 // refetches the current versioned module (with the current compiled runtime).
-export const OFFLINE_APPS_CACHE = 'mobius-offline-apps-v7'
+// Bumped -v7 → -v8 (2026-08-15): a device may hold a News (or any Wasm app)
+// frame cached before/around the WebAssembly CSP change whose stored response
+// headers block Wasm compilation. Because the frame is served cache-first under
+// a `?v=<app.updated_at>` key that has not changed, only a cache-name bump forces
+// eviction: activation evicts v7 and the next app open refetches the current
+// WebAssembly-enabled frame.
+export const OFFLINE_APPS_CACHE = 'mobius-offline-apps-v8'
 // Bumped -v2 → -v3 (2026-07-30): v2 standalone documents executed app-authored
 // modules directly at owner origin. The secure host now mounts the shared
 // opaque AppCanvas frame; activation must evict every cached v2 document so an


### PR DESCRIPTION
## Summary
- allow WebAssembly in older WebKit app frames while keeping the broader permission out of the shell
- force the speech worker to revalidate so an older cached security policy cannot keep blocking startup
- rotate the offline app cache so devices refetch frames with the corrected policy

## Security
The broader WebAssembly compatibility source is confined to opaque, sandboxed app frames. The owner shell keeps the narrower WebAssembly-only source and restricts workers to same-origin assets.

## Testing
- `scripts/wt-pytest.sh backend/tests/test_security_headers.py -q`
- `node --loader=./src/lib/__tests__/vite-env-loader.mjs --test src/lib/__tests__/swCachePolicy.test.js`