### PR TITLE
Refresh durable chat state on return

### DIFF
--- a/frontend/src/hooks/queries.js
+++ b/frontend/src/hooks/queries.js
@@ -143,6 +143,13 @@ function useChatsQuery({ reconcile } = {}) {
       const rows = await fetchChats(context)
       return reconcile ? reconcile(rows) : rows
     },
+    // The system stream accelerates drawer updates, but its process-local
+    // events are intentionally not replayed after a restart and browsers may
+    // suspend it without a clean disconnect. The list is the durable owner of
+    // running and owner-input state, so every real return/reconnect revalidates
+    // it even when the persisted query snapshot is still inside staleTime.
+    refetchOnWindowFocus: 'always',
+    refetchOnReconnect: 'always',
   })
 }
 


### PR DESCRIPTION
## Summary

- always revalidate the durable chat list when the workspace regains focus or reconnects
- keep the system event stream as an update accelerator rather than the only freshness source
- use the query owner's native return/reconnect policy instead of adding another browser-event coordinator

## Why

Browsers can suspend a live event stream without a clean disconnect, and process-local events are not replayed after a restart. The persisted chat query owns the durable drawer state, so real return boundaries should refresh it even while its cached snapshot is still inside the normal stale window.

## Verification

- 28 focused query and chat-policy tests passed
- the full frontend pretest currently stops on a pre-existing stale generated runtime in upstream main; this change does not touch that runtime
- full one-file diff reviewed for query ownership and duplicate-listener avoidance