### PR TITLE
Show when a chat needs owner input

### DIFF
--- a/backend/app/owner_input.py
+++ b/backend/app/owner_input.py
@@ -1,0 +1,38 @@
+"""Shell-level contract for chats waiting on their owner.
+
+Owner-input events carry state only: the kind of interaction that is waiting
+and, for durable questions, the exact id used by the question lifecycle.
+Secure field metadata and values stay on the chat-scoped secure-input channel.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from app.broadcast import get_system_broadcast
+
+
+OwnerInputKind = Literal["question", "secure_input"]
+_QUESTION_ID_UNSET = object()
+
+
+def publish_owner_input_changed(
+  chat_id: str,
+  input_kind: OwnerInputKind | None,
+  *,
+  question_id: str | None | object = _QUESTION_ID_UNSET,
+) -> None:
+  """Tell every shell whether a chat is waiting for owner involvement.
+
+  ``questionId`` is optional rather than always nullable. Question producers
+  include it so the shell can patch the durable question projection; secure
+  inputs omit it so they never overwrite an unrelated question lifecycle.
+  """
+  event = {
+    "type": "chat_owner_input_changed",
+    "chatId": chat_id,
+    "inputKind": input_kind,
+  }
+  if question_id is not _QUESTION_ID_UNSET:
+    event["questionId"] = question_id
+  get_system_broadcast().publish(event)

--- a/backend/app/question_bridge.py
+++ b/backend/app/question_bridge.py
@@ -14,7 +14,7 @@ from collections.abc import MutableMapping, Sequence
 from typing import Any
 from uuid import uuid4
 
-from app.broadcast import get_system_broadcast
+from app.owner_input import publish_owner_input_changed
 from app.pending_questions import PendingQuestion
 
 
@@ -62,11 +62,11 @@ async def park_question(
         "question_id": pending.question_id,
         "questions": payload,
       })
-      get_system_broadcast().publish({
-        "type": "chat_owner_input_changed",
-        "chatId": chat_id,
-        "questionId": pending.question_id,
-      })
+      publish_owner_input_changed(
+        chat_id,
+        "question",
+        question_id=pending.question_id,
+      )
     except Exception as exc:
       raise QuestionPersistenceError(
         "could not save the question"

--- a/backend/app/question_bridge.py
+++ b/backend/app/question_bridge.py
@@ -14,6 +14,7 @@ from collections.abc import MutableMapping, Sequence
 from typing import Any
 from uuid import uuid4
 
+from app.broadcast import get_system_broadcast
 from app.pending_questions import PendingQuestion
 
 
@@ -60,6 +61,11 @@ async def park_question(
         "type": "question",
         "question_id": pending.question_id,
         "questions": payload,
+      })
+      get_system_broadcast().publish({
+        "type": "chat_owner_input_changed",
+        "chatId": chat_id,
+        "questionId": pending.question_id,
       })
     except Exception as exc:
       raise QuestionPersistenceError(

--- a/backend/app/routes/chats.py
+++ b/backend/app/routes/chats.py
@@ -14,7 +14,9 @@ from sqlalchemy import Text, case, cast, func
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from app import activity, auth, chat_search, models, providers, questions
+from app import (
+  activity, auth, chat_search, models, providers, questions, secure_inputs,
+)
 from app.chat_visibility import coerce_agent_settings, visible_in_owner_drawer
 from app.config import get_settings
 from app.chat import (
@@ -30,6 +32,7 @@ from app.chat_retention import purge_expired_chat_tombstones
 from app.chat_titles import first_user_message_title
 from app.database import get_db
 from app.memory_observability import record_memory_checkpoint_once
+from app.owner_input import OwnerInputKind
 from app.deps import (
   Principal, get_owner_or_chat_embed_principal, get_current_owner, get_principal,
   reject_cross_site,
@@ -323,7 +326,12 @@ def issue_media_token(
   return {"token": token, "expires_in": 900}
 
 
-def _owner_chat_summary(chat, *, durable_running: bool = False) -> dict:
+def _owner_chat_summary(
+  chat,
+  *,
+  durable_running: bool = False,
+  transient_owner_input_kind: OwnerInputKind | None = None,
+) -> dict:
   """Canonical owner-list shape for a Chat or its lightweight projection."""
   return {
     "id": chat.id,
@@ -339,6 +347,14 @@ def _owner_chat_summary(chat, *, durable_running: bool = False) -> dict:
     # shell excludes it from the reload-defer's active-turn test. The durable
     # column is the source of truth (see `_open_question_id_for`).
     "pending_question_id": chat.pending_question_id,
+    # The shell only needs to know which non-secret interaction is waiting.
+    # Questions win if a transient interaction somehow overlaps because their
+    # durable id also governs answer routing and restart recovery.
+    "owner_input_kind": (
+      "question"
+      if chat.pending_question_id is not None
+      else transient_owner_input_kind
+    ),
   }
 
 
@@ -582,13 +598,18 @@ def list_chats(
     # owner conversation into the drawer by setting owner_visible at creation.
     chats = [c for c in chats if _visible_in_owner_drawer(c)]
   durable_running = running_chat_ids(db, (chat.id for chat in chats))
+  secure_input_chats = secure_inputs.pending_chat_ids()
   record_memory_checkpoint_once(
     "shell_chat_list_first_response",
     chat_count=len(chats),
   )
   return [
     _owner_chat_summary(
-      chat, durable_running=chat.id in durable_running,
+      chat,
+      durable_running=chat.id in durable_running,
+      transient_owner_input_kind=(
+        "secure_input" if chat.id in secure_input_chats else None
+      ),
     )
     for chat in chats
   ]

--- a/backend/app/routes/chats_stream.py
+++ b/backend/app/routes/chats_stream.py
@@ -640,6 +640,11 @@ async def send_message(
             "question_id": body.question_id or pending.question_id,
             "answers": body.answers,
           })
+        get_system_broadcast().publish({
+          "type": "chat_owner_input_changed",
+          "chatId": chat_id,
+          "questionId": None,
+        })
         return _answer_delivered_response(chat_id)
       # No in-memory pending question. If the chat is still alive, this is a
       # stale/foreign card (or Stop cancelled the question) and must not answer

--- a/backend/app/routes/chats_stream.py
+++ b/backend/app/routes/chats_stream.py
@@ -41,6 +41,7 @@ from app.runner_registry import RunnerKind, registry
 from app.config import get_settings
 from app.database import get_db
 from app.memory_observability import record_memory_checkpoint_once
+from app.owner_input import publish_owner_input_changed
 from app.deps import (
   Principal, get_chat_view_principal, get_owner_or_chat_embed_principal,
   get_current_owner, reject_cross_site,
@@ -640,11 +641,7 @@ async def send_message(
             "question_id": body.question_id or pending.question_id,
             "answers": body.answers,
           })
-        get_system_broadcast().publish({
-          "type": "chat_owner_input_changed",
-          "chatId": chat_id,
-          "questionId": None,
-        })
+        publish_owner_input_changed(chat_id, None, question_id=None)
         return _answer_delivered_response(chat_id)
       # No in-memory pending question. If the chat is still alive, this is a
       # stale/foreign card (or Stop cancelled the question) and must not answer

--- a/backend/app/routes/secure_inputs.py
+++ b/backend/app/routes/secure_inputs.py
@@ -82,19 +82,12 @@ async def create_secure_input(
       description=description,
       fields=fields,
     )
+    secure_inputs.publish_request(pending)
   except ValueError as exc:
     raise HTTPException(409, detail=str(exc)) from exc
   except RuntimeError as exc:
     raise HTTPException(503, detail=str(exc)) from exc
 
-  # Route through the turn's sink when present: it owns both the live event and
-  # the durable safe receipt. The event contains prompt metadata only.
-  from app.chat_event_sink import get_active_sink
-  sink = get_active_sink(chat_id)
-  if sink is not None and sink.bc is bc:
-    sink.publish(pending.public_event())
-  else:
-    bc.publish(pending.public_event())
   return {
     "request_id": pending.request_id,
     "capability": capability,

--- a/backend/app/secure_inputs.py
+++ b/backend/app/secure_inputs.py
@@ -21,6 +21,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from app.broadcast import get_broadcast
+from app.owner_input import publish_owner_input_changed
 
 
 REQUEST_TTL_SECONDS = 15 * 60
@@ -211,13 +212,18 @@ def _capability_matches(request: SecureInputRequest, capability: str) -> bool:
 
 
 def _publish(request: SecureInputRequest, event_type: str) -> None:
-  bc = get_broadcast(request.chat_id)
-  if bc is not None and bc.running:
-    event = {
+  event = (
+    request.public_event()
+    if event_type == "secure_input_request"
+    else {
       "type": event_type,
       "request_id": request.request_id,
       "status": request.status,
     }
+  )
+  bc = get_broadcast(request.chat_id)
+  chat_event_published = False
+  if bc is not None and bc.running:
     # The live sink owns both broadcast and chat persistence. Import lazily to
     # avoid the module cycle: ChatEventSink imports this module's reveal scrub.
     from app.chat_event_sink import get_active_sink
@@ -228,6 +234,9 @@ def _publish(request: SecureInputRequest, event_type: str) -> None:
       # Defensive fallback for synthetic/tests or a teardown race. Values are
       # still absent; the active production path always has the owning sink.
       bc.publish(event)
+    chat_event_published = True
+  if event_type == "secure_input_request" and not chat_event_published:
+    raise RuntimeError("This chat is not running.")
 
 
 def _clear_values(request: SecureInputRequest) -> None:
@@ -244,12 +253,15 @@ def _settle(
 ) -> None:
   if request.status in {"completed", "failed", "cancelled", "expired"}:
     return
+  was_waiting_for_owner = request.status == "pending"
   _clear_values(request)
   request.status = status
   request.result = result
   request.settled_at = time.monotonic()
   request.event.set()
   _publish(request, "secure_input_settled")
+  if was_waiting_for_owner:
+    publish_owner_input_changed(request.chat_id, None)
 
 
 def _cleanup() -> None:
@@ -320,6 +332,31 @@ def get_request(request_id: str) -> SecureInputRequest | None:
   return _requests.get(request_id)
 
 
+def pending_chat_ids() -> frozenset[str]:
+  """Snapshot chats whose secure-input card still needs owner involvement."""
+  _cleanup()
+  return frozenset(
+    request.chat_id
+    for request in _requests.values()
+    if request.status == "pending"
+  )
+
+
+def publish_request(request: SecureInputRequest) -> None:
+  """Publish one newly registered prompt through both of its safe channels."""
+  if request.status != "pending":
+    raise ValueError("Secure input request is no longer open.")
+  try:
+    _publish(request, "secure_input_request")
+    publish_owner_input_changed(request.chat_id, "secure_input")
+  except Exception:
+    # No value has been submitted yet. Remove an unpresented request so a
+    # failed/racing publish cannot strand the chat behind an invisible card.
+    if _requests.get(request.request_id) is request:
+      _requests.pop(request.request_id, None)
+    raise
+
+
 def authorize(
   request_id: str, capability: str,
 ) -> SecureInputRequest | None:
@@ -336,6 +373,7 @@ def fill_request(request: SecureInputRequest, values: dict[str, str]) -> None:
   request.status = "filled"
   request.event.set()
   _publish(request, "secure_input_filled")
+  publish_owner_input_changed(request.chat_id, None)
 
 
 def consume_request(request: SecureInputRequest) -> dict[str, str]:

--- a/backend/tests/test_chats_stream_answer_race.py
+++ b/backend/tests/test_chats_stream_answer_race.py
@@ -160,11 +160,22 @@ def _activity_at(chat_id: str) -> datetime:
 
 
 def test_answer_delivers_immediately_when_pending_registered(
-  client, auth, chat,
+  client, auth, chat, monkeypatch,
 ):
   """Pending question already in the registry — POST resolves the
   future and returns 202 answer_delivered without any waiting."""
   async def go():
+    system_events = []
+
+    class _SystemEvents:
+      def publish(self, event):
+        system_events.append(event)
+
+    monkeypatch.setattr(
+      chats_stream,
+      "get_system_broadcast",
+      lambda: _SystemEvents(),
+    )
     loop = asyncio.get_event_loop()
     fut = loop.create_future()
     pending = _make_pending(fut)
@@ -195,6 +206,11 @@ def test_answer_delivers_immediately_when_pending_registered(
     assert fut.result() == {"Pick one": "a"}
     # Registry cleared atomically by claim().
     assert questions.get(chat.id) is None
+    assert system_events == [{
+      "type": "chat_owner_input_changed",
+      "chatId": chat.id,
+      "questionId": None,
+    }]
     assert _activity_at(chat.id).replace(tzinfo=UTC) > old_activity
     # No grace-period delay on the happy path. 500ms cap; 250ms
     # leaves comfortable headroom for slow CI without making the

--- a/backend/tests/test_chats_stream_answer_race.py
+++ b/backend/tests/test_chats_stream_answer_race.py
@@ -214,10 +214,9 @@ def test_answer_delivers_immediately_when_pending_registered(
       "questionId": None,
     }]
     assert _activity_at(chat.id).replace(tzinfo=UTC) > old_activity
-    # No grace-period delay on the happy path. 500ms cap; 250ms
-    # leaves comfortable headroom for slow CI without making the
-    # test useless.
-    assert elapsed < 0.25, (
+    # No grace-period delay on the happy path. A 500ms cap leaves comfortable
+    # headroom for slow CI while still catching the old one-second wait.
+    assert elapsed < 0.5, (
       f"happy path waited unexpectedly long: {elapsed:.3f}s"
     )
 

--- a/backend/tests/test_chats_stream_answer_race.py
+++ b/backend/tests/test_chats_stream_answer_race.py
@@ -167,14 +167,15 @@ def test_answer_delivers_immediately_when_pending_registered(
   async def go():
     system_events = []
 
-    class _SystemEvents:
-      def publish(self, event):
-        system_events.append(event)
-
     monkeypatch.setattr(
       chats_stream,
-      "get_system_broadcast",
-      lambda: _SystemEvents(),
+      "publish_owner_input_changed",
+      lambda chat_id, input_kind, *, question_id: system_events.append({
+        "type": "chat_owner_input_changed",
+        "chatId": chat_id,
+        "inputKind": input_kind,
+        "questionId": question_id,
+      }),
     )
     loop = asyncio.get_event_loop()
     fut = loop.create_future()
@@ -209,6 +210,7 @@ def test_answer_delivers_immediately_when_pending_registered(
     assert system_events == [{
       "type": "chat_owner_input_changed",
       "chatId": chat.id,
+      "inputKind": None,
       "questionId": None,
     }]
     assert _activity_at(chat.id).replace(tzinfo=UTC) > old_activity

--- a/backend/tests/test_owner_input.py
+++ b/backend/tests/test_owner_input.py
@@ -1,0 +1,49 @@
+"""Safe shell-level owner-input event contract."""
+
+from app import owner_input
+
+
+def test_owner_input_event_keeps_question_identity_optional(monkeypatch):
+  events = []
+
+  class _SystemEvents:
+    def publish(self, event):
+      events.append(event)
+
+  monkeypatch.setattr(
+    owner_input,
+    "get_system_broadcast",
+    lambda: _SystemEvents(),
+  )
+
+  owner_input.publish_owner_input_changed("chat-1", "secure_input")
+  owner_input.publish_owner_input_changed(
+    "chat-2",
+    "question",
+    question_id="question-1",
+  )
+  owner_input.publish_owner_input_changed(
+    "chat-2",
+    None,
+    question_id=None,
+  )
+
+  assert events == [
+    {
+      "type": "chat_owner_input_changed",
+      "chatId": "chat-1",
+      "inputKind": "secure_input",
+    },
+    {
+      "type": "chat_owner_input_changed",
+      "chatId": "chat-2",
+      "inputKind": "question",
+      "questionId": "question-1",
+    },
+    {
+      "type": "chat_owner_input_changed",
+      "chatId": "chat-2",
+      "inputKind": None,
+      "questionId": None,
+    },
+  ]

--- a/backend/tests/test_question_bridge.py
+++ b/backend/tests/test_question_bridge.py
@@ -35,13 +35,14 @@ def test_park_question_publishes_before_waiting_and_cleans_exact_entry(
     bus = _Bus()
     system_events = []
 
-    class _SystemEvents:
-      def publish(self, event):
-        system_events.append(event)
-
     monkeypatch.setattr(
-      "app.question_bridge.get_system_broadcast",
-      lambda: _SystemEvents(),
+      "app.question_bridge.publish_owner_input_changed",
+      lambda chat_id, input_kind, *, question_id: system_events.append({
+        "type": "chat_owner_input_changed",
+        "chatId": chat_id,
+        "inputKind": input_kind,
+        "questionId": question_id,
+      }),
     )
     task = asyncio.create_task(park_question(
       chat_id="chat-1",
@@ -61,6 +62,7 @@ def test_park_question_publishes_before_waiting_and_cleans_exact_entry(
     assert system_events == [{
       "type": "chat_owner_input_changed",
       "chatId": "chat-1",
+      "inputKind": "question",
       "questionId": pending.question_id,
     }]
     pending.future.set_result({"Pick": "First"})

--- a/backend/tests/test_question_bridge.py
+++ b/backend/tests/test_question_bridge.py
@@ -27,10 +27,22 @@ class _Bus:
     self.events.append(event)
 
 
-def test_park_question_publishes_before_waiting_and_cleans_exact_entry():
+def test_park_question_publishes_before_waiting_and_cleans_exact_entry(
+  monkeypatch,
+):
   async def exercise():
     registry: dict[str, PendingQuestion] = {}
     bus = _Bus()
+    system_events = []
+
+    class _SystemEvents:
+      def publish(self, event):
+        system_events.append(event)
+
+    monkeypatch.setattr(
+      "app.question_bridge.get_system_broadcast",
+      lambda: _SystemEvents(),
+    )
     task = asyncio.create_task(park_question(
       chat_id="chat-1",
       questions=[{"question": "Pick"}],
@@ -45,6 +57,11 @@ def test_park_question_publishes_before_waiting_and_cleans_exact_entry():
       "type": "question",
       "question_id": pending.question_id,
       "questions": [{"question": "Pick"}],
+    }]
+    assert system_events == [{
+      "type": "chat_owner_input_changed",
+      "chatId": "chat-1",
+      "questionId": pending.question_id,
     }]
     pending.future.set_result({"Pick": "First"})
     assert await task == {"Pick": "First"}

--- a/backend/tests/test_secure_inputs.py
+++ b/backend/tests/test_secure_inputs.py
@@ -105,6 +105,102 @@ def test_sealed_values_never_enter_events_status_or_chat(
   assert chat.pending_messages == []
 
 
+def test_pending_secure_input_projects_one_generic_owner_input_state(
+  client, auth, chat, monkeypatch,
+):
+  from app import secure_inputs
+
+  owner_input_events = []
+  monkeypatch.setattr(
+    secure_inputs,
+    "publish_owner_input_changed",
+    lambda chat_id, input_kind: owner_input_events.append({
+      "chat_id": chat_id,
+      "input_kind": input_kind,
+    }),
+  )
+
+  _, created = _create_request(client, auth, chat)
+  assert owner_input_events == [{
+    "chat_id": chat.id,
+    "input_kind": "secure_input",
+  }]
+  assert secure_inputs.pending_chat_ids() == frozenset({chat.id})
+
+  listed = client.get("/api/chats", headers=auth)
+  row = next(item for item in listed.json() if item["id"] == chat.id)
+  assert row["owner_input_kind"] == "secure_input"
+  assert row["pending_question_id"] is None
+  assert "capability" not in json.dumps(row)
+
+  submitted = client.post(
+    f"/api/secure-inputs/{chat.id}/{created['request_id']}/submit",
+    headers=auth,
+    json={
+      "fields": {
+        "username": "private-owner@example.test",
+        "password": "still-never-list-this",
+      },
+    },
+  )
+  assert submitted.status_code == 200
+  assert owner_input_events[-1] == {
+    "chat_id": chat.id,
+    "input_kind": None,
+  }
+  assert secure_inputs.pending_chat_ids() == frozenset()
+
+  listed = client.get("/api/chats", headers=auth)
+  row = next(item for item in listed.json() if item["id"] == chat.id)
+  assert row["owner_input_kind"] is None
+
+  # Settlement after submission does not repeat the already-cleared shell
+  # transition and trigger another cache reconciliation.
+  secure_inputs.cancel_request(secure_inputs.get_request(created["request_id"]))
+  assert [event["input_kind"] for event in owner_input_events] == [
+    "secure_input", None,
+  ]
+
+  # Cancelling while the card itself is still pending does clear the marker.
+  _, second = _create_request(client, auth, chat)
+  cancelled = client.post(
+    f"/api/secure-inputs/{second['request_id']}/cancel",
+    json={"capability": second["capability"]},
+  )
+  assert cancelled.status_code == 200
+  assert [event["input_kind"] for event in owner_input_events] == [
+    "secure_input", None, "secure_input", None,
+  ]
+
+
+def test_failed_prompt_publish_does_not_leave_an_invisible_open_request(
+  client, auth, chat, monkeypatch,
+):
+  from app import secure_inputs
+  from app.broadcast import create_broadcast
+
+  create_broadcast(chat.id)
+  monkeypatch.setattr(secure_inputs, "get_broadcast", lambda _chat_id: None)
+
+  response = client.post(
+    f"/api/secure-inputs/{chat.id}",
+    headers=auth,
+    json={
+      "mode": "sealed",
+      "title": "Private connection",
+      "description": "Values bypass model context.",
+      "fields": [{
+        "name": "password",
+        "label": "Password",
+        "type": "password",
+      }],
+    },
+  )
+
+  assert response.status_code == 503
+  assert secure_inputs.pending_chat_ids() == frozenset()
+
+
 def test_sink_builds_a_persistable_prompt_only_receipt(client, auth, chat):
   from app.broadcast import create_broadcast
   from app.chat_event_sink import (

--- a/frontend/src/components/Drawer/Drawer.css
+++ b/frontend/src/components/Drawer/Drawer.css
@@ -797,6 +797,21 @@
   background: var(--accent);
 }
 
+/* "The agent needs YOUR answer" — amber is reserved here for a blocked
+   handoff, while the diamond silhouette keeps the state distinguishable
+   without colour. Mixing the amber toward --text preserves 3:1+ contrast
+   against the drawer in both built-in themes without adding a second theme
+   palette that custom themes would have to maintain. */
+.drawer__owner-input-dot {
+  flex-shrink: 0;
+  width: 6px;
+  height: 6px;
+  margin-right: 2px;
+  border-radius: 1px;
+  background: color-mix(in srgb, #f59e0b 60%, var(--text));
+  transform: rotate(45deg);
+}
+
 /* "The latest background run FINISHED while you were elsewhere" — a
    different row state from the streaming dot above, and it has to stay
    legible as one now that motion no longer separates them. Colour alone

--- a/frontend/src/components/Drawer/Drawer.css
+++ b/frontend/src/components/Drawer/Drawer.css
@@ -808,7 +808,7 @@
   height: 6px;
   margin-right: 2px;
   border-radius: 1px;
-  background: color-mix(in srgb, #f59e0b 60%, var(--text));
+  background: color-mix(in srgb, var(--owner-input, #f59e0b) 60%, var(--text));
   transform: rotate(45deg);
 }
 

--- a/frontend/src/components/Drawer/Drawer.jsx
+++ b/frontend/src/components/Drawer/Drawer.jsx
@@ -105,9 +105,9 @@ export default function Drawer({
   // active across the whole app). Defaults to an empty Set so the
   // drawer renders cleanly if no parent supplies the prop.
   streamingChatIds,
-  // Set of chat ids parked on a question that needs the owner's answer.
-  // This state takes visual precedence over streaming because the agent
-  // cannot make progress until the owner acts.
+  // Set of chat ids with an interaction waiting on the owner. This state takes
+  // visual precedence over streaming because the agent cannot make progress
+  // until the owner acts.
   ownerInputChatIds,
   // Set of chat ids whose latest background run finished while the
   // user was elsewhere. Rendered as a green attention dot, distinct by

--- a/frontend/src/components/Drawer/Drawer.jsx
+++ b/frontend/src/components/Drawer/Drawer.jsx
@@ -105,6 +105,10 @@ export default function Drawer({
   // active across the whole app). Defaults to an empty Set so the
   // drawer renders cleanly if no parent supplies the prop.
   streamingChatIds,
+  // Set of chat ids parked on a question that needs the owner's answer.
+  // This state takes visual precedence over streaming because the agent
+  // cannot make progress until the owner acts.
+  ownerInputChatIds,
   // Set of chat ids whose latest background run finished while the
   // user was elsewhere. Rendered as a green attention dot, distinct by
   // colour from the accent streaming dot above (neither animates).
@@ -125,6 +129,7 @@ export default function Drawer({
   drawerRowGesturesRef,
 }) {
   const streamingSet = streamingChatIds || EMPTY_SET
+  const ownerInputSet = ownerInputChatIds || EMPTY_SET
   const attentionSet = attentionChatIds || EMPTY_SET
   const newAppSet = newAppIds || EMPTY_SET
   // One source of truth for which row the focused pane is showing, so a chat
@@ -1113,6 +1118,9 @@ export default function Drawer({
                       kind={kind}
                       item={item}
                       surface="drawer"
+                      needsOwnerInput={kind === 'chat'
+                        ? ownerInputSet.has(item.id)
+                        : !!(item.chat_id && ownerInputSet.has(item.chat_id))}
                       streaming={kind === 'chat' && streamingSet.has(item.id)}
                       building={kind === 'app' && !!(item.chat_id && streamingSet.has(item.chat_id))}
                       attention={kind === 'chat'
@@ -1153,6 +1161,9 @@ export default function Drawer({
                     kind={kind}
                     item={item}
                     surface="drawer"
+                    needsOwnerInput={kind === 'chat'
+                      ? ownerInputSet.has(item.id)
+                      : !!(item.chat_id && ownerInputSet.has(item.chat_id))}
                     streaming={kind === 'chat' && streamingSet.has(item.id)}
                     building={kind === 'app' && !!(item.chat_id && streamingSet.has(item.chat_id))}
                     attention={kind === 'chat'
@@ -1246,6 +1257,7 @@ export default function Drawer({
               item={app}
               variant="card"
               surface="directory"
+              needsOwnerInput={!!(app.chat_id && ownerInputSet.has(app.chat_id))}
               building={!!(app.chat_id && streamingSet.has(app.chat_id))}
               attention={newAppSet.has(Number(app.id))}
               active={activeView === 'canvas' && Number(activeAppId) === Number(app.id)}
@@ -1336,6 +1348,7 @@ const DrawerRow = memo(function DrawerRow({
   variant = 'row',
   surface = 'drawer',
   active,
+  needsOwnerInput,
   streaming,
   // App rows only: the app's owning chat is streaming, i.e. the agent is
   // actively building/editing this app right now. Reuses the streaming
@@ -1926,7 +1939,14 @@ const DrawerRow = memo(function DrawerRow({
         {/* Status dot. Sits before the text so the user's eye
             picks it up alongside the label rather than at the row's
             edge (where the pin lives). aria-label exposes the state. */}
-        {streaming ? (
+        {needsOwnerInput ? (
+          <span
+            className="drawer__owner-input-dot"
+            role="img"
+            aria-label="Your input is needed"
+            title="Your input is needed"
+          />
+        ) : streaming ? (
           <span
             className="drawer__streaming-dot"
             aria-label="Currently streaming"

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -82,8 +82,9 @@ import {
   withoutConfirmedDeletions,
 } from './confirmedDeletion.js'
 import {
+  ownerInputChangeFromEvent,
   withChatOwnerActivity,
-  withChatPendingQuestion,
+  withChatOwnerInput,
   withChatRename,
   withChatRunState,
 } from './chatListProjection.js'
@@ -1589,7 +1590,11 @@ export default function Shell({ onInitialVisualReady }) {
   const ownerInputChatIds = useMemo(() => {
     const next = new Set()
     for (const chat of chats) {
-      if (chat.pending_question_id != null) next.add(chat.id)
+      if (
+        chat.owner_input_kind != null
+        // Compatibility with the prior list shape during live activation.
+        || chat.pending_question_id != null
+      ) next.add(chat.id)
     }
     return next
   }, [chats])
@@ -1853,8 +1858,8 @@ export default function Shell({ onInitialVisualReady }) {
       running,
     ))
   }, [projectChatList])
-  const markChatPendingQuestion = useCallback((chatId, questionId) => {
-    projectChatList(rows => withChatPendingQuestion(rows, chatId, questionId))
+  const markChatOwnerInput = useCallback((chatId, change) => {
+    projectChatList(rows => withChatOwnerInput(rows, chatId, change))
   }, [projectChatList])
   const applyChatRenameEvent = useCallback((event) => {
     projectChatList(rows => withChatRename(rows, event.chatId, {
@@ -2447,16 +2452,11 @@ export default function Shell({ onInitialVisualReady }) {
       })
     } else if (ev.type === 'chat_owner_input_changed') {
       if (ev.chatId) {
-        const knownInDrawer = chatsRef.current.some(
-          c => String(c.id) === String(ev.chatId),
-        )
-        markChatPendingQuestion(ev.chatId, ev.questionId)
-        // A background/system-created chat can ask before its start-event list
-        // refresh has inserted the row. The question was committed before this
-        // event, so a fresh read is authoritative and cannot lose the marker.
-        if (ev.questionId && !knownInDrawer) {
-          void invalidateShellListCache('chats').then(refreshChats)
-        }
+        markChatOwnerInput(ev.chatId, ownerInputChangeFromEvent(ev))
+        // Patch immediately, then reconcile durable/transient server truth and
+        // refill the PWA's list cache. Input transitions are rare, and always
+        // refreshing avoids stale offline markers and missing background rows.
+        void invalidateShellListCache('chats').then(refreshChats)
       }
     } else if (ev.type === 'chat_run_started') {
       if (ev.chatId) {
@@ -2469,7 +2469,7 @@ export default function Shell({ onInitialVisualReady }) {
         markChatRunActivity(ev.chatId)
         markStreamingStart(ev.chatId)
         markChatRunState(ev.chatId, true)
-        markChatPendingQuestion(ev.chatId, null)
+        markChatOwnerInput(ev.chatId, { kind: null, questionId: null })
         // A run can be the drawer's FIRST evidence of a chat created entirely
         // server-side — the platform/app conflict resolver, a background or
         // morning agent, autopilot. selectChat only navigates; it never
@@ -2489,7 +2489,7 @@ export default function Shell({ onInitialVisualReady }) {
         markChatRunFinished(chatId)
         markStreamingEnd(chatId)
         markChatRunState(chatId, false)
-        markChatPendingQuestion(chatId, null)
+        markChatOwnerInput(chatId, { kind: null, questionId: null })
         // Attention iff the finished chat is NOT visible in ANY pane — membership
         // in the visible set, not equality with one global id, so a chat visible
         // in a background split gets no false dot (finding D-iii).
@@ -2553,7 +2553,7 @@ export default function Shell({ onInitialVisualReady }) {
     confirmAppDeleted, confirmAppIdentityIsLive, confirmAppRecovered,
     confirmChatDeleted, confirmChatIdentityIsLive, confirmChatRecovered,
     loadTheme, markChatRunActivity, markChatRunFinished,
-    markChatPendingQuestion, markChatRunState, markStreamingEnd, markStreamingStart,
+    markChatOwnerInput, markChatRunState, markStreamingEnd, markStreamingStart,
     onNotificationCreated, placeInWorkspace, queryClient,
     refreshApps, refreshChats, warmAppCode,
   ])

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -83,6 +83,7 @@ import {
 } from './confirmedDeletion.js'
 import {
   withChatOwnerActivity,
+  withChatPendingQuestion,
   withChatRename,
   withChatRunState,
 } from './chatListProjection.js'
@@ -1585,6 +1586,13 @@ export default function Shell({ onInitialVisualReady }) {
     }
     return next
   }, [localStreamingChatIds, chats])
+  const ownerInputChatIds = useMemo(() => {
+    const next = new Set()
+    for (const chat of chats) {
+      if (chat.pending_question_id != null) next.add(chat.id)
+    }
+    return next
+  }, [chats])
   const streamingChatIdsRef = useRef(streamingChatIds)
   useEffect(() => { streamingChatIdsRef.current = streamingChatIds }, [streamingChatIds])
   // Whether the chat the owner is looking at is parked on an AskUserQuestion
@@ -1844,6 +1852,9 @@ export default function Shell({ onInitialVisualReady }) {
       chatId,
       running,
     ))
+  }, [projectChatList])
+  const markChatPendingQuestion = useCallback((chatId, questionId) => {
+    projectChatList(rows => withChatPendingQuestion(rows, chatId, questionId))
   }, [projectChatList])
   const applyChatRenameEvent = useCallback((event) => {
     projectChatList(rows => withChatRename(rows, event.chatId, {
@@ -2434,6 +2445,19 @@ export default function Shell({ onInitialVisualReady }) {
           onAction: () => navToRef.current('canvas', { appId: appStore.id }),
         } : undefined,
       })
+    } else if (ev.type === 'chat_owner_input_changed') {
+      if (ev.chatId) {
+        const knownInDrawer = chatsRef.current.some(
+          c => String(c.id) === String(ev.chatId),
+        )
+        markChatPendingQuestion(ev.chatId, ev.questionId)
+        // A background/system-created chat can ask before its start-event list
+        // refresh has inserted the row. The question was committed before this
+        // event, so a fresh read is authoritative and cannot lose the marker.
+        if (ev.questionId && !knownInDrawer) {
+          void invalidateShellListCache('chats').then(refreshChats)
+        }
+      }
     } else if (ev.type === 'chat_run_started') {
       if (ev.chatId) {
         // Capture drawer membership BEFORE the mark* projections below: those
@@ -2445,6 +2469,7 @@ export default function Shell({ onInitialVisualReady }) {
         markChatRunActivity(ev.chatId)
         markStreamingStart(ev.chatId)
         markChatRunState(ev.chatId, true)
+        markChatPendingQuestion(ev.chatId, null)
         // A run can be the drawer's FIRST evidence of a chat created entirely
         // server-side — the platform/app conflict resolver, a background or
         // morning agent, autopilot. selectChat only navigates; it never
@@ -2464,6 +2489,7 @@ export default function Shell({ onInitialVisualReady }) {
         markChatRunFinished(chatId)
         markStreamingEnd(chatId)
         markChatRunState(chatId, false)
+        markChatPendingQuestion(chatId, null)
         // Attention iff the finished chat is NOT visible in ANY pane — membership
         // in the visible set, not equality with one global id, so a chat visible
         // in a background split gets no false dot (finding D-iii).
@@ -2527,7 +2553,7 @@ export default function Shell({ onInitialVisualReady }) {
     confirmAppDeleted, confirmAppIdentityIsLive, confirmAppRecovered,
     confirmChatDeleted, confirmChatIdentityIsLive, confirmChatRecovered,
     loadTheme, markChatRunActivity, markChatRunFinished,
-    markChatRunState, markStreamingEnd, markStreamingStart,
+    markChatPendingQuestion, markChatRunState, markStreamingEnd, markStreamingStart,
     onNotificationCreated, placeInWorkspace, queryClient,
     refreshApps, refreshChats, warmAppCode,
   ])
@@ -3621,6 +3647,7 @@ export default function Shell({ onInitialVisualReady }) {
         onNowPlayingOpen={handleNowPlayingOpen}
         onNowPlayingControl={handleNowPlayingControl}
         streamingChatIds={streamingChatIds}
+        ownerInputChatIds={ownerInputChatIds}
         attentionChatIds={attentionChatIds}
         newAppIds={appAttentionSet}
         settingsWarning={providerAuth.needsAttention}

--- a/frontend/src/components/Shell/__tests__/chatListProjection.test.js
+++ b/frontend/src/components/Shell/__tests__/chatListProjection.test.js
@@ -1,9 +1,10 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import {
+  ownerInputChangeFromEvent,
   withChatListRowPatch,
   withChatOwnerActivity,
-  withChatPendingQuestion,
+  withChatOwnerInput,
   withChatRename,
   withChatRunState,
 } from '../chatListProjection.js'
@@ -44,11 +45,39 @@ test('run and rename events project only the committed fields they carry', () =>
   assert.equal(renamed[0].updated_at, '2026-08-01T12:30:00Z')
 })
 
-test('pending-question events project the durable owner-input marker', () => {
-  const waiting = withChatPendingQuestion(rows, 'a', 'question-1')
+test('owner-input events project kind while only questions update their durable id', () => {
+  const waiting = withChatOwnerInput(rows, 'a', {
+    kind: 'question',
+    questionId: 'question-1',
+  })
+  assert.equal(waiting[0].owner_input_kind, 'question')
   assert.equal(waiting[0].pending_question_id, 'question-1')
   assert.equal(waiting[1], rows[1])
 
-  const answered = withChatPendingQuestion(waiting, 'a', null)
+  const secure = withChatOwnerInput(waiting, 'a', { kind: 'secure_input' })
+  assert.equal(secure[0].owner_input_kind, 'secure_input')
+  assert.equal(secure[0].pending_question_id, 'question-1')
+
+  const answered = withChatOwnerInput(waiting, 'a', {
+    kind: null,
+    questionId: null,
+  })
+  assert.equal(answered[0].owner_input_kind, null)
   assert.equal(answered[0].pending_question_id, null)
+})
+
+test('owner-input event normalization supports both shell generations', () => {
+  assert.deepEqual(ownerInputChangeFromEvent({
+    inputKind: 'secure_input',
+  }), { kind: 'secure_input' })
+  assert.deepEqual(ownerInputChangeFromEvent({
+    inputKind: 'question',
+    questionId: 'question-1',
+  }), { kind: 'question', questionId: 'question-1' })
+  assert.deepEqual(ownerInputChangeFromEvent({
+    questionId: 'legacy-question',
+  }), { kind: 'question', questionId: 'legacy-question' })
+  assert.deepEqual(ownerInputChangeFromEvent({
+    questionId: null,
+  }), { kind: null, questionId: null })
 })

--- a/frontend/src/components/Shell/__tests__/chatListProjection.test.js
+++ b/frontend/src/components/Shell/__tests__/chatListProjection.test.js
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict'
 import {
   withChatListRowPatch,
   withChatOwnerActivity,
+  withChatPendingQuestion,
   withChatRename,
   withChatRunState,
 } from '../chatListProjection.js'
@@ -41,4 +42,13 @@ test('run and rename events project only the committed fields they carry', () =>
   })
   assert.equal(renamed[0].title, 'Current topic')
   assert.equal(renamed[0].updated_at, '2026-08-01T12:30:00Z')
+})
+
+test('pending-question events project the durable owner-input marker', () => {
+  const waiting = withChatPendingQuestion(rows, 'a', 'question-1')
+  assert.equal(waiting[0].pending_question_id, 'question-1')
+  assert.equal(waiting[1], rows[1])
+
+  const answered = withChatPendingQuestion(waiting, 'a', null)
+  assert.equal(answered[0].pending_question_id, null)
 })

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -861,8 +861,8 @@ test('opening navigation is presentation-only and never refetches whole lists', 
 test('chat drawer indicators distinguish owner input, active work, and unseen completion', () => {
   assert.match(
     shell,
-    /ev\.type === 'chat_owner_input_changed'[\s\S]*?markChatPendingQuestion\(ev\.chatId, ev\.questionId\)[\s\S]*?ev\.questionId && !knownInDrawer[\s\S]*?refreshChats/,
-    'an owner-input event must project the durable marker and recover a missing background row',
+    /ev\.type === 'chat_owner_input_changed'[\s\S]*?markChatOwnerInput\(ev\.chatId, ownerInputChangeFromEvent\(ev\)\)[\s\S]*?invalidateShellListCache\('chats'\)\.then\(refreshChats\)/,
+    'an owner-input event must project immediately and reconcile the durable PWA cache',
   )
   assert.match(
     shell,
@@ -885,7 +885,7 @@ test('chat drawer indicators distinguish owner input, active work, and unseen co
     'owner input must take precedence over active work and unseen completion',
   )
   assert.match(drawerCss, /\.drawer__owner-input-dot\s*\{[\s\S]*?transform:\s*rotate\(45deg\)/)
-  assert.match(drawerCss, /\.drawer__owner-input-dot\s*\{[\s\S]*?#f59e0b/)
+  assert.match(drawerCss, /\.drawer__owner-input-dot\s*\{[\s\S]*?var\(--owner-input, #f59e0b\)/)
   assert.match(drawerCss, /\.drawer__streaming-dot\s*\{[\s\S]*?background:\s*var\(--accent\)/)
   assert.match(drawerCss, /\.drawer__attention-dot\s*\{[\s\S]*?border:\s*1\.5px solid var\(--green\)/)
 })

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -858,7 +858,12 @@ test('opening navigation is presentation-only and never refetches whole lists', 
     'a run started in another live client must still advance drawer recency')
 })
 
-test('chat drawer dots distinguish active work from unseen completion', () => {
+test('chat drawer indicators distinguish owner input, active work, and unseen completion', () => {
+  assert.match(
+    shell,
+    /ev\.type === 'chat_owner_input_changed'[\s\S]*?markChatPendingQuestion\(ev\.chatId, ev\.questionId\)[\s\S]*?ev\.questionId && !knownInDrawer[\s\S]*?refreshChats/,
+    'an owner-input event must project the durable marker and recover a missing background row',
+  )
   assert.match(
     shell,
     /ev\.type === 'chat_run_started'[\s\S]*?markStreamingStart\(ev\.chatId\)/,
@@ -876,9 +881,11 @@ test('chat drawer dots distinguish active work from unseen completion', () => {
   )
   assert.match(
     drawer,
-    /streaming \? \([\s\S]*?drawer__streaming-dot[\s\S]*?: attention \? \([\s\S]*?drawer__attention-dot/,
-    'active work must take precedence over unseen completion in a row',
+    /needsOwnerInput \? \([\s\S]*?drawer__owner-input-dot[\s\S]*?: streaming \? \([\s\S]*?drawer__streaming-dot[\s\S]*?: attention \? \([\s\S]*?drawer__attention-dot/,
+    'owner input must take precedence over active work and unseen completion',
   )
+  assert.match(drawerCss, /\.drawer__owner-input-dot\s*\{[\s\S]*?transform:\s*rotate\(45deg\)/)
+  assert.match(drawerCss, /\.drawer__owner-input-dot\s*\{[\s\S]*?#f59e0b/)
   assert.match(drawerCss, /\.drawer__streaming-dot\s*\{[\s\S]*?background:\s*var\(--accent\)/)
   assert.match(drawerCss, /\.drawer__attention-dot\s*\{[\s\S]*?border:\s*1\.5px solid var\(--green\)/)
 })

--- a/frontend/src/components/Shell/chatListProjection.js
+++ b/frontend/src/components/Shell/chatListProjection.js
@@ -40,9 +40,30 @@ export function withChatRunState(rows, chatId, running) {
   })
 }
 
-export function withChatPendingQuestion(rows, chatId, questionId) {
+export function ownerInputChangeFromEvent(event) {
+  const safeEvent = event && typeof event === 'object' ? event : {}
+  const hasQuestionId = Object.hasOwn(safeEvent, 'questionId')
+  const inputKind = ['question', 'secure_input'].includes(safeEvent.inputKind)
+    ? safeEvent.inputKind
+    // Compatibility while a new frontend and the prior backend generation can
+    // briefly overlap during a live platform update.
+    : hasQuestionId && safeEvent.questionId ? 'question' : null
+  return {
+    kind: inputKind,
+    ...(hasQuestionId ? { questionId: safeEvent.questionId || null } : {}),
+  }
+}
+
+export function withChatOwnerInput(
+  rows,
+  chatId,
+  { kind = null, questionId } = {},
+) {
   return withChatListRowPatch(rows, chatId, {
-    pending_question_id: questionId || null,
+    owner_input_kind: kind,
+    ...(questionId !== undefined
+      ? { pending_question_id: questionId || null }
+      : {}),
   })
 }
 

--- a/frontend/src/components/Shell/chatListProjection.js
+++ b/frontend/src/components/Shell/chatListProjection.js
@@ -40,6 +40,12 @@ export function withChatRunState(rows, chatId, running) {
   })
 }
 
+export function withChatPendingQuestion(rows, chatId, questionId) {
+  return withChatListRowPatch(rows, chatId, {
+    pending_question_id: questionId || null,
+  })
+}
+
 export function withChatRename(rows, chatId, { title, updatedAt } = {}) {
   return withChatListRowPatch(rows, chatId, {
     ...(typeof title === 'string' ? { title } : {}),

--- a/tests/navigation.spec.mjs
+++ b/tests/navigation.spec.mjs
@@ -358,6 +358,33 @@ test.describe('Navigation basics', () => {
     expect(state.url).toBe('/shell/')
   })
 
+  test('owner-input status is named and outranks the active-work dot', async ({ page }) => {
+    const chats = NAV_CHATS.map((chat, index) => ({
+      ...chat,
+      running: index < 2,
+      owner_input_kind: index === 0 ? 'secure_input' : null,
+      pending_question_id: null,
+    }))
+    await setup(page, { width: 1512, height: 861 }, { chats })
+
+    const navigation = page.getByRole('navigation', {
+      name: 'Primary navigation',
+    })
+    const waiting = navigation.getByRole('button', {
+      name: `Your input is needed ${chats[0].title}`,
+      exact: true,
+    })
+    await expect(waiting.locator('.drawer__owner-input-dot')).toBeVisible()
+    await expect(waiting.locator('.drawer__streaming-dot')).toHaveCount(0)
+
+    const working = navigation.getByRole('button', {
+      name: `Currently streaming ${chats[1].title}`,
+      exact: true,
+    })
+    await expect(working.locator('.drawer__streaming-dot')).toBeVisible()
+    await expect(working.locator('.drawer__owner-input-dot')).toHaveCount(0)
+  })
+
   test('2. Navigate between two chats — back returns to first', async ({ page }) => {
     await setup(page)
     const state1 = await getNavState(page)


### PR DESCRIPTION
## Summary
- show a distinct amber diamond whenever a chat is waiting for owner involvement
- use one owner-input lifecycle for questions and secure-entry prompts while keeping question recovery durable
- reconcile live drawer state with the cached chat list so offline reloads cannot restore stale markers
- roll back unpresented secure prompts and emit cache-refresh signals only on real owner-input transitions
- let custom themes override the owner-input color without changing the built-in accessible fallback

## Testing
- focused backend owner-input, question, chat-list, and secure-input lifecycle tests
- complete frontend unit and hook suites
- Playwright drawer-state contract added for owner-input precedence and accessible naming
- visual and accessibility verification in the live shell
