### PR TITLE
Speed up overflowing pane title movement

### DIFF
--- a/frontend/src/components/Shell/PaneStrip.jsx
+++ b/frontend/src/components/Shell/PaneStrip.jsx
@@ -4,11 +4,11 @@ import * as tabModel from './tabModel.js'
 import { STRIP_H } from './paneModel.js'
 import { captureLayoutSpace, clientLengthToLayout } from '../../lib/layoutSpace.js'
 
-// Each direction owns 40% of the one-shot cycle, so 1000/12 ms per clipped pixel
-// keeps travel at a readable 30px/s. The cycle runs once, returns to the beginning,
+// Each direction owns 40% of the one-shot cycle, so 1000/14.4 ms per clipped pixel
+// keeps travel at a readable 36px/s. The cycle runs once, returns to the beginning,
 // and stops; duration therefore scales with distance instead of making long manual
 // titles accelerate.
-const TITLE_CYCLE_MS_PER_PX = 1000 / 12
+const TITLE_CYCLE_MS_PER_PX = 1000 / 14.4
 
 function paneDomToken(value) {
   return encodeURIComponent(String(value))

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -779,7 +779,7 @@ test('an active overflowing chat title cycles once, then becomes idle', () => {
     'clipped titles must not share a fixed duration; distance owns the cadence')
   assert.doesNotMatch(paneStrip, /TITLE_CYCLE_MAX_MS|Math\.min/,
     'long titles must not accelerate through a duration cap')
-  assert.match(paneStrip, /const TITLE_CYCLE_MS_PER_PX = 1000 \/ 12/)
+  assert.match(paneStrip, /const TITLE_CYCLE_MS_PER_PX = 1000 \/ 14\.4/)
   assert.match(paneStrip, /className="shell__tab-text-inner"/)
   const cycle = shellCss.match(/\.shell__tabstrip:not\(\.workspace__strip\)[\s\S]*?shell-tab-title-cycle var\(--tab-title-duration\) linear 700ms 1 both/)?.[0] || ''
   assert.match(cycle, /\.workspace__strip--focused/)

--- a/tests/workspace-panes.spec.mjs
+++ b/tests/workspace-panes.spec.mjs
@@ -1212,7 +1212,7 @@ test.describe('Workspace drag (PR3)', () => {
     const durationMs = Number.parseFloat(motion.duration) * 1000
     const expectedDurationMs = Math.min(
       32000,
-      Math.round(Math.abs(motion.shift) * (1000 / 12)),
+      Math.round(Math.abs(motion.shift) * (1000 / 14.4)),
     )
     expect(durationMs).toBeCloseTo(expectedDurationMs, -1)
     expect(durationMs).toBeGreaterThan(4800)
@@ -1220,7 +1220,7 @@ test.describe('Workspace drag (PR3)', () => {
     expect(motion.shift).toBeLessThan(0)
     if (expectedDurationMs < 32000) {
       const travelPxPerSecond = Math.abs(motion.shift) / (durationMs * 0.4 / 1000)
-      expect(travelPxPerSecond).toBeCloseTo(30, 0)
+      expect(travelPxPerSecond).toBeCloseTo(36, 0)
     }
 
     // A long title must visibly advance soon after the fixed delay. The previous


### PR DESCRIPTION
## Summary

- increase overflowing active pane title movement from 30px/s to 36px/s
- preserve the existing delay, pauses, distance scaling, and one-pass behavior
- update the focused shell regression check for the new cadence

## Testing

- `node --test frontend/src/components/Shell/__tests__/workspaceUi.test.js`