### PR TITLE
Complete global search quick switching

### DIFF
--- a/frontend/src/components/GlobalSearch/GlobalSearch.css
+++ b/frontend/src/components/GlobalSearch/GlobalSearch.css
@@ -202,6 +202,14 @@
   gap: 7px;
 }
 
+.global-search__group-heading {
+  min-height: 26px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
 .global-search__group h3 {
   display: flex;
   align-items: center;
@@ -222,6 +230,30 @@
   background: var(--surface);
   font-size: 10px;
   text-align: center;
+}
+
+.global-search__clear {
+  flex: none;
+  min-height: 26px;
+  padding: 2px 8px;
+  border: 0;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--muted);
+  font: 600 11px/1.4 var(--font, system-ui);
+  cursor: pointer;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .global-search__clear:hover {
+    background: var(--surface);
+    color: var(--text);
+  }
+}
+
+.global-search__clear:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
 }
 
 .global-search__results {

--- a/frontend/src/components/GlobalSearch/GlobalSearch.jsx
+++ b/frontend/src/components/GlobalSearch/GlobalSearch.jsx
@@ -7,7 +7,7 @@ import {
   X,
 } from '@openai/apps-sdk-ui/components/Icon'
 import { api } from '../../api/client.js'
-import { appQueries } from '../../hooks/queries.js'
+import { appQueries, chatQueries } from '../../hooks/queries.js'
 import useDialogFocus from '../../hooks/useDialogFocus.js'
 import { requestChatSearchReveal } from '../../lib/chatSearchReveal.js'
 import AppIcon from '../AppIcon.jsx'
@@ -18,11 +18,14 @@ import {
 import { searchSnippetPresentation } from '../../lib/searchTermHighlight.js'
 import { formatRelativeTime } from '../../lib/relativeTime.js'
 import {
+  clearRecentSelections,
   chatSearchOpenTarget,
   chatSearchResultIsCurrent,
   moveSearchSelection,
-  readLastSearch,
-  rememberLastSearch,
+  pointerPositionChanged,
+  readRecentSelections,
+  rememberRecentSelection,
+  resolveRecentSelections,
   resolvedSearchSelection,
   searchInstalledApps,
   visibleChatSearchState,
@@ -30,6 +33,97 @@ import {
 import './GlobalSearch.css'
 
 const SEARCH_DEBOUNCE_MS = 180
+
+function GlobalSearchResult({
+  row,
+  activeResultIndex,
+  onOpen,
+  onPointerActivity,
+  onSelect,
+}) {
+  const { index } = row
+  const selected = activeResultIndex === index
+  const resultClass = `global-search__result${
+    selected ? ' global-search__result--selected' : ''
+  }`
+  const sharedProps = {
+    id: `global-search-result-${index}`,
+    type: 'button',
+    role: 'option',
+    'aria-selected': selected,
+    'data-search-result-index': index,
+    className: resultClass,
+    // Some browsers emit pointerenter AND a zero-distance pointermove when the
+    // dialog mounts beneath a stationary cursor. The parent compares actual
+    // coordinates before treating either event as selection intent.
+    onPointerEnter: event => onPointerActivity(index, event),
+    onPointerMove: event => onPointerActivity(index, event),
+    onFocus: () => onSelect(index),
+    onClick: () => onOpen(row),
+  }
+
+  if (row.kind === 'app') {
+    const app = row.value
+    return (
+      <button {...sharedProps}>
+        <AppIcon
+          item={app}
+          label={app.name}
+          className="global-search__result-icon"
+        />
+        <span className="global-search__result-main">
+          <span className="global-search__result-title">{app.name}</span>
+          <span className="global-search__result-detail">
+            {app.description || app.slug}
+          </span>
+        </span>
+        <span className="global-search__match-kind">{row.matchArea}</span>
+      </button>
+    )
+  }
+
+  const result = row.value
+  const lastActiveValue = result.last_active
+    || result.activity_at
+    || result.updated_at
+    || result.created_at
+  const lastActive = formatRelativeTime(lastActiveValue)
+  return (
+    <button {...sharedProps}>
+      <span className="global-search__result-icon" aria-hidden="true">
+        <Chat width={18} height={18} />
+      </span>
+      <span className="global-search__result-main">
+        <span className="global-search__result-title">
+          {result.title || 'Untitled chat'}
+        </span>
+        {result.snippet && (
+          <span className="global-search__result-detail">
+            {result.snippetParts.map((part, partIndex) => (
+              part.marked
+                ? <mark key={partIndex}>{part.text}</mark>
+                : <span key={partIndex}>{part.text}</span>
+            ))}
+          </span>
+        )}
+      </span>
+      <span className="global-search__result-meta">
+        <span className="global-search__match-kind">
+          {row.recent ? 'Recent' : (result.anchor_key ? 'Conversation' : 'Title')}
+        </span>
+        {lastActive && (
+          <time
+            className="global-search__result-time"
+            dateTime={lastActiveValue}
+            title={`Last active ${new Date(lastActiveValue).toLocaleString()}`}
+          >
+            {lastActive}
+          </time>
+        )}
+      </span>
+    </button>
+  )
+}
 
 export function GlobalSearchButton({ active = false, buttonRef, onClick }) {
   const shortcut = shortcutLabel(SHELL_SHORTCUTS.openSearch)
@@ -55,33 +149,24 @@ export default function GlobalSearch({ onClose, onOpenTarget }) {
   const inputRef = useRef(null)
   const contentRef = useRef(null)
   const chatSearchControllerRef = useRef(null)
-  // Reopening restores the owner's last search (see rememberLastSearch), so the
-  // in-flight-result guard has to start from that same term rather than '' —
-  // otherwise clicking a restored result before the revalidating fetch lands
-  // would be discarded as stale.
-  const restored = useRef(readLastSearch()).current
-  const latestQueryRef = useRef(restored.query.trim())
-  const [query, setQuery] = useState(restored.query)
-  const [chatState, setChatState] = useState(restored.chatState)
+  const latestQueryRef = useRef('')
+  const [query, setQuery] = useState('')
+  const [chatState, setChatState] = useState({
+    query: '', status: 'idle', results: [],
+  })
+  const [recentSelectionRefs, setRecentSelectionRefs] = useState(
+    () => readRecentSelections(),
+  )
   const [selectionIndex, setSelectionIndex] = useState(0)
+  const pointerPositionRef = useRef(null)
   const appsQuery = appQueries.list.useQuery()
+  const chatsQuery = chatQueries.list.useQuery()
 
   useDialogFocus({
     containerRef: dialogRef,
     initialFocusRef: inputRef,
     onClose,
   })
-
-  // A restored term is a starting point, not something to edit around: select
-  // it so the next keystroke replaces it, exactly like reopening a browser's
-  // find bar. Runs once, after useDialogFocus has moved focus to the input.
-  useEffect(() => {
-    if (restored.query) inputRef.current?.select()
-  }, [restored.query])
-
-  useEffect(() => {
-    rememberLastSearch(query, chatState)
-  }, [query, chatState])
 
   useEffect(() => {
     const normalizedQuery = query.trim()
@@ -95,16 +180,7 @@ export default function GlobalSearch({ onClose, onOpenTarget }) {
 
     const controller = new AbortController()
     chatSearchControllerRef.current = controller
-    // Reopening re-runs the query so a chat renamed, added, or deleted since
-    // last time is reflected. Keep the restored results on screen while that
-    // happens: blanking them to "Searching chats…" would undo the point of
-    // restoring them. A genuinely new term has no settled results to hold, so
-    // it still shows the loading state.
-    setChatState(previous => (
-      previous.query === normalizedQuery && previous.status === 'ready'
-        ? previous
-        : { query: normalizedQuery, status: 'loading', results: [] }
-    ))
+    setChatState({ query: normalizedQuery, status: 'loading', results: [] })
     const timer = window.setTimeout(async () => {
       try {
         const response = await api.chats.search(normalizedQuery, {
@@ -149,8 +225,17 @@ export default function GlobalSearch({ onClose, onOpenTarget }) {
     () => searchInstalledApps(appsQuery.data, normalizedQuery),
     [appsQuery.data, normalizedQuery],
   )
+  const recentSelectionRows = useMemo(
+    () => resolveRecentSelections(
+      recentSelectionRefs,
+      chatsQuery.data,
+      appsQuery.data,
+    ),
+    [appsQuery.data, chatsQuery.data, recentSelectionRefs],
+  )
   const openChat = useCallback((result) => {
     if (!chatSearchResultIsCurrent(result, latestQueryRef.current)) return
+    rememberRecentSelection({ kind: 'chat', id: result.id })
     if (result.anchor_key) {
       requestChatSearchReveal(result.id, {
         anchorKey: result.anchor_key,
@@ -163,25 +248,99 @@ export default function GlobalSearch({ onClose, onOpenTarget }) {
 
   const openApp = useCallback((app) => {
     if (!app?.id) return
+    rememberRecentSelection({ kind: 'app', id: app.id })
     onClose()
     onOpenTarget?.({ view: 'canvas', app: String(app.id), intent: null })
   }, [onClose, onOpenTarget])
 
-  const selectableResults = useMemo(() => [
-    ...appResults.map(({ app }) => ({ kind: 'app', value: app })),
-    ...visibleChats.results.map(result => ({ kind: 'chat', value: result })),
-  ], [appResults, visibleChats.results])
+  const openRecentChat = useCallback((chat) => {
+    if (!chat?.id) return
+    rememberRecentSelection({ kind: 'chat', id: chat.id })
+    onClose()
+    onOpenTarget?.(chatSearchOpenTarget(chat))
+  }, [onClose, onOpenTarget])
+
+  const resultGroups = useMemo(() => {
+    const groups = normalizedQuery
+      ? [
+          ...(appResults.length ? [{
+            headingId: 'global-search-apps',
+            listId: 'global-search-app-results',
+            label: 'Apps',
+            rows: appResults.map(({ app, matchArea }) => ({
+              kind: 'app', value: app, matchArea,
+            })),
+          }] : []),
+          {
+            headingId: 'global-search-chats',
+            listId: 'global-search-chat-results',
+            label: 'Chats',
+            status: visibleChats.status,
+            rows: visibleChats.results.map(result => ({
+              kind: 'chat', value: result,
+            })),
+          },
+        ]
+      : [
+          ...(recentSelectionRows.length ? [{
+            headingId: 'global-search-recent-selections',
+            listId: 'global-search-recent-selection-results',
+            label: 'Recent selections',
+            clearable: true,
+            rows: recentSelectionRows.map(({ kind, value }) => ({
+              kind,
+              value,
+              recent: true,
+              matchArea: 'Recent',
+            })),
+          }] : []),
+        ]
+
+    let nextIndex = 0
+    return groups.map(group => ({
+      ...group,
+      rows: group.rows.map(row => ({ ...row, index: nextIndex++ })),
+    }))
+  }, [appResults, normalizedQuery, recentSelectionRows, visibleChats])
+
+  const selectableResults = useMemo(
+    () => resultGroups.flatMap(group => group.rows),
+    [resultGroups],
+  )
   const activeResultIndex = resolvedSearchSelection(
     selectionIndex,
     selectableResults.length,
   )
-  const resultListId = selectableResults.length ? 'global-search-results' : undefined
+  const resultListIds = resultGroups
+    .filter(group => group.rows.length)
+    .map(group => group.listId)
+    .join(' ')
+
+  const openResult = useCallback((row) => {
+    if (row?.kind === 'app') openApp(row.value)
+    if (row?.kind === 'chat' && row.recent) openRecentChat(row.value)
+    if (row?.kind === 'chat' && !row.recent) openChat(row.value)
+  }, [openApp, openChat, openRecentChat])
 
   const openSelectedResult = useCallback(() => {
-    const selected = selectableResults[activeResultIndex]
-    if (selected?.kind === 'app') openApp(selected.value)
-    if (selected?.kind === 'chat') openChat(selected.value)
-  }, [activeResultIndex, openApp, openChat, selectableResults])
+    openResult(selectableResults[activeResultIndex])
+  }, [activeResultIndex, openResult, selectableResults])
+
+  const clearSelectionHistory = useCallback(() => {
+    clearRecentSelections()
+    setRecentSelectionRefs([])
+    setSelectionIndex(0)
+  }, [])
+
+  const handleResultPointerActivity = useCallback((index, event) => {
+    const nextPosition = { x: event.clientX, y: event.clientY }
+    const moved = pointerPositionChanged(
+      pointerPositionRef.current,
+      nextPosition,
+    )
+    pointerPositionRef.current = nextPosition
+    if (moved) setSelectionIndex(index)
+  }, [])
 
   const handleSearchKeyDown = useCallback((event) => {
     if (event.isComposing || event.metaKey || event.ctrlKey || event.altKey) return
@@ -210,6 +369,11 @@ export default function GlobalSearch({ onClose, onOpenTarget }) {
     && visibleChats.status === 'ready'
     && visibleChats.results.length === 0
     && appResults.length === 0
+  const loadingRecentSelections = !normalizedQuery
+    && resultGroups.length === 0
+    && recentSelectionRefs.some(selection => (
+      selection.kind === 'app' ? appsQuery.isLoading : chatsQuery.isLoading
+    ))
 
   return createPortal(
     <div
@@ -258,7 +422,7 @@ export default function GlobalSearch({ onClose, onOpenTarget }) {
             aria-label="Search chats, apps, and app details"
             role="combobox"
             aria-autocomplete="list"
-            aria-controls={resultListId}
+            aria-controls={resultListIds || undefined}
             aria-expanded={selectableResults.length > 0}
             aria-activedescendant={
               activeResultIndex === -1
@@ -276,138 +440,71 @@ export default function GlobalSearch({ onClose, onOpenTarget }) {
           className="global-search__content"
           aria-live="polite"
         >
-          {!normalizedQuery && (
+          {!normalizedQuery && resultGroups.length === 0 && (
             <div className="global-search__empty">
               <span className="global-search__empty-icon" aria-hidden="true">
                 <MagnifyingGlassSearch width={30} height={30} />
               </span>
-              <h3>Find anything you’ve worked on</h3>
-              <p>Search chat titles and conversation text, plus app names and app details.</p>
+              <h3>{loadingRecentSelections ? 'Loading recent selections…' : 'No recent selections yet'}</h3>
+              <p>
+                {loadingRecentSelections
+                  ? 'The chats and apps you opened through search will appear here.'
+                  : 'Search for a chat or app and open it. It will appear here the next time you use ⌘K.'}
+              </p>
             </div>
           )}
 
-          {normalizedQuery && (
-            <div
-              id="global-search-results"
-              className="global-search__groups"
-              role="listbox"
-              aria-label="Search results"
-            >
-              {appResults.length > 0 && (
+          {resultGroups.length > 0 && (
+            <div className="global-search__groups">
+              {resultGroups.map(group => (
                 <section
+                  key={group.listId}
                   className="global-search__group"
-                  role="group"
-                  aria-labelledby="global-search-apps"
+                  aria-labelledby={group.headingId}
                 >
-                  <h3 id="global-search-apps">Apps <span>{appResults.length}</span></h3>
-                  <div className="global-search__results">
-                    {appResults.map(({ app, matchArea }, index) => (
+                  <div className="global-search__group-heading">
+                    <h3 id={group.headingId}>
+                      {group.label} <span>{group.rows.length}</span>
+                    </h3>
+                    {group.clearable && (
                       <button
-                        key={app.id}
-                        id={`global-search-result-${index}`}
                         type="button"
-                        role="option"
-                        aria-selected={activeResultIndex === index}
-                        data-search-result-index={index}
-                        className={`global-search__result${
-                          activeResultIndex === index ? ' global-search__result--selected' : ''
-                        }`}
-                        onPointerEnter={() => setSelectionIndex(index)}
-                        onFocus={() => setSelectionIndex(index)}
-                        onClick={() => openApp(app)}
+                        className="global-search__clear"
+                        onClick={clearSelectionHistory}
                       >
-                        <AppIcon
-                          item={app}
-                          label={app.name}
-                          className="global-search__result-icon"
-                        />
-                        <span className="global-search__result-main">
-                          <span className="global-search__result-title">{app.name}</span>
-                          <span className="global-search__result-detail">
-                            {app.description || app.slug}
-                          </span>
-                        </span>
-                        <span className="global-search__match-kind">{matchArea}</span>
+                        Clear
                       </button>
-                    ))}
+                    )}
                   </div>
+                  {group.status === 'loading' && (
+                    <p className="global-search__status" role="status">Searching chats…</p>
+                  )}
+                  {group.status === 'error' && (
+                    <p className="global-search__status global-search__status--error" role="alert">
+                      Chat search is unavailable right now. App results still work.
+                    </p>
+                  )}
+                  {group.rows.length > 0 && (
+                    <div
+                      id={group.listId}
+                      className="global-search__results"
+                      role="listbox"
+                      aria-labelledby={group.headingId}
+                    >
+                      {group.rows.map(row => (
+                        <GlobalSearchResult
+                          key={`${row.kind}-${row.value.id}`}
+                          row={row}
+                          activeResultIndex={activeResultIndex}
+                          onOpen={openResult}
+                          onPointerActivity={handleResultPointerActivity}
+                          onSelect={setSelectionIndex}
+                        />
+                      ))}
+                    </div>
+                  )}
                 </section>
-              )}
-
-              <section
-                className="global-search__group"
-                role="group"
-                aria-labelledby="global-search-chats"
-              >
-                <h3 id="global-search-chats">
-                  Chats
-                  {visibleChats.status === 'ready' && <span>{visibleChats.results.length}</span>}
-                </h3>
-                {visibleChats.status === 'loading' && (
-                  <p className="global-search__status" role="status">Searching chats…</p>
-                )}
-                {visibleChats.status === 'error' && (
-                  <p className="global-search__status global-search__status--error" role="alert">
-                    Chat search is unavailable right now. App results still work.
-                  </p>
-                )}
-                {visibleChats.results.length > 0 && (
-                  <div className="global-search__results">
-                    {visibleChats.results.map((result, chatIndex) => {
-                      const index = appResults.length + chatIndex
-                      const lastActive = formatRelativeTime(result.last_active)
-                      return (
-                        <button
-                          key={result.id}
-                          id={`global-search-result-${index}`}
-                          type="button"
-                          role="option"
-                          aria-selected={activeResultIndex === index}
-                          data-search-result-index={index}
-                          className={`global-search__result${
-                            activeResultIndex === index ? ' global-search__result--selected' : ''
-                          }`}
-                          onPointerEnter={() => setSelectionIndex(index)}
-                          onFocus={() => setSelectionIndex(index)}
-                          onClick={() => openChat(result)}
-                        >
-                          <span className="global-search__result-icon" aria-hidden="true">
-                            <Chat width={18} height={18} />
-                          </span>
-                          <span className="global-search__result-main">
-                            <span className="global-search__result-title">
-                              {result.title || 'Untitled chat'}
-                            </span>
-                            {result.snippet && (
-                              <span className="global-search__result-detail">
-                                {result.snippetParts.map((part, index) => (
-                                  part.marked
-                                    ? <mark key={index}>{part.text}</mark>
-                                    : <span key={index}>{part.text}</span>
-                                ))}
-                              </span>
-                            )}
-                          </span>
-                          <span className="global-search__result-meta">
-                            <span className="global-search__match-kind">
-                              {result.anchor_key ? 'Conversation' : 'Title'}
-                            </span>
-                            {lastActive && (
-                              <time
-                                className="global-search__result-time"
-                                dateTime={result.last_active}
-                                title={`Last active ${new Date(result.last_active).toLocaleString()}`}
-                              >
-                                {lastActive}
-                              </time>
-                            )}
-                          </span>
-                        </button>
-                      )
-                    })}
-                  </div>
-                )}
-              </section>
+              ))}
 
               {noResults && (
                 <div className="global-search__empty global-search__empty--results">

--- a/frontend/src/components/GlobalSearch/__tests__/globalSearchModel.test.js
+++ b/frontend/src/components/GlobalSearch/__tests__/globalSearchModel.test.js
@@ -4,14 +4,34 @@ import {
   appManifestSearchDocument,
   chatSearchOpenTarget,
   chatSearchResultIsCurrent,
-  clearLastSearch,
+  clearRecentSelections,
   moveSearchSelection,
-  readLastSearch,
-  rememberLastSearch,
+  pointerPositionChanged,
+  readRecentSelections,
+  rememberRecentSelection,
+  resolveRecentSelections,
   resolvedSearchSelection,
   searchInstalledApps,
   visibleChatSearchState,
 } from '../globalSearchModel.js'
+
+class MemoryStorage {
+  constructor(initial = {}) {
+    this.values = new Map(Object.entries(initial))
+  }
+
+  getItem(key) {
+    return this.values.get(key) ?? null
+  }
+
+  setItem(key, value) {
+    this.values.set(key, String(value))
+  }
+
+  removeItem(key) {
+    this.values.delete(key)
+  }
+}
 
 const apps = [
   {
@@ -85,6 +105,53 @@ test('all query terms must match and result limits are stable', () => {
   assert.equal(searchInstalledApps(apps, 'news', 1).length, 1)
 })
 
+test('recent selections persist as a deduplicated most-recent-first list', () => {
+  const storage = new MemoryStorage()
+  assert.deepEqual(readRecentSelections(storage), [])
+
+  rememberRecentSelection({ kind: 'chat', id: 'chat-1' }, storage)
+  rememberRecentSelection({ kind: 'app', id: 42 }, storage)
+  rememberRecentSelection({ kind: 'chat', id: 'chat-1' }, storage)
+
+  assert.deepEqual(readRecentSelections(storage), [
+    { kind: 'chat', id: 'chat-1' },
+    { kind: 'app', id: '42' },
+  ])
+
+  for (let index = 0; index < 14; index += 1) {
+    rememberRecentSelection({ kind: 'chat', id: `chat-${index}` }, storage)
+  }
+  const bounded = readRecentSelections(storage)
+  assert.equal(bounded.length, 12)
+  assert.deepEqual(bounded.slice(0, 2), [
+    { kind: 'chat', id: 'chat-13' },
+    { kind: 'chat', id: 'chat-12' },
+  ])
+
+  clearRecentSelections(storage)
+  assert.deepEqual(readRecentSelections(storage), [])
+})
+
+test('recent selections resolve current items in selection order and omit missing ones', () => {
+  const chats = [
+    { id: 'chat-1', title: 'First chat' },
+    { id: 'chat-2', title: 'Second chat' },
+  ]
+  const installedApps = [
+    { id: 7, name: 'Memory' },
+  ]
+  const rows = resolveRecentSelections([
+    { kind: 'app', id: '7' },
+    { kind: 'chat', id: 'missing' },
+    { kind: 'chat', id: 'chat-2' },
+  ], chats, installedApps)
+
+  assert.deepEqual(rows, [
+    { kind: 'app', value: installedApps[0] },
+    { kind: 'chat', value: chats[1] },
+  ])
+})
+
 test('keyboard search selection starts at the first result and wraps with arrows', () => {
   assert.equal(resolvedSearchSelection(0, 3), 0)
   assert.equal(resolvedSearchSelection(-1, 3), 0)
@@ -96,6 +163,14 @@ test('keyboard search selection starts at the first result and wraps with arrows
   assert.equal(moveSearchSelection(0, 'ArrowUp', 3), 2)
   assert.equal(moveSearchSelection(2, 'ArrowUp', 3), 1)
   assert.equal(moveSearchSelection(0, 'ArrowDown', 0), -1)
+})
+
+test('a stationary pointer cannot replace the keyboard-selected result', () => {
+  const initial = { x: 800, y: 420 }
+  assert.equal(pointerPositionChanged(null, initial), false)
+  assert.equal(pointerPositionChanged(initial, { x: 800, y: 420 }), false)
+  assert.equal(pointerPositionChanged(initial, { x: 801, y: 420 }), true)
+  assert.equal(pointerPositionChanged(initial, { x: 800, y: 419 }), true)
 })
 
 test('a changed chat query hides and rejects stale result actions', () => {
@@ -124,44 +199,4 @@ test('chat destinations focus either the matched row or the ordinary composer', 
     chatId: 'chat-row',
     focusComposer: false,
   })
-})
-
-test('the last search survives a close/reopen so the term does not have to be retyped', () => {
-  clearLastSearch()
-  assert.deepEqual(readLastSearch(), {
-    query: '',
-    chatState: { query: '', status: 'idle', results: [] },
-  })
-
-  const settled = {
-    query: 'password',
-    status: 'ready',
-    results: [{ id: 'chat-1', searchQuery: 'password' }],
-  }
-  rememberLastSearch('password', settled)
-
-  // What a reopened dialog seeds its state from: the term AND the results the
-  // owner was looking at, so the list is on screen before any refetch lands.
-  const restored = readLastSearch()
-  assert.equal(restored.query, 'password')
-  assert.equal(restored.chatState.status, 'ready')
-  assert.deepEqual(restored.chatState.results, settled.results)
-  assert.deepEqual(visibleChatSearchState(restored.chatState, restored.query), settled)
-  // The restored rows stay clickable: the staleness guard keys off the term the
-  // dialog reopens with, not a fresh empty one.
-  assert.equal(chatSearchResultIsCurrent(restored.chatState.results[0], restored.query), true)
-
-  clearLastSearch()
-})
-
-test('an unsettled search is not restored, only its term', () => {
-  clearLastSearch()
-  for (const status of ['loading', 'error', 'idle']) {
-    rememberLastSearch('half typed', { query: 'half typed', status, results: [] })
-    const restored = readLastSearch()
-    assert.equal(restored.query, 'half typed', `${status} keeps the term`)
-    assert.equal(restored.chatState.status, 'idle', `${status} is not replayed`)
-    assert.deepEqual(restored.chatState.results, [])
-  }
-  clearLastSearch()
 })

--- a/frontend/src/components/GlobalSearch/globalSearchModel.js
+++ b/frontend/src/components/GlobalSearch/globalSearchModel.js
@@ -94,6 +94,88 @@ export function searchInstalledApps(apps, query, limit = 8) {
     .map(({ score: _score, ...result }) => result)
 }
 
+export const RECENT_SELECTION_LIMIT = 12
+const RECENT_SELECTIONS_STORAGE_KEY = 'mobius:global-search:recent-selections:v1'
+
+function browserStorage() {
+  try {
+    return globalThis.localStorage || null
+  } catch (_) {
+    return null
+  }
+}
+
+function normalizedRecentSelections(selections) {
+  const seen = new Set()
+  const normalized = []
+  for (const selection of Array.isArray(selections) ? selections : []) {
+    if (!['app', 'chat'].includes(selection?.kind)) continue
+    const id = String(selection?.id ?? '').trim()
+    if (!id) continue
+    const key = `${selection.kind}:${id}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    normalized.push({ kind: selection.kind, id })
+    if (normalized.length === RECENT_SELECTION_LIMIT) break
+  }
+  return normalized
+}
+
+// Selection history intentionally stores only stable item references. Titles,
+// snippets, and the owner's query text remain in their owning data sources and
+// are resolved afresh when the dialog opens.
+export function readRecentSelections(storage = browserStorage()) {
+  try {
+    return normalizedRecentSelections(JSON.parse(
+      storage?.getItem(RECENT_SELECTIONS_STORAGE_KEY) || '[]',
+    ))
+  } catch (_) {
+    return []
+  }
+}
+
+export function rememberRecentSelection(selection, storage = browserStorage()) {
+  const next = normalizedRecentSelections([
+    selection,
+    ...readRecentSelections(storage),
+  ])
+  try {
+    storage?.setItem(RECENT_SELECTIONS_STORAGE_KEY, JSON.stringify(next))
+  } catch (_) {
+    // Restricted and private browsing contexts may reject Web Storage. Search
+    // still works; it simply has no history on the next open.
+  }
+  return next
+}
+
+export function clearRecentSelections(storage = browserStorage()) {
+  try {
+    storage?.removeItem(RECENT_SELECTIONS_STORAGE_KEY)
+  } catch (_) {
+    // Clearing an unavailable store is already the desired end state.
+  }
+}
+
+export function resolveRecentSelections(selections, chats, apps) {
+  const chatsById = new Map(
+    (Array.isArray(chats) ? chats : [])
+      .filter(chat => chat?.id)
+      .map(chat => [String(chat.id), chat]),
+  )
+  const appsById = new Map(
+    (Array.isArray(apps) ? apps : [])
+      .filter(app => app?.id)
+      .map(app => [String(app.id), app]),
+  )
+
+  return normalizedRecentSelections(selections).flatMap(selection => {
+    const value = selection.kind === 'chat'
+      ? chatsById.get(selection.id)
+      : appsById.get(selection.id)
+    return value ? [{ kind: selection.kind, value }] : []
+  })
+}
+
 export function resolvedSearchSelection(index, resultCount) {
   if (resultCount === 0) return -1
   return Math.min(Math.max(index, 0), resultCount - 1)
@@ -107,33 +189,10 @@ export function moveSearchSelection(index, key, resultCount) {
   return current
 }
 
-// The dialog unmounts on close (NotificationCenter renders it behind
-// `searchOpen &&`), so component state cannot survive a reopen. The owner's
-// last search lives here instead: type a term, open a result, reopen search,
-// and the term and its results are still there rather than a blank field.
-//
-// Memory-only on purpose. It is owner-authored content, so it must not outlive
-// the session — and because nothing is written to storage, a reload or logout
-// drops it without any explicit clean-up path to keep correct.
-const IDLE_CHAT_STATE = { query: '', status: 'idle', results: [] }
-let lastSearch = { query: '', chatState: IDLE_CHAT_STATE }
-
-export function readLastSearch() {
-  return lastSearch
-}
-
-// Only a settled result set is worth restoring: replaying a `loading` or
-// `error` snapshot would reopen the dialog into a state the owner never saw
-// settle, and the mount effect re-runs the query anyway.
-export function rememberLastSearch(query, chatState) {
-  lastSearch = {
-    query: String(query || ''),
-    chatState: chatState?.status === 'ready' ? chatState : IDLE_CHAT_STATE,
-  }
-}
-
-export function clearLastSearch() {
-  lastSearch = { query: '', chatState: IDLE_CHAT_STATE }
+export function pointerPositionChanged(previous, next) {
+  return Boolean(previous && next) && (
+    previous.x !== next.x || previous.y !== next.y
+  )
 }
 
 export function visibleChatSearchState(chatState, query) {


### PR DESCRIPTION
## Summary
- open global search with the first available result selected and support ArrowUp, ArrowDown, and Enter across grouped app and chat results
- reopen with an empty query and show up to 12 deduplicated recently opened items
- let deliberate pointer movement change selection without letting a stationary cursor override keyboard focus
- expose grouped listboxes, active selection, clear history, and useful loading and empty states

Compared with #804, this keeps the keyboard navigation and adds the complete recent-item, reopen-state, and pointer-intent behavior in one review.

## Testing
- focused GlobalSearch model tests
- focused ESLint
- structural-test ratchet
- rendered Cmd/Ctrl+K keyboard navigation and Enter flow
- rendered recent-item persistence, reordering, and clear-history flow
- stationary-pointer and one-pixel movement checks