### PR TITLE
Retire deprecated backend test calls

### DIFF
--- a/backend/tests/test_activity.py
+++ b/backend/tests/test_activity.py
@@ -879,7 +879,7 @@ def test_shared_storage_put_emits_storage_write(client, auth):
   r = client.put(
     "/api/storage/shared/agent-experience.md",
     headers={**auth, "Content-Type": "text/plain"},
-    data="seed content\n",
+    content="seed content\n",
   )
   assert r.status_code == 204, r.text
 
@@ -896,7 +896,7 @@ def test_shared_storage_delete_emits_negative_delta(client, auth):
   client.put(
     "/api/storage/shared/scratch.txt",
     headers={**auth, "Content-Type": "text/plain"},
-    data="bye\n",
+    content="bye\n",
   )
   activity._reset_for_tests()
   r = client.delete("/api/storage/shared/scratch.txt", headers=auth)
@@ -914,7 +914,7 @@ def test_shared_storage_put_debounces_within_window(client, auth):
     r = client.put(
       "/api/storage/shared/agent-experience.md",
       headers={**auth, "Content-Type": "text/plain"},
-      data="v\n",
+      content="v\n",
     )
     assert r.status_code == 204
   writes = [l for l in _read_lines() if l["ev"] == "storage_write"]

--- a/backend/tests/test_connector_gcloud.py
+++ b/backend/tests/test_connector_gcloud.py
@@ -325,7 +325,7 @@ def test_gcloud_complete_multi_project_then_set_and_broker(
   # A project-less gcloud grant must NOT be brokered even if reached directly.
   db.expire_all()
   cap0 = core.mint_broker_capability(
-    cid, db.query(models.Connector).get(cid).capability_id,
+    cid, db.get(models.Connector, cid).capability_id,
   )
   with TestClient(client.app, client=("127.0.0.1", 43110)) as loopback:
     refused = loopback.post(
@@ -353,7 +353,7 @@ def test_gcloud_complete_multi_project_then_set_and_broker(
   assert "ya29" not in json.dumps(out)
 
   # Choose a project.
-  gen2 = db.query(models.Connector).get(cid).capability_id
+  gen2 = db.get(models.Connector, cid).capability_id
   chosen = client.post(
     f"/api/connectors/{cid}/oauth/gcloud/project",
     headers=_headers(auth, gen2), json={"project_id": "proj-2"},
@@ -366,7 +366,7 @@ def test_gcloud_complete_multi_project_then_set_and_broker(
 
   # Broker attaches BOTH the bearer token and the quota-project header.
   cap = core.mint_broker_capability(
-    cid, db.query(models.Connector).get(cid).capability_id,
+    cid, db.get(models.Connector, cid).capability_id,
   )
   with TestClient(client.app, client=("127.0.0.1", 43110)) as loopback:
     brokered = loopback.post(
@@ -468,7 +468,7 @@ def test_gcloud_list_projects_for_signed_in_connection(
     json={"state": started["state"], "code": "4/x", "project_id": "proj-2"},
   )
   db.expire_all()
-  gen2 = db.query(models.Connector).get(cid).capability_id
+  gen2 = db.get(models.Connector, cid).capability_id
   listed = client.get(
     f"/api/connectors/{cid}/oauth/gcloud/projects", headers=_headers(auth, gen2),
   )
@@ -595,7 +595,7 @@ def test_gcloud_reuse_signin_across_connections(client, auth, db, monkeypatch):
   b = db.query(models.ConnectorOAuth).filter_by(connector_id=b_id).one()
   assert b.refresh_token_encrypted and b.client_id == a.client_id
   cap = core.mint_broker_capability(
-    b_id, db.query(models.Connector).get(b_id).capability_id,
+    b_id, db.get(models.Connector, b_id).capability_id,
   )
   with TestClient(client.app, client=("127.0.0.1", 43110)) as loopback:
     brokered = loopback.post(
@@ -784,7 +784,7 @@ def test_gcloud_disconnect_does_not_revoke_shared_credential(
     json={"source_connector_id": a_id, "source_generation": a_gen},
   )
   db.expire_all()
-  a_gen_now = db.query(models.Connector).get(a_id).capability_id
+  a_gen_now = db.get(models.Connector, a_id).capability_id
   out = client.post(
     f"/api/connectors/{a_id}/oauth/disconnect", headers=_headers(auth, a_gen_now),
   )
@@ -809,7 +809,7 @@ def test_gcloud_disconnect_revokes_when_unshared(client, auth, db, monkeypatch):
     db.query(models.ConnectorOAuth).filter_by(connector_id=cid).one()
     .refresh_token_encrypted
   )
-  gen_now = db.query(models.Connector).get(cid).capability_id
+  gen_now = db.get(models.Connector, cid).capability_id
   client.post(
     f"/api/connectors/{cid}/oauth/disconnect", headers=_headers(auth, gen_now),
   )
@@ -845,7 +845,7 @@ def test_gcloud_projectless_stays_withheld_after_recheck(
   assert out["needs_project"] is True
   assert out["connection"]["status"] == "oauth_required"
   db.expire_all()
-  gen_now = db.query(models.Connector).get(cid).capability_id
+  gen_now = db.get(models.Connector, cid).capability_id
   rechecked = client.post(
     f"/api/connectors/{cid}/refresh", headers=_headers(auth, gen_now),
   )
@@ -873,15 +873,15 @@ def test_gcloud_reuse_clears_stale_project(client, auth, db, monkeypatch):
   # A must look signed-in to the 2-project mock too; re-sign A so its token is
   # valid against the new mock.
   _complete_signin(client, auth, a_id,
-                   db.query(models.Connector).get(a_id).capability_id,
+                   db.get(models.Connector, a_id).capability_id,
                    project_id="proj-1")
   db.expire_all()
   reused = client.post(
     f"/api/connectors/{b_id}/oauth/gcloud/reuse",
-    headers=_headers(auth, db.query(models.Connector).get(b_id).capability_id),
+    headers=_headers(auth, db.get(models.Connector, b_id).capability_id),
     json={
       "source_connector_id": a_id,
-      "source_generation": db.query(models.Connector).get(a_id).capability_id,
+      "source_generation": db.get(models.Connector, a_id).capability_id,
     },  # no project_id → none auto-selected
   )
   assert reused.status_code == 200

--- a/backend/tests/test_connector_oauth.py
+++ b/backend/tests/test_connector_oauth.py
@@ -296,7 +296,7 @@ def test_oauth_add_signin_broker_and_disconnect(client, auth, db, provider):
   # 5. Broker attaches the token to a loopback MCP call.
   db.expire_all()
   cap = core.mint_broker_capability(
-    cid, db.query(models.Connector).get(cid).capability_id,
+    cid, db.get(models.Connector, cid).capability_id,
   )
   with TestClient(client.app, client=("127.0.0.1", 43110)) as loopback:
     brokered = loopback.post(
@@ -313,7 +313,7 @@ def test_oauth_add_signin_broker_and_disconnect(client, auth, db, provider):
   refresh_before = db.query(models.ConnectorOAuth).filter_by(
     connector_id=cid).one().refresh_token_encrypted
   assert refresh_before is not None
-  gen_now = db.query(models.Connector).get(cid).capability_id
+  gen_now = db.get(models.Connector, cid).capability_id
   disconnected = client.post(
     f"/api/connectors/{cid}/oauth/disconnect",
     headers=_headers(auth, gen_now),
@@ -778,7 +778,7 @@ def test_callback_rejects_forged_state(client, auth, db, provider):
   assert forged.status_code == 200
   assert "failed" in forged.text
   db.expire_all()
-  assert db.query(models.Connector).get(created["id"]).status == "oauth_required"
+  assert db.get(models.Connector, created["id"]).status == "oauth_required"
 
 
 def test_callback_rejects_issuer_mismatch(client, auth, db, provider):

--- a/backend/tests/test_lifecycle.py
+++ b/backend/tests/test_lifecycle.py
@@ -1,5 +1,5 @@
 # backend/tests/test_lifecycle.py
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 import uuid
 
@@ -11,7 +11,7 @@ from sqlalchemy import event
 def test_ttl_is_seven_days(db, chat):
   """Chats deleted fewer than 7 days ago must not be purged."""
   chat_id = chat.id  # capture before any purge
-  chat.deleted_at = datetime.utcnow() - timedelta(days=6)
+  chat.deleted_at = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=6)
   db.commit()
 
   purge_expired_chat_tombstones(db)
@@ -25,7 +25,7 @@ def test_ttl_is_seven_days(db, chat):
 def test_purge_after_seven_days(db, chat):
   """Chats deleted more than 7 days ago must be hard-deleted."""
   chat_id = chat.id  # capture before purge deletes the row
-  chat.deleted_at = datetime.utcnow() - timedelta(days=8)
+  chat.deleted_at = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=8)
   db.commit()
 
   purge_expired_chat_tombstones(db)
@@ -51,7 +51,7 @@ def test_hard_purge_removes_derived_search_transcript_without_later_search(
   )
 
   chat_id = chat.id
-  chat.deleted_at = datetime.utcnow() - timedelta(days=8)
+  chat.deleted_at = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=8)
   db.commit()
   purge_expired_chat_tombstones(db)
 
@@ -75,7 +75,7 @@ def test_expired_tombstone_purge_does_not_hydrate_transcript_json(
   """The retention sweep selects tombstone ids, not complete Chat entities."""
   chat_id = chat.id
   chat.messages = [{"role": "user", "content": "large transcript sentinel"}]
-  chat.deleted_at = datetime.utcnow() - timedelta(days=8)
+  chat.deleted_at = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=8)
   db.commit()
   # Remove the fixture entity from this session so an accidental
   # ``query(Chat).all()`` must instantiate it and fire the load event below.
@@ -98,7 +98,7 @@ def test_expired_tombstone_purge_does_not_hydrate_transcript_json(
 def test_expired_tombstone_survives_drawer_reads(client, db, auth, chat):
   """GET /api/chats is projection-only and never performs permanent cleanup."""
   chat_id = chat.id
-  chat.deleted_at = datetime.utcnow() - timedelta(days=8)
+  chat.deleted_at = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=8)
   db.commit()
 
   response = client.get("/api/chats", headers=auth)
@@ -117,7 +117,7 @@ def test_new_delete_reclaims_older_expired_tombstones(
     id=expired_id,
     title="Expired tombstone",
     messages=[],
-    deleted_at=datetime.utcnow() - timedelta(days=8),
+    deleted_at=datetime.now(UTC).replace(tzinfo=None) - timedelta(days=8),
   ))
   db.commit()
 
@@ -138,7 +138,7 @@ def test_old_empty_chat_survives_drawer_reads(client, db, auth):
     messages=[],
     pending_messages=[],
     session_id=None,
-    created_at=datetime.utcnow() - timedelta(days=365),
+    created_at=datetime.now(UTC).replace(tzinfo=None) - timedelta(days=365),
   ))
   db.commit()
 
@@ -154,7 +154,7 @@ def test_purge_removes_data_dir(db, chat):
   """Hard delete must remove /data/chats/{id}/ directory."""
   import os
   chat_id = chat.id  # capture before purge
-  chat.deleted_at = datetime.utcnow() - timedelta(days=8)
+  chat.deleted_at = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=8)
   db.commit()
 
   data_dir = os.environ["DATA_DIR"]
@@ -178,7 +178,7 @@ def test_purge_removes_agent_browser_profile(db, chat):
   """
   import os
   chat_id = chat.id  # capture before purge
-  chat.deleted_at = datetime.utcnow() - timedelta(days=8)
+  chat.deleted_at = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=8)
   db.commit()
 
   data_dir = os.environ["DATA_DIR"]
@@ -204,7 +204,7 @@ def test_purge_removes_memory_note_dir(db, chat):
   """
   import os
   chat_id = chat.id  # capture before purge
-  chat.deleted_at = datetime.utcnow() - timedelta(days=8)
+  chat.deleted_at = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=8)
   db.commit()
 
   data_dir = os.environ["DATA_DIR"]
@@ -230,7 +230,7 @@ def test_old_notifications_survive_chat_drawer_reads(client, db, auth):
     source_id=notif_source,
     title="Old",
     body="should be purged",
-    sent_at=datetime.utcnow() - timedelta(days=91),
+    sent_at=datetime.now(UTC).replace(tzinfo=None) - timedelta(days=91),
   )
   recent = models.Notification(
     id="recent-notif",
@@ -239,7 +239,7 @@ def test_old_notifications_survive_chat_drawer_reads(client, db, auth):
     source_id=notif_source,
     title="Recent",
     body="should survive",
-    sent_at=datetime.utcnow() - timedelta(days=30),
+    sent_at=datetime.now(UTC).replace(tzinfo=None) - timedelta(days=30),
   )
   db.add(old)
   db.add(recent)

