### PR TITLE
Make automatic Goal promotion provider-neutral

### DIFF
--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -11,6 +11,11 @@ from jwt.exceptions import InvalidTokenError
 from app.config import get_settings
 
 
+# Covers the platform's at-most-24-hour turn capabilities with clock skew.
+# deps._resolve_owner also rejects it as soon as the exact run stops running.
+AGENT_RUN_TOKEN_TTL = timedelta(hours=26)
+
+
 # bcrypt ignores bytes after the first 72. Pre-hashing new passwords makes the
 # full UTF-8 input significant while retaining bcrypt's salt and work factor.
 # The prefix makes the format self-describing so hashes created by older Mobius
@@ -76,6 +81,26 @@ def create_access_token(
     payload["epoch"] = token_epoch
   return jwt.encode(
     payload, settings.secret_key, algorithm="HS256"
+  )
+
+
+def create_agent_token(
+  chat_id: str,
+  run_id: str,
+  owner_username: str,
+  token_epoch: int,
+  *,
+  expires_delta: timedelta = AGENT_RUN_TOKEN_TTL,
+) -> str:
+  """Create the owner bearer bound to one ordinary interactive agent run."""
+  return create_access_token(
+    {
+      "sub": owner_username,
+      "agent_chat": chat_id,
+      "agent_run": run_id,
+    },
+    expires_delta=expires_delta,
+    token_epoch=token_epoch,
   )
 
 

--- a/backend/app/chat.py
+++ b/backend/app/chat.py
@@ -3591,6 +3591,20 @@ def _should_ensure_chat_note(
   )
 
 
+def _run_owns_active_goal(
+  db: Session, *, chat_id: str, run_token: str | None,
+) -> bool:
+  """Whether the exact physical run currently owns committed Goal state."""
+  if not chat_id or not run_token:
+    return False
+  return db.query(models.ChatRun.id).filter(
+    models.ChatRun.id == run_token,
+    models.ChatRun.chat_id == chat_id,
+    models.ChatRun.status.in_(models.NONTERMINAL_RUN_STATUSES),
+    models.ChatRun.goal_objective.isnot(None),
+  ).first() is not None
+
+
 async def _ensure_chat_note(
   data_dir: str,
   chat_id: str,
@@ -3888,8 +3902,19 @@ async def _run_chat_impl_with_db(
   goal_mode = _chat_has_goal_intent(messages)
   goal_continue = (raw_user_message or "").strip().lower() == "continue"
   question_checkpoint = None
-  if settings.ensure_chat_note and chat_id and goal_mode:
+  if settings.ensure_chat_note and chat_id:
     async def question_checkpoint() -> None:
+      # Automatic promotion happens after this runner has started, so
+      # transcript intent captured above is not authoritative here. Read the
+      # exact physical run at checkpoint time and summarize only if it owns a
+      # committed Goal then.
+      from app.database import SessionLocal
+      with SessionLocal() as checkpoint_db:
+        active_goal = _run_owns_active_goal(
+          checkpoint_db, chat_id=chat_id, run_token=run_token,
+        )
+      if not active_goal:
+        return
       await _ensure_chat_note(
         settings.data_dir,
         chat_id,
@@ -4152,10 +4177,8 @@ async def _run_chat_impl_with_db(
     from app.delegations import mint_app_token
     agent_token = mint_app_token(db, run_policy)
   else:
-    agent_token = auth.create_access_token(
-      {"sub": owner.username},
-      expires_delta=timedelta(hours=2),
-      token_epoch=owner.token_epoch,
+    agent_token = auth.create_agent_token(
+      chat_id, run_token, owner.username, owner.token_epoch,
     )
 
   # Build the base environment shared by all providers.
@@ -4174,7 +4197,9 @@ async def _run_chat_impl_with_db(
     "CHAT_ID": chat_id,
   })
   base_env.update(app_context_env)
-  if run_policy is not None:
+  if run_policy is None:
+    base_env["MOBIUS_RUN_TOKEN"] = run_token
+  else:
     base_env.update({
       "MOBIUS_SUBAGENT_DEPTH": "1",
       "MOBIUS_DELEGATION_ID": run_policy.delegation_id,

--- a/backend/app/chat_writer.py
+++ b/backend/app/chat_writer.py
@@ -421,6 +421,22 @@ class StartTurn(_Command):
   initiated_by_app_id: int | None = None
 
 
+@dataclass(frozen=True)
+class GoalPromotionRejected:
+  """Expected refusal when a run cannot accept the requested Goal."""
+
+  reason: str
+
+
+@dataclass
+class PromoteRunToGoal(_Command):
+  """Attach the exact currently-running physical turn to a visible Goal."""
+
+  chat_id: str = ""
+  run_token: str = ""
+  objective: str = ""
+
+
 @dataclass
 class AppendPending(_Command):
   """Queue a send behind an active turn (or stale pending).
@@ -1494,6 +1510,8 @@ class ChatWriterActor:
       return self._reconcile_startup_chat(db, cmd)
     if isinstance(cmd, StartTurn):
       return self._start_turn(db, cmd)
+    if isinstance(cmd, PromoteRunToGoal):
+      return self._promote_run_to_goal(db, cmd)
     if isinstance(cmd, AppendPending):
       return self._append_pending(db, cmd)
     if isinstance(cmd, AppendSteeredUserMessage):
@@ -2188,6 +2206,57 @@ class ChatWriterActor:
       "history": history,
       "session_id": chat.session_id,
       "provider": chat.provider,
+    }
+
+  def _promote_run_to_goal(
+    self, db, cmd: PromoteRunToGoal,
+  ) -> dict | GoalPromotionRejected:
+    """Atomically bind one exact live turn and its logical root to a Goal."""
+    run = db.query(models.ChatRun).filter(
+      models.ChatRun.id == cmd.run_token,
+      models.ChatRun.chat_id == cmd.chat_id,
+    ).first()
+    if run is None or run.status != "running":
+      db.rollback()
+      return GoalPromotionRejected("run_not_active")
+
+    latest = (
+      db.query(models.ChatRun.id)
+      .filter(models.ChatRun.chat_id == cmd.chat_id)
+      .order_by(models.ChatRun.started_at.desc(), models.ChatRun.id.desc())
+      .first()
+    )
+    if latest is None or latest[0] != run.id:
+      db.rollback()
+      return GoalPromotionRejected("run_not_current")
+    if run.goal_objective not in (None, cmd.objective):
+      db.rollback()
+      return GoalPromotionRejected("different_goal_active")
+
+    root_id = run.root_run_id or run.id
+    root = db.query(models.ChatRun).filter(
+      models.ChatRun.id == root_id,
+      models.ChatRun.chat_id == cmd.chat_id,
+    ).first()
+    if root is None:
+      db.rollback()
+      return GoalPromotionRejected("logical_root_missing")
+    if root.goal_objective not in (None, cmd.objective):
+      db.rollback()
+      return GoalPromotionRejected("different_goal_active")
+
+    changed = run.goal_objective is None or root.goal_objective is None
+    run.goal_objective = cmd.objective
+    root.goal_objective = cmd.objective
+    if changed and not _commit_or_rollback(db):
+      raise _PersistFailed("PromoteRunToGoal did not persist")
+    if not changed:
+      db.rollback()
+    return {
+      "objective": cmd.objective,
+      "root_run_id": root_id,
+      "run_id": run.id,
+      "state": "promoted" if changed else "active",
     }
 
   def _append_pending(self, db, cmd: AppendPending) -> dict:

--- a/backend/app/chat_writer.py
+++ b/backend/app/chat_writer.py
@@ -2220,13 +2220,10 @@ class ChatWriterActor:
       db.rollback()
       return GoalPromotionRejected("run_not_active")
 
-    latest = (
-      db.query(models.ChatRun.id)
-      .filter(models.ChatRun.chat_id == cmd.chat_id)
-      .order_by(models.ChatRun.started_at.desc(), models.ChatRun.id.desc())
-      .first()
-    )
-    if latest is None or latest[0] != run.id:
+    from app.run_state import latest_run
+
+    latest = latest_run(db, cmd.chat_id)
+    if latest is None or latest.id != run.id:
       db.rollback()
       return GoalPromotionRejected("run_not_current")
     if run.goal_objective not in (None, cmd.objective):

--- a/backend/app/codex_sdk_runner.py
+++ b/backend/app/codex_sdk_runner.py
@@ -210,6 +210,21 @@ def _codex_config_overrides(
   return overrides
 
 
+def _needs_native_goal_control(
+  *,
+  goal_mode: bool,
+  goal_objective: str | None,
+  goal_clear: bool,
+  goal_continue: bool,
+  fallback_goal_objective: str | None,
+) -> bool:
+  """Whether this turn already belongs to Codex's explicit Goal lifecycle."""
+  return bool(
+    goal_mode or goal_objective is not None or goal_clear
+    or (goal_mode and goal_continue) or fallback_goal_objective is not None
+  )
+
+
 def _codex_app_server_launch_args(
   codex_bin: str | None,
   config_overrides: list[str],
@@ -1580,10 +1595,17 @@ async def run_codex_sdk_turn(
   # Delegated children disable those optional tools at this provider-owned seam.
   codex_bin = shutil.which("codex")
   delegated = run_policy is not None
+  needs_goal_control = _needs_native_goal_control(
+    goal_mode=goal_mode,
+    goal_objective=goal_objective,
+    goal_clear=goal_clear,
+    goal_continue=goal_continue,
+    fallback_goal_objective=fallback_goal_objective,
+  )
   config_overrides = _codex_config_overrides(
     allow_questions=not delegated,
     allow_multi_agent=not delegated,
-    allow_goals=not delegated,
+    allow_goals=not delegated and needs_goal_control,
   )
   launch_args = _codex_app_server_launch_args(codex_bin, config_overrides)
   config_kwargs: dict[str, Any] = dict(
@@ -1678,10 +1700,6 @@ async def run_codex_sdk_turn(
   try:
     codex, entry_cancel = await _enter_codex_context_owned(codex_context)
     async with _EnteredCodexContext(codex_context, codex) as codex:
-      needs_goal_control = bool(
-        goal_mode or goal_objective is not None or goal_clear
-        or goal_continue or fallback_goal_objective is not None
-      )
       goal_client = control_client(codex) if needs_goal_control else None
       record_memory_checkpoint_once(
         "codex_first_client_connected",

--- a/backend/app/codex_sdk_runner.py
+++ b/backend/app/codex_sdk_runner.py
@@ -215,13 +215,12 @@ def _needs_native_goal_control(
   goal_mode: bool,
   goal_objective: str | None,
   goal_clear: bool,
-  goal_continue: bool,
   fallback_goal_objective: str | None,
 ) -> bool:
   """Whether this turn already belongs to Codex's explicit Goal lifecycle."""
   return bool(
     goal_mode or goal_objective is not None or goal_clear
-    or (goal_mode and goal_continue) or fallback_goal_objective is not None
+    or fallback_goal_objective is not None
   )
 
 
@@ -1599,7 +1598,6 @@ async def run_codex_sdk_turn(
     goal_mode=goal_mode,
     goal_objective=goal_objective,
     goal_clear=goal_clear,
-    goal_continue=goal_continue,
     fallback_goal_objective=fallback_goal_objective,
   )
   config_overrides = _codex_config_overrides(

--- a/backend/app/deps.py
+++ b/backend/app/deps.py
@@ -91,6 +91,7 @@ class Principal:
   app_instance_id: str | None = None
   scope: str = "owner"
   chat_id: str | None = None
+  run_id: str | None = None
   embed_instance_id: str | None = None
   embed_session_id: str | None = None
   embed_role: str | None = None
@@ -170,6 +171,18 @@ def _resolve_owner(
     raise HTTPException(status_code=401, detail="Owner not found.")
   if payload.get("epoch", 0) != owner.token_epoch:
     raise HTTPException(status_code=401, detail="Token revoked.")
+  agent_chat = payload.get("agent_chat")
+  agent_run = payload.get("agent_run")
+  if agent_chat is not None or agent_run is not None:
+    if not isinstance(agent_chat, str) or not isinstance(agent_run, str):
+      raise HTTPException(status_code=401, detail="Invalid agent token.")
+    live_run = db.query(models.ChatRun.id).filter(
+      models.ChatRun.id == agent_run,
+      models.ChatRun.chat_id == agent_chat,
+      models.ChatRun.status == "running",
+    ).first()
+    if live_run is None:
+      raise HTTPException(status_code=401, detail="Agent run is no longer active.")
   return owner, payload
 
 
@@ -521,7 +534,28 @@ def get_principal(
     app_id=app_id,
     app_instance_id=payload.get("app_nonce") if app_id is not None else None,
     scope="app" if app_id is not None else "owner",
+    chat_id=payload.get("agent_chat"),
+    run_id=payload.get("agent_run"),
   )
+
+
+def get_agent_run_principal(
+  token: str = Depends(_oauth2),
+  db: Session = Depends(get_db),
+) -> Principal:
+  """Resolve the short-lived owner bearer minted for one physical agent run."""
+  principal = get_principal(token, db)
+  if (
+    principal.scope != "owner"
+    or principal.app_id is not None
+    or not isinstance(principal.chat_id, str)
+    or not isinstance(principal.run_id, str)
+  ):
+    raise HTTPException(
+      status_code=403,
+      detail="This operation requires the current agent run.",
+    )
+  return principal
 
 
 def get_chat_view_principal(

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -77,7 +77,7 @@ class Owner(Base):
   # other onboarding signals later — same shape as a SCD type 1 row.
   walkthrough_completed_at = Column(DateTime, nullable=True, default=None)
   # Monotonic JWT-validity generation. Every owner-derived token (the
-  # 30-day login token, the 8h app token, the 2h agent token, the
+  # 30-day login token, the 8h app token, the run-bound agent token, the
   # 90-day service token) is stamped with the owner's token_epoch at
   # mint time; the owner-resolving dependency in deps.py rejects any
   # token whose stamped epoch is behind this value. Incrementing it is

--- a/backend/app/routes/chats_stream.py
+++ b/backend/app/routes/chats_stream.py
@@ -78,6 +78,7 @@ _SNAPSHOT_REPLAY_EVENT_TYPES = frozenset({
   "app_updated",
   "build_phase",
   "goal_plan_updated",
+  "goal_activated",
   "chat_run_finished",
   "chat_run_started",
   "queued_turn_starting",

--- a/backend/app/routes/goal_plans.py
+++ b/backend/app/routes/goal_plans.py
@@ -5,13 +5,14 @@ from __future__ import annotations
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 from sqlalchemy.orm import Session
 
 from app.broadcast import get_broadcast
 from app.database import get_db
 from app.deps import (
   Principal,
+  get_agent_run_principal,
   get_owner_or_chat_embed_principal,
   reject_cross_site,
   require_chat_embed_operation,
@@ -35,6 +36,20 @@ class GoalPlanReplace(BaseModel):
 
   expected_revision: int = Field(ge=0)
   tasks: list[dict[str, Any]]
+
+
+class GoalPromotionRequest(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  objective: str = Field(min_length=1, max_length=1000)
+
+  @field_validator("objective")
+  @classmethod
+  def clean_objective(cls, value: str) -> str:
+    cleaned = value.strip()
+    if not cleaned:
+      raise ValueError("objective must not be empty")
+    return cleaned
 
 
 class GoalTaskUpdate(BaseModel):
@@ -85,6 +100,56 @@ def get_goal_plan(
   get_active_chat_for_principal(db, chat_id, principal)
   rows = active_goal_rows(db, chat_id)
   return {"plan": serialize_plan(*rows) if rows is not None else None}
+
+
+@router.post(
+  "/{chat_id}/goal",
+  dependencies=[Depends(reject_cross_site)],
+)
+async def promote_current_run_to_goal(
+  chat_id: str,
+  body: GoalPromotionRequest,
+  principal: Principal = Depends(get_agent_run_principal),
+  db: Session = Depends(get_db),
+):
+  """Attach the caller's exact running turn to a platform-owned Goal."""
+  if principal.chat_id != chat_id:
+    raise HTTPException(status_code=403, detail="Agent run belongs to another chat.")
+  get_active_chat_for_principal(db, chat_id, principal)
+  from app import chat_queue
+  from app.chat_writer import (
+    GoalPromotionRejected,
+    PromoteRunToGoal,
+    await_ack,
+    get_writer,
+  )
+  async with chat_queue.get_transition_lock(chat_id):
+    result = await await_ack(get_writer().submit(PromoteRunToGoal(
+      chat_id=chat_id,
+      run_token=principal.run_id or "",
+      objective=body.objective,
+    )))
+  if isinstance(result, GoalPromotionRejected):
+    messages = {
+      "run_not_active": "The initiating agent turn is no longer active.",
+      "run_not_current": "A newer agent turn now owns this chat.",
+      "different_goal_active": "This turn already owns a different Goal.",
+      "logical_root_missing": "The running turn has no durable logical root.",
+    }
+    raise HTTPException(
+      status_code=409,
+      detail=messages.get(result.reason, "This turn cannot become a Goal."),
+    )
+  if result["state"] == "promoted":
+    broadcast = get_broadcast(chat_id)
+    if broadcast is not None and broadcast.running:
+      broadcast.publish({
+        "type": "goal_activated",
+        "objective": result["objective"],
+        "root_run_id": result["root_run_id"],
+        "run_id": result["run_id"],
+      })
+  return result
 
 
 @router.put(

--- a/backend/scripts/goal_promote.py
+++ b/backend/scripts/goal_promote.py
@@ -1,13 +1,5 @@
 #!/usr/bin/env python3
-"""Queue a verified hidden native-Goal activation for the current chat.
-
-The working agent decides whether an ordinary owner request deserves durable
-Goal mode.  This helper performs only the state transition: it reserves a
-hidden ``/goal`` message behind the currently running turn using the ordinary
-chat-send boundary.  When that turn settles, the existing queue handoff starts
-the provider's native Goal loop.  No classifier and no second Goal engine live
-here.
-"""
+"""Attach the current physical agent turn to a platform-owned Goal."""
 
 from __future__ import annotations
 
@@ -15,31 +7,39 @@ import argparse
 import json
 import os
 import sys
-import uuid
 from urllib.error import HTTPError, URLError
 from urllib.parse import quote
 from urllib.request import Request, urlopen
 
 
-def _settings() -> tuple[str, str, str]:
+def _settings() -> tuple[str, str, str, str]:
   base = (os.environ.get("API_BASE_URL") or "").rstrip("/")
   token = os.environ.get("AGENT_TOKEN") or ""
   chat_id = os.environ.get("CHAT_ID") or ""
+  run_id = os.environ.get("MOBIUS_RUN_TOKEN") or ""
   missing = [
     name for name, value in (
-      ("API_BASE_URL", base), ("AGENT_TOKEN", token), ("CHAT_ID", chat_id),
+      ("API_BASE_URL", base),
+      ("AGENT_TOKEN", token),
+      ("CHAT_ID", chat_id),
+      ("MOBIUS_RUN_TOKEN", run_id),
     ) if not value
   ]
   if missing:
     raise SystemExit(f"missing environment: {', '.join(missing)}")
-  return base, token, chat_id
+  return base, token, chat_id, run_id
 
 
-def _request(method: str, path: str, body=None):
-  base, token, _ = _settings()
-  data = None if body is None else json.dumps(body).encode("utf-8")
+def promote_goal(objective: str) -> dict:
+  objective = objective.strip()
+  if not objective:
+    raise SystemExit("goal promotion failed: objective is empty")
+
+  base, token, chat_id, run_id = _settings()
   request = Request(
-    f"{base}{path}", data=data, method=method,
+    f"{base}/api/chats/{quote(chat_id)}/goal",
+    data=json.dumps({"objective": objective}).encode("utf-8"),
+    method="POST",
     headers={
       "Authorization": f"Bearer {token}",
       "Content-Type": "application/json",
@@ -47,8 +47,7 @@ def _request(method: str, path: str, body=None):
   )
   try:
     with urlopen(request, timeout=30) as response:
-      raw = response.read()
-      return json.loads(raw) if raw else None
+      payload = json.loads(response.read())
   except HTTPError as exc:
     raw = exc.read().decode("utf-8", errors="replace")
     try:
@@ -61,121 +60,30 @@ def _request(method: str, path: str, body=None):
   except URLError as exc:
     raise SystemExit(f"goal promotion failed: {exc.reason}") from exc
 
-
-def _latest_visible_owner_cid(detail: dict) -> str:
-  for message in reversed(list(detail.get("messages") or [])):
-    if (
-      isinstance(message, dict)
-      and message.get("role") == "user"
-      and not message.get("hidden")
-      and isinstance(message.get("cid"), str)
-      and message["cid"]
-    ):
-      return message["cid"]
-  raise SystemExit(
-    "goal promotion failed: no visible owner request identifies this turn"
-  )
-
-
-def _activation_cid(chat_id: str, source_cid: str, objective: str) -> str:
-  """Make a retry of one decision idempotent without merging later requests."""
-  return str(uuid.uuid5(
-    uuid.NAMESPACE_URL,
-    f"mobius:auto-goal:v1:{chat_id}:{source_cid}:{objective}",
-  ))
-
-
-def _activation_is_durable(
-  runtime: dict, detail: dict, *, cid: str, objective: str,
-) -> str | None:
-  if runtime.get("active_goal_objective") == objective:
-    return "active"
-  for message in list(runtime.get("pending_messages") or []):
-    if (
-      isinstance(message, dict)
-      and message.get("cid") == cid
-      and message.get("hidden") is True
-      and message.get("content") == f"/goal {objective}"
-    ):
-      return "queued"
-  for message in list(detail.get("messages") or []):
-    if (
-      isinstance(message, dict)
-      and message.get("cid") == cid
-      and message.get("hidden") is True
-      and message.get("content") == f"/goal {objective}"
-    ):
-      return "started"
-  return None
-
-
-def promote_goal(objective: str) -> str:
-  objective = objective.strip()
-  if not objective:
-    raise SystemExit("goal promotion failed: objective is empty")
-
-  _, _, chat_id = _settings()
-  runtime = _request("GET", f"/api/chats/{quote(chat_id)}/runtime") or {}
-  active = runtime.get("active_goal_objective")
-  if active:
-    if active == objective:
-      return "active"
-    raise SystemExit(
-      "goal promotion failed: this chat already has a different active Goal"
-    )
-  if runtime.get("running") is not True:
-    raise SystemExit(
-      "goal promotion failed: automatic promotion must run during the "
-      "owner request it is promoting"
-    )
-
-  detail = _request("GET", f"/api/chats/{quote(chat_id)}?limit=100") or {}
-  source_cid = _latest_visible_owner_cid(detail)
-  cid = _activation_cid(chat_id, source_cid, objective)
-  _request(
-    "POST", f"/api/chats/{quote(chat_id)}/messages",
-    {
-      "content": f"/goal {objective}",
-      "hidden": True,
-      "cid": cid,
-    },
-  )
-
-  # The send acknowledgement is not enough: verify the exact hidden activation
-  # now exists in the active Goal, durable queue, or transcript.  The cid makes
-  # this proof safe across a lost response and retry.
-  runtime = _request("GET", f"/api/chats/{quote(chat_id)}/runtime") or {}
-  detail = _request("GET", f"/api/chats/{quote(chat_id)}?limit=100") or {}
-  state = _activation_is_durable(
-    runtime, detail, cid=cid, objective=objective,
-  )
-  if state is None:
-    raise SystemExit(
-      "goal promotion failed: the hidden native-Goal activation was not "
-      "durably verified"
-    )
-  return state
+  if (
+    not isinstance(payload, dict)
+    or payload.get("objective") != objective
+    or payload.get("state") not in {"promoted", "active"}
+    or not isinstance(payload.get("root_run_id"), str)
+    or payload.get("run_id") != run_id
+  ):
+    raise SystemExit("goal promotion failed: activation was not verified")
+  return payload
 
 
 def main() -> int:
   parser = argparse.ArgumentParser(
-    description="Promote the current ordinary request into a native Goal.",
+    description="Promote the current request into a platform-owned Goal.",
   )
   parser.add_argument(
     "objective",
     help="concise outcome and observable completion condition",
   )
-  args = parser.parse_args()
-  state = promote_goal(args.objective)
-  if state == "active":
-    print("Goal promotion verified: the native Goal is active.")
-  elif state == "queued":
-    print(
-      "Goal promotion verified: hidden native activation is queued behind "
-      "this turn."
-    )
+  result = promote_goal(parser.parse_args().objective)
+  if result["state"] == "active":
+    print("Goal promotion verified: this turn already owns the Goal.")
   else:
-    print("Goal promotion verified: hidden native activation has started.")
+    print("Goal promotion verified: this turn now owns the Goal.")
   return 0
 
 

--- a/backend/scripts/goal_promote.py
+++ b/backend/scripts/goal_promote.py
@@ -47,7 +47,11 @@ def promote_goal(objective: str) -> dict:
   )
   try:
     with urlopen(request, timeout=30) as response:
-      payload = json.loads(response.read())
+      raw = response.read()
+    try:
+      payload = json.loads(raw) if raw else {}
+    except json.JSONDecodeError:
+      raise SystemExit("goal promotion failed: malformed response")
   except HTTPError as exc:
     raw = exc.read().decode("utf-8", errors="replace")
     try:

--- a/backend/scripts/init_skills.py
+++ b/backend/scripts/init_skills.py
@@ -66,6 +66,8 @@ _UNMODIFIED_MIGRATIONS = {
     # so existing instances learn the completion preflight without clobbering
     # any owner-authored planning guidance.
     "2adb39457e0ec2ee9d9a3596cb96e5a6240bae23d725e6459ba0f6e77d5474c4",
+    # Dependency-aware plan seed before provider-neutral automatic promotion.
+    "a3edc5fcc453a5305102e144c2d58ae16b828612ac93a6a7442be7e267779f59",
   },
   "reflection.md": {
     "c0f57c227f61cd8539a56b70eadfbbe2212125c23b7137472dd173a578baacd8",

--- a/backend/scripts/seed-skills/goal-planning.md
+++ b/backend/scripts/seed-skills/goal-planning.md
@@ -1,9 +1,48 @@
 # Goal planning
 
-Use this whenever a native `/goal` is created or resumed. It turns a genuinely
-multi-step Goal into the visible, dependency-aware todo list above the composer.
-Read it before doing material work on an active Goal that has multiple
-verifiable stages, repeated work, or stages that can safely run in parallel.
+Read this before material work on every ordinary prompt that delegates an
+outcome, and whenever a Goal is created or resumed. It turns genuinely durable
+work into the visible, dependency-aware todo list above the composer. Questions
+and explanation-only prompts are not delegated outcomes and do not need this
+routing read. Automatic promotion belongs to a top-level owner turn; a delegated
+subagent keeps its assigned task bounded rather than starting another Goal.
+
+## Decide whether the request should become a Goal
+
+Automatically promote the current turn only when all of these are true:
+
+- The partner delegated an outcome to complete, not merely an explanation,
+  recommendation, critique, or investigation to report back.
+- Completion has an observable condition the agent can eventually verify.
+- Durability materially helps because the route likely spans multiple
+  independently verifiable stages or turns, repeated work, dynamic discovery,
+  safe parallel branches, a long operation, or a plausible restart.
+- Work can begin without first waiting for a material owner choice, destructive
+  approval, or external event.
+
+Do not infer a Goal from message length, words such as “thoroughly,” a
+multi-file edit, or the mere fact that a useful task list could be written.
+Keep bounded work that can honestly finish in one turn as a standard prompt.
+Honor “just answer,” “one pass,” and “don't make this a Goal” as opt-outs.
+
+When the criteria hold, promote the current physical turn before material work:
+
+```bash
+python3 /data/platform/backend/scripts/goal_promote.py \
+  'Concise outcome and observable completion condition'
+```
+
+Run that helper as its own command. It attaches the already-running turn to
+Möbius's provider-neutral Goal state and verifies the committed identity; it
+does not add a hidden message or start a second turn. Do not call a
+provider-private `create_goal` from an ordinary turn, queue a synthetic `/goal`,
+or claim activation before the helper succeeds. Explicit `/goal` remains
+authoritative.
+
+If an ordinary turn begins bounded but discovery later reveals substantial
+durable work that now meets every criterion, promote at that point before
+starting the newly discovered branch. Do not rewrite completed work as if the
+Goal existed earlier.
 
 ## Decide whether the Goal earns a plan
 
@@ -15,6 +54,10 @@ not a keyword parser: do not manufacture busywork merely to fill a list.
 The Goal remains the stable outcome. Tasks describe the current route to it and
 may be revised as evidence changes, but revising the route never authorizes
 silently changing the requested outcome.
+
+When discovery adds work, run `show`, then replace the complete plan with
+`set --tasks-json`, preserving every existing task's truthful status, note, and
+progress while adding or rewiring only the newly understood route.
 
 ## Publish the dependency graph
 
@@ -74,8 +117,10 @@ completion preflight as its own command:
 python3 /data/platform/backend/scripts/goal_plan.py check-complete
 ```
 
-Only call `update_goal` with `status: complete` when that command exits zero
-and the actual requested outcome has been achieved. The preflight allows a
+Only finish the Goal when that command exits zero and the actual requested
+outcome has been achieved. Where an explicit provider Goal exposes mediated
+`update_goal`, call it with `status: complete` only after this check; otherwise
+the verified end of the agent turn completes the Goal. The preflight allows a
 deliberately unplanned one-step Goal; for a planned Goal it rejects pending,
 running, blocked, or failed tasks. Cancelled tasks are treated as deliberately
 removed from the route. A green todo list supports the completion audit; it

--- a/backend/tests/test_chat_note.py
+++ b/backend/tests/test_chat_note.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 import pytest
 
-from app import chat, chat_queue
+from app import chat, chat_queue, models
 
 
 def _settings(on=True):
@@ -70,6 +70,35 @@ def test_skips_on_non_settled_dispositions(tmp_path):
     assert not chat._should_ensure_chat_note(
       _settings(on=True), "c1", d, str(tmp_path), 0.0
     ), d
+
+
+def test_active_goal_checkpoint_reads_the_exact_current_run(
+  client, owner_token, db,
+):
+  owner_auth = {"Authorization": f"Bearer {owner_token}"}
+  chat_id = client.post(
+    "/api/chats", json={"title": "Dynamic Goal"}, headers=owner_auth,
+  ).json()["id"]
+  run = models.ChatRun(
+    id="dynamic-goal-run", root_run_id="dynamic-goal-run", chat_id=chat_id,
+    status="running", provider="claude",
+  )
+  db.add(run)
+  db.commit()
+
+  assert not chat._run_owns_active_goal(
+    db, chat_id=chat_id, run_token=run.id,
+  )
+  run.goal_objective = "Discover and repair every represented defect"
+  db.commit()
+  assert chat._run_owns_active_goal(
+    db, chat_id=chat_id, run_token=run.id,
+  )
+  run.status = "completed"
+  db.commit()
+  assert not chat._run_owns_active_goal(
+    db, chat_id=chat_id, run_token=run.id,
+  )
 
 
 def test_fires_on_limit_parked(tmp_path):

--- a/backend/tests/test_codex_sdk_runner.py
+++ b/backend/tests/test_codex_sdk_runner.py
@@ -3281,14 +3281,6 @@ def test_ordinary_codex_turns_do_not_expose_provider_private_goal_tools():
     goal_mode=False,
     goal_objective=None,
     goal_clear=False,
-    goal_continue=False,
-    fallback_goal_objective=None,
-  ) is False
-  assert codex_sdk_runner._needs_native_goal_control(
-    goal_mode=False,
-    goal_objective=None,
-    goal_clear=False,
-    goal_continue=True,
     fallback_goal_objective=None,
   ) is False
   assert "features.goals=true" not in codex_sdk_runner._codex_config_overrides(
@@ -3298,7 +3290,6 @@ def test_ordinary_codex_turns_do_not_expose_provider_private_goal_tools():
     goal_mode=True,
     goal_objective="Ship and verify",
     goal_clear=False,
-    goal_continue=False,
     fallback_goal_objective=None,
   ) is True
 

--- a/backend/tests/test_codex_sdk_runner.py
+++ b/backend/tests/test_codex_sdk_runner.py
@@ -3276,6 +3276,33 @@ def test_codex_config_overrides_enable_native_goal_runtime(monkeypatch):
   assert "features.goals=true" in codex_sdk_runner._codex_config_overrides()
 
 
+def test_ordinary_codex_turns_do_not_expose_provider_private_goal_tools():
+  assert codex_sdk_runner._needs_native_goal_control(
+    goal_mode=False,
+    goal_objective=None,
+    goal_clear=False,
+    goal_continue=False,
+    fallback_goal_objective=None,
+  ) is False
+  assert codex_sdk_runner._needs_native_goal_control(
+    goal_mode=False,
+    goal_objective=None,
+    goal_clear=False,
+    goal_continue=True,
+    fallback_goal_objective=None,
+  ) is False
+  assert "features.goals=true" not in codex_sdk_runner._codex_config_overrides(
+    allow_goals=False,
+  )
+  assert codex_sdk_runner._needs_native_goal_control(
+    goal_mode=True,
+    goal_objective="Ship and verify",
+    goal_clear=False,
+    goal_continue=False,
+    fallback_goal_objective=None,
+  ) is True
+
+
 def test_codex_app_server_launch_args_preserve_overrides_under_setsid(
   monkeypatch,
 ):

--- a/backend/tests/test_goal_plans.py
+++ b/backend/tests/test_goal_plans.py
@@ -1,9 +1,13 @@
 """Durable Goal-plan validation, ordering, progress, and route contracts."""
 
+from datetime import timedelta
 import importlib.util
 from pathlib import Path
 
-from app import models
+import pytest
+
+from app import auth as auth_mod, models
+from app import broadcast as broadcast_mod
 
 
 def _goal_plan_script():
@@ -29,6 +33,205 @@ def _active_goal(client, owner_token, db):
   ))
   db.commit()
   return auth, chat_id
+
+
+def _agent_run_auth(db, chat_id, run_id):
+  owner = db.query(models.Owner).first()
+  token = auth_mod.create_agent_token(
+    chat_id,
+    run_id,
+    owner.username,
+    owner.token_epoch,
+    expires_delta=timedelta(minutes=5),
+  )
+  return {"Authorization": f"Bearer {token}"}
+
+
+def test_current_turn_promotes_atomically_without_a_goal_message(
+  client, owner_token, db,
+):
+  owner_auth = {"Authorization": f"Bearer {owner_token}"}
+  created = client.post("/api/chats", json={"title": "Ordinary"}, headers=owner_auth)
+  chat_id = created.json()["id"]
+  db.add(models.ChatRun(
+    id="ordinary-run",
+    root_run_id="ordinary-run",
+    chat_id=chat_id,
+    status="running",
+    provider="codex",
+  ))
+  db.commit()
+  agent_auth = _agent_run_auth(db, chat_id, "ordinary-run")
+
+  broadcast = broadcast_mod.create_broadcast(chat_id)
+  try:
+    promoted = client.post(
+      f"/api/chats/{chat_id}/goal",
+      json={"objective": "Repair every defect and verify the suite"},
+      headers=agent_auth,
+    )
+    assert promoted.status_code == 200, promoted.text
+    assert promoted.json() == {
+      "objective": "Repair every defect and verify the suite",
+      "root_run_id": "ordinary-run",
+      "run_id": "ordinary-run",
+      "state": "promoted",
+    }
+    assert [
+      event["type"] for event in broadcast.event_log
+    ] == ["goal_activated"]
+    db.expire_all()
+    run = db.query(models.ChatRun).filter(models.ChatRun.id == "ordinary-run").one()
+    assert run.goal_objective == "Repair every defect and verify the suite"
+    chat = db.query(models.Chat).filter(models.Chat.id == chat_id).one()
+    assert all(
+      "/goal" not in str(message.get("content", ""))
+      for message in chat.messages
+    )
+
+    retry = client.post(
+      f"/api/chats/{chat_id}/goal",
+      json={"objective": "Repair every defect and verify the suite"},
+      headers=agent_auth,
+    )
+    assert retry.status_code == 200
+    assert retry.json()["state"] == "active"
+    assert [
+      event["type"] for event in broadcast.event_log
+    ] == ["goal_activated"]
+    conflict = client.post(
+      f"/api/chats/{chat_id}/goal",
+      json={"objective": "Do something else"},
+      headers=agent_auth,
+    )
+    assert conflict.status_code == 409
+
+    plan = client.put(
+      f"/api/chats/{chat_id}/goal-plan",
+      json={
+        "expected_revision": 0,
+        "tasks": [{"id": "repair", "title": "Repair every defect"}],
+      },
+      headers=agent_auth,
+    )
+    assert plan.status_code == 200, plan.text
+    assert (
+      plan.json()["plan"]["objective"]
+      == "Repair every defect and verify the suite"
+    )
+  finally:
+    broadcast_mod.remove_broadcast(chat_id)
+
+
+def test_goal_promotion_rejects_browser_wrong_chat_and_terminal_run_tokens(
+  client, owner_token, db,
+):
+  owner_auth = {"Authorization": f"Bearer {owner_token}"}
+  first = client.post("/api/chats", json={"title": "First"}, headers=owner_auth).json()
+  second = client.post("/api/chats", json={"title": "Second"}, headers=owner_auth).json()
+  db.add_all([
+    models.ChatRun(
+      id="live-run", root_run_id="live-run", chat_id=first["id"],
+      status="running", provider="claude",
+    ),
+    models.ChatRun(
+      id="settled-run", root_run_id="settled-run", chat_id=first["id"],
+      status="completed", provider="claude",
+    ),
+  ])
+  db.commit()
+  agent_auth = _agent_run_auth(db, first["id"], "live-run")
+  settled_auth = _agent_run_auth(db, first["id"], "settled-run")
+
+  browser = client.post(
+    f"/api/chats/{first['id']}/goal",
+    json={"objective": "Not allowed"}, headers=owner_auth,
+  )
+  assert browser.status_code == 403
+  wrong_chat = client.post(
+    f"/api/chats/{second['id']}/goal",
+    json={"objective": "Not allowed"}, headers=agent_auth,
+  )
+  assert wrong_chat.status_code == 403
+  terminal = client.post(
+    f"/api/chats/{first['id']}/goal",
+    json={"objective": "Too late"}, headers=settled_auth,
+  )
+  assert terminal.status_code == 401
+  assert "no longer active" in terminal.json()["detail"]
+
+
+def test_promotion_of_a_continuation_stamps_its_logical_root(
+  client, owner_token, db,
+):
+  owner_auth = {"Authorization": f"Bearer {owner_token}"}
+  chat_id = client.post(
+    "/api/chats", json={"title": "Continued"}, headers=owner_auth,
+  ).json()["id"]
+  db.add_all([
+    models.ChatRun(
+      id="logical-root", root_run_id="logical-root", chat_id=chat_id,
+      status="interrupted", provider="claude",
+    ),
+    models.ChatRun(
+      id="physical-resume", root_run_id="logical-root", chat_id=chat_id,
+      status="running", provider="claude",
+    ),
+  ])
+  db.commit()
+
+  promoted = client.post(
+    f"/api/chats/{chat_id}/goal",
+    json={"objective": "Finish the resumed migration"},
+    headers=_agent_run_auth(db, chat_id, "physical-resume"),
+  )
+
+  assert promoted.status_code == 200, promoted.text
+  assert promoted.json()["root_run_id"] == "logical-root"
+  db.expire_all()
+  roots = {
+    row.id: row.goal_objective
+    for row in db.query(models.ChatRun).filter(models.ChatRun.chat_id == chat_id)
+  }
+  assert roots == {
+    "logical-root": "Finish the resumed migration",
+    "physical-resume": "Finish the resumed migration",
+  }
+
+
+def test_goal_promotion_commit_failure_is_loud_and_atomic(
+  client, owner_token, db, monkeypatch,
+):
+  from app import chat_writer
+
+  owner_auth = {"Authorization": f"Bearer {owner_token}"}
+  chat_id = client.post(
+    "/api/chats", json={"title": "Atomic failure"}, headers=owner_auth,
+  ).json()["id"]
+  db.add(models.ChatRun(
+    id="failing-run", root_run_id="failing-run", chat_id=chat_id,
+    status="running", provider="codex",
+  ))
+  db.commit()
+
+  def fail_commit(session):
+    session.rollback()
+    return False
+
+  monkeypatch.setattr(chat_writer, "_commit_or_rollback", fail_commit)
+  with pytest.raises(chat_writer._PersistFailed, match="PromoteRunToGoal"):
+    chat_writer.get_writer()._promote_run_to_goal(
+      db,
+      chat_writer.PromoteRunToGoal(
+        chat_id=chat_id,
+        run_token="failing-run",
+        objective="Persist all-or-nothing",
+      ),
+    )
+
+  db.expire_all()
+  run = db.query(models.ChatRun).filter(models.ChatRun.id == "failing-run").one()
+  assert run.goal_objective is None
 
 
 def test_parallel_roots_release_dependent_task_only_after_all_complete(

--- a/backend/tests/test_goal_promote.py
+++ b/backend/tests/test_goal_promote.py
@@ -1,6 +1,7 @@
-"""Automatic Goal promotion reserves one verified hidden native activation."""
+"""Automatic Goal promotion uses one typed, run-bound platform operation."""
 
 import importlib.util
+import json
 from pathlib import Path
 
 import pytest
@@ -14,67 +15,86 @@ def _helper():
   return module
 
 
-def test_promotion_queues_hidden_activation_with_turn_scoped_identity(
-  monkeypatch,
-):
-  helper = _helper()
+class _Response:
+  def __init__(self, payload):
+    self.payload = payload
+
+  def __enter__(self):
+    return self
+
+  def __exit__(self, *_args):
+    return False
+
+  def read(self):
+    return json.dumps(self.payload).encode("utf-8")
+
+
+def _env(monkeypatch):
   monkeypatch.setenv("API_BASE_URL", "http://mobius.test")
-  monkeypatch.setenv("AGENT_TOKEN", "owner-token")
+  monkeypatch.setenv("AGENT_TOKEN", "run-bound-token")
   monkeypatch.setenv("CHAT_ID", "chat-1")
+  monkeypatch.setenv("MOBIUS_RUN_TOKEN", "run-1")
+
+
+def test_promotion_posts_one_typed_request_without_message_text(monkeypatch):
+  helper = _helper()
+  _env(monkeypatch)
   calls = []
-  pending = []
 
-  def request(method, path, body=None):
-    calls.append((method, path, body))
-    if method == "GET" and path.endswith("/runtime"):
-      return {
-        "running": True,
-        "active_goal_objective": None,
-        "pending_messages": list(pending),
-      }
-    if method == "GET":
-      return {"messages": [
-        {"role": "user", "content": "Do the work", "cid": "owner-turn"},
-      ]}
-    pending.append(dict(body))
-    return {"status": "queued"}
+  def open_request(request, timeout):
+    calls.append((request, timeout))
+    return _Response({
+      "state": "promoted",
+      "objective": "Finish every stage and verify the result",
+      "root_run_id": "run-1",
+      "run_id": "run-1",
+    })
 
-  monkeypatch.setattr(helper, "_request", request)
+  monkeypatch.setattr(helper, "urlopen", open_request)
   objective = "Finish every stage and verify the result"
 
-  assert helper.promote_goal(objective) == "queued"
-  post = next(call for call in calls if call[0] == "POST")
-  assert post[2]["content"] == f"/goal {objective}"
-  assert post[2]["hidden"] is True
-  assert post[2]["cid"] == helper._activation_cid(
-    "chat-1", "owner-turn", objective,
-  )
+  assert helper.promote_goal(objective)["state"] == "promoted"
+  assert len(calls) == 1
+  request, timeout = calls[0]
+  assert request.full_url == "http://mobius.test/api/chats/chat-1/goal"
+  assert request.method == "POST"
+  assert timeout == 30
+  assert json.loads(request.data) == {"objective": objective}
+  assert b"/goal" not in request.data
 
 
-def test_retry_identity_changes_only_with_the_owner_turn():
+def test_promotion_accepts_an_idempotent_active_response(monkeypatch):
   helper = _helper()
-  objective = "Ship and verify"
-  first = helper._activation_cid("chat", "turn-a", objective)
+  _env(monkeypatch)
+  monkeypatch.setattr(helper, "urlopen", lambda *_args, **_kwargs: _Response({
+    "state": "active",
+    "objective": "Ship and verify",
+    "root_run_id": "run-1",
+    "run_id": "run-1",
+  }))
 
-  assert helper._activation_cid("chat", "turn-a", objective) == first
-  assert helper._activation_cid("chat", "turn-b", objective) != first
+  assert helper.promote_goal("Ship and verify")["state"] == "active"
 
 
-def test_promotion_refuses_to_queue_outside_the_request_it_promotes(
-  monkeypatch,
-):
+def test_promotion_rejects_a_response_for_another_run(monkeypatch):
+  helper = _helper()
+  _env(monkeypatch)
+  monkeypatch.setattr(helper, "urlopen", lambda *_args, **_kwargs: _Response({
+    "state": "promoted",
+    "objective": "Ship and verify",
+    "root_run_id": "run-1",
+    "run_id": "newer-run",
+  }))
+
+  with pytest.raises(SystemExit, match="activation was not verified"):
+    helper.promote_goal("Ship and verify")
+
+
+def test_promotion_requires_the_current_physical_run(monkeypatch):
   helper = _helper()
   monkeypatch.setenv("API_BASE_URL", "http://mobius.test")
   monkeypatch.setenv("AGENT_TOKEN", "owner-token")
   monkeypatch.setenv("CHAT_ID", "chat-1")
-  monkeypatch.setattr(
-    helper, "_request",
-    lambda *_args, **_kwargs: {
-      "running": False,
-      "active_goal_objective": None,
-      "pending_messages": [],
-    },
-  )
 
-  with pytest.raises(SystemExit, match="must run during the owner request"):
+  with pytest.raises(SystemExit, match="MOBIUS_RUN_TOKEN"):
     helper.promote_goal("Ship and verify")

--- a/backend/tests/test_memory_boot.py
+++ b/backend/tests/test_memory_boot.py
@@ -133,6 +133,7 @@ def test_controlled_skills_have_fix_forward_migrations():
 
   assert module._UNMODIFIED_MIGRATIONS["goal-planning.md"] == {
     "2adb39457e0ec2ee9d9a3596cb96e5a6240bae23d725e6459ba0f6e77d5474c4",
+    "a3edc5fcc453a5305102e144c2d58ae16b828612ac93a6a7442be7e267779f59",
   }
   assert "1086688efd4dede48ebc95b12b92fb958280e67896a53e52e02cd5def3aa265f" in (
     module._UNMODIFIED_MIGRATIONS["reflection.md"]

--- a/backend/tests/test_system_broadcast.py
+++ b/backend/tests/test_system_broadcast.py
@@ -618,6 +618,13 @@ async def test_notify_catch_up_unsafe_event_is_system_bus_only(
     bc_mod.remove_broadcast("live-chat-2")
 
 
+def test_notify_rejects_server_owned_goal_activation(client, auth):
+  response = client.post(
+    "/api/notify", headers=auth, json={"type": "goal_activated"},
+  )
+  assert response.status_code == 422
+
+
 # --- Chat-scoped build_phase milestone rail (feature 212) --------------
 
 

--- a/backend/tests/test_token_revocation.py
+++ b/backend/tests/test_token_revocation.py
@@ -144,6 +144,34 @@ def test_token_stamped_at_wrong_epoch_is_rejected(client, owner_token, db):
   assert r.status_code == 401
 
 
+def test_agent_token_is_valid_only_while_its_exact_run_is_running(
+  client, owner_token, db,
+):
+  owner_auth = {"Authorization": f"Bearer {owner_token}"}
+  chat_id = client.post(
+    "/api/chats", json={"title": "Run-bound agent"}, headers=owner_auth,
+  ).json()["id"]
+  owner = db.query(models.Owner).filter(models.Owner.username == "test").one()
+  db.add(models.ChatRun(
+    id="agent-run", root_run_id="agent-run", chat_id=chat_id,
+    status="running", provider="codex",
+  ))
+  db.commit()
+  token = auth.create_agent_token(
+    chat_id, "agent-run", owner.username, owner.token_epoch,
+  )
+  agent_auth = {"Authorization": f"Bearer {token}"}
+
+  assert client.get("/api/apps/", headers=agent_auth).status_code == 200
+
+  run = db.query(models.ChatRun).filter(models.ChatRun.id == "agent-run").one()
+  run.status = "completed"
+  db.commit()
+  response = client.get("/api/apps/", headers=agent_auth)
+  assert response.status_code == 401
+  assert response.json()["detail"] == "Agent run is no longer active."
+
+
 def test_bump_revokes_query_param_token_on_module_route(client, owner_token):
   """The module route takes the token on `?token=` (iframe import can't
   set headers) and used to skip the revocation check. After the bump,

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -1305,6 +1305,11 @@ export default function ChatView({
       onStreamEnd?.({ continues })
     },
     onSystemEvent: event => {
+      if (event?.type === 'goal_activated') {
+        setActiveGoalPlan(null)
+        setActiveGoalState(event.objective || '')
+        return
+      }
       if (event?.type === 'goal_plan_updated') {
         setActiveGoalPlan(current => newestGoalPlan(current, event.plan || null))
         return

--- a/frontend/src/components/ChatView/__tests__/chatSystemEvents.test.js
+++ b/frontend/src/components/ChatView/__tests__/chatSystemEvents.test.js
@@ -11,6 +11,7 @@ test('chat stream recognizes catch-up-safe system events without swallowing unkn
   assert.equal(isChatStreamSystemEvent('app_updated'), true)
   assert.equal(isChatStreamSystemEvent('build_phase'), true)
   assert.equal(isChatStreamSystemEvent('goal_plan_updated'), true)
+  assert.equal(isChatStreamSystemEvent('goal_activated'), true)
   assert.equal(isChatStreamSystemEvent('text'), false)
 })
 
@@ -32,7 +33,7 @@ test('catch-up-unsafe events never ride the chat stream (system-bus-only)', () =
 })
 
 test('every recognized chat-stream system event forwards (all are catch-up-safe)', () => {
-  for (const type of ['theme_updated', 'app_updated', 'build_phase', 'goal_plan_updated', 'chat_run_started', 'chat_run_finished']) {
+  for (const type of ['theme_updated', 'app_updated', 'build_phase', 'goal_plan_updated', 'goal_activated', 'chat_run_started', 'chat_run_finished']) {
     assert.equal(
       shouldForwardChatStreamSystemEvent({ type }),
       true,

--- a/frontend/src/components/ChatView/chatSystemEvents.js
+++ b/frontend/src/components/ChatView/chatSystemEvents.js
@@ -24,6 +24,9 @@ export const CHAT_STREAM_SYSTEM_EVENTS = new Set([
   // Goal plans are persisted before publication and carry the complete
   // revisioned snapshot, so both live delivery and reconnect replay are safe.
   'goal_plan_updated',
+  // A typed promotion updates the live Goal before its optional plan exists.
+  // Reconnect recovers the same fact from active_goal_objective.
+  'goal_activated',
   'chat_run_started',
   'chat_run_finished',
 ])

--- a/skill/core.md
+++ b/skill/core.md
@@ -104,11 +104,19 @@ Then triage the prompt into one of three tiers:
   clarifying-question tool, and wait for a pick. Recommendations in prose alone
   do not count as waiting.
 
-**Automatic Goal routing.** Before material work on every ordinary prompt that
-delegates an outcome, read the `goal-planning` skill and make its conservative
-Goal-versus-standard decision. Questions and explanation-only prompts are not
-delegated outcomes. Use the working agent's judgment, never a keyword/length
-classifier or a separate model call. Explicit `/goal` remains authoritative.
+**Automatic Goal routing.** Before material work on an ordinary top-level
+partner request that delegates an outcome, create a Goal only when completion
+is observable and durability materially helps (multiple stages/turns,
+repetition, discovery, parallel work,
+or restart risk), and work can begin without an owner choice or external event.
+When those criteria hold, before material work read `goal-planning`, then run
+`python3 /data/platform/backend/scripts/goal_promote.py '<objective>'`. Never use a
+provider-private Goal or synthetic `/goal` message.
+If discovery makes the criteria true only later, promote promptly before
+starting the newly discovered durable branch.
+Keep questions, explanations, and honestly bounded one-turn work standard.
+Delegated subagents remain bounded tasks rather than starting their own Goals.
+Explicit `/goal` and explicit opt-outs remain authoritative.
 
 **Scope check before any restyle.** "The app" is ambiguous: it can mean the whole Möbius shell with one global look or a single mini-app with app-scoped styling. Resolve which BEFORE styling — "restyle the whole app / make everything feel like X" most likely means the shell, not the last mini-app you happened to build. Confirm scope if it's at all ambiguous, follow the matching injected skill, and in your reply say what you changed and what you left untouched.
 


### PR DESCRIPTION
## Summary

- replace the hidden `/goal` follow-up message with one atomic promotion of the turn that is already doing the work
- keep Möbius's Goal state authoritative for both Claude and Codex, while ordinary Codex turns no longer expose a separate provider-private Goal path
- update the live Goal UI and active-Goal checkpoint summaries as soon as promotion commits
- teach conservative initial and discovery-time promotion without turning bounded prompts or delegated child tasks into Goals

## Why

#824 introduced conservative automatic routing, but its hidden `/goal` carrier started a second turn and could leave Möbius and the provider disagreeing about whether the Goal was live. This follow-up keeps the judgment-based policy while making the state transition exact, idempotent, run-bound, and provider-neutral. It builds on the dependency-aware plan introduced in #807.

The longer-lived agent credential is also tied to the exact running turn, so it stops authorizing requests as soon as that run ends.

## Testing

- `scripts/test.sh --fast`
- focused Goal, auth, summary, provider, and event tests
- `npm test`
- `npm run lint` (no errors; existing warning baseline only)