### PR TITLE
Allow packaged app links to open safe destination tabs

### DIFF
--- a/backend/app/response_policy.py
+++ b/backend/app/response_policy.py
@@ -131,7 +131,8 @@ CHAT_EMBED_CSP = (
 def static_embed_csp(frontend_origin: str) -> str:
   origin = _validated_frontend_origin(frontend_origin)
   return (
-    "sandbox allow-scripts allow-forms allow-pointer-lock; "
+    "sandbox allow-scripts allow-forms allow-pointer-lock allow-popups "
+    "allow-popups-to-escape-sandbox; "
     f"default-src {origin}; "
     f"script-src {origin} 'unsafe-inline'; "
     f"style-src {origin} 'unsafe-inline'; "

--- a/backend/tests/test_app_assets_cache.py
+++ b/backend/tests/test_app_assets_cache.py
@@ -41,7 +41,11 @@ def _write_static(app_id, relpath, content):
 
 def _assert_opaque_embed_policy(response, status_code):
   assert response.status_code == status_code
-  assert response.headers["content-security-policy"] == _STATIC_EMBED_CSP
+  policy = response.headers["content-security-policy"]
+  assert policy == _STATIC_EMBED_CSP
+  assert "allow-popups-to-escape-sandbox" in policy
+  assert "allow-same-origin" not in policy
+  assert "allow-top-navigation" not in policy
   assert "x-frame-options" not in response.headers
 
 

--- a/backend/tests/test_security_headers.py
+++ b/backend/tests/test_security_headers.py
@@ -147,7 +147,14 @@ def test_static_embed_policy_authoritatively_replaces_route_headers(monkeypatch)
   response = TestClient(app).get("/app-embeds/by-id/999/index.html")
 
   assert response.status_code == 418
-  assert response.headers["content-security-policy"] == _STATIC_EMBED_CSP
+  policy = response.headers["content-security-policy"]
+  assert policy == _STATIC_EMBED_CSP
+  # A packaged app may opt into a user-opened destination tab at its own iframe
+  # boundary. The destination must escape this opaque sandbox or signed-in
+  # storage and same-origin requests on sites such as GitHub remain broken.
+  assert "allow-popups-to-escape-sandbox" in policy
+  assert "allow-same-origin" not in policy
+  assert "allow-top-navigation" not in policy
   assert "x-frame-options" not in response.headers
 
 


### PR DESCRIPTION
## Summary
- allow packaged static documents to open user-activated destination tabs
- let those tabs escape the opaque sandbox so destination sites retain normal origin, storage, and sign-in behavior
- keep same-origin and top-level shell navigation permissions absent
- enforce the policy on normal, cached, and error responses

## Why
CubeRun’s hard-coded author link uses `target="_blank"`, but the packaged static-document policy currently blocks all popups even when the app wrapper explicitly opts in. Ordinary mini-app frames already permit this narrow destination-tab behavior.

## Validation
- `python3 -m py_compile backend/app/response_policy.py`
- 40 focused response-policy and static-asset tests passed (1 skipped)
- 83 fast backend contract tests passed