### PR TITLE
Make global search keyboard navigable

### DIFF
--- a/frontend/src/components/GlobalSearch/GlobalSearch.css
+++ b/frontend/src/components/GlobalSearch/GlobalSearch.css
@@ -250,6 +250,11 @@
   border-top: 1px solid var(--border-light);
 }
 
+.global-search__result--selected {
+  background: color-mix(in srgb, var(--accent) 10%, var(--surface2));
+  box-shadow: inset 3px 0 0 var(--accent);
+}
+
 @media (hover: hover) and (pointer: fine) {
   .global-search__result:hover { background: var(--surface2); }
   .global-search__close:hover { background: var(--surface2); }

--- a/frontend/src/components/GlobalSearch/GlobalSearch.jsx
+++ b/frontend/src/components/GlobalSearch/GlobalSearch.jsx
@@ -20,8 +20,10 @@ import { formatRelativeTime } from '../../lib/relativeTime.js'
 import {
   chatSearchOpenTarget,
   chatSearchResultIsCurrent,
+  moveSearchSelection,
   readLastSearch,
   rememberLastSearch,
+  resolvedSearchSelection,
   searchInstalledApps,
   visibleChatSearchState,
 } from './globalSearchModel.js'
@@ -51,6 +53,7 @@ export function GlobalSearchButton({ active = false, buttonRef, onClick }) {
 export default function GlobalSearch({ onClose, onOpenTarget }) {
   const dialogRef = useRef(null)
   const inputRef = useRef(null)
+  const contentRef = useRef(null)
   const chatSearchControllerRef = useRef(null)
   // Reopening restores the owner's last search (see rememberLastSearch), so the
   // in-flight-result guard has to start from that same term rather than '' —
@@ -60,6 +63,7 @@ export default function GlobalSearch({ onClose, onOpenTarget }) {
   const latestQueryRef = useRef(restored.query.trim())
   const [query, setQuery] = useState(restored.query)
   const [chatState, setChatState] = useState(restored.chatState)
+  const [selectionIndex, setSelectionIndex] = useState(0)
   const appsQuery = appQueries.list.useQuery()
 
   useDialogFocus({
@@ -163,6 +167,45 @@ export default function GlobalSearch({ onClose, onOpenTarget }) {
     onOpenTarget?.({ view: 'canvas', app: String(app.id), intent: null })
   }, [onClose, onOpenTarget])
 
+  const selectableResults = useMemo(() => [
+    ...appResults.map(({ app }) => ({ kind: 'app', value: app })),
+    ...visibleChats.results.map(result => ({ kind: 'chat', value: result })),
+  ], [appResults, visibleChats.results])
+  const activeResultIndex = resolvedSearchSelection(
+    selectionIndex,
+    selectableResults.length,
+  )
+  const resultListId = selectableResults.length ? 'global-search-results' : undefined
+
+  const openSelectedResult = useCallback(() => {
+    const selected = selectableResults[activeResultIndex]
+    if (selected?.kind === 'app') openApp(selected.value)
+    if (selected?.kind === 'chat') openChat(selected.value)
+  }, [activeResultIndex, openApp, openChat, selectableResults])
+
+  const handleSearchKeyDown = useCallback((event) => {
+    if (event.isComposing || event.metaKey || event.ctrlKey || event.altKey) return
+    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+      if (!selectableResults.length) return
+      event.preventDefault()
+      setSelectionIndex(current => (
+        moveSearchSelection(current, event.key, selectableResults.length)
+      ))
+      return
+    }
+    if (event.key === 'Enter' && activeResultIndex !== -1) {
+      event.preventDefault()
+      openSelectedResult()
+    }
+  }, [activeResultIndex, openSelectedResult, selectableResults.length])
+
+  useEffect(() => {
+    if (activeResultIndex === -1) return
+    dialogRef.current
+      ?.querySelector(`[data-search-result-index="${activeResultIndex}"]`)
+      ?.scrollIntoView({ block: 'nearest' })
+  }, [activeResultIndex])
+
   const noResults = normalizedQuery
     && visibleChats.status === 'ready'
     && visibleChats.results.length === 0
@@ -205,16 +248,34 @@ export default function GlobalSearch({ onClose, onOpenTarget }) {
             ref={inputRef}
             type="search"
             value={query}
-            onChange={event => setQuery(event.target.value)}
+            onChange={event => {
+              setQuery(event.target.value)
+              setSelectionIndex(0)
+              if (contentRef.current) contentRef.current.scrollTop = 0
+            }}
+            onKeyDown={handleSearchKeyDown}
             placeholder="Search chats, apps, and app details"
             aria-label="Search chats, apps, and app details"
+            role="combobox"
+            aria-autocomplete="list"
+            aria-controls={resultListId}
+            aria-expanded={selectableResults.length > 0}
+            aria-activedescendant={
+              activeResultIndex === -1
+                ? undefined
+                : `global-search-result-${activeResultIndex}`
+            }
             autoComplete="off"
             spellCheck="false"
           />
           <kbd>{shortcutLabel(SHELL_SHORTCUTS.openSearch)}</kbd>
         </label>
 
-        <div className="global-search__content" aria-live="polite">
+        <div
+          ref={contentRef}
+          className="global-search__content"
+          aria-live="polite"
+        >
           {!normalizedQuery && (
             <div className="global-search__empty">
               <span className="global-search__empty-icon" aria-hidden="true">
@@ -226,16 +287,33 @@ export default function GlobalSearch({ onClose, onOpenTarget }) {
           )}
 
           {normalizedQuery && (
-            <div className="global-search__groups">
+            <div
+              id="global-search-results"
+              className="global-search__groups"
+              role="listbox"
+              aria-label="Search results"
+            >
               {appResults.length > 0 && (
-                <section className="global-search__group" aria-labelledby="global-search-apps">
+                <section
+                  className="global-search__group"
+                  role="group"
+                  aria-labelledby="global-search-apps"
+                >
                   <h3 id="global-search-apps">Apps <span>{appResults.length}</span></h3>
                   <div className="global-search__results">
-                    {appResults.map(({ app, matchArea }) => (
+                    {appResults.map(({ app, matchArea }, index) => (
                       <button
                         key={app.id}
+                        id={`global-search-result-${index}`}
                         type="button"
-                        className="global-search__result"
+                        role="option"
+                        aria-selected={activeResultIndex === index}
+                        data-search-result-index={index}
+                        className={`global-search__result${
+                          activeResultIndex === index ? ' global-search__result--selected' : ''
+                        }`}
+                        onPointerEnter={() => setSelectionIndex(index)}
+                        onFocus={() => setSelectionIndex(index)}
                         onClick={() => openApp(app)}
                       >
                         <AppIcon
@@ -256,7 +334,11 @@ export default function GlobalSearch({ onClose, onOpenTarget }) {
                 </section>
               )}
 
-              <section className="global-search__group" aria-labelledby="global-search-chats">
+              <section
+                className="global-search__group"
+                role="group"
+                aria-labelledby="global-search-chats"
+              >
                 <h3 id="global-search-chats">
                   Chats
                   {visibleChats.status === 'ready' && <span>{visibleChats.results.length}</span>}
@@ -271,13 +353,22 @@ export default function GlobalSearch({ onClose, onOpenTarget }) {
                 )}
                 {visibleChats.results.length > 0 && (
                   <div className="global-search__results">
-                    {visibleChats.results.map((result) => {
+                    {visibleChats.results.map((result, chatIndex) => {
+                      const index = appResults.length + chatIndex
                       const lastActive = formatRelativeTime(result.last_active)
                       return (
                         <button
                           key={result.id}
+                          id={`global-search-result-${index}`}
                           type="button"
-                          className="global-search__result"
+                          role="option"
+                          aria-selected={activeResultIndex === index}
+                          data-search-result-index={index}
+                          className={`global-search__result${
+                            activeResultIndex === index ? ' global-search__result--selected' : ''
+                          }`}
+                          onPointerEnter={() => setSelectionIndex(index)}
+                          onFocus={() => setSelectionIndex(index)}
                           onClick={() => openChat(result)}
                         >
                           <span className="global-search__result-icon" aria-hidden="true">

--- a/frontend/src/components/GlobalSearch/__tests__/globalSearchModel.test.js
+++ b/frontend/src/components/GlobalSearch/__tests__/globalSearchModel.test.js
@@ -5,8 +5,10 @@ import {
   chatSearchOpenTarget,
   chatSearchResultIsCurrent,
   clearLastSearch,
+  moveSearchSelection,
   readLastSearch,
   rememberLastSearch,
+  resolvedSearchSelection,
   searchInstalledApps,
   visibleChatSearchState,
 } from '../globalSearchModel.js'
@@ -81,6 +83,19 @@ test('all query terms must match and result limits are stable', () => {
   }])
   assert.deepEqual(searchInstalledApps(apps, 'news missing'), [])
   assert.equal(searchInstalledApps(apps, 'news', 1).length, 1)
+})
+
+test('keyboard search selection starts at the first result and wraps with arrows', () => {
+  assert.equal(resolvedSearchSelection(0, 3), 0)
+  assert.equal(resolvedSearchSelection(-1, 3), 0)
+  assert.equal(resolvedSearchSelection(8, 3), 2)
+  assert.equal(resolvedSearchSelection(0, 0), -1)
+
+  assert.equal(moveSearchSelection(0, 'ArrowDown', 3), 1)
+  assert.equal(moveSearchSelection(2, 'ArrowDown', 3), 0)
+  assert.equal(moveSearchSelection(0, 'ArrowUp', 3), 2)
+  assert.equal(moveSearchSelection(2, 'ArrowUp', 3), 1)
+  assert.equal(moveSearchSelection(0, 'ArrowDown', 0), -1)
 })
 
 test('a changed chat query hides and rejects stale result actions', () => {

--- a/frontend/src/components/GlobalSearch/globalSearchModel.js
+++ b/frontend/src/components/GlobalSearch/globalSearchModel.js
@@ -94,6 +94,19 @@ export function searchInstalledApps(apps, query, limit = 8) {
     .map(({ score: _score, ...result }) => result)
 }
 
+export function resolvedSearchSelection(index, resultCount) {
+  if (resultCount === 0) return -1
+  return Math.min(Math.max(index, 0), resultCount - 1)
+}
+
+export function moveSearchSelection(index, key, resultCount) {
+  const current = resolvedSearchSelection(index, resultCount)
+  if (current === -1) return -1
+  if (key === 'ArrowDown') return (current + 1) % resultCount
+  if (key === 'ArrowUp') return (current - 1 + resultCount) % resultCount
+  return current
+}
+
 // The dialog unmounts on close (NotificationCenter renders it behind
 // `searchOpen &&`), so component state cannot survive a reopen. The owner's
 // last search lives here instead: type a term, open a result, reopen search,


### PR DESCRIPTION
## Summary
- select the first available global-search result while leaving focus in the search field
- navigate app and chat results as one ordered set with ArrowUp/ArrowDown, wrapping at either end
- open the active result with Enter and keep it scrolled into view
- expose active selection through one controlled, grouped listbox and a visible selected state

## Testing
- focused GlobalSearch model tests
- focused ESLint
- structural-test ratchet
- production/PWA build
- rendered Cmd/Ctrl+K → ArrowUp/ArrowDown → Enter flow
- scoped axe accessibility audit (0 violations)
