### PR TITLE
Make frontend watcher build tests hermetic

### DIFF
--- a/backend/tests/test_frontend_watcher_publish.py
+++ b/backend/tests/test_frontend_watcher_publish.py
@@ -52,6 +52,8 @@ def fw_dirs(tmp_path, monkeypatch):
     "attic": frontend / ".assets-attic",
     "cache": frontend / ".vite-cache",
     "tmp": frontend / ".vite-tmp",
+    "rebuild_cache": frontend / ".vite-cache-rebuild",
+    "rebuild_tmp": frontend / ".vite-tmp-rebuild",
   }
   monkeypatch.setattr(fw, "_FRONTEND_DIR", frontend)
   monkeypatch.setattr(fw, "_DIST_DIR", dirs["dist"])
@@ -62,6 +64,8 @@ def fw_dirs(tmp_path, monkeypatch):
   monkeypatch.setattr(fw, "_ATTIC_DIR", dirs["attic"])
   monkeypatch.setattr(fw, "_CACHE_DIR", dirs["cache"])
   monkeypatch.setattr(fw, "_TMP_DIR", dirs["tmp"])
+  monkeypatch.setattr(fw, "_REBUILD_CACHE_DIR", dirs["rebuild_cache"])
+  monkeypatch.setattr(fw, "_REBUILD_TMP_DIR", dirs["rebuild_tmp"])
   monkeypatch.setattr(fw, "_memory_is_tight", lambda: False)
   monkeypatch.setattr(fw, "require_vite_build_admission", lambda: None)
   monkeypatch.setattr(
@@ -514,14 +518,39 @@ def test_explicit_rebuild_builds_after_admission(
   runs = []
 
   def run(*args, **kwargs):
-    runs.append(args)
+    command = args[0]
+    runs.append(command)
     _write_build(fw_dirs["rebuild"], "explicit")
-    return fw.subprocess.CompletedProcess(args, 0, "vite build complete", None)
+    return fw.subprocess.CompletedProcess(
+      command, 0, "vite build complete", None,
+    )
 
   monkeypatch.setattr(fw.subprocess, "run", run)
 
   assert fw._run_vite_build_once(fw_dirs["rebuild"]) == "vite build complete"
-  assert len(runs) == 1
+  assert runs == [fw._vite_build_cmd(fw_dirs["rebuild"])]
+
+
+def test_vite_environment_prunes_only_stale_node_compile_cache(
+  fw_dirs, monkeypatch,
+):
+  cache_root = fw_dirs["tmp"] / "node-compile-cache"
+  current = cache_root / "v22-current"
+  stale = cache_root / "v21-stale"
+  current.mkdir(parents=True)
+  stale.mkdir()
+
+  def current_cache(*_args, **_kwargs):
+    return fw.subprocess.CompletedProcess(
+      ["node"], 0, str(current), "",
+    )
+
+  monkeypatch.setattr(fw.subprocess, "run", current_cache)
+
+  fw._vite_env(fw_dirs["cache"], fw_dirs["tmp"])
+
+  assert current.is_dir()
+  assert not stale.exists()
 
 
 def test_explicit_rebuild_defers_before_mutating_or_starting_vite(


### PR DESCRIPTION
## Summary

- isolate explicit rebuild tests from the live watcher cache and temporary directories
- assert the exact build command instead of relying on incidental subprocess argument nesting
- verify stale Node compile caches are removed without deleting the active cache

## Verification

- 28 focused frontend-watcher tests passed
- full one-file diff reviewed for isolation and cache-preservation behavior