--- a/backend/tests/test_recover.py
+++ b/backend/tests/test_recover.py
@@ -1,11 +1,11 @@
 # backend/tests/test_recover.py
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from app import models
 
 
 def test_recover_deleted_chat(client, db, auth, chat):
   """The chat recovery endpoint must clear deleted_at."""
-  chat.deleted_at = datetime.utcnow() - timedelta(days=1)
+  chat.deleted_at = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=1)
   db.commit()
 
   res = client.post(f"/api/chats/{chat.id}/recover", headers=auth)
@@ -18,7 +18,7 @@ def test_recover_deleted_chat(client, db, auth, chat):
 
 def test_recover_expired_chat(client, db, auth, chat):
   """Chat recovery past the 7-day window must return 410."""
-  chat.deleted_at = datetime.utcnow() - timedelta(days=8)
+  chat.deleted_at = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=8)
   db.commit()
 
   res = client.post(f"/api/chats/{chat.id}/recover", headers=auth)

--- a/backend/tests/test_storage.py
+++ b/backend/tests/test_storage.py
@@ -102,7 +102,7 @@ def test_put_text_accepts_raw_text_body(client, auth, owner_token):
 
   r = client.put(
     f"/api/storage/apps/{app_id}/notes.txt",
-    data="plain text body",
+    content="plain text body",
     headers={**auth, "Content-Type": "text/plain; charset=utf-8"},
   )
   assert r.status_code == 204
@@ -118,7 +118,7 @@ def test_put_binary_accepts_raw_bytes(client, auth, owner_token):
 
   r = client.put(
     f"/api/storage/apps/{app_id}/blob.bin",
-    data=data,
+    content=data,
     headers={**auth, "Content-Type": "application/octet-stream"},
   )
   assert r.status_code == 204
@@ -376,7 +376,7 @@ def test_put_text_accepts_non_json_content_type(client, auth, owner_token):
 
   r = client.put(
     f"/api/storage/apps/{app_id}/notes.txt",
-    data="raw body",
+    content="raw body",
     headers={**auth, "Content-Type": "text/plain"},
   )
   assert r.status_code == 204
@@ -387,7 +387,7 @@ def test_list_returns_entries_with_metadata(client, auth, owner_token):
   app_id = _make_app(client, owner_token)
   client.put(
     f"/api/storage/apps/{app_id}/reports/2026-06-01.html",
-    data="<p>hi</p>",
+    content="<p>hi</p>",
     headers={**auth, "Content-Type": "text/html"},
   )
   client.put(
@@ -433,7 +433,7 @@ def test_list_can_include_bounded_json_content(
     )
   client.put(
     f"/api/storage/apps/{app_id}/records/note.txt",
-    data="plain",
+    content="plain",
     headers={**auth, "Content-Type": "text/plain"},
   )
 

--- a/backend/tests/test_storage_quota_mime.py
+++ b/backend/tests/test_storage_quota_mime.py
@@ -65,7 +65,7 @@ def test_extensionless_blob_cold_read_serves_stored_mime(
 
   r = client.put(
     f"/api/storage/apps/{app_id}/avatar",
-    data=png,
+    content=png,
     headers={**auth, "Content-Type": "image/png"},
   )
   assert r.status_code == 204
@@ -87,7 +87,7 @@ def test_custom_mime_overrides_extension_guess(client, auth, owner_token):
 
   r = client.put(
     f"/api/storage/apps/{app_id}/model.bin",
-    data=data,
+    content=data,
     headers={**auth, "Content-Type": "model/gltf-binary"},
   )
   assert r.status_code == 204
@@ -101,7 +101,7 @@ def test_listing_reports_sidecar_mime(client, auth, owner_token):
   app_id = _make_app(client, owner_token)
   client.put(
     f"/api/storage/apps/{app_id}/media/clip",
-    data=b"\x00\x01\x02",
+    content=b"\x00\x01\x02",
     headers={**auth, "Content-Type": "audio/webm"},
   )
 
@@ -117,7 +117,7 @@ def test_sidecar_not_listed_in_app_tree(client, auth, owner_token):
   app_id = _make_app(client, owner_token)
   client.put(
     f"/api/storage/apps/{app_id}/avatar",
-    data=b"\x89PNG",
+    content=b"\x89PNG",
     headers={**auth, "Content-Type": "image/png"},
   )
 
@@ -135,7 +135,7 @@ def test_delete_removes_sidecar(client, auth, owner_token):
   app_id = _make_app(client, owner_token)
   client.put(
     f"/api/storage/apps/{app_id}/asset",
-    data=b"\x89PNG",
+    content=b"\x89PNG",
     headers={**auth, "Content-Type": "image/png"},
   )
   # The sidecar must physically vanish on delete.
@@ -154,7 +154,7 @@ def test_delete_removes_sidecar(client, auth, owner_token):
   # Re-create the same path with a different type — no stale shadow.
   client.put(
     f"/api/storage/apps/{app_id}/asset",
-    data=b"%PDF-1.4",
+    content=b"%PDF-1.4",
     headers={**auth, "Content-Type": "application/pdf"},
   )
   r = client.get(f"/api/storage/apps/{app_id}/asset", headers=auth)
@@ -215,7 +215,7 @@ def test_move_folder_onto_stale_meta_dest_does_not_nest_sidecars(tmp_path):
 def _put_blob(client, auth, app_id, name, nbytes):
   return client.put(
     f"/api/storage/apps/{app_id}/{name}",
-    data=b"a" * nbytes,
+    content=b"a" * nbytes,
     headers={**auth, "Content-Type": "application/octet-stream"},
   )
 


### PR DESCRIPTION
## Summary

- replace deprecated SQLAlchemy query lookups with the session identity API
- replace deprecated raw TestClient request bodies with explicit content
- replace deprecated naive UTC test timestamps with an explicit UTC source while preserving the database's naive representation

## Verification

- 222 focused backend tests passed
- full mechanical diff reviewed to confirm behavior and test fixtures remain unchanged