### PR TITLE
Recover settled replies without disrupting fresh sends

### DIFF
--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -117,6 +117,7 @@ import {
   openAppCtaViewModel,
   shouldRetireRestoredQuestionSnapshot,
   shouldAttachRunningStream,
+  shouldRecoverSettledRuntime,
   shouldRetryStopAfterConfirm,
   stopConfirmedIdle,
   stopRequestSucceeded,
@@ -497,6 +498,7 @@ export default function ChatView({
   // control. Keep its necessary detail refresh single-flight per exact owner;
   // the invariant below retries naturally after an honest fetch failure.
   const parkedQuestionHydrationRef = useRef(null)
+  const retireSettledStreamRef = useRef(null)
   // The pending-question and resume "tap to jump to it" nudges each track
   // whether their card is scrolled out of the viewport. Both use one shared
   // observer hook (useOffscreenNudge, below); their booleans are computed near
@@ -747,6 +749,13 @@ export default function ChatView({
   // useStreamConnection and is exposed below as `isStreamingRef`.
   const sendingRef = useRef(false)
   sendingRef.current = sending
+  // Identity of the one fresh-send request that has rendered locally but has
+  // not settled its POST yet. This is deliberately a transaction ref, not a
+  // fourth "running" flag: it never renders UI and is cleared by the exact
+  // request that created it. Runtime polling may observe the previous idle
+  // snapshot while app context, settings, or the POST is still in flight;
+  // that snapshot cannot retire this locally-owned start.
+  const localStartRequestRef = useRef(null)
   // Re-entrancy guard for doSendSilent (answer submissions). sendingRef
   // alone cannot guard doSendSilent because answer sends are deliberately
   // allowed while sendingRef is true (the runner is parked waiting for
@@ -1077,8 +1086,33 @@ export default function ChatView({
       // when the stream is genuinely dead (a stale Stop with no real turn) does
       // the server snapshot win. Event-driven over polling — see
       // docs/architecture.md "determinism".
+      const localStartInFlight =
+        localStartRequestRef.current?.chatId === String(chatId)
       const localAuthoritative =
-        handlingStopRef.current || isStreamingRef.current
+        handlingStopRef.current || localStartInFlight || isStreamingRef.current
+      if (shouldRecoverSettledRuntime({
+        runtimeWasObservedRunning: serverRunningRef.current,
+        runtimeRunning: !!data.running,
+        pendingCount: serverPending.length,
+        streamStillActive: isStreamingRef.current,
+        stopInFlight: handlingStopRef.current,
+        localStartInFlight,
+      })) {
+        // The backend has durably finalized a run but this browser missed its
+        // terminal SSE event. Re-read the transcript before retiring the stale
+        // transport so a saved final reply can never remain hidden behind the
+        // cached in-flight surface. A failed refresh leaves serverRunning
+        // latched, so the next runtime poll retries instead of declaring idle.
+        const settled = await fetchMessages({
+          force: true,
+          terminal204: true,
+          authoritative: true,
+        })
+        if (settled?.running === false) {
+          retireSettledStreamRef.current?.()
+        }
+        return
+      }
       if (data.running) {
         setSending(true)
       } else if (serverPending.length === 0 && !localAuthoritative) {
@@ -1404,6 +1438,11 @@ export default function ChatView({
     },
   })
 
+  retireSettledStreamRef.current = () => {
+    disconnect({ clearStreaming: true })
+    clearStreamItems()
+  }
+
   // useScrollMode's layout effect is registered before this one. At a steer
   // cut it therefore commits the new row's PIN_USER_MSG/ANCHOR_AT position
   // first; only then may a still-focused, otherwise-unchanged touch composer
@@ -1473,7 +1512,9 @@ export default function ChatView({
         processedExternalSignalRef.current = target
         const delta = chatRunSignalDelta(previous, target)
         const locallyActive = (
-          sendingRef.current || isStreamingRef.current
+          sendingRef.current
+          || isStreamingRef.current
+          || localStartRequestRef.current?.chatId === String(chatId)
         ) && !externalClaimedRunRef.current
         if (locallyActive) {
           // The local optimistic turn remains authoritative for its suffix,
@@ -1532,7 +1573,7 @@ export default function ChatView({
         queueMicrotask(reconcileExternalActivity)
       }
     }
-  }, [connectToStream, embedded, fetchMessages, isStreamingRef])
+  }, [chatId, connectToStream, embedded, fetchMessages, isStreamingRef])
   useEffect(() => {
     if (hidden) return
     reconcileExternalActivity()
@@ -2671,6 +2712,8 @@ export default function ChatView({
     }
 
     // FRESH SEND PATH: no active turn, no queue.
+    const localStartRequest = { chatId: String(chatId), cid }
+    localStartRequestRef.current = localStartRequest
     fetchGenRef.current += 1
     onMessageStartRef.current?.()
     promotedRef.current = false
@@ -2705,7 +2748,6 @@ export default function ChatView({
       // comment above for the full rationale.
     }
     setSending(true)
-    setServerRunningState(true)
     // Pin per the R2 send rule via the funnel: it arms the reservation spacer
     // on every send and, when not pinning, retires any stale PIN to the
     // reader's anchor so their viewport stays fixed. The row carries its final
@@ -2858,6 +2900,12 @@ export default function ChatView({
         revealPendingQuestion()
       } else {
         onStreamEndRef.current?.({ continues: false })
+      }
+    } finally {
+      // A newer retry/chat transition must not be cleared by an older request
+      // settling late. Object identity makes this an exact transaction handoff.
+      if (localStartRequestRef.current === localStartRequest) {
+        localStartRequestRef.current = null
       }
     }
     // doSend doesn't need `sending` / `isStreaming` in deps anymore —

--- a/frontend/src/components/ChatView/__tests__/chatRuntimeState.test.js
+++ b/frontend/src/components/ChatView/__tests__/chatRuntimeState.test.js
@@ -18,6 +18,7 @@ import {
   serverSnapshotBehindLocal,
   shouldAttachRunningStream,
   shouldRetireRestoredQuestionSnapshot,
+  shouldRecoverSettledRuntime,
   shouldRetryStopAfterConfirm,
   shouldShowOpenAppCta,
   startedMessagesFromResponse,
@@ -135,6 +136,45 @@ test('a parked owner question uses compact history until its answer resumes the 
     running: false,
     pendingQuestionId: null,
   }), false)
+})
+
+test('a known server run settling recovers a live stream that missed its terminal event', () => {
+  assert.equal(shouldRecoverSettledRuntime({
+    runtimeWasObservedRunning: true,
+    runtimeRunning: false,
+    pendingCount: 0,
+    streamStillActive: true,
+  }), true)
+
+  assert.equal(shouldRecoverSettledRuntime({
+    runtimeWasObservedRunning: false,
+    runtimeRunning: false,
+    pendingCount: 0,
+    streamStillActive: true,
+  }), false, 'the optimistic send window is not mistaken for a settled turn')
+
+  assert.equal(shouldRecoverSettledRuntime({
+    runtimeWasObservedRunning: true,
+    runtimeRunning: false,
+    pendingCount: 1,
+    streamStillActive: true,
+  }), false, 'a queued continuation still owns the handoff')
+
+  assert.equal(shouldRecoverSettledRuntime({
+    runtimeWasObservedRunning: true,
+    runtimeRunning: false,
+    pendingCount: 0,
+    streamStillActive: true,
+    stopInFlight: true,
+  }), false, 'the explicit stop flow owns its own settlement')
+
+  assert.equal(shouldRecoverSettledRuntime({
+    runtimeWasObservedRunning: true,
+    runtimeRunning: false,
+    pendingCount: 0,
+    streamStillActive: true,
+    localStartInFlight: true,
+  }), false, 'an unacknowledged local start owns the idle-snapshot race')
 })
 
 test('only a cold stream prefix missing the durable question is retired', () => {

--- a/frontend/src/components/ChatView/__tests__/streamPromotion.test.js
+++ b/frontend/src/components/ChatView/__tests__/streamPromotion.test.js
@@ -458,6 +458,35 @@ test('a stream carrying the same question may expose newer parallel output', () 
   })
 })
 
+test('saved final prose wins over a detailed stale replay after compact activity grouping', () => {
+  const msg = {
+    role: 'assistant',
+    ts: 2,
+    blocks: [
+      { type: 'thinking', thinking_deferred: true, thinking_revision: 20 },
+      { type: 'text', content: 'I’ll inspect the broken article.' },
+      { type: 'activity', count: 12 },
+      { type: 'text', content: 'I found the blocked embed.' },
+      { type: 'activity', count: 8 },
+      { type: 'text', content: 'It is fixed now, and the fallback is visible.' },
+    ],
+  }
+  const staleReplay = [
+    { type: 'thinking', content: 'A long private trace that adds weight.' },
+    { type: 'text', content: 'I’ll inspect the broken article.' },
+    { type: 'tool', tool: 'Bash', status: 'done', output: 'x'.repeat(200) },
+    { type: 'text', content: 'I found the blocked embed.' },
+    { type: 'tool', tool: 'Bash', status: 'done', output: 'y'.repeat(200) },
+  ]
+
+  assert.equal(assistantStreamCoversMessage(msg, staleReplay), false)
+  assert.equal(messageCoversAssistantStream(msg, staleReplay), false)
+  assert.deepEqual(chooseActiveAssistantSurface(msg, staleReplay), {
+    hideMessage: false,
+    suppressStream: true,
+  })
+})
+
 test('chooseActiveAssistantSurface does not collapse unrelated assistant and stream surfaces', () => {
   const msg = {
     role: 'assistant',

--- a/frontend/src/components/ChatView/chatRuntimeState.js
+++ b/frontend/src/components/ChatView/chatRuntimeState.js
@@ -151,6 +151,28 @@ export function shouldRetireRestoredQuestionSnapshot({
   ))
 }
 
+/**
+ * A durable running -> idle transition settles a live transport that missed
+ * its terminal event. Requiring the prior server-running observation avoids
+ * mistaking the short optimistic send window (before StartTurn is persisted)
+ * for a completed turn.
+ */
+export function shouldRecoverSettledRuntime({
+  runtimeWasObservedRunning = false,
+  runtimeRunning = false,
+  pendingCount = 0,
+  streamStillActive = false,
+  stopInFlight = false,
+  localStartInFlight = false,
+} = {}) {
+  return !!runtimeWasObservedRunning
+    && runtimeRunning === false
+    && pendingCount === 0
+    && !!streamStillActive
+    && !stopInFlight
+    && !localStartInFlight
+}
+
 function coldBlockRenderCost(block) {
   if (block?.type !== 'text') return 1
   // Markdown reports create work roughly in proportion to their source size,

--- a/frontend/src/components/ChatView/streamPromotion.js
+++ b/frontend/src/components/ChatView/streamPromotion.js
@@ -308,6 +308,23 @@ export function chooseActiveAssistantSurface(msg, items) {
     return { hideMessage: false, suppressStream: true }
   }
 
+  // Compact durable messages deliberately collapse thinking/tool runs into
+  // activity blocks, so their block arrays cannot prove ordinary prefix
+  // coverage against the detailed replay stream. Visible assistant prose is
+  // still monotonic: when one related surface strictly extends the other's
+  // text, keep the longer answer instead of letting private activity weight
+  // hide a saved final paragraph behind a stale live replay.
+  const msgText = normalizeMirrorText(assistantMessageText(msg))
+  const streamText = normalizeMirrorText(streamPayload.content)
+  if (msgText && streamText && msgText.length !== streamText.length) {
+    if (msgText.startsWith(streamText)) {
+      return { hideMessage: false, suppressStream: true }
+    }
+    if (streamText.startsWith(msgText)) {
+      return { hideMessage: true, suppressStream: false }
+    }
+  }
+
   const msgPayload = {
     content: assistantMessageText(msg),
     blocks: Array.isArray(msg.blocks) ? msg.blocks.filter(Boolean) : [],

--- a/tests/fresh-send-runtime-race.spec.mjs
+++ b/tests/fresh-send-runtime-race.spec.mjs
@@ -1,0 +1,101 @@
+import { test, expect } from '@playwright/test'
+import { attachCleanup, createTaggedChat } from './_chatTracker.mjs'
+
+const BASE = process.env.MOBIUS_URL || 'http://localhost:8001'
+
+function deferred() {
+  let resolve
+  const promise = new Promise(settle => { resolve = settle })
+  return { promise, resolve }
+}
+
+test.use({ serviceWorkers: 'block' })
+attachCleanup()
+
+test('an idle runtime snapshot cannot retire an unacknowledged fresh send', async ({ page }) => {
+  await page.setViewportSize({ width: 412, height: 915 })
+  await page.goto(BASE, { waitUntil: 'domcontentloaded' })
+  const chat = await createTaggedChat(page, 'fresh-send-runtime-race')
+  expect(chat?.id).toBeTruthy()
+
+  const sendStarted = deferred()
+  const idleSnapshotReturned = deferred()
+  const releaseAcknowledgement = deferred()
+  let raceArmed = false
+  let detailReadsAfterSend = 0
+
+  await page.route(new RegExp(`/api/chats/${chat.id}/messages$`), async route => {
+    const request = route.request().postDataJSON()
+    sendStarted.resolve()
+    await releaseAcknowledgement.promise
+    await route.fulfill({
+      status: 202,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        status: 'started',
+        message: {
+          role: 'user',
+          content: request.content,
+          blocks: [{ type: 'text', content: request.content }],
+          ts: 1700001000000,
+          cid: request.cid,
+        },
+      }),
+    })
+  })
+  await page.route(new RegExp(`/api/chats/${chat.id}/runtime(?:\\?.*)?$`), async route => {
+    if (raceArmed) await sendStarted.promise
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        running: false,
+        active_goal_objective: null,
+        pending_messages: [],
+        pending_question_id: null,
+      }),
+    })
+    if (raceArmed) idleSnapshotReturned.resolve()
+  })
+  await page.route(new RegExp(`/api/chats/${chat.id}(?:\\?.*)?$`), route => {
+    if (route.request().method() !== 'GET') return route.continue()
+    if (raceArmed) detailReadsAfterSend += 1
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: chat.id,
+        messages: [],
+        total: 0,
+        offset: 0,
+        running: false,
+        pending_messages: [],
+        pending_question_id: null,
+        provider: 'codex',
+      }),
+    })
+  })
+
+  await page.goto(`${BASE}/shell/?chat=${encodeURIComponent(chat.id)}`, {
+    waitUntil: 'domcontentloaded',
+  })
+  const surface = page.locator('[data-chat-surface="painted"]')
+  const input = surface.getByRole('textbox', { name: 'Message Möbius…' })
+  await expect(input).toBeVisible()
+
+  await input.fill('Fresh send held before acknowledgement')
+  raceArmed = true
+  await page.keyboard.press('Enter')
+  await Promise.all([sendStarted.promise, idleSnapshotReturned.promise])
+  await page.evaluate(() => new Promise(resolve => {
+    let frames = 8
+    const next = () => (--frames ? requestAnimationFrame(next) : resolve())
+    requestAnimationFrame(next)
+  }))
+
+  expect(detailReadsAfterSend).toBe(0)
+  await expect(surface.locator('.chat__msg--user')).toHaveCount(1)
+  await expect(surface.locator('.chat__thinking')).toBeVisible()
+  await expect(surface.locator('.chat__stop')).toBeVisible()
+  releaseAcknowledgement.resolve()
+})


### PR DESCRIPTION
## Problem

A mounted chat can miss the terminal stream event even though the final assistant reply was saved. The runtime poll needs to recover that reply, but the first implementation could mistake the previous idle snapshot for the completion of a brand-new send. That temporarily removed the optimistic message, thinking indicator, stop control, and reply-space reservation, producing a visible jump before the acknowledgement arrived.

## Changes

- Recover a missed terminal event only after this viewer has actually observed the server-side run as active.
- Give an unacknowledged fresh send one exact local transaction owner, so stale idle snapshots cannot retire its visible state.
- Prefer the longer related assistant prose when compact persisted activity and a detailed stale replay cannot be compared block-for-block.
- Add focused unit coverage for the runtime transition and assistant-surface handoff, plus a deterministic browser regression for the pre-acknowledgement race.

## Verification

- Frontend library/component suite: 2,518 passed.
- Frontend hook suite: 83 passed.
- Production/PWA build passed.
- Targeted lint passed with no errors (pre-existing hook-dependency warnings remain).
- The browser regression is staged for the repository's isolated Playwright checks; this container does not provide the Docker host required by the local runner.