### PR TITLE
Allow authenticated loopback tests to load app frames

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,6 +5,7 @@ static files.  API routes are registered first; the frontend SPA is
 mounted last as a catch-all so that client-side routing works.
 """
 
+import ipaddress
 import json
 import logging
 import mimetypes
@@ -16,6 +17,7 @@ from contextlib import asynccontextmanager
 from datetime import timezone
 from email.utils import formatdate, parsedate_to_datetime
 from pathlib import Path
+from urllib.parse import urlparse
 
 # Do this before importing FastAPI, SQLAlchemy, or any app module that may
 # create worker threads. See allocator.limit_glibc_arenas for the observed
@@ -51,6 +53,7 @@ from app.memory_observability import record_memory_checkpoint
 from app.response_policy import (
   CHAT_EMBED_CSP,
   PUBLISHED_SITE_CSP,
+  absolute_csp_origin,
   app_frame_csp,
   shell_csp,
   static_embed_csp,
@@ -320,14 +323,50 @@ _APP_FRAME_PATH = re.compile(r"^/api/apps/[^/]+/frame$")
 # and it still cannot reach the shell's localStorage, cookies, or owner token.
 _STATIC_EMBED_CSP = static_embed_csp(settings.frontend_origin)
 _SHELL_CSP = shell_csp(os.environ.get("MOBIUS_SERVICE_GATEWAY_ORIGIN", ""))
+_SERVICE_GATEWAY_ORIGIN = os.environ.get("MOBIUS_SERVICE_GATEWAY_ORIGIN", "")
+_BROWSER_API_ORIGIN = os.environ.get("API_BASE_URL", "")
 _APP_FRAME_CSP = app_frame_csp(
   settings.frontend_origin,
-  os.environ.get("MOBIUS_SERVICE_GATEWAY_ORIGIN", ""),
+  _SERVICE_GATEWAY_ORIGIN,
   # Only an explicitly configured browser-reachable API origin belongs in a
   # frame policy. settings.api_base_url defaults to backend-local localhost
   # for agents and jobs, which must not become the viewer's localhost.
-  os.environ.get("API_BASE_URL", ""),
+  _BROWSER_API_ORIGIN,
 )
+
+def _loopback_delivery_origin(scope) -> str | None:
+  """Return the exact loopback origin serving this request, if any."""
+  headers = dict(scope.get("headers") or ())
+  try:
+    authority = headers.get(b"host", b"").decode("ascii")
+    scheme = str(scope.get("scheme") or "http")
+    origin = absolute_csp_origin(f"{scheme}://{authority}")
+    if origin is None:
+      return None
+    hostname = urlparse(origin).hostname
+    is_loopback = (
+      hostname == "localhost"
+      or (hostname is not None and ipaddress.ip_address(hostname).is_loopback)
+    )
+  except (UnicodeDecodeError, ValueError, TypeError):
+    return None
+  if not is_loopback:
+    return None
+  return origin
+
+
+def _app_frame_csp_for_scope(scope) -> str:
+  """Let the loopback test harness exercise the real opaque app frame."""
+  delivery_origin = _loopback_delivery_origin(scope)
+  if delivery_origin is None:
+    return _APP_FRAME_CSP
+  return app_frame_csp(
+    settings.frontend_origin,
+    _SERVICE_GATEWAY_ORIGIN,
+    _BROWSER_API_ORIGIN,
+    delivery_origin,
+  )
+
 
 # Published sites (`/sites/<token>/`) are public snapshots of the owner's own
 # agent-authored artifacts and Web Studio builds. The `sandbox` directive
@@ -397,7 +436,7 @@ class _SecurityHeadersMiddleware:
       elif chat_embed:
         csp = CHAT_EMBED_CSP
       elif app_frame:
-        csp = _APP_FRAME_CSP
+        csp = _app_frame_csp_for_scope(scope)
       else:
         csp = _SHELL_CSP
       response_headers.append((

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -335,9 +335,17 @@ _APP_FRAME_CSP = app_frame_csp(
 )
 
 def _loopback_delivery_origin(scope) -> str | None:
-  """Return the exact loopback origin serving this request, if any."""
+  """Return the exact loopback origin serving a loopback request, if any."""
   headers = dict(scope.get("headers") or ())
   try:
+    client = scope.get("client")
+    peer = client[0] if isinstance(client, (list, tuple)) and client else None
+    peer_is_loopback = (
+      peer == "localhost"
+      or (isinstance(peer, str) and ipaddress.ip_address(peer).is_loopback)
+    )
+    if not peer_is_loopback:
+      return None
     authority = headers.get(b"host", b"").decode("ascii")
     scheme = str(scope.get("scheme") or "http")
     origin = absolute_csp_origin(f"{scheme}://{authority}")

--- a/backend/app/response_policy.py
+++ b/backend/app/response_policy.py
@@ -51,11 +51,17 @@ def app_frame_csp(
   frontend_origin: str,
   gateway_origin: str = "",
   api_origin: str = "",
+  delivery_origin: str = "",
 ) -> str:
   """Complete policy for the opaque mini-app document."""
   origin = _validated_frontend_origin(frontend_origin)
-  frame_sources = [origin]
-  connect_sources = [origin]
+  resource_sources = [origin]
+  delivery = absolute_csp_origin(delivery_origin)
+  if delivery is not None and delivery != origin:
+    resource_sources.append(delivery)
+  resource_source = " ".join(resource_sources)
+  frame_sources = list(resource_sources)
+  connect_sources = list(resource_sources)
   api = absolute_csp_origin(api_origin)
   if api is not None and api != origin:
     connect_sources.append(api)
@@ -66,7 +72,7 @@ def app_frame_csp(
     "sandbox allow-scripts allow-forms allow-popups "
     "allow-popups-to-escape-sandbox "
     "allow-top-navigation-by-user-activation; "
-    f"default-src {origin}; "
+    f"default-src {resource_source}; "
     # `'wasm-unsafe-eval'` is the narrow modern source for WebAssembly, but older
     # WebKit-based installed apps (older iOS Safari / installed-PWA engines)
     # ignore it and still gate WebAssembly compilation on `'unsafe-eval'`.
@@ -74,12 +80,12 @@ def app_frame_csp(
     # frames, so both sources are required for it to start on those browsers.
     # The permission stays confined to the isolated app-frame policy; the shell
     # and other documents keep only the narrow modern source.
-    f"script-src {origin} 'unsafe-inline' 'wasm-unsafe-eval' 'unsafe-eval' "
+    f"script-src {resource_source} 'unsafe-inline' 'wasm-unsafe-eval' 'unsafe-eval' "
     "blob: https://esm.sh; "
-    f"style-src {origin} 'unsafe-inline' https://fonts.googleapis.com; "
-    f"font-src {origin} https://fonts.gstatic.com https://cdn.openai.com; "
+    f"style-src {resource_source} 'unsafe-inline' https://fonts.googleapis.com; "
+    f"font-src {resource_source} https://fonts.gstatic.com https://cdn.openai.com; "
     f"connect-src {' '.join(connect_sources)}; "
-    f"img-src {origin} data: blob:; "
+    f"img-src {resource_source} data: blob:; "
     f"frame-src {' '.join(frame_sources)}; "
     "frame-ancestors 'self'"
   )

--- a/backend/tests/test_frame.py
+++ b/backend/tests/test_frame.py
@@ -84,6 +84,51 @@ def test_frame_returns_etag_and_cache_control(client, owner_token):
   assert "allow-same-origin" not in sandbox
 
 
+def test_loopback_frame_can_fetch_from_its_delivery_origin(
+  client, owner_token,
+):
+  """The authenticated visual-test harness serves frames over loopback.
+
+  An opaque sandbox does not treat CSP ``'self'`` as that delivery origin, so
+  the exact loopback origin must be named without changing the production
+  frame policy.
+  """
+  app_id = _make_app(
+    client, {"Authorization": f"Bearer {owner_token}"}, "loopback-frame-test",
+  )
+
+  response = client.get(
+    f"/api/apps/{app_id}/frame",
+    headers={"host": "127.0.0.1:8123"},
+  )
+
+  policy = response.headers["content-security-policy"]
+  assert "connect-src" in policy
+  assert "http://127.0.0.1:8123" in policy
+
+
+def test_loopback_frame_accepts_bracketed_ipv6_delivery_origin(
+  client, owner_token,
+):
+  app_id = _make_app(
+    client, {"Authorization": f"Bearer {owner_token}"}, "ipv6-frame-test",
+  )
+  response = client.get(
+    f"/api/apps/{app_id}/frame", headers={"host": "[::1]:8123"},
+  )
+  assert "http://[::1]:8123" in response.headers["content-security-policy"]
+
+
+def test_non_loopback_host_does_not_enter_frame_policy(client, owner_token):
+  app_id = _make_app(
+    client, {"Authorization": f"Bearer {owner_token}"}, "public-frame-test",
+  )
+  response = client.get(
+    f"/api/apps/{app_id}/frame", headers={"host": "example.test:8123"},
+  )
+  assert "example.test" not in response.headers["content-security-policy"]
+
+
 def test_frame_304_on_matching_if_none_match(client, owner_token):
   """Repeated GET with the previous ETag returns 304 + empty body —
   closes the round-trip without re-sending the frame HTML."""

--- a/backend/tests/test_frame.py
+++ b/backend/tests/test_frame.py
@@ -1,5 +1,7 @@
 """Tests for the mini-app frame endpoint."""
 
+from fastapi.testclient import TestClient
+
 from test_app_fixtures import create_local_app
 
 
@@ -97,10 +99,11 @@ def test_loopback_frame_can_fetch_from_its_delivery_origin(
     client, {"Authorization": f"Bearer {owner_token}"}, "loopback-frame-test",
   )
 
-  response = client.get(
-    f"/api/apps/{app_id}/frame",
-    headers={"host": "127.0.0.1:8123"},
-  )
+  with TestClient(client.app, client=("127.0.0.1", 43110)) as loopback:
+    response = loopback.get(
+      f"/api/apps/{app_id}/frame",
+      headers={"host": "127.0.0.1:8123"},
+    )
 
   policy = response.headers["content-security-policy"]
   assert "connect-src" in policy
@@ -113,9 +116,10 @@ def test_loopback_frame_accepts_bracketed_ipv6_delivery_origin(
   app_id = _make_app(
     client, {"Authorization": f"Bearer {owner_token}"}, "ipv6-frame-test",
   )
-  response = client.get(
-    f"/api/apps/{app_id}/frame", headers={"host": "[::1]:8123"},
-  )
+  with TestClient(client.app, client=("::1", 43110)) as loopback:
+    response = loopback.get(
+      f"/api/apps/{app_id}/frame", headers={"host": "[::1]:8123"},
+    )
   assert "http://[::1]:8123" in response.headers["content-security-policy"]
 
 
@@ -127,6 +131,21 @@ def test_non_loopback_host_does_not_enter_frame_policy(client, owner_token):
     f"/api/apps/{app_id}/frame", headers={"host": "example.test:8123"},
   )
   assert "example.test" not in response.headers["content-security-policy"]
+
+
+def test_spoofed_loopback_host_from_remote_peer_does_not_enter_frame_policy(
+  client, owner_token,
+):
+  app_id = _make_app(
+    client, {"Authorization": f"Bearer {owner_token}"}, "remote-frame-test",
+  )
+  with TestClient(client.app, client=("198.51.100.7", 43110)) as remote:
+    response = remote.get(
+      f"/api/apps/{app_id}/frame", headers={"host": "127.0.0.1:8123"},
+    )
+  assert "http://127.0.0.1:8123" not in response.headers[
+    "content-security-policy"
+  ]
 
 
 def test_frame_304_on_matching_if_none_match(client, owner_token):


### PR DESCRIPTION
## Summary

- add the exact loopback delivery origin to opaque app-frame resource directives during authenticated local visual tests
- leave non-loopback and production frame policy unchanged
- validate the request origin through the shared absolute-origin parser
- cover IPv4, bracketed IPv6, and non-loopback hosts

## Why

Opaque sandboxed frames cannot use CSP `self` for their own relative modules. The authenticated screenshot helper deliberately serves the real app frame over loopback, so rendered verification failed even though production delivery was healthy. Naming only that validated loopback origin restores the test path without broadening production policy.

This is a distinct follow-up to #761, which added a configured browser API origin. That production setting remains separate; this change is scoped to the request's exact loopback delivery origin.

## Validation

- `scripts/wt-pytest.sh backend/tests/test_frame.py backend/tests/test_security_headers.py --tb=short -q` — 32 tests passed
- used the restored path to verify the Memory and Reflection interfaces at the owner viewport