### PR TITLE
Recover mounted chat panes after server reconnect

### DIFF
--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -26,7 +26,11 @@ import useScrollMode, {
 } from './useScrollMode.js'
 import useVoiceInput from './useVoiceInput.js'
 import useOnlineStatus from '../../hooks/useOnlineStatus.js'
-import { getOnlineSnapshot } from '../../lib/connectivityStore.js'
+import {
+  getOnlineSnapshot,
+  getRecoverySnapshot,
+  subscribeRecovery,
+} from '../../lib/connectivityStore.js'
 import useSystemEventStream from '../../hooks/useSystemEventStream.js'
 import usePendingQueue from './hooks/usePendingQueue.js'
 import useBridgePartial from './hooks/useBridgePartial.js'
@@ -115,6 +119,7 @@ import {
   isOwnerUserMessage,
   jumpToLatestShown,
   openAppCtaViewModel,
+  runtimeStreamAttachAction,
   shouldRetireRestoredQuestionSnapshot,
   shouldAttachRunningStream,
   shouldRecoverSettledRuntime,
@@ -1067,7 +1072,7 @@ export default function ChatView({
   // refresh. While a turn or visible queue exists, poll the small chat state
   // payload and hydrate only runtime fields — do not replace the transcript.
   const reconcileRuntimeState = useCallback(async () => {
-    if (hiddenRef.current) return
+    if (hiddenRef.current) return null
     const gen = fetchGenRef.current
     try {
       const res = await apiFetch(
@@ -1075,9 +1080,13 @@ export default function ChatView({
         { timeoutMs: CHAT_FETCH_TIMEOUT_MS },
       )
       const data = await jsonOrThrow(res, 'Runtime refresh failed')
-      if (chatIdStaleRef.current) return
-      if (fetchGenRef.current !== gen) return
+      if (chatIdStaleRef.current) return null
+      if (fetchGenRef.current !== gen) return null
       const serverPending = data.pending_messages || []
+      const runtime = {
+        running: !!data.running,
+        pendingQuestionId: data.pending_question_id || null,
+      }
       // The SSE stream is the source of truth for "a turn is live" — this poll
       // is only a fallback. While the stream is alive (isStreamingRef) or a Stop
       // is in flight, local optimistic state is authoritative: this background
@@ -1132,7 +1141,7 @@ export default function ChatView({
         data, cachedGoalObjective,
       )
       setActiveGoalObjective(runtimeGoalObjective)
-      const pendingQuestionId = data.pending_question_id || null
+      const pendingQuestionId = runtime.pendingQuestionId
       setLiveQuestionId(pendingQuestionId)
       updateChatRuntimeCache(queryClient, chatMessagesQueryKey(chatId), {
         running: !!data.running,
@@ -1165,7 +1174,9 @@ export default function ChatView({
           }
         })
       }
+      return runtime
     } catch { /* background reconciliation is best-effort */ }
+    return null
   }, [
     chatId,
     fetchMessages,
@@ -1579,14 +1590,14 @@ export default function ChatView({
     reconcileExternalActivity()
   }, [effectiveRunSignal.seq, hidden, reconcileExternalActivity])
 
-  const ensureRuntimeStreamConnected = useCallback(() => {
-    if (hiddenRef.current) return
-    if (connectionError === 'disconnected') return
-    if (!shouldAttachRunningStream({
-      running: serverRunningRef.current,
-      pendingQuestionId: liveQuestionId,
-    })) return
-    if (isStreamingRef.current) return
+  const ensureRuntimeStreamConnected = useCallback((runtime) => {
+    const action = runtimeStreamAttachAction({
+      ...runtime,
+      isStreaming: isStreamingRef.current,
+      connectionError,
+      hidden: hiddenRef.current,
+    })
+    if (action === 'none') return
     if (runtimeReconnectInFlightRef.current) return
 
     runtimeReconnectInFlightRef.current = true
@@ -1594,12 +1605,13 @@ export default function ChatView({
     // client has no live SSE attached: Android can pause/kill the fetch
     // during app switch, network handoff, or a shell rebuild. Reconnect
     // from the server verdict instead of waiting for a full remount.
-    Promise.resolve(connectToStream(true))
+    const attaching = action === 'retry' ? retry() : connectToStream(true)
+    Promise.resolve(attaching)
       .catch(() => {})
       .finally(() => {
         runtimeReconnectInFlightRef.current = false
       })
-  }, [connectToStream, connectionError, isStreamingRef, liveQuestionId])
+  }, [connectToStream, connectionError, isStreamingRef, retry])
 
   const wasHiddenRef = useRef(hidden)
   useLayoutEffect(() => {
@@ -3775,10 +3787,11 @@ export default function ChatView({
       // against a wedged backend. Skip a tick while the prior one is in flight;
       // the fetch is time-boxed (apiFetch timeoutMs) so inFlight always clears.
       inFlight = true
-      reconcileRuntimeState().finally(() => {
-        inFlight = false
-        if (!cancelled) ensureRuntimeStreamConnected()
-      })
+      reconcileRuntimeState()
+        .then(runtime => {
+          if (!cancelled && runtime) ensureRuntimeStreamConnected(runtime)
+        })
+        .finally(() => { inFlight = false })
     }
     run()
     const intervalMs = hasQueue ? 1000 : 3000
@@ -3807,10 +3820,11 @@ export default function ChatView({
   useEffect(() => {
     if (hidden) return
     let cancelled = false
+    let observedRecoveryGeneration = getRecoverySnapshot()
     const run = () => {
       if (cancelled) return
-      reconcileRuntimeState().finally(() => {
-        if (!cancelled) ensureRuntimeStreamConnected()
+      reconcileRuntimeState().then(runtime => {
+        if (!cancelled && runtime) ensureRuntimeStreamConnected(runtime)
       })
     }
     const onVisible = () => {
@@ -3820,8 +3834,15 @@ export default function ChatView({
     window.addEventListener('pageshow', run)
     window.addEventListener('online', run)
     document.addEventListener('visibilitychange', onVisible)
+    const unsubscribeRecovery = subscribeRecovery(() => {
+      const generation = getRecoverySnapshot()
+      if (generation === observedRecoveryGeneration) return
+      observedRecoveryGeneration = generation
+      run()
+    })
     return () => {
       cancelled = true
+      unsubscribeRecovery()
       window.removeEventListener('focus', run)
       window.removeEventListener('pageshow', run)
       window.removeEventListener('online', run)

--- a/frontend/src/components/ChatView/__tests__/chatRuntimeState.test.js
+++ b/frontend/src/components/ChatView/__tests__/chatRuntimeState.test.js
@@ -15,6 +15,7 @@ import {
   openAppCtaViewModel,
   previewReadyAnnouncement,
   previewUpdatedAnnouncement,
+  runtimeStreamAttachAction,
   serverSnapshotBehindLocal,
   shouldAttachRunningStream,
   shouldRetireRestoredQuestionSnapshot,
@@ -175,6 +176,35 @@ test('a known server run settling recovers a live stream that missed its termina
     streamStillActive: true,
     localStartInFlight: true,
   }), false, 'an unacknowledged local start owns the idle-snapshot race')
+})
+
+test('a fresh running verdict repairs only an exhausted visible stream', () => {
+  assert.equal(runtimeStreamAttachAction({
+    running: true,
+    connectionError: 'disconnected',
+  }), 'retry')
+  assert.equal(runtimeStreamAttachAction({
+    running: true,
+    connectionError: null,
+  }), 'connect')
+  assert.equal(runtimeStreamAttachAction({
+    running: true,
+    connectionError: 'retrying',
+  }), 'none', 'the bounded retry loop keeps sole ownership while active')
+  assert.equal(runtimeStreamAttachAction({
+    running: true,
+    pendingQuestionId: 'question-1',
+    connectionError: 'disconnected',
+  }), 'none', 'a parked question has no live output to attach to')
+  assert.equal(runtimeStreamAttachAction({
+    running: true,
+    connectionError: 'disconnected',
+    hidden: true,
+  }), 'none', 'only the visible pane owns transport recovery')
+  assert.equal(runtimeStreamAttachAction({
+    running: false,
+    connectionError: 'disconnected',
+  }), 'none', 'an idle server verdict must not resurrect a stream')
 })
 
 test('only a cold stream prefix missing the durable question is retired', () => {

--- a/frontend/src/components/ChatView/__tests__/offlineFooter.test.js
+++ b/frontend/src/components/ChatView/__tests__/offlineFooter.test.js
@@ -73,8 +73,9 @@ test('floating actions precede the measured rail → connection → queued → c
 })
 
 test('the shell is the one persistent connection owner while send failures stay contextual', () => {
-  assert.match(shell, /\{!online && \([\s\S]*?className="shell__offline"[\s\S]*?Offline/)
-  assert.doesNotMatch(shell, /Reconnecting/)
+  assert.match(shell, /ReachabilityPhase\.CHECKING[\s\S]*?'Reconnecting…'/)
+  assert.match(shell, /ReachabilityPhase\.OFFLINE \? 'Offline'/)
+  assert.match(shell, /\{reachabilityLabel && \([\s\S]*?className="shell__connection-status"[\s\S]*?shell__sr-only/)
   assert.doesNotMatch(chatView, /You're offline — chat needs a connection\./)
   assert.doesNotMatch(chatInputBar, /You're offline — chat needs a connection\./)
   assert.match(

--- a/frontend/src/components/ChatView/chatRuntimeState.js
+++ b/frontend/src/components/ChatView/chatRuntimeState.js
@@ -133,6 +133,27 @@ export function shouldAttachRunningStream({
   return !!running && !pendingQuestionId
 }
 
+/**
+ * A fresh runtime verdict may repair a mounted pane whose stream exhausted.
+ * The stream hook keeps sole ownership while its bounded retry loop is active;
+ * after exhaustion, restart that owner rather than creating a parallel loop.
+ */
+export function runtimeStreamAttachAction({
+  running,
+  pendingQuestionId,
+  isStreaming = false,
+  connectionError = null,
+  hidden = false,
+} = {}) {
+  if (
+    hidden
+    || isStreaming
+    || !shouldAttachRunningStream({ running, pendingQuestionId })
+  ) return 'none'
+  if (connectionError === 'retrying') return 'none'
+  return connectionError === 'disconnected' ? 'retry' : 'connect'
+}
+
 /** Retire only a cold restored prefix proven older than the durable card. */
 export function shouldRetireRestoredQuestionSnapshot({
   isStreaming = false,

--- a/frontend/src/components/Shell/Shell.css
+++ b/frontend/src/components/Shell/Shell.css
@@ -486,17 +486,28 @@
    guidance. The old drawer banner stays retired. Sub-app installation
    lives in the standalone card surfaced from drawer ⋮ on a mini-app. */
 
-  /* The one persistent offline indicator. */
-  .shell__offline {
+  /* One compact indicator covers both the initial reachability check and the
+     confirmed-offline retry loop. The live text remains available to assistive
+     technology without competing for scarce phone-header space. */
+  .shell__connection-status {
     align-self: center;
-    padding: 3px 10px;
-    border-radius: 999px;
-    font-size: 12px;
-    font-weight: 600;
-    color: var(--danger, #f87171);
-    background: color-mix(in srgb, var(--danger, #f87171) 14%, transparent);
-    border: 1px solid color-mix(in srgb, var(--danger, #f87171) 35%, transparent);
-    white-space: nowrap;
+    display: grid;
+    place-items: center;
+    width: 28px;
+    height: 28px;
+    flex: 0 0 28px;
+  }
+  .shell__connection-status::before {
+    content: "";
+    width: 8px;
+    height: 8px;
+    background: var(--accent, #8b6cf7);
+    border-radius: 50%;
+    box-shadow: 0 0 0 4px color-mix(in srgb, var(--accent, #8b6cf7) 14%, transparent);
+    animation: shell-connection-pulse 1.4s ease-in-out infinite;
+  }
+  @keyframes shell-connection-pulse {
+    50% { opacity: 0.48; scale: 0.78; }
   }
 /* The ONE Settings wrapper is a solid surface in BOTH geometries: full-bleed as
    the takeover overlay (single mode / flag off) and paned as a builder tab. The
@@ -683,6 +694,7 @@
   .shell__logo { transition: none; }
   .shell__wordmark { transition: none; }
   .shell__tab-text-inner { animation: none !important; }
+  .shell__connection-status::before { animation: none; }
   /* No completion motion under reduced motion — the ignite/snap AND the hold's
      descriptor-owned release are both skipped (the toggle commits instantly, so
      is-beat-held is never even emitted; this is the belt-and-braces). The direct

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -26,7 +26,8 @@ import { recordClientError } from '../../lib/errorLog.js'
 import useSystemEventStream from '../../hooks/useSystemEventStream.js'
 import useTheme from '../../hooks/useTheme.js'
 import useProviderAuthStatus from '../../hooks/useProviderAuthStatus.js'
-import useOnlineStatus from '../../hooks/useOnlineStatus.js'
+import { useReachabilityPhase } from '../../hooks/useOnlineStatus.js'
+import { ReachabilityPhase } from '../../lib/connectivityStore.js'
 import {
   appQueries,
   chatMessagesQueryKey,
@@ -781,7 +782,11 @@ export default function Shell({ onInitialVisualReady }) {
   // One shell-wide indicator owns the persistent offline explanation. Chat
   // still disables sends while unavailable, but does not repeat this status
   // beside the composer.
-  const online = useOnlineStatus()
+  const reachabilityPhase = useReachabilityPhase()
+  const online = reachabilityPhase !== ReachabilityPhase.OFFLINE
+  const reachabilityLabel = reachabilityPhase === ReachabilityPhase.CHECKING
+    ? 'Reconnecting…'
+    : (reachabilityPhase === ReachabilityPhase.OFFLINE ? 'Offline' : null)
   const chatsLoadedRef = useRef(false)
   const knownExistingOffListChatIdsRef = useRef(new Set())
   // Always-current chats, for reading inside callbacks that may hold a stale
@@ -3602,9 +3607,13 @@ export default function Shell({ onInitialVisualReady }) {
           </button>
         </nav>
         <div className="shell__bar-actions">
-          {!online && (
-            <span className="shell__offline" role="status" aria-live="polite">
-              Offline
+          {reachabilityLabel && (
+            <span
+              className="shell__connection-status"
+              role="status"
+              aria-live="polite"
+            >
+              <span className="shell__sr-only">{reachabilityLabel}</span>
             </span>
           )}
           <NotificationCenter

--- a/frontend/src/components/Shell/__tests__/useSystemEventStream.test.js
+++ b/frontend/src/components/Shell/__tests__/useSystemEventStream.test.js
@@ -1,0 +1,61 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { renderHook } from '../../ChatView/hooks/__tests__/react-hook-shim.mjs'
+
+function target(extra = {}) {
+  return {
+    ...extra,
+    addEventListener() {},
+    removeEventListener() {},
+    dispatchEvent() {},
+  }
+}
+
+async function flushMicrotasks() {
+  for (let index = 0; index < 10; index += 1) await Promise.resolve()
+}
+
+test('a clean system-stream EOF enters the shared reachability owner', async () => {
+  globalThis.window = target({ location: { reload() {} } })
+  globalThis.document = target({ visibilityState: 'visible' })
+  Object.defineProperty(globalThis, 'navigator', {
+    configurable: true,
+    value: { onLine: true },
+  })
+  globalThis.localStorage = {
+    getItem(key) { return key === 'token' ? 'owner-token' : null },
+    removeItem() {},
+  }
+  globalThis.sessionStorage = { setItem() {} }
+
+  const requests = []
+  let holdHealthProbe
+  globalThis.fetch = async (url) => {
+    requests.push(String(url))
+    if (String(url).endsWith('/api/health')) {
+      return new Promise(resolve => { holdHealthProbe = resolve })
+    }
+    return {
+      ok: true,
+      status: 200,
+      body: { getReader: () => ({ read: async () => ({ done: true }) }) },
+    }
+  }
+
+  const connectivity = await import('../../../lib/connectivityStore.js')
+  const { default: useSystemEventStream } = await import(
+    '../../../hooks/useSystemEventStream.js'
+  )
+  const hook = renderHook(useSystemEventStream, () => {})
+  await flushMicrotasks()
+
+  assert.equal(requests.filter(url => url.endsWith('/api/events/system')).length, 1)
+  assert.equal(requests.filter(url => url.endsWith('/api/health')).length, 1)
+  assert.equal(
+    connectivity.getReachabilityPhaseSnapshot(),
+    connectivity.ReachabilityPhase.CHECKING,
+  )
+
+  holdHealthProbe?.({ ok: true })
+  hook.unmount()
+})

--- a/frontend/src/hooks/useOnlineStatus.js
+++ b/frontend/src/hooks/useOnlineStatus.js
@@ -1,6 +1,8 @@
 import { useSyncExternalStore } from 'react'
 import {
   getOnlineSnapshot,
+  getReachabilityPhaseSnapshot,
+  ReachabilityPhase,
   subscribeOnline,
 } from '../lib/connectivityStore.js'
 
@@ -9,4 +11,12 @@ import {
 // health probes, browser listeners, intervals, or mobile radio wakeups.
 export default function useOnlineStatus() {
   return useSyncExternalStore(subscribeOnline, getOnlineSnapshot, () => true)
+}
+
+export function useReachabilityPhase() {
+  return useSyncExternalStore(
+    subscribeOnline,
+    getReachabilityPhaseSnapshot,
+    () => ReachabilityPhase.ONLINE,
+  )
 }

--- a/frontend/src/hooks/useSystemEventStream.js
+++ b/frontend/src/hooks/useSystemEventStream.js
@@ -118,14 +118,17 @@ export default function useSystemEventStream(
         }
       } catch (err) {
         if (cancelled || err.name === 'AbortError') return
-        void verifyConnectivity()
       } finally {
         controller = null
       }
       // Reconnect with capped exponential backoff. The shell-level
       // stream is supposed to live as long as the Shell — any drop
-      // (network blip, server restart) should self-heal.
+      // (network blip, server restart) should self-heal. Feed the drop into
+      // the shared reachability owner before retrying: its Checking/Offline
+      // phase drives the one shell-wide dot, and its later recovery generation
+      // wakes chat streams whose own bounded retries exhausted during a restart.
       if (!cancelled) {
+        void verifyConnectivity()
         await new Promise(r => setTimeout(r, backoffMs))
         backoffMs = Math.min(backoffMs * 2, 30_000)
         connect()

--- a/frontend/src/hooks/useSystemEventStream.js
+++ b/frontend/src/hooks/useSystemEventStream.js
@@ -4,6 +4,10 @@ import {
   clearToken, clearQueryCache,
 } from '../api/client.js'
 import * as setupSession from '../lib/setupSession.js'
+import {
+  reportNetworkReachable,
+  verifyConnectivity,
+} from '../lib/connectivityStore.js'
 
 /**
  * Persistent SSE subscription to /api/events/system. Lives on the
@@ -60,6 +64,7 @@ export default function useSystemEventStream(
           headers: getAuthHeaders(),
           signal: controller.signal,
         })
+        reportNetworkReachable()
         if (res.status === 401) {
           if (isEphemeralAuth()) {
             window.dispatchEvent(new CustomEvent('mobius:chat-embed-auth-expired'))
@@ -113,6 +118,7 @@ export default function useSystemEventStream(
         }
       } catch (err) {
         if (cancelled || err.name === 'AbortError') return
+        void verifyConnectivity()
       } finally {
         controller = null
       }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -445,10 +445,10 @@ textarea:focus-visible {
    chrome gets the lock.  buttons already get this via the rule above;
    these selectors cover labelled containers that aren't `<button>`. */
 
-/* Shell header (logo, wordmark, brand area, offline pill). */
+/* Shell header (logo, wordmark, brand area, connection status). */
 .shell__bar,
 .shell__brand,
-.shell__offline,
+.shell__connection-status,
 .shell__wordmark {
   user-select: none;
   -webkit-user-select: none;

--- a/frontend/src/lib/__tests__/connectivityStore.test.js
+++ b/frontend/src/lib/__tests__/connectivityStore.test.js
@@ -248,7 +248,11 @@ test('the durable system stream wakes visible chat runtime reconciliation', () =
     'utf8',
   )
   assert.match(systemStream, /await fetch\([\s\S]*?reportNetworkReachable\(\)/)
-  assert.match(systemStream, /catch \(err\) \{[\s\S]*?void verifyConnectivity\(\)/)
+  assert.match(
+    systemStream,
+    /if \(!cancelled\) \{[\s\S]*?void verifyConnectivity\(\)[\s\S]*?setTimeout/,
+    'an unexpected system-stream close must enter shared reachability recovery',
+  )
   assert.match(
     chatView,
     /reconcileRuntimeState\(\)\.then\(runtime => \{[\s\S]*?subscribeRecovery\([\s\S]*?getRecoverySnapshot\(\)[\s\S]*?run\(\)/,

--- a/frontend/src/lib/__tests__/connectivityStore.test.js
+++ b/frontend/src/lib/__tests__/connectivityStore.test.js
@@ -238,20 +238,10 @@ test('the hook and API client consume the shared store contract', () => {
   assert.match(client, /void verifyConnectivity\(\)/)
 })
 
-test('the durable system stream wakes visible chat runtime reconciliation', () => {
-  const systemStream = readFileSync(
-    new URL('../../hooks/useSystemEventStream.js', import.meta.url),
-    'utf8',
-  )
+test('visible chats subscribe their runtime owner to shared recovery', () => {
   const chatView = readFileSync(
     new URL('../../components/ChatView/ChatView.jsx', import.meta.url),
     'utf8',
-  )
-  assert.match(systemStream, /await fetch\([\s\S]*?reportNetworkReachable\(\)/)
-  assert.match(
-    systemStream,
-    /if \(!cancelled\) \{[\s\S]*?void verifyConnectivity\(\)[\s\S]*?setTimeout/,
-    'an unexpected system-stream close must enter shared reachability recovery',
   )
   assert.match(
     chatView,

--- a/frontend/src/lib/__tests__/connectivityStore.test.js
+++ b/frontend/src/lib/__tests__/connectivityStore.test.js
@@ -4,6 +4,7 @@ import assert from 'node:assert/strict'
 import {
   AMBIGUOUS_VERDICT_CONFIRM_MS,
   createConnectivityStore,
+  ReachabilityPhase,
 } from '../connectivityStore.js'
 
 function eventTarget(extra = {}) {
@@ -95,18 +96,21 @@ test('all subscribers share one monitor and the last unsubscribe removes it', as
   assert.equal(h.documentTarget.listenerCount('visibilitychange'), 0)
 })
 
-test('a stale-online failure is confirmed promptly and published once', async () => {
+test('a stale-online failure publishes checking before it is confirmed offline', async () => {
   const h = harness(async () => { throw new TypeError('offline') })
   let notifications = 0
   const stop = h.store.subscribe(() => { notifications += 1 })
   await flushMicrotasks()
 
   assert.equal(h.store.getSnapshot(), true)
+  assert.equal(h.store.getPhaseSnapshot(), ReachabilityPhase.CHECKING)
+  assert.equal(notifications, 1)
   h.timers.runTimeout(AMBIGUOUS_VERDICT_CONFIRM_MS)
   await flushMicrotasks()
 
   assert.equal(h.store.getSnapshot(), false)
-  assert.equal(notifications, 1)
+  assert.equal(h.store.getPhaseSnapshot(), ReachabilityPhase.OFFLINE)
+  assert.equal(notifications, 2)
   stop()
 })
 
@@ -142,22 +146,62 @@ test('a live mutation response repairs a stale offline verdict immediately', asy
 
   h.store.reportReachable()
   assert.equal(h.store.getSnapshot(), true)
-  assert.equal(notifications, 2)
+  assert.equal(h.store.getPhaseSnapshot(), ReachabilityPhase.ONLINE)
+  assert.equal(h.store.getRecoverySnapshot(), 1)
+  assert.equal(notifications, 3)
   stop()
 })
 
 test('a live mutation response outranks an older in-flight failed probe', async () => {
-  let settleProbe
-  const h = harness(() => new Promise((resolve) => { settleProbe = resolve }))
+  let rejectProbe
+  const h = harness(() => new Promise((resolve, reject) => { rejectProbe = reject }))
   h.navigatorTarget.onLine = false
   const stop = h.store.subscribe(() => {})
 
   h.store.reportReachable()
-  settleProbe({ ok: false })
+  rejectProbe(new TypeError('offline'))
   await flushMicrotasks()
 
   assert.equal(h.store.getSnapshot(), true)
   assert.equal(h.timers.timeoutCount(), 0)
+  stop()
+})
+
+test('any HTTP response proves transport reachability regardless of status', async () => {
+  const h = harness(async () => ({ ok: false, status: 503 }))
+  const stop = h.store.subscribe(() => {})
+  await flushMicrotasks()
+
+  assert.equal(h.store.getSnapshot(), true)
+  assert.equal(h.store.getPhaseSnapshot(), ReachabilityPhase.ONLINE)
+  stop()
+})
+
+test('verification exposes uncertainty immediately and recovery emits one generation', async () => {
+  let reachable = true
+  const h = harness(async () => {
+    if (!reachable) throw new TypeError('offline')
+    return { ok: true }
+  })
+  let notifications = 0
+  const stop = h.store.subscribe(() => { notifications += 1 })
+  await flushMicrotasks()
+
+  reachable = false
+  const failedCheck = h.store.verify()
+  assert.equal(h.store.getPhaseSnapshot(), ReachabilityPhase.CHECKING)
+  assert.equal(h.store.getSnapshot(), true, 'uncertainty must not disable actions')
+  await failedCheck
+
+  reachable = true
+  await h.store.verify()
+  assert.equal(h.store.getPhaseSnapshot(), ReachabilityPhase.ONLINE)
+  assert.equal(h.store.getRecoverySnapshot(), 1)
+  assert.equal(notifications, 2)
+
+  h.store.reportReachable()
+  assert.equal(h.store.getRecoverySnapshot(), 1)
+  assert.equal(notifications, 2, 'settled responses must not repeat recovery')
   stop()
 })
 
@@ -189,6 +233,25 @@ test('the hook and API client consume the shared store contract', () => {
   const hook = readFileSync(new URL('../../hooks/useOnlineStatus.js', import.meta.url), 'utf8')
   const client = readFileSync(new URL('../../api/client.js', import.meta.url), 'utf8')
   assert.match(hook, /useSyncExternalStore\(subscribeOnline, getOnlineSnapshot/)
+  assert.match(hook, /getReachabilityPhaseSnapshot/)
   assert.doesNotMatch(hook, /fetch\(|setInterval\(/)
   assert.match(client, /void verifyConnectivity\(\)/)
+})
+
+test('the durable system stream wakes visible chat runtime reconciliation', () => {
+  const systemStream = readFileSync(
+    new URL('../../hooks/useSystemEventStream.js', import.meta.url),
+    'utf8',
+  )
+  const chatView = readFileSync(
+    new URL('../../components/ChatView/ChatView.jsx', import.meta.url),
+    'utf8',
+  )
+  assert.match(systemStream, /await fetch\([\s\S]*?reportNetworkReachable\(\)/)
+  assert.match(systemStream, /catch \(err\) \{[\s\S]*?void verifyConnectivity\(\)/)
+  assert.match(
+    chatView,
+    /reconcileRuntimeState\(\)\.then\(runtime => \{[\s\S]*?subscribeRecovery\([\s\S]*?getRecoverySnapshot\(\)[\s\S]*?run\(\)/,
+    'every visible pane rechecks durable runtime after shared reachability recovers',
+  )
 })

--- a/frontend/src/lib/__tests__/vite-env-loader.mjs
+++ b/frontend/src/lib/__tests__/vite-env-loader.mjs
@@ -26,6 +26,7 @@ const REACT_SHIM = new URL(
 const REACT_SHIMMED_MODULES = [
   '/components/Shell/useAppIntentNavigation.js',
   '/components/Shell/useShellReloadController.js',
+  '/hooks/useSystemEventStream.js',
   '/components/ChatView/useFileUpload.js',
   '/components/ChatView/hooks/useComposerDraftState.js',
   '/components/ChatView/useScrollMode.js',

--- a/frontend/src/lib/connectivityStore.js
+++ b/frontend/src/lib/connectivityStore.js
@@ -25,6 +25,18 @@ export const POLL_INTERVAL_MS = 20000
 // or a recovered PWA labelled offline until the regular poll.
 export const AMBIGUOUS_VERDICT_CONFIRM_MS = 1000
 
+export const ReachabilityPhase = Object.freeze({
+  ONLINE: 'online',
+  CHECKING: 'checking',
+  OFFLINE: 'offline',
+})
+
+function reachabilityPhase(state) {
+  if (!state.online) return ReachabilityPhase.OFFLINE
+  if (state.failureStreak > 0) return ReachabilityPhase.CHECKING
+  return ReachabilityPhase.ONLINE
+}
+
 /**
  * One reachability monitor shared by every shell consumer. The dependency
  * arguments keep the state machine directly testable without browser globals.
@@ -41,19 +53,38 @@ export function createConnectivityStore({
   clearIntervalFn = clearInterval,
 } = {}) {
   const listeners = new Set()
-  let snapshot = navigatorTarget?.onLine !== false
-  let connectivityState = { successStreak: 0, failureStreak: 0, online: snapshot }
+  let connectivityState = {
+    successStreak: 0,
+    failureStreak: 0,
+    online: navigatorTarget?.onLine !== false,
+  }
+  let phase = reachabilityPhase(connectivityState)
+  let recoveryGeneration = 0
   let monitor = null
   let verificationCheck = null
   let authoritativeReachabilityRevision = 0
 
   function getSnapshot() {
-    return snapshot
+    return phase !== ReachabilityPhase.OFFLINE
   }
 
-  function publish(next) {
-    if (snapshot === next) return
-    snapshot = next
+  function getPhaseSnapshot() {
+    return phase
+  }
+
+  function getRecoverySnapshot() {
+    return recoveryGeneration
+  }
+
+  function publish(nextState, nextPhase = reachabilityPhase(nextState)) {
+    const recovered = (
+      nextPhase === ReachabilityPhase.ONLINE
+      && phase !== ReachabilityPhase.ONLINE
+    )
+    connectivityState = nextState
+    if (phase === nextPhase) return
+    if (recovered) recoveryGeneration += 1
+    phase = nextPhase
     listeners.forEach((listener) => listener())
   }
 
@@ -65,12 +96,14 @@ export function createConnectivityStore({
       if (controller) {
         timer = setTimeoutFn(() => controller.abort(), PROBE_TIMEOUT_MS)
       }
-      const response = await fetchImpl(HEALTH_URL, {
+      await fetchImpl(HEALTH_URL, {
         method: 'GET',
         cache: 'no-store',
         signal: controller?.signal,
       })
-      return response.ok
+      // Any response proves transport reachability. Status handling belongs to
+      // the request owner and must not masquerade as an offline connection.
+      return true
     } catch {
       return false
     } finally {
@@ -79,27 +112,27 @@ export function createConnectivityStore({
   }
 
   function applyProbe(reachable) {
-    connectivityState = resolveOnline(
+    const next = resolveOnline(
       reachable,
       navigatorTarget?.onLine !== false,
       connectivityState,
     )
-    publish(connectivityState.online)
-    return connectivityState
+    publish(next)
+    return next
   }
 
-  // An uncached mutation response is stronger evidence than navigator.onLine
-  // or a cacheable health probe: it could only have come from the live server.
-  // Let owning write paths repair a stale offline verdict immediately instead
-  // of waiting for the next poll or Android's delayed `online` event.
+  // An authenticated HTTP response is stronger evidence than navigator.onLine
+  // or a failed health probe: it could only have come from the live server.
+  // Let durable streams and owning write paths repair a stale offline verdict
+  // immediately instead of waiting for the next poll or `online` event.
   function reportReachable() {
     authoritativeReachabilityRevision += 1
-    connectivityState = {
+    const next = {
       successStreak: Math.max(1, connectivityState.successStreak),
       failureStreak: 0,
       online: true,
     }
-    publish(true)
+    publish(next)
   }
 
   function startMonitor() {
@@ -219,6 +252,9 @@ export function createConnectivityStore({
   // reuse their coalesced monitor. Without consumers, perform one bounded probe
   // only—never create an ownerless polling interval.
   function verify() {
+    if (phase === ReachabilityPhase.ONLINE) {
+      publish(connectivityState, ReachabilityPhase.CHECKING)
+    }
     if (monitor) return monitor.check()
     if (verificationCheck) return verificationCheck
     const startedRevision = authoritativeReachabilityRevision
@@ -235,12 +271,22 @@ export function createConnectivityStore({
     return verificationCheck
   }
 
-  return { getSnapshot, subscribe, verify, reportReachable }
+  return {
+    getSnapshot,
+    getPhaseSnapshot,
+    getRecoverySnapshot,
+    subscribe,
+    verify,
+    reportReachable,
+  }
 }
 
 const connectivityStore = createConnectivityStore()
 
 export const getOnlineSnapshot = connectivityStore.getSnapshot
+export const getReachabilityPhaseSnapshot = connectivityStore.getPhaseSnapshot
+export const getRecoverySnapshot = connectivityStore.getRecoverySnapshot
 export const subscribeOnline = connectivityStore.subscribe
+export const subscribeRecovery = connectivityStore.subscribe
 export const verifyConnectivity = connectivityStore.verify
 export const reportNetworkReachable = connectivityStore.reportReachable

--- a/tests/chat-offline.spec.mjs
+++ b/tests/chat-offline.spec.mjs
@@ -15,7 +15,7 @@ test('shell notes offline once while composer disables, then both recover', asyn
   await expect(page.locator('[data-chat-surface="painted"] button[aria-label="Send"]')).toBeEnabled()
 
   await context.setOffline(true)
-  await expect(page.locator('.shell__offline')).toHaveText(/Offline/i)
+  await expect(page.locator('.shell__connection-status')).toHaveText(/Offline/i)
   await expect(
     page.locator('[data-chat-surface="painted"]')
       .getByText("You're offline — chat needs a connection."),
@@ -23,6 +23,6 @@ test('shell notes offline once while composer disables, then both recover', asyn
   await expect(page.locator('[data-chat-surface="painted"] button[aria-label="Send"]')).toBeDisabled()
 
   await context.setOffline(false)
-  await expect(page.locator('.shell__offline')).toHaveCount(0)
+  await expect(page.locator('.shell__connection-status')).toHaveCount(0)
   await expect(page.locator('[data-chat-surface="painted"] button[aria-label="Send"]')).toBeEnabled()
 })

--- a/tests/notifications.spec.mjs
+++ b/tests/notifications.spec.mjs
@@ -187,7 +187,7 @@ test('phone header preserves the 44px bell and widest badge without collisions',
 
   await context.setOffline(true)
   await page.evaluate(() => window.dispatchEvent(new Event('offline')))
-  const pill = page.locator('.shell__offline')
+  const pill = page.locator('.shell__connection-status')
   await expect(pill).toBeVisible({ timeout: 15000 })
 
   const box = locator => locator.boundingBox()


### PR DESCRIPTION
## Problem

After a server restart, a durable chat continuation can resume while an already-mounted chat pane remains stuck in its terminal connection-loss state. The chat stream's bounded retries finish during the outage, and leaving and reopening the pane remounts the stream owner, which is why navigation appears to fix it.

A real planned restart exposed the missing edge: the shell's durable system stream can end with a clean EOF rather than a thrown network error. Its reconnect loop retried silently, so the shared reachability state never left Online. That suppressed the shell-wide connection dot and, when the server returned, meant there was no recovery generation to wake an exhausted chat stream.

## Changes

- expose a non-disabling `checking` phase and one monotonic recovery edge from the existing process-wide connectivity store
- feed every unexpected system-stream close—clean EOF or thrown failure—into that owner before retrying; any authenticated HTTP response proves transport recovery
- after recovery, let each visible retained chat fetch its compact authoritative runtime state and re-enter the existing bounded stream retry owner only when the server still reports a running turn with no unanswered question
- keep hidden panes, idle chats, parked questions, live streams, and active retry loops inert
- replace the header's text connection states with one compact accessible purple pulse dot for both checking and confirmed offline; reduced-motion users keep the same static dot

This adds no polling loop and no second stream owner. Uncertainty remains publicly online, so one slow probe does not disable normal actions.

## Related work

This builds on the stale-PWA reachability recovery in #376, the non-terminal connection-loss boundary in #508, and durable missed-question hydration in #732. The open container-rebuild work in #813 controls a different restart surface; this change is limited to client reconnection after any server recovery.

## Verification

- the exact clean-disconnect regression test on this PR head: 11 connectivity/recovery tests passed
- complete integrated frontend suites carrying the same correction: 2,536 library/component tests and 84 hook tests passed
- frontend lint: 0 errors (44 existing warnings, within the repository cap)
- production frontend and PWA/offline build passed
- rendered equivalent mobile shell state checked at 320 × 700, including the reduced-motion rule

The failing real restart was reproduced and traced before the correction. A second deliberately disruptive restart has not yet been triggered after the correction, so that exact service-interruption cycle remains a manual/hosted validation step.
