### PR TITLE
Return panes to recently used tabs after close or move

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1095,10 +1095,12 @@ placement intent and never encode pane ids, split directions, or breakpoints.
 `frontend/src/components/Shell/paneModel.js` is the pure workspace model. A
 workspace contains a binary `layout` tree, a map of pane records, a focused pane,
 a presentation mode (`single` or `panes`), and the single-screen slot. Each pane
-owns its ordered tabs and `activeTabKey`; tab identity and navigation mapping
-remain in `tabModel.js`. The model normalizes persisted input, enforces unique
-tabs across panes, bounds pane count/depth, collapses empty splits, and returns
-the same reference for no-op transitions.
+owns its visible tab order, `activeTabKey`, and a most-recent-first
+`recentTabKeys` permutation used when its active tab closes or moves away; tab
+identity and navigation mapping remain in `tabModel.js`. The model normalizes
+persisted input, seeds older blobs from the former neighbour-close order,
+enforces unique tabs across panes, bounds pane count/depth, collapses empty
+splits, and returns the same reference for no-op transitions.
 
 `useWorkspaceSession.js` is the live state owner. It composes reducer transitions
 through a synchronous ref boundary, persists the sole versioned

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -3326,7 +3326,7 @@ export default function Shell({ onInitialVisualReady }) {
     // Drop the tab pinned to this chat (local delete only — see deleteApp).
     // reason:'deleted' clears the undo slot so Cmd/Z can't resurrect a
     // tombstoned chat outside the backend recovery path. CLOSE_TAB already
-    // activates the pane's neighbour tab when one exists; only if that leaves
+    // activates the pane's most recently used surviving tab; only if that leaves
     // the focused pane EMPTY (we deleted its sole/active tab) do we open a fresh
     // chat — so a background sibling tab is preserved rather than overridden.
     dispatchWorkspace({
@@ -3395,7 +3395,7 @@ export default function Shell({ onInitialVisualReady }) {
     // (contract §4.1.5), tombstone its route so Back can't recreate the tab
     // (§5.1.1), then scrub the nav-stack, then close its tab. The
     // CLOSE_TAB(reason:'deleted') owns the view transition — the derived triple
-    // follows the workspace to the pane's neighbour/collapse; no global demote.
+    // follows the workspace to its recent tab or collapsed sibling; no global demote.
     retireAppHistory(id, 'deleted')
     tombstoneRoute('app', id)
     const sid = String(id)

--- a/frontend/src/components/Shell/__tests__/paneModel.test.js
+++ b/frontend/src/components/Shell/__tests__/paneModel.test.js
@@ -77,8 +77,15 @@ function assertInvariants(ws) {
       assert.ok(!seenTab.has(key), 'a tab is unique workspace-wide')
       seenTab.add(key)
     }
+    assert.deepEqual(
+      [...pane.recentTabKeys].sort(), [...keys].sort(),
+      'recency is a duplicate-free permutation of the pane tabs',
+    )
     if (keys.length === 0) assert.equal(pane.activeTabKey, null)
-    else assert.ok(keys.includes(pane.activeTabKey), 'active tab is a member')
+    else {
+      assert.ok(keys.includes(pane.activeTabKey), 'active tab is a member')
+      assert.equal(pane.recentTabKeys[0], pane.activeTabKey, 'active tab is most recent')
+    }
   }
 }
 
@@ -88,6 +95,7 @@ test('seedFromFlatTabs makes a single focused pane with the last tab active', ()
   assert.equal(ws.focusedPaneId, 'p0')
   assert.deepEqual(paneModel.flatten(ws), [makeTab('chat', 'a'), makeTab('app', 42)])
   assert.equal(ws.panes.p0.activeTabKey, 'app:42')
+  assert.deepEqual(ws.panes.p0.recentTabKeys, ['app:42', 'chat:a'])
   assertInvariants(ws)
 })
 
@@ -157,6 +165,8 @@ test('normalize coerces a stale active tab to a real member', () => {
     nextId: 1,
   })
   assert.equal(ws.panes.p0.activeTabKey, 'chat:b', 'falls back to the last tab')
+  assert.deepEqual(ws.panes.p0.recentTabKeys, ['chat:b', 'chat:a'],
+    'an older blob seeds recency from the former close order')
 })
 
 test('normalize keeps a sole empty root but removes any other empty pane', () => {
@@ -357,8 +367,8 @@ test('seedFromFlatTabs preserves more than six deduplicated tabs', () => {
   assertInvariants(ws)
 })
 
-test('closeTab activates the neighbour before it, or the new last when at index 0', () => {
-  const base = paneModel.normalize({
+test('closeTab returns to the most recently visited surviving tab in that pane', () => {
+  let base = paneModel.normalize({
     v: 1,
     layout: 'p0',
     panes: {
@@ -371,15 +381,41 @@ test('closeTab activates the neighbour before it, or the new last when at index 
     focusedPaneId: 'p0',
     nextId: 1,
   })
-  const afterMid = paneModel.closeTab(base, 'chat:c')
-  assert.equal(afterMid.panes.p0.activeTabKey, 'chat:b', 'neighbour at index-1 activates')
+  // Visit A, then C. A is not adjacent to C, so this distinguishes MRU from
+  // the old left-neighbour selection.
+  base = paneModel.setActiveTab(base, 'p0', 'chat:a')
+  base = paneModel.setActiveTab(base, 'p0', 'chat:c')
+  assert.deepEqual(base.panes.p0.recentTabKeys, ['chat:c', 'chat:a', 'chat:b', 'chat:d'])
+  const afterBackground = paneModel.closeTab(base, 'chat:d')
+  assert.equal(afterBackground.panes.p0.activeTabKey, 'chat:c',
+    'closing a background tab leaves the active tab unchanged')
+  assert.deepEqual(afterBackground.panes.p0.recentTabKeys, ['chat:c', 'chat:a', 'chat:b'])
 
-  const headActive = paneModel.setActiveTab(base, 'p0', 'chat:a')
-  const afterHead = paneModel.closeTab(headActive, 'chat:a')
-  assert.equal(afterHead.panes.p0.activeTabKey, 'chat:d', 'closing the head activates the new last')
+  const afterMid = paneModel.closeTab(afterBackground, 'chat:c')
+  assert.equal(afterMid.panes.p0.activeTabKey, 'chat:a', 'the previously visited tab activates')
+
+  const afterPrevious = paneModel.closeTab(afterMid, 'chat:a')
+  assert.equal(afterPrevious.panes.p0.activeTabKey, 'chat:b', 'repeated closes keep walking recency')
 
   assert.equal(paneModel.closeTab(base, 'chat:absent'), base, 'closing an absent tab is a no-op')
   assertInvariants(afterMid)
+})
+
+test('moving the active tab away reveals the source pane MRU and activates it at destination', () => {
+  let ws = paneModel.seedFromFlatTabs(
+    ['a', 'b', 'c', 'd', 'destination'].map(id => makeTab('chat', id)),
+  )
+  ws = paneModel.moveTab(ws, 'chat:destination', { paneId: 'p0', edge: 'right' })
+  const destinationPaneId = paneModel.paneOf(ws, 'chat:destination').id
+
+  ws = paneModel.setActiveTab(ws, 'p0', 'chat:a')
+  ws = paneModel.setActiveTab(ws, 'p0', 'chat:c')
+  assert.deepEqual(ws.panes.p0.recentTabKeys.slice(0, 2), ['chat:c', 'chat:a'])
+
+  const moved = paneModel.moveTab(ws, 'chat:c', { paneId: destinationPaneId })
+  assert.equal(moved.panes.p0.activeTabKey, 'chat:a', 'the source returns to its previous tab')
+  assert.equal(moved.panes[destinationPaneId].activeTabKey, 'chat:c', 'the moved tab is active at destination')
+  assertInvariants(moved)
 })
 
 test('closeTab that empties a pane collapses the workspace', () => {
@@ -890,8 +926,13 @@ test('parseWorkspace accepts a persisted pane with more than six tabs', () => {
     nextId: 1,
   })
   const parsed = paneModel.parseWorkspace(raw)
+  assert.equal(paneModel.isValidWorkspaceBlob(raw), true,
+    'an older v1 blob remains authoritative while recency is added')
   assert.deepEqual(parsed.panes.p0.tabs, many)
   assert.equal(parsed.panes.p0.activeTabKey, 'chat:c0')
+  assert.deepEqual(parsed.panes.p0.recentTabKeys,
+    ['chat:c0', 'chat:c9', 'chat:c8', 'chat:c7', 'chat:c6', 'chat:c5', 'chat:c4', 'chat:c3', 'chat:c2', 'chat:c1'],
+    'the missing recency field is seeded from the prior close order')
   assertInvariants(parsed)
 })
 

--- a/frontend/src/components/Shell/paneModel.js
+++ b/frontend/src/components/Shell/paneModel.js
@@ -2,10 +2,10 @@
 //
 // tabModel.js owns a single flat open set and computes active-ness against one
 // global nav focus. This module generalizes that to a binary split tree of
-// panes: each pane holds its own set of tabModel tabs plus its own active tab,
-// and the workspace tracks which pane has focus. A single pane is the trivial
-// leaf. The state shape, normalize() invariants, reducer contract, and rendering
-// constraints are documented in ARCHITECTURE.md.
+// panes: each pane holds its own set of tabModel tabs, active tab, and recency
+// order, while the workspace tracks which pane has focus. A single pane is the
+// trivial leaf. The state shape, normalize() invariants, reducer contract, and
+// rendering constraints are documented in ARCHITECTURE.md.
 //
 // Everything here is pure and dependency-free except tabModel.js. Tab identity,
 // construction, the numeric-app-id posture, and nav mapping all stay in
@@ -196,6 +196,45 @@ function dedupTabs(tabs) {
   return out
 }
 
+// The pre-recency close policy walked left from the active tab and wrapped from
+// the first tab to the end. Use that exact order to seed an older workspace, so
+// installing the recency field is behavior-preserving until the owner visits a
+// different tab. The visible tab order itself remains untouched.
+function legacyRecentTabKeys(keys, activeKey) {
+  if (keys.length === 0) return []
+  const activeIndex = keys.indexOf(activeKey)
+  const start = activeIndex === -1 ? keys.length - 1 : activeIndex
+  return keys.map((_, offset) => keys[(start - offset + keys.length) % keys.length])
+}
+
+// Every non-empty pane stores one permutation of its live keys, most-recent
+// first. `activeTabKey` remains the render-facing selection for compatibility;
+// normalize keeps it equal to the first recency entry. Missing/corrupt history
+// is repaired from the old close policy, so the v1 workspace blob needs no
+// migration branch or parallel persistence format.
+function normalizeRecentTabKeys(tabs, activeKey, rawRecent) {
+  const keys = tabs.map(tabModel.tabKey)
+  const live = new Set(keys)
+  const recent = []
+  const seen = new Set()
+  const add = (key) => {
+    if (typeof key !== 'string' || !live.has(key) || seen.has(key)) return
+    seen.add(key)
+    recent.push(key)
+  }
+
+  // An explicit live selection is always the most recent entry.
+  add(activeKey)
+  if (Array.isArray(rawRecent)) rawRecent.forEach(add)
+
+  // Append any new/background tabs in the deterministic legacy order. For an
+  // older blob this seeds the whole list; for a current blob it normally adds
+  // only a newly opened tab at the cold end.
+  const fallbackActive = live.has(activeKey) ? activeKey : keys.at(-1)
+  legacyRecentTabKeys(keys, fallbackActive).forEach(add)
+  return recent
+}
+
 // Structural equality that ignores object key order, so a normalized rebuild can
 // be compared against its input to preserve reference identity on a no-op.
 function deepEqual(a, b) {
@@ -292,6 +331,7 @@ export function normalize(ws) {
       id,
       tabs: sanitizeTabs(src && Array.isArray(src.tabs) ? src.tabs : []),
       activeTabKey: src ? src.activeTabKey : null,
+      recentTabKeys: src ? src.recentTabKeys : null,
     })
   }
 
@@ -322,23 +362,26 @@ export function normalize(ws) {
     const rootId = (typeof ws.focusedPaneId === 'string' && cleaned.has(ws.focusedPaneId))
       ? ws.focusedPaneId
       : (orderedIds[0] || 'p0')
-    cleaned.set(rootId, { id: rootId, tabs: [], activeTabKey: null })
+    cleaned.set(rootId, { id: rootId, tabs: [], activeTabKey: null, recentTabKeys: [] })
     placed.clear()
     placed.add(rootId)
     layout = rootId
   }
 
-  // Rebuild the panes map from the surviving leaves only, coercing each active
-  // tab to a real member (else the last tab, else null for an empty root).
+  // Rebuild the panes map from the surviving leaves only. Recency owns fallback
+  // selection: removing the active key exposes the most recently used survivor.
   const panes = {}
   for (const id of placed) {
     const pane = cleaned.get(id)
-    const keys = pane.tabs.map(tabModel.tabKey)
-    let active = pane.activeTabKey
-    if (active == null || !keys.includes(active)) {
-      active = keys.length ? keys[keys.length - 1] : null
+    const recentTabKeys = normalizeRecentTabKeys(
+      pane.tabs, pane.activeTabKey, pane.recentTabKeys,
+    )
+    panes[id] = {
+      id,
+      tabs: pane.tabs,
+      activeTabKey: recentTabKeys[0] ?? null,
+      recentTabKeys,
     }
-    panes[id] = { id, tabs: pane.tabs, activeTabKey: active }
   }
 
   // Focus must name a live pane; else the nearest surviving leaf.
@@ -422,6 +465,7 @@ export function seedFromFlatTabs(tabs) {
         id: paneId,
         tabs: clean,
         activeTabKey: keys.length ? keys[keys.length - 1] : null,
+        recentTabKeys: [...keys].reverse(),
       },
     },
     focusedPaneId: paneId,
@@ -841,19 +885,15 @@ export function openTabAt(ws, tab, target) {
   return openTab(ws, clean)
 }
 
-// Close a tab; if it was the pane's active tab, activate the neighbour before it
-// (else the new last tab) — fixing today's close-the-viewed-tab-into-nothing.
+// Close a tab. If it was active, clearing the render-facing selection lets
+// normalize expose the first surviving recentTabKeys entry. Closing a background
+// tab leaves the current selection untouched.
 export function closeTab(ws, tabKey) {
   const pane = paneOf(ws, tabKey)
   if (!pane) return ws
   const removedIndex = pane.tabs.findIndex(tab => tabModel.tabKey(tab) === tabKey)
   const tabs = pane.tabs.filter((_, i) => i !== removedIndex)
-  let active = pane.activeTabKey
-  if (active === tabKey) {
-    if (tabs.length === 0) active = null
-    else if (removedIndex - 1 >= 0) active = tabModel.tabKey(tabs[removedIndex - 1])
-    else active = tabModel.tabKey(tabs[tabs.length - 1])
-  }
+  const active = pane.activeTabKey === tabKey ? null : pane.activeTabKey
   return commit(ws, {
     ...ws,
     panes: { ...ws.panes, [pane.id]: { ...pane, tabs, activeTabKey: active } },
@@ -1509,6 +1549,7 @@ function isValidWorkspace(ws) {
   for (const id of ids) {
     const pane = ws.panes[id]
     const keys = pane.tabs.map(tabModel.tabKey)
+    const keySet = new Set(keys)
     for (const tab of pane.tabs) {
       if (tab.kind === 'app' && !Number.isFinite(Number(tab.id))) return false
       const key = tabModel.tabKey(tab)
@@ -1516,7 +1557,12 @@ function isValidWorkspace(ws) {
       seenTab.add(key)
     }
     if (pane.activeTabKey == null && keys.length > 0) return false
-    if (pane.activeTabKey != null && !keys.includes(pane.activeTabKey)) return false
+    if (pane.activeTabKey != null && !keySet.has(pane.activeTabKey)) return false
+    if (!Array.isArray(pane.recentTabKeys)) return false
+    if (pane.recentTabKeys.length !== keys.length) return false
+    if (new Set(pane.recentTabKeys).size !== keys.length) return false
+    if (pane.recentTabKeys.some(key => !keySet.has(key))) return false
+    if ((pane.recentTabKeys[0] ?? null) !== pane.activeTabKey) return false
   }
   return true
 }


### PR DESCRIPTION
## Summary
- track recently used tabs independently within each pane
- return to the previously used surviving tab when the active tab closes or moves
- preserve existing saved workspaces and their former close behavior until new visits establish recency

## Testing
- `npm test` (2,600 tests)
- focused pane model and placement tests (149 tests)
- ESLint on the changed shell sources