### PR TITLE
proxy: send an identifiable User-Agent on outbound requests

### DIFF
--- a/backend/app/routes/proxy.py
+++ b/backend/app/routes/proxy.py
@@ -21,6 +21,14 @@ from app.net_utils import validate_url_safe
 
 router = APIRouter(prefix="/api/proxy", tags=["proxy"])
 
+# Identify outbound proxy requests with a real User-Agent. httpx's default
+# ("python-httpx/x.y") is 403'd by several public APIs that require an
+# identifiable client (OSM Nominatim, Photon and others enforce this per their
+# usage policy, and Nominatim additionally asks for a contact URL). A stable
+# app-identifying UA keeps those endpoints usable for every mini-app; same
+# convention as _FAVICON_USER_AGENT below.
+_PROXY_USER_AGENT = "Mobius/1.0 (app proxy; +https://github.com/mobius-os/mobius)"
+
 # Hard limit on response size to avoid pulling in huge payloads.
 _MAX_BYTES = 2 * 1024 * 1024  # 2 MB
 
@@ -339,6 +347,7 @@ async def proxy_get(
   async with httpx.AsyncClient(follow_redirects=False, timeout=15) as client:
     req = client.build_request("GET", pinned_url)
     req.headers["host"] = host_header
+    req.headers["user-agent"] = _PROXY_USER_AGENT
     # httpcore/anyio require text here. Bytes reach idna2008_resolve(), which
     # calls .encode() itself and turns every real HTTPS proxy request into 502.
     req.extensions["sni_hostname"] = sni_host
@@ -361,5 +370,6 @@ async def proxy_post(
       headers={"Content-Type": body.content_type},
     )
     req.headers["host"] = host_header
+    req.headers["user-agent"] = _PROXY_USER_AGENT
     req.extensions["sni_hostname"] = sni_host
     return await _capped_response(client, req)

--- a/backend/tests/test_proxy.py
+++ b/backend/tests/test_proxy.py
@@ -299,6 +299,45 @@ def test_proxy_post_passes_sni_hostname_as_text(
   assert r.text == "ok"
 
 
+def test_proxy_sends_identifiable_user_agent(client, owner_token, monkeypatch):
+  """Both proxy verbs identify themselves instead of using httpx's default.
+
+  Public APIs with client-identification policies (OSM Nominatim, Photon)
+  reject "python-httpx/x.y" with 403, breaking every app that fetches them
+  through the proxy.
+  """
+  from app.routes.proxy import _PROXY_USER_AGENT
+
+  seen = []
+
+  def fake_validate_url_safe(url):
+    return "https://93.184.216.34/data", "example.com", "example.com"
+
+  async def fake_capped_response(_client, req):
+    seen.append(req.headers.get("user-agent"))
+    return Response(content=b"ok", media_type="text/plain")
+
+  monkeypatch.setattr("app.routes.proxy.validate_url_safe", fake_validate_url_safe)
+  monkeypatch.setattr("app.routes.proxy._capped_response", fake_capped_response)
+
+  auth = {"Authorization": f"Bearer {owner_token}"}
+  r = client.get(
+    "/api/proxy",
+    params={"url": "https://example.com/data"},
+    headers=auth,
+  )
+  assert r.status_code == 200
+  r = client.post(
+    "/api/proxy",
+    json={"url": "https://example.com/data", "body": "value=1"},
+    headers=auth,
+  )
+  assert r.status_code == 200
+
+  assert seen == [_PROXY_USER_AGENT, _PROXY_USER_AGENT]
+  assert seen[0].startswith("Mobius/1.0")
+
+
 def test_proxy_forwards_rate_limit_headers():
   class _RateLimitedResponse:
     status_code = 429


### PR DESCRIPTION
## Problem

Requests that mini-apps make through `/api/proxy` go out with httpx's default User-Agent (`python-httpx/x.y`). Several public APIs enforce client-identification policies and reject that UA with 403 — OSM Nominatim and Photon both do — so any app that geocodes or fetches those services through the proxy fails with an opaque error.

## Fix

Send a stable, app-identifying User-Agent on both proxy verbs, following the existing convention for purpose-scoped UA constants (`_FAVICON_USER_AGENT` in the same file, `_DEVICE_ASSET_USER_AGENT` in app_runtime):

```
Mobius/1.0 (app proxy; +https://github.com/mobius-os/mobius)
```

The contact URL is deliberate: Nominatim's usage policy asks for an identifiable agent with a way to reach the operator. The header is set on the built request alongside the existing `host`/`sni_hostname` handling, so redirect pinning and SSRF validation are unchanged.

## Tests

`test_proxy_sends_identifiable_user_agent` asserts both GET and POST carry the constant instead of the httpx default; the full `tests/test_proxy.py` suite passes (25 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)