### PR TITLE
Reveal sends that supersede cold chat activation

### DIFF
--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -1850,6 +1850,16 @@ export default function ChatView({
       return response.json()
     }
 
+    const settleSupersededActivation = () => {
+      // A fresh send or Stop has advanced the local generation and now owns
+      // the mounted transcript. The stale activation must not apply its
+      // server snapshot, but it still owns the entry gate it opened above.
+      // Retire that gate so the newer local owner can become paintable.
+      setInitialEntryPhase('ready')
+      setLoading(false)
+      setActivationSettled(true)
+    }
+
     const settleRuntime = (runtime, visibleMessages) => {
       const running = !!runtime.running
       const attachesToStream = shouldAttachRunningStream({
@@ -1946,7 +1956,11 @@ export default function ChatView({
         detailCache = chatDetailCacheValue(runtime)
       }
 
-      if (cancelled || fetchGenRef.current !== gen) return
+      if (cancelled) return
+      if (fetchGenRef.current !== gen) {
+        settleSupersededActivation()
+        return
+      }
       const msgs = detailCache.messages
       const failedAttempt = failedSendAttemptRef.current
       if (failedAttempt) {
@@ -2077,14 +2091,7 @@ export default function ChatView({
         await yieldToMainThread()
         if (cancelled) return
         if (fetchGenRef.current !== gen) {
-          // A newer generation owns the runtime now (a fresh send, or Stop
-          // clearing the queue), so this fetch must NOT apply its own runtime
-          // state — settleRuntime would re-hydrate the queue Stop just
-          // cleared. But 'preparing' is a hidden gate that only this path
-          // sets, and neither superseding path releases it: returning here
-          // without releasing it strands the chat blank until remount.
-          setInitialEntryPhase('ready')
-          setLoading(false)
+          settleSupersededActivation()
           return
         }
         // React may batch state updates across async task yields and discard
@@ -2098,6 +2105,10 @@ export default function ChatView({
     loadActivation()
       .catch((err) => {
         if (cancelled) return
+        if (fetchGenRef.current !== gen) {
+          settleSupersededActivation()
+          return
+        }
         // Offline degradation may use a complete cached restoration window,
         // but never a truncated one that cannot resolve the saved address.
         const cacheIsSafeFallback = activationCache

--- a/tests/navigation.spec.mjs
+++ b/tests/navigation.spec.mjs
@@ -351,6 +351,62 @@ async function goForward(page) {
 test.use({ serviceWorkers: 'block' })
 
 test.describe('Navigation basics', () => {
+  test('a first send retires the cold activation gate it supersedes', async ({ page }) => {
+    let releaseChatDetail
+    const wait = new Promise(resolve => { releaseChatDetail = resolve })
+    const blank = {
+      ...NAV_CHATS[0],
+      title: 'Cold empty chat',
+      has_messages: false,
+    }
+
+    await setup(page, undefined, {
+      chats: [blank],
+      detailForChat: emptyChatDetail,
+      chatDetailGate: { id: blank.id, wait },
+    })
+
+    let releaseStream
+    const streamWait = new Promise(resolve => { releaseStream = resolve })
+    let sendRequests = 0
+    await page.route(/\/api\/chats\/[0-9a-f-]+\/messages$/, route => {
+      sendRequests += 1
+      return route.fulfill({ status: 202, body: '{}' })
+    })
+    await page.route(/\/api\/chats\/[0-9a-f-]+\/stream$/, async route => {
+      await streamWait
+      return route.fulfill({ status: 204, body: '' })
+    })
+
+    try {
+      const composer = page.locator('#main-content')
+        .getByRole('textbox', { name: 'Message Möbius…' })
+      await expect(composer).toBeVisible()
+      await composer.fill('Visible after superseding the cold read')
+      await composer.press('Enter')
+
+      await expect.poll(() => sendRequests).toBe(1)
+      releaseChatDetail()
+
+      const painted = page.locator(
+        `[data-chat-surface="painted"][data-chat-id="${blank.id}"]`,
+      )
+      const userRow = painted.locator('.chat__msg--user')
+      await expect(userRow).toContainText('Visible after superseding the cold read')
+      await expect(userRow).toBeVisible()
+
+      const position = await userRow.evaluate((row) => {
+        const scroll = row.closest('.chat__scroll')
+        return Math.round(row.getBoundingClientRect().top - scroll.getBoundingClientRect().top)
+      })
+      expect(position).toBeGreaterThanOrEqual(-2)
+      expect(position).toBeLessThanOrEqual(10)
+    } finally {
+      releaseChatDetail()
+      releaseStream()
+    }
+  })
+
   test('1. Initial state — chat view, URL is /shell/', async ({ page }) => {
     await setup(page)
     const state = await getNavState(page)


### PR DESCRIPTION
## Summary
- release a cold chat’s entry gate when a new local send supersedes its stale history request
- preserve the locally owned transcript instead of applying the late empty snapshot
- cover the exact open-and-send race, including immediate visibility and top pinning

## Testing
- frontend unit and hook suites
- production frontend build