### PR TITLE
Add conservative automatic Goal routing

### DIFF
--- a/backend/app/routes/chats_stream.py
+++ b/backend/app/routes/chats_stream.py
@@ -874,7 +874,15 @@ async def _send_message_locked(
     if (
       is_chat_running(chat_id)
       and not questions.is_waiting(chat_id)
-      and (body.force_steer or body.direct_steer or _steer_enabled(chat))
+      and (
+        body.force_steer
+        or body.direct_steer
+        # Hidden sends are product control carriers, not owner-authored course
+        # corrections.  They must keep their queue boundary even when the
+        # owner has enabled automatic steering; explicit internal direct/force
+        # steering above remains available for the few flows that own it.
+        or (not body.hidden and _steer_enabled(chat))
+      )
       and (
         body.force_steer
         or body.direct_steer

--- a/backend/scripts/chat_note.py
+++ b/backend/scripts/chat_note.py
@@ -127,6 +127,12 @@ def _render_messages(msgs: list[dict], *, start_index: int = 0) -> str:
   """Render user-visible messages as role-prefixed transcript text."""
   lines: list[str] = []
   for m in msgs[max(0, start_index):]:
+    # Hidden rows are product control messages, not owner-authored dialogue.
+    # Their visible effect is already represented by the surrounding question,
+    # Goal rail, or continuation state; feeding the raw carrier to the summary
+    # would leak implementation syntax such as an automatic ``/goal`` marker.
+    if m.get("hidden"):
+      continue
     # Provider handoffs are derived from this note. Re-ingesting them would
     # recursively duplicate the same context on every later re-switch.
     if m.get("kind") == "compaction":

--- a/backend/scripts/goal_promote.py
+++ b/backend/scripts/goal_promote.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Queue a verified hidden native-Goal activation for the current chat.
+
+The working agent decides whether an ordinary owner request deserves durable
+Goal mode.  This helper performs only the state transition: it reserves a
+hidden ``/goal`` message behind the currently running turn using the ordinary
+chat-send boundary.  When that turn settles, the existing queue handoff starts
+the provider's native Goal loop.  No classifier and no second Goal engine live
+here.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import uuid
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+
+def _settings() -> tuple[str, str, str]:
+  base = (os.environ.get("API_BASE_URL") or "").rstrip("/")
+  token = os.environ.get("AGENT_TOKEN") or ""
+  chat_id = os.environ.get("CHAT_ID") or ""
+  missing = [
+    name for name, value in (
+      ("API_BASE_URL", base), ("AGENT_TOKEN", token), ("CHAT_ID", chat_id),
+    ) if not value
+  ]
+  if missing:
+    raise SystemExit(f"missing environment: {', '.join(missing)}")
+  return base, token, chat_id
+
+
+def _request(method: str, path: str, body=None):
+  base, token, _ = _settings()
+  data = None if body is None else json.dumps(body).encode("utf-8")
+  request = Request(
+    f"{base}{path}", data=data, method=method,
+    headers={
+      "Authorization": f"Bearer {token}",
+      "Content-Type": "application/json",
+    },
+  )
+  try:
+    with urlopen(request, timeout=30) as response:
+      raw = response.read()
+      return json.loads(raw) if raw else None
+  except HTTPError as exc:
+    raw = exc.read().decode("utf-8", errors="replace")
+    try:
+      detail = json.loads(raw).get("detail", raw)
+    except json.JSONDecodeError:
+      detail = raw
+    raise SystemExit(
+      f"goal promotion failed ({exc.code}): {detail}"
+    ) from exc
+  except URLError as exc:
+    raise SystemExit(f"goal promotion failed: {exc.reason}") from exc
+
+
+def _latest_visible_owner_cid(detail: dict) -> str:
+  for message in reversed(list(detail.get("messages") or [])):
+    if (
+      isinstance(message, dict)
+      and message.get("role") == "user"
+      and not message.get("hidden")
+      and isinstance(message.get("cid"), str)
+      and message["cid"]
+    ):
+      return message["cid"]
+  raise SystemExit(
+    "goal promotion failed: no visible owner request identifies this turn"
+  )
+
+
+def _activation_cid(chat_id: str, source_cid: str, objective: str) -> str:
+  """Make a retry of one decision idempotent without merging later requests."""
+  return str(uuid.uuid5(
+    uuid.NAMESPACE_URL,
+    f"mobius:auto-goal:v1:{chat_id}:{source_cid}:{objective}",
+  ))
+
+
+def _activation_is_durable(
+  runtime: dict, detail: dict, *, cid: str, objective: str,
+) -> str | None:
+  if runtime.get("active_goal_objective") == objective:
+    return "active"
+  for message in list(runtime.get("pending_messages") or []):
+    if (
+      isinstance(message, dict)
+      and message.get("cid") == cid
+      and message.get("hidden") is True
+      and message.get("content") == f"/goal {objective}"
+    ):
+      return "queued"
+  for message in list(detail.get("messages") or []):
+    if (
+      isinstance(message, dict)
+      and message.get("cid") == cid
+      and message.get("hidden") is True
+      and message.get("content") == f"/goal {objective}"
+    ):
+      return "started"
+  return None
+
+
+def promote_goal(objective: str) -> str:
+  objective = objective.strip()
+  if not objective:
+    raise SystemExit("goal promotion failed: objective is empty")
+
+  _, _, chat_id = _settings()
+  runtime = _request("GET", f"/api/chats/{quote(chat_id)}/runtime") or {}
+  active = runtime.get("active_goal_objective")
+  if active:
+    if active == objective:
+      return "active"
+    raise SystemExit(
+      "goal promotion failed: this chat already has a different active Goal"
+    )
+  if runtime.get("running") is not True:
+    raise SystemExit(
+      "goal promotion failed: automatic promotion must run during the "
+      "owner request it is promoting"
+    )
+
+  detail = _request("GET", f"/api/chats/{quote(chat_id)}?limit=100") or {}
+  source_cid = _latest_visible_owner_cid(detail)
+  cid = _activation_cid(chat_id, source_cid, objective)
+  _request(
+    "POST", f"/api/chats/{quote(chat_id)}/messages",
+    {
+      "content": f"/goal {objective}",
+      "hidden": True,
+      "cid": cid,
+    },
+  )
+
+  # The send acknowledgement is not enough: verify the exact hidden activation
+  # now exists in the active Goal, durable queue, or transcript.  The cid makes
+  # this proof safe across a lost response and retry.
+  runtime = _request("GET", f"/api/chats/{quote(chat_id)}/runtime") or {}
+  detail = _request("GET", f"/api/chats/{quote(chat_id)}?limit=100") or {}
+  state = _activation_is_durable(
+    runtime, detail, cid=cid, objective=objective,
+  )
+  if state is None:
+    raise SystemExit(
+      "goal promotion failed: the hidden native-Goal activation was not "
+      "durably verified"
+    )
+  return state
+
+
+def main() -> int:
+  parser = argparse.ArgumentParser(
+    description="Promote the current ordinary request into a native Goal.",
+  )
+  parser.add_argument(
+    "objective",
+    help="concise outcome and observable completion condition",
+  )
+  args = parser.parse_args()
+  state = promote_goal(args.objective)
+  if state == "active":
+    print("Goal promotion verified: the native Goal is active.")
+  elif state == "queued":
+    print(
+      "Goal promotion verified: hidden native activation is queued behind "
+      "this turn."
+    )
+  else:
+    print("Goal promotion verified: hidden native activation has started.")
+  return 0
+
+
+if __name__ == "__main__":
+  sys.exit(main())

--- a/backend/tests/test_chat_note.py
+++ b/backend/tests/test_chat_note.py
@@ -329,6 +329,24 @@ def test_render_transcript_labels_automatic_continuation_as_product_event():
   assert "user: continue" not in rendered
 
 
+def test_render_transcript_excludes_hidden_product_control_messages():
+  cn = _load_chat_note()
+  raw = json.dumps([
+    {"role": "user", "content": "Address every issue"},
+    {
+      "role": "user", "hidden": True,
+      "content": "/goal Address every issue and verify the result",
+    },
+    {"role": "assistant", "content": "All checks pass."},
+  ])
+
+  rendered = cn._render_transcript(raw)
+
+  assert "Address every issue" in rendered
+  assert "All checks pass." in rendered
+  assert "/goal" not in rendered
+
+
 def test_claude_summary_prompt_receives_complete_transcript(monkeypatch):
   cn = _load_chat_note()
   monkeypatch.setattr(cn, "_configured_provider", lambda _provider=None: "claude")

--- a/backend/tests/test_chats_stream_steer.py
+++ b/backend/tests/test_chats_stream_steer.py
@@ -228,6 +228,38 @@ def test_steers_into_live_codex_turn_when_flag_on(
   ]
 
 
+def test_hidden_control_message_queues_even_when_auto_steer_is_enabled(
+  client, auth, monkeypatch,
+):
+  """Product control carriers must retain their next-turn boundary."""
+  chat_id = "hiddencontrolqueues"
+  message_cid = "hidden-control-cid"
+  _make_codex_chat(chat_id, steer_enabled=True)
+  registry.register(_make_active_codex_turn(chat_id))
+  create_broadcast(chat_id)
+
+  async def _must_not_steer(*_args, **_kwargs):
+    raise AssertionError("hidden control messages must not auto-steer")
+
+  _patch_codex_steer(monkeypatch, _must_not_steer)
+  res = client.post(
+    f"/api/chats/{chat_id}/messages",
+    json={
+      "content": "/goal Finish and verify the migration",
+      "cid": message_cid,
+      "hidden": True,
+    },
+    headers=auth,
+  )
+
+  assert res.status_code == 202, res.text
+  assert res.json()["status"] == "queued"
+  chat = _read_chat(chat_id)
+  assert [cid_of(row) for row in chat.pending_messages] == [message_cid]
+  assert chat.pending_messages[0]["hidden"] is True
+  assert chat.pending_messages[0]["content"].startswith("/goal ")
+
+
 def test_direct_steer_reserves_and_converts_new_codex_message_in_one_request(
   client, auth, monkeypatch,
 ):

--- a/backend/tests/test_goal_promote.py
+++ b/backend/tests/test_goal_promote.py
@@ -1,0 +1,80 @@
+"""Automatic Goal promotion reserves one verified hidden native activation."""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+def _helper():
+  path = Path(__file__).resolve().parents[1] / "scripts" / "goal_promote.py"
+  spec = importlib.util.spec_from_file_location("goal_promote_script", path)
+  module = importlib.util.module_from_spec(spec)
+  spec.loader.exec_module(module)
+  return module
+
+
+def test_promotion_queues_hidden_activation_with_turn_scoped_identity(
+  monkeypatch,
+):
+  helper = _helper()
+  monkeypatch.setenv("API_BASE_URL", "http://mobius.test")
+  monkeypatch.setenv("AGENT_TOKEN", "owner-token")
+  monkeypatch.setenv("CHAT_ID", "chat-1")
+  calls = []
+  pending = []
+
+  def request(method, path, body=None):
+    calls.append((method, path, body))
+    if method == "GET" and path.endswith("/runtime"):
+      return {
+        "running": True,
+        "active_goal_objective": None,
+        "pending_messages": list(pending),
+      }
+    if method == "GET":
+      return {"messages": [
+        {"role": "user", "content": "Do the work", "cid": "owner-turn"},
+      ]}
+    pending.append(dict(body))
+    return {"status": "queued"}
+
+  monkeypatch.setattr(helper, "_request", request)
+  objective = "Finish every stage and verify the result"
+
+  assert helper.promote_goal(objective) == "queued"
+  post = next(call for call in calls if call[0] == "POST")
+  assert post[2]["content"] == f"/goal {objective}"
+  assert post[2]["hidden"] is True
+  assert post[2]["cid"] == helper._activation_cid(
+    "chat-1", "owner-turn", objective,
+  )
+
+
+def test_retry_identity_changes_only_with_the_owner_turn():
+  helper = _helper()
+  objective = "Ship and verify"
+  first = helper._activation_cid("chat", "turn-a", objective)
+
+  assert helper._activation_cid("chat", "turn-a", objective) == first
+  assert helper._activation_cid("chat", "turn-b", objective) != first
+
+
+def test_promotion_refuses_to_queue_outside_the_request_it_promotes(
+  monkeypatch,
+):
+  helper = _helper()
+  monkeypatch.setenv("API_BASE_URL", "http://mobius.test")
+  monkeypatch.setenv("AGENT_TOKEN", "owner-token")
+  monkeypatch.setenv("CHAT_ID", "chat-1")
+  monkeypatch.setattr(
+    helper, "_request",
+    lambda *_args, **_kwargs: {
+      "running": False,
+      "active_goal_objective": None,
+      "pending_messages": [],
+    },
+  )
+
+  with pytest.raises(SystemExit, match="must run during the owner request"):
+    helper.promote_goal("Ship and verify")

--- a/skill/core.md
+++ b/skill/core.md
@@ -99,6 +99,12 @@ Then triage the prompt into one of three tiers:
   clarifying-question tool, and wait for a pick. Recommendations in prose alone
   do not count as waiting.
 
+**Automatic Goal routing.** Before material work on every ordinary prompt that
+delegates an outcome, read the `goal-planning` skill and make its conservative
+Goal-versus-standard decision. Questions and explanation-only prompts are not
+delegated outcomes. Use the working agent's judgment, never a keyword/length
+classifier or a separate model call. Explicit `/goal` remains authoritative.
+
 **Scope check before any restyle.** "The app" is ambiguous: it can mean the whole Möbius shell with one global look or a single mini-app with app-scoped styling. Resolve which BEFORE styling — "restyle the whole app / make everything feel like X" most likely means the shell, not the last mini-app you happened to build. Confirm scope if it's at all ambiguous, follow the matching injected skill, and in your reply say what you changed and what you left untouched.
 
 ### 2. Propose (only when needed)


### PR DESCRIPTION
## Summary

- let the working agent conservatively promote suitable ordinary requests into native Goals
- queue one hidden, turn-scoped activation behind the current request instead of adding a second goal engine
- keep hidden control messages out of automatic steering and generated chat summaries
- verify the exact activation is durable before reporting success

## Why

Some delegated outcomes span multiple independently verifiable stages and materially benefit from durable continuation, but requiring the owner to know and type a special command makes that durability easy to miss. This preserves explicit `/goal` while letting the working agent make the same conservative decision from the request it is already handling. Questions, explanations, one-pass work, and requests needing a material owner choice remain ordinary turns.

## Verification

- 86 focused backend tests passed
- full diff reviewed for control-message visibility, steering ownership, idempotency, and summary isolation