### PR TITLE
Fix Codex compaction markers for current app-server events

### DIFF
--- a/backend/app/codex_sdk_runner.py
+++ b/backend/app/codex_sdk_runner.py
@@ -976,6 +976,7 @@ def _sdk_imports() -> dict[str, Any]:
     CommandExecutionOutputDeltaNotification,
     CommandExecutionThreadItem,
     ContextCompactedNotification,
+    ContextCompactionThreadItem,
     DynamicToolCallThreadItem,
     ErrorNotification,
     FileChangePatchUpdatedNotification,
@@ -1073,6 +1074,7 @@ def _sdk_imports() -> dict[str, Any]:
     ),
     "CommandExecutionThreadItem": CommandExecutionThreadItem,
     "ContextCompactedNotification": ContextCompactedNotification,
+    "ContextCompactionThreadItem": ContextCompactionThreadItem,
     "DynamicToolCallThreadItem": DynamicToolCallThreadItem,
     "ErrorNotification": ErrorNotification,
     "FileChangePatchUpdatedNotification": FileChangePatchUpdatedNotification,
@@ -1427,6 +1429,24 @@ def _install_request_user_input_handler(
   log.debug(
     "Codex request_user_input bridge installed chat_id=%s", chat_id,
   )
+
+
+def _publish_codex_context_compaction(bc: Any, chat_id: str) -> None:
+  """Make provider-native compaction visible without affecting the turn."""
+  log.info("Codex context compacted for chat %s", chat_id)
+  try:
+    bc.publish({
+      "type": "context_compacted",
+      "provider": "codex",
+    })
+  except Exception:
+    # Visibility must never interfere with the provider's own compaction or
+    # the rest of its turn.
+    log.warning(
+      "Codex context-compaction marker failed for chat %s",
+      chat_id,
+      exc_info=True,
+    )
 
 
 async def run_codex_sdk_turn(
@@ -2169,6 +2189,9 @@ async def run_codex_sdk_turn(
 
         if isinstance(payload, sdk["ItemCompletedNotification"]):
           item = payload.item.root if hasattr(payload.item, "root") else payload.item
+          if isinstance(item, sdk["ContextCompactionThreadItem"]):
+            _publish_codex_context_compaction(bc, chat_id)
+            continue
           if isinstance(item, sdk["AgentMessageThreadItem"]):
             completed_message_phases.append(_agent_message_phase(item, sdk))
           collab_cls = sdk.get("CollabAgentToolCallThreadItem")
@@ -2219,20 +2242,9 @@ async def run_codex_sdk_turn(
           continue
 
         if isinstance(payload, sdk["ContextCompactedNotification"]):
-          log.info("Codex context compacted for chat %s", chat_id)
-          try:
-            bc.publish({
-              "type": "context_compacted",
-              "provider": "codex",
-            })
-          except Exception:
-            # Visibility must never interfere with the provider's own
-            # compaction or the rest of its turn.
-            log.warning(
-              "Codex context-compaction marker failed for chat %s",
-              chat_id,
-              exc_info=True,
-            )
+          # Compatibility for older app-server releases. Current v2 servers
+          # expose compaction as a ContextCompactionThreadItem instead.
+          _publish_codex_context_compaction(bc, chat_id)
           continue
 
         ratelimit_cls = sdk.get("AccountRateLimitsUpdatedNotification")

--- a/backend/tests/test_codex_sdk_contract.py
+++ b/backend/tests/test_codex_sdk_contract.py
@@ -199,6 +199,26 @@ def test_subagent_activity_is_natively_modeled_and_fallback_removed():
   assert not hasattr(codex_sdk_runner, "_is_subagent_activity_resume_validation_error")
 
 
+def test_context_compaction_item_is_available_to_the_runner():
+  """Pin the canonical item lifecycle that makes Codex compaction visible.
+
+  Current app-server v2 emits ``contextCompaction`` through item completion
+  and suppresses the deprecated ``thread/compacted`` notification. A runtime
+  bump that drops or renames this generated item must fail here rather than
+  silently removing every compaction marker from the chat timeline.
+  """
+  pytest.importorskip("openai_codex")
+  from openai_codex.generated import v2_all
+  from app import codex_sdk_runner
+
+  schema = json.dumps(v2_all.ThreadItem.model_json_schema())
+  assert getattr(v2_all, "ContextCompactionThreadItem", None) is not None
+  assert "contextCompaction" in schema
+  assert codex_sdk_runner._sdk_imports()["ContextCompactionThreadItem"] is (
+    v2_all.ContextCompactionThreadItem
+  )
+
+
 def test_native_image_view_item_is_wired_to_tool_dispatch():
   """Codex image inspection must not disappear from the visible transcript."""
   import inspect

--- a/backend/tests/test_codex_sdk_runner.py
+++ b/backend/tests/test_codex_sdk_runner.py
@@ -319,6 +319,7 @@ def _fake_sdk(async_codex_cls):
     "CommandExecutionOutputDeltaNotification": _Dummy,
     "CommandExecutionThreadItem": _Dummy,
     "ContextCompactedNotification": _Dummy,
+    "ContextCompactionThreadItem": _Dummy,
     "DynamicToolCallThreadItem": _Dummy,
     "ErrorNotification": _FakeErrorNotification,
     "FileChangePatchUpdatedNotification": _Dummy,
@@ -2011,16 +2012,37 @@ def test_run_codex_sdk_turn_cleans_up_active_session_on_stream_exception(
   assert mark_finished_calls == [True]
 
 
-def test_run_codex_sdk_turn_publishes_context_compaction_marker(monkeypatch):
+@pytest.mark.parametrize(
+  "event_kind",
+  ["context_compaction_item", "legacy_notification"],
+)
+def test_run_codex_sdk_turn_publishes_marker_from_current_and_legacy_events(
+  monkeypatch, event_kind,
+):
+  class ContextCompactionThreadItem:
+    pass
+
   class ContextCompactedNotification:
     pass
 
-  completed_turn = SimpleNamespace(id="turn-1", usage=None, error=None)
-  turn_handle = _FakeTurnHandle([
-    SimpleNamespace(
+  class ItemCompletedNotification:
+    def __init__(self, item):
+      self.item = SimpleNamespace(root=item)
+
+  if event_kind == "context_compaction_item":
+    event = SimpleNamespace(
+      method="item/completed",
+      payload=ItemCompletedNotification(ContextCompactionThreadItem()),
+    )
+  else:
+    event = SimpleNamespace(
       method="thread/compacted",
       payload=ContextCompactedNotification(),
-    ),
+    )
+
+  completed_turn = SimpleNamespace(id="turn-1", usage=None, error=None)
+  turn_handle = _FakeTurnHandle([
+    event,
     SimpleNamespace(
       method="turn/completed",
       payload=_FakeTurnCompletedNotification(completed_turn),
@@ -2043,6 +2065,8 @@ def test_run_codex_sdk_turn_publishes_context_compaction_marker(monkeypatch):
 
   sdk = _fake_sdk(FakeAsyncCodex)
   sdk["ContextCompactedNotification"] = ContextCompactedNotification
+  sdk["ContextCompactionThreadItem"] = ContextCompactionThreadItem
+  sdk["ItemCompletedNotification"] = ItemCompletedNotification
   monkeypatch.setattr(codex_sdk_runner, "_sdk_imports", lambda: sdk)
 
   bc = _FakeBroadcast()
@@ -2058,10 +2082,14 @@ def test_run_codex_sdk_turn_publishes_context_compaction_marker(monkeypatch):
   ))
 
   assert result["error"] is None
-  assert {
+  markers = [
+    event for event in bc.events
+    if event.get("type") == "context_compacted"
+  ]
+  assert markers == [{
     "type": "context_compacted",
     "provider": "codex",
-  } in bc.events
+  }]
 
 
 class _KilledTransportError(_SdkTransportClosedError):

--- a/frontend/src/components/ChatView/ContextCompactionMarker.css
+++ b/frontend/src/components/ChatView/ContextCompactionMarker.css
@@ -29,8 +29,3 @@
   color: color-mix(in srgb, var(--text) 68%, var(--muted));
   font-weight: 550;
 }
-
-.chat__context-compaction-meta {
-  color: var(--muted);
-  font-size: 10.5px;
-}

--- a/frontend/src/components/ChatView/ContextCompactionMarker.jsx
+++ b/frontend/src/components/ChatView/ContextCompactionMarker.jsx
@@ -2,31 +2,14 @@
 
 import './ContextCompactionMarker.css'
 
-const PROVIDER_LABELS = {
-  claude: 'Claude',
-  codex: 'Codex',
-}
-
-function compactionMeta(block) {
-  const provider = PROVIDER_LABELS[block?.provider] || null
-  const trigger = block?.trigger === 'manual' ? 'manual' : null
-  return [provider, trigger].filter(Boolean).join(' · ')
-}
-
-export default function ContextCompactionMarker({ block }) {
-  const meta = compactionMeta(block)
-  const ariaLabel = meta
-    ? `Context compacted — ${meta}`
-    : 'Context compacted'
-
+export default function ContextCompactionMarker() {
   // Intentionally not MarkerCard: native provider compaction exposes no
   // readable briefing and asks for no interaction. A borderless rule keeps it
   // chronological and visible without borrowing the accent card reserved for
   // deliberate conversation summaries and provider handoffs.
   return (
-    <div className="chat__context-compaction" role="note" aria-label={ariaLabel}>
+    <div className="chat__context-compaction" role="note" aria-label="Context compacted">
       <span className="chat__context-compaction-label">Context compacted</span>
-      {meta && <span className="chat__context-compaction-meta">{meta}</span>}
     </div>
   )
 }

--- a/frontend/src/components/ChatView/MsgContent.jsx
+++ b/frontend/src/components/ChatView/MsgContent.jsx
@@ -241,7 +241,6 @@ function MsgContentInner({
         return (
           <ContextCompactionMarker
             key={assistantBlockKey(block, i)}
-            block={block}
           />
         )
       }

--- a/frontend/src/components/ChatView/__tests__/accessibilityHardening.test.js
+++ b/frontend/src/components/ChatView/__tests__/accessibilityHardening.test.js
@@ -100,6 +100,13 @@ test('QuestionCard gives the custom answer area a durable accessible name', () =
   assert.match(source, /placeholder=\{answered \? 'No custom answer' : 'Or type your own answer…'\}/)
 })
 
+test('context compaction is a provider-neutral accessible timeline marker', () => {
+  const source = read('../ContextCompactionMarker.jsx')
+  assert.match(source, /role="note" aria-label="Context compacted"/)
+  assert.match(source, />Context compacted<\/span>/)
+  assert.doesNotMatch(source, /PROVIDER_LABELS|compactionMeta|block\?\.provider/)
+})
+
 test('message references are an accessible lazy disclosure with safe links', () => {
   const source = read('../MessageSources.jsx')
   const msgContent = read('../MsgContent.jsx')


### PR DESCRIPTION
## Summary
- observe Codex's canonical `contextCompaction` completed item so native compaction appears in chat
- retain the deprecated `thread/compacted` notification as a compatibility path
- show a provider-neutral “Context compacted” timeline marker while retaining provider metadata internally
- pin both the provider event and accessible-copy contracts

This is a focused follow-up to #733. The original implementation listened for Codex's deprecated compaction notification, while current app-server v2 exposes compaction through item lifecycle events instead.

## Testing
- focused Codex runner, SDK contract, and runner-registry tests
- event persistence, transcript projection, and Claude compaction tests
- backend fast contract suite
- full frontend behavioral and hook suites
- targeted shell lint and accessible marker contract test
- rendered DOM verification and live provider-native Codex compaction after restart