### PR TITLE
Let owners edit queued messages inline

### DIFF
--- a/backend/app/chat_writer.py
+++ b/backend/app/chat_writer.py
@@ -384,12 +384,12 @@ class ReconcileStartupChat(_Command):
 # These own the read-modify-write of the chat's `messages` /
 # `pending_messages` blobs: initial-send (`StartTurn`, from
 # routes/chats_stream.py), append (`AppendPending`), cancel
-# (`CancelPending`), promote (`PromotePending`, from chat_queue.py), and
-# clear / run markers (`ClearPending`, from chat.py).  The routes/queue
-# submit these instead of mutating the row directly, so every mutation is
-# serialized on the actor thread.  Each is must-persist (commit-before-ack,
-# non-coalescing) and fences any pending coalescible snapshot for its
-# (chat_id, run_token) key on submit.
+# (`CancelPending`), edit (`UpdatePending`), promote (`PromotePending`, from
+# chat_queue.py), and clear / run markers (`ClearPending`, from chat.py).  The
+# routes/queue submit these instead of mutating the row directly, so every
+# mutation is serialized on the actor thread.  Each is must-persist (commit-
+# before-ack, non-coalescing) and fences any pending coalescible snapshot for
+# its (chat_id, run_token) key on submit.
 
 
 @dataclass(frozen=True)
@@ -516,6 +516,22 @@ class CancelPending(_Command):
   chat_id: str = ""
   run_token: str = ""
   cid: str = ""
+
+
+@dataclass
+class UpdatePending(_Command):
+  """Replace one still-queued message's text without changing its identity.
+
+  The stable `cid`, ordering `ts`, attachments, and queue position stay
+  untouched. Returns `{"updated", "pending"}`; `updated` is False when a
+  racing promotion or cancellation already pulled the row from the queue, so
+  the caller can tell a real edit from a no-op instead of assuming success.
+  """
+
+  chat_id: str = ""
+  run_token: str = ""
+  cid: str = ""
+  content: str = ""
 
 
 @dataclass
@@ -771,6 +787,7 @@ _FENCE_COMMANDS = (
   AppendSteeredUserMessage,
   PromotePending,
   CancelPending,
+  UpdatePending,
   ClearPending,
   ReplaceTranscript,
   FinishRun,
@@ -1506,6 +1523,8 @@ class ChatWriterActor:
       return self._promote_pending(db, cmd)
     if isinstance(cmd, CancelPending):
       return self._cancel_pending(db, cmd)
+    if isinstance(cmd, UpdatePending):
+      return self._update_pending(db, cmd)
     if isinstance(cmd, ClearPending):
       return self._clear_pending(db, cmd)
     if isinstance(cmd, ReplaceTranscript):
@@ -2645,6 +2664,37 @@ class ChatWriterActor:
       if not _commit_or_rollback(db):
         raise _PersistFailed("CancelPending did not persist")
     return {"pending": remaining}
+
+  def _update_pending(self, db, cmd: UpdatePending) -> dict:
+    """Replace one still-queued message's text, preserving every other field.
+
+    Matches on `cid_of` like `_cancel_pending`; stamps `updated_at` and commits
+    only when the row is still queued. Returns `{"updated", "pending"}` —
+    `updated` is False when a racing promote or cancel already removed the row,
+    so the caller can distinguish a real edit from a no-op.
+    """
+    from datetime import UTC, datetime
+
+    from app.models import Chat
+
+    chat = db.query(Chat).filter(Chat.id == cmd.chat_id).first()
+    if chat is None:
+      raise _PersistFailed("UpdatePending: chat not found")
+    pending = list(chat.pending_messages or [])
+    updated = False
+    next_pending = []
+    for message in pending:
+      if not updated and cid_of(message) == cmd.cid:
+        next_pending.append({**message, "content": cmd.content})
+        updated = True
+      else:
+        next_pending.append(message)
+    if updated:
+      chat.pending_messages = next_pending
+      chat.updated_at = datetime.now(UTC)
+      if not _commit_or_rollback(db):
+        raise _PersistFailed("UpdatePending did not persist")
+    return {"updated": updated, "pending": next_pending}
 
   def _clear_pending(self, db, cmd: ClearPending) -> dict:
     """Empty the pending queue; return the count + the cleared cids.

--- a/backend/app/routes/chats_stream.py
+++ b/backend/app/routes/chats_stream.py
@@ -29,6 +29,7 @@ from app.chat_writer import (
   CancelPending,
   StartTurn,
   StartTurnBlockedByPendingQuestion,
+  UpdatePending,
   alloc_run_token,
   await_ack,
   cid_of,
@@ -1190,6 +1191,42 @@ async def cancel_pending_message(
   )
   result = await await_ack(ack)
   return {"pending_messages": result["pending"]}
+
+
+@router.patch(
+  "/{chat_id}/pending/{cid}",
+  status_code=200,
+  dependencies=[Depends(reject_cross_site)],
+)
+async def update_pending_message(
+  chat_id: str,
+  cid: str,
+  body: schemas.PendingMessageUpdate,
+  principal: Principal = Depends(get_owner_or_chat_embed_principal),
+  db: Session = Depends(get_db),
+):
+  """Edits one queued (not-yet-started) user message in place, identified by
+  its stable `cid`. Only the text changes; the actor's UpdatePending preserves
+  the row's identity, ordering, attachments, and queue position.
+
+  Returns `updated` plus the current pending queue so the client can reconcile
+  drift: `updated` is False when a racing promotion or cancellation pulled the
+  message into the active turn between the owner saving and the PATCH landing.
+  """
+  if principal.scope == "app":
+    raise HTTPException(status_code=403, detail="App token is not valid here.")
+  require_chat_embed_operation(principal, "chat:send")
+  require_active_chat_access(db, chat_id, principal)
+  content = body.content.strip()
+  if not content:
+    raise HTTPException(status_code=422, detail="Queued message cannot be empty.")
+  # The actor's UpdatePending is the SOLE runtime mutator of pending_messages,
+  # so an edit racing a concurrent promote/cancel can't lost-update.
+  ack = get_writer().submit(
+    UpdatePending(chat_id=chat_id, run_token="", cid=cid, content=content)
+  )
+  result = await await_ack(ack)
+  return {"updated": result["updated"], "pending_messages": result["pending"]}
 
 
 @router.get("/{chat_id}/stream")

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -739,6 +739,13 @@ class SendMessage(BaseModel):
     return self
 
 
+class PendingMessageUpdate(BaseModel):
+  # New text for one already-queued message. Only the content is client-
+  # supplied; the row's stable `cid`, ordering `ts`, attachments, and queue
+  # position are preserved server-side and never taken from the request.
+  content: str
+
+
 class PushKeys(BaseModel):
   p256dh: str
   auth: str

--- a/backend/tests/test_augmentation.py
+++ b/backend/tests/test_augmentation.py
@@ -877,6 +877,89 @@ def test_cancel_pending_message_by_cid(client, db, auth):
   assert [m["ts"] for m in c.pending_messages] == [100, 300]
 
 
+def test_update_pending_message_preserves_identity_order_and_attachments(
+  client, db, auth,
+):
+  """PATCH changes only queued text; delivery identity and files stay put."""
+  from app import models
+
+  c = models.Chat(
+    id="edit-pending",
+    title="t",
+    messages=[],
+    pending_messages=[
+      {
+        "role": "user", "content": "before", "ts": 100, "cid": "c-edit",
+        "position": 1, "attachments": [{"name": "notes.txt"}],
+      },
+      {"role": "user", "content": "second", "ts": 200, "cid": "c-next"},
+    ],
+  )
+  db.add(c)
+  db.commit()
+
+  resp = client.patch(
+    "/api/chats/edit-pending/pending/c-edit",
+    headers=auth,
+    json={"content": "  after  "},
+  )
+  assert resp.status_code == 200, resp.text
+  data = resp.json()
+  assert data["updated"] is True
+  assert [row["cid"] for row in data["pending_messages"]] == ["c-edit", "c-next"]
+  edited = data["pending_messages"][0]
+  assert edited == {
+    "role": "user", "content": "after", "ts": 100, "cid": "c-edit",
+    "position": 1, "attachments": [{"name": "notes.txt"}],
+  }
+
+  db.refresh(c)
+  assert c.pending_messages == data["pending_messages"]
+
+
+def test_update_pending_message_reports_a_racing_promotion(client, db, auth):
+  """A row that already left the queue is not recreated by a late edit."""
+  from app import models
+
+  c = models.Chat(id="edit-gone", title="t", messages=[], pending_messages=[])
+  db.add(c)
+  db.commit()
+
+  resp = client.patch(
+    "/api/chats/edit-gone/pending/c-gone",
+    headers=auth,
+    json={"content": "too late"},
+  )
+  assert resp.status_code == 200
+  assert resp.json() == {"updated": False, "pending_messages": []}
+
+
+def test_update_pending_message_rejects_empty_content(client, db, auth):
+  """Whitespace-only text is refused so an edit cannot blank a queued row."""
+  from app import models
+
+  c = models.Chat(
+    id="edit-empty",
+    title="t",
+    messages=[],
+    pending_messages=[
+      {"role": "user", "content": "keep", "ts": 100, "cid": "c-keep"},
+    ],
+  )
+  db.add(c)
+  db.commit()
+
+  resp = client.patch(
+    "/api/chats/edit-empty/pending/c-keep",
+    headers=auth,
+    json={"content": "   "},
+  )
+  assert resp.status_code == 422
+
+  db.refresh(c)
+  assert c.pending_messages[0]["content"] == "keep"
+
+
 def test_cancel_pending_row_by_backfilled_legacy_cid(client, db, auth):
   """A card-221-backfilled row carries an explicit `legacy-<ts>` cid; cancelling
   by that value removes it (the value is stored now, not derived at read time)."""

--- a/backend/tests/test_chat_writer_contention.py
+++ b/backend/tests/test_chat_writer_contention.py
@@ -41,6 +41,7 @@ from app.chat_writer import (
   ReplaceTranscript,
   StartTurn,
   StartTurnBlockedByPendingQuestion,
+  UpdatePending,
 )
 from app.database import SessionLocal
 
@@ -511,6 +512,44 @@ def test_concurrent_append_cancel_promote_preserve_order(actor):
   assert chat["pending_messages"] == []
   assert "m0" in promoted["promoted"]["content"]
   assert "m3" not in promoted["promoted"]["content"]
+
+
+def test_update_pending_preserves_non_text_fields(actor):
+  """UpdatePending replaces only the matched row's text; identity, ordering,
+  and attachments on it and its neighbours are untouched."""
+  _seed_chat(pending=[
+    {
+      "role": "user", "content": "before", "ts": 10, "cid": "c-edit",
+      "position": 1, "attachments": [{"name": "notes.txt"}],
+    },
+    {"role": "user", "content": "next", "ts": 20, "cid": "c-next"},
+  ])
+  result = _await(actor.submit(UpdatePending(
+    chat_id="c1", run_token="", cid="c-edit", content="after",
+  )))
+  assert result["updated"] is True
+  assert result["pending"] == [
+    {
+      "role": "user", "content": "after", "ts": 10, "cid": "c-edit",
+      "position": 1, "attachments": [{"name": "notes.txt"}],
+    },
+    {"role": "user", "content": "next", "ts": 20, "cid": "c-next"},
+  ]
+
+
+def test_update_pending_missing_cid_is_a_noop(actor):
+  """Editing a cid no longer queued reports updated:False and rewrites nothing
+  (the promote/cancel race the UI reconciles instead of assuming success)."""
+  _seed_chat(pending=[
+    {"role": "user", "content": "keep", "ts": 10, "cid": "c-keep"},
+  ])
+  result = _await(actor.submit(UpdatePending(
+    chat_id="c1", run_token="", cid="c-gone", content="late",
+  )))
+  assert result["updated"] is False
+  assert result["pending"] == [
+    {"role": "user", "content": "keep", "ts": 10, "cid": "c-keep"},
+  ]
 
 
 # -- cid identity: dedup + idempotency ------------------------------------

--- a/frontend/src/components/ChatView/ChatView.css
+++ b/frontend/src/components/ChatView/ChatView.css
@@ -3588,6 +3588,59 @@
   text-overflow: ellipsis;
 }
 
+.queued__row--editing {
+  padding: 6px;
+  background: var(--bg);
+}
+
+.queued__editor {
+  flex: 1;
+  min-width: 0;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: start;
+  gap: 4px;
+}
+
+.queued__editor-input {
+  box-sizing: border-box;
+  width: 100%;
+  min-height: 56px;
+  max-height: 160px;
+  padding: 8px 10px;
+  resize: vertical;
+  border: 1px solid var(--border);
+  border-radius: 9px;
+  outline: none;
+  background: var(--surface);
+  color: var(--text);
+  font: inherit;
+  font-size: 14px;
+  line-height: 1.4;
+}
+
+.queued__editor-input:focus {
+  border-color: color-mix(in srgb, var(--accent) 60%, var(--border));
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.queued__editor-actions {
+  display: flex;
+  align-items: flex-start;
+}
+
+.queued__edit-save:not(:disabled) {
+  color: var(--accent);
+}
+
+.queued__editor-error {
+  grid-column: 1 / -1;
+  padding: 0 4px 2px;
+  color: var(--danger);
+  font-size: 11px;
+  line-height: 1.3;
+}
+
 .queued__action {
   --queued-action-visual-shift: 0px;
   flex-shrink: 0;

--- a/frontend/src/components/ChatView/ChatView.css
+++ b/frontend/src/components/ChatView/ChatView.css
@@ -3615,7 +3615,8 @@
   background: var(--surface);
   color: var(--text);
   font: inherit;
-  font-size: 14px;
+  /* Keep at 16px: iOS Safari zooms focused inputs below 16px (see contract above). */
+  font-size: 16px;
   line-height: 1.4;
 }
 

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -3200,6 +3200,37 @@ export default function ChatView({
     }
   }, [chatId, pendingQueue])
 
+  const handleUpdatePending = useCallback(async (cid, content) => {
+    // Let any in-flight enqueue for this cid settle first, so we PATCH a row
+    // the server already knows about rather than racing its POST.
+    const queueWrite = queuedSendRequestsRef.current.get(cid)
+    if (queueWrite) await Promise.allSettled([queueWrite])
+    try {
+      const res = await apiFetch(
+        `/chats/${chatId}/pending/${encodeURIComponent(cid)}`,
+        {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ content }),
+          timeoutMs: CHAT_FETCH_TIMEOUT_MS,
+        },
+      )
+      const data = await jsonOrThrow(res, 'Queued-message edit failed')
+      if (data.updated && Array.isArray(data.pending_messages)) {
+        // Reconcile the edited text from server truth.
+        pendingQueue.hydrate(data.pending_messages)
+        return 'saved'
+      }
+      // updated:false — a racing promotion or cancel already pulled this row
+      // from the queue, so the edit could not apply. Report it distinctly
+      // instead of a phantom success; the normal stream reconcile drops the
+      // stale row and the editor explains why.
+      return 'gone'
+    } catch {
+      return 'error'
+    }
+  }, [chatId, pendingQueue])
+
   async function handleStop() {
     // Re-entry guard. Without this, two rapid Stop clicks would both
     // snapshot the same pending queue (the snapshot happens BEFORE
@@ -4617,6 +4648,7 @@ export default function ChatView({
           <QueuedMessages
             items={pendingQueue.visiblePendingMessages}
             onCancel={handleCancelPending}
+            onEdit={handleUpdatePending}
             onSteerOne={handleSteerOne}
             steerActive={turnActive && !hasPendingQuestion}
             steerBusy={steerBusy}

--- a/frontend/src/components/ChatView/QueuedMessages.jsx
+++ b/frontend/src/components/ChatView/QueuedMessages.jsx
@@ -1,6 +1,12 @@
 import { useRef, useState } from 'react'
-import { ChevronDown, DoubleChevronRight, X } from '@openai/apps-sdk-ui/components/Icon'
-import { stripAugmentation } from './msgText.js'
+import {
+  Check,
+  ChevronDown,
+  DoubleChevronRight,
+  Pencil,
+  X,
+} from '@openai/apps-sdk-ui/components/Icon'
+import { augmentationSuffix, stripAugmentation } from './msgText.js'
 import { cidOf } from './messageIdentity.js'
 import {
   pointerSelectionChangedWithin,
@@ -25,10 +31,14 @@ const TRUNCATE_AT = 80
  * the chat list and the input form. Empty queue → nothing rendered.
  */
 export default function QueuedMessages({
-  items, onCancel, onSteerOne, steerActive, steerBusy = false,
+  items, onCancel, onEdit, onSteerOne, steerActive, steerBusy = false,
 }) {
   const [expanded, setExpanded] = useState(() => new Set())
   const [collapsed, setCollapsed] = useState(false)
+  const [editingCid, setEditingCid] = useState(null)
+  const [editDraft, setEditDraft] = useState('')
+  const [editSaving, setEditSaving] = useState(false)
+  const [editError, setEditError] = useState('')
   const pointerSelectionRef = useRef(null)
 
   if (!items || items.length === 0) return null
@@ -52,6 +62,52 @@ export default function QueuedMessages({
 
   function toggleCollapsed() {
     setCollapsed(c => !c)
+  }
+
+  function beginEdit(msg) {
+    const cid = cidOf(msg)
+    setEditingCid(cid)
+    setEditDraft(stripAugmentation(msg.content || ''))
+    setEditError('')
+    // Expand so the whole message is visible while editing a truncated row.
+    setExpanded(prev => new Set(prev).add(cid))
+  }
+
+  function cancelEdit() {
+    if (editSaving) return
+    setEditingCid(null)
+    setEditDraft('')
+    setEditError('')
+  }
+
+  async function saveEdit(msg) {
+    if (editSaving) return
+    const visible = editDraft.trim()
+    if (!visible) {
+      setEditError('Queued message cannot be empty.')
+      return
+    }
+    if (visible === stripAugmentation(msg.content || '').trim()) {
+      cancelEdit()
+      return
+    }
+    // Replace only the visible text; keep the hidden session-file manifest so
+    // an edited message still points the agent at its uploads.
+    const content = visible + augmentationSuffix(msg.content || '')
+    setEditSaving(true)
+    setEditError('')
+    // onEdit reports an explicit outcome so a race can't read as success:
+    // 'saved' applied, 'gone' already promoted/cancelled, 'error' transport.
+    const outcome = await onEdit?.(cidOf(msg), content)
+    setEditSaving(false)
+    if (outcome === 'saved') {
+      setEditingCid(null)
+      setEditDraft('')
+    } else if (outcome === 'gone') {
+      setEditError('This message already started — it can’t be edited now.')
+    } else {
+      setEditError('Couldn’t save this edit. Try again.')
+    }
   }
 
   function onHdrKeyDown(e) {
@@ -107,82 +163,152 @@ export default function QueuedMessages({
               ? firstLine.slice(0, TRUNCATE_AT) + '…'
               : firstLine + (text.includes('\n') ? ' …' : '')
             const MessageSurface = needsTruncation ? 'button' : 'div'
+            const isEditing = editingCid === key
 
             return (
               <div
                 key={key}
-                className={`queued__row${isExpanded ? ' queued__row--expanded' : ''}`}
+                className={`queued__row${isExpanded ? ' queued__row--expanded' : ''}${isEditing ? ' queued__row--editing' : ''}`}
                 role="listitem"
               >
-                <MessageSurface
-                  type={needsTruncation ? 'button' : undefined}
-                  className={`queued__toggle${needsTruncation ? '' : ' queued__toggle--static'}`}
-                  onPointerDown={needsTruncation ? () => {
-                    pointerSelectionRef.current = textSelectionSnapshot()
-                  } : undefined}
-                  onClick={needsTruncation ? (event) => {
-                    const selectionBeforePointer = pointerSelectionRef.current
-                    pointerSelectionRef.current = null
-                    if (
-                      event.detail !== 0
-                      && pointerSelectionChangedWithin(
-                        selectionBeforePointer,
-                        event.currentTarget,
-                      )
-                    ) return
-                    toggle(key)
-                  } : undefined}
-                  aria-expanded={needsTruncation ? isExpanded : undefined}
-                  aria-label={needsTruncation
-                    ? (isExpanded ? 'Collapse message' : 'Expand message')
-                    : undefined}
-                >
-                  {needsTruncation && (
-                    <ChevronDown
-                      className={`queued__chevron${isExpanded ? ' queued__chevron--open' : ''}`}
-                      width={10}
-                      height={10}
-                      aria-hidden="true"
+                {isEditing ? (
+                  <div className="queued__editor">
+                    <textarea
+                      className="queued__editor-input"
+                      value={editDraft}
+                      onChange={(event) => {
+                        setEditDraft(event.target.value)
+                        setEditError('')
+                      }}
+                      onKeyDown={(event) => {
+                        if (event.key === 'Escape') {
+                          event.preventDefault()
+                          cancelEdit()
+                        } else if (
+                          event.key === 'Enter' && (event.metaKey || event.ctrlKey)
+                        ) {
+                          event.preventDefault()
+                          void saveEdit(msg)
+                        }
+                      }}
+                      aria-label="Edit queued message"
+                      rows={2}
+                      autoFocus
+                      disabled={editSaving}
                     />
-                  )}
-                  <span className="queued__text">
-                    {isExpanded ? text : preview}
-                  </span>
-                </MessageSurface>
-                {steerActive && (
-                  // Per-row fast-forward (owner ask, 2026-07-17): the same
-                  // double-chevron as the composer's steer button, in the
-                  // queue action's compact neutral well — send exactly THIS
-                  // message into the running turn now.
-                  // Render it with the optimistic row so the action well and
-                  // cancel-X arrive together. An early tap waits for this
-                  // row's queue write in ChatView before force-steering it.
-                  <button
-                    type="button"
-                    className="queued__action queued__steer"
-                    onPointerDown={(e) => e.preventDefault()}
-                    onTouchEnd={(e) => {
-                      e.preventDefault()
-                      onSteerOne?.(cidOf(msg))
-                    }}
-                    onClick={() => onSteerOne?.(cidOf(msg))}
-                    aria-label="Send this queued message now"
-                    title="Send now"
-                    disabled={steerBusy}
-                  >
-                    <DoubleChevronRight width={16} height={16} aria-hidden="true" />
-                  </button>
+                    <div className="queued__editor-actions">
+                      <button
+                        type="button"
+                        className="queued__action queued__edit-save"
+                        onPointerDown={(e) => e.preventDefault()}
+                        onClick={() => void saveEdit(msg)}
+                        aria-label="Save queued message edit"
+                        title="Save edit"
+                        disabled={editSaving || !editDraft.trim()}
+                      >
+                        <Check width={16} height={16} aria-hidden="true" />
+                      </button>
+                      <button
+                        type="button"
+                        className="queued__action queued__edit-cancel"
+                        onPointerDown={(e) => e.preventDefault()}
+                        onClick={cancelEdit}
+                        aria-label="Discard queued message edit"
+                        title="Discard edit"
+                        disabled={editSaving}
+                      >
+                        <X width={16} height={16} aria-hidden="true" />
+                      </button>
+                    </div>
+                    {editError && (
+                      <div className="queued__editor-error" role="status">
+                        {editError}
+                      </div>
+                    )}
+                  </div>
+                ) : (
+                  <>
+                    <MessageSurface
+                      type={needsTruncation ? 'button' : undefined}
+                      className={`queued__toggle${needsTruncation ? '' : ' queued__toggle--static'}`}
+                      onPointerDown={needsTruncation ? () => {
+                        pointerSelectionRef.current = textSelectionSnapshot()
+                      } : undefined}
+                      onClick={needsTruncation ? (event) => {
+                        const selectionBeforePointer = pointerSelectionRef.current
+                        pointerSelectionRef.current = null
+                        if (
+                          event.detail !== 0
+                          && pointerSelectionChangedWithin(
+                            selectionBeforePointer,
+                            event.currentTarget,
+                          )
+                        ) return
+                        toggle(key)
+                      } : undefined}
+                      aria-expanded={needsTruncation ? isExpanded : undefined}
+                      aria-label={needsTruncation
+                        ? (isExpanded ? 'Collapse message' : 'Expand message')
+                        : undefined}
+                    >
+                      {needsTruncation && (
+                        <ChevronDown
+                          className={`queued__chevron${isExpanded ? ' queued__chevron--open' : ''}`}
+                          width={10}
+                          height={10}
+                          aria-hidden="true"
+                        />
+                      )}
+                      <span className="queued__text">
+                        {isExpanded ? text : preview}
+                      </span>
+                    </MessageSurface>
+                    <button
+                      type="button"
+                      className="queued__action queued__edit"
+                      onPointerDown={(e) => e.preventDefault()}
+                      onClick={() => beginEdit(msg)}
+                      aria-label="Edit queued message"
+                      title="Edit"
+                    >
+                      <Pencil width={16} height={16} aria-hidden="true" />
+                    </button>
+                    {steerActive && (
+                      // Per-row fast-forward (owner ask, 2026-07-17): the same
+                      // double-chevron as the composer's steer button, in the
+                      // queue action's compact neutral well — send exactly THIS
+                      // message into the running turn now.
+                      // Render it with the optimistic row so the action well and
+                      // cancel-X arrive together. An early tap waits for this
+                      // row's queue write in ChatView before force-steering it.
+                      <button
+                        type="button"
+                        className="queued__action queued__steer"
+                        onPointerDown={(e) => e.preventDefault()}
+                        onTouchEnd={(e) => {
+                          e.preventDefault()
+                          onSteerOne?.(cidOf(msg))
+                        }}
+                        onClick={() => onSteerOne?.(cidOf(msg))}
+                        aria-label="Send this queued message now"
+                        title="Send now"
+                        disabled={steerBusy}
+                      >
+                        <DoubleChevronRight width={16} height={16} aria-hidden="true" />
+                      </button>
+                    )}
+                    <button
+                      type="button"
+                      className="queued__action queued__cancel"
+                      onPointerDown={(e) => e.preventDefault()}
+                      onClick={() => onCancel?.(cidOf(msg))}
+                      aria-label="Cancel queued message"
+                      title="Cancel"
+                    >
+                      <X width={16} height={16} aria-hidden="true" />
+                    </button>
+                  </>
                 )}
-                <button
-                  type="button"
-                  className="queued__action queued__cancel"
-                  onPointerDown={(e) => e.preventDefault()}
-                  onClick={() => onCancel?.(cidOf(msg))}
-                  aria-label="Cancel queued message"
-                  title="Cancel"
-                >
-                  <X width={16} height={16} aria-hidden="true" />
-                </button>
               </div>
             )
           })}

--- a/frontend/src/components/ChatView/__tests__/stripAugmentation.test.js
+++ b/frontend/src/components/ChatView/__tests__/stripAugmentation.test.js
@@ -1,7 +1,7 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
 
-import { stripAugmentation } from '../msgText.js'
+import { augmentationSuffix, stripAugmentation } from '../msgText.js'
 
 test('stripAugmentation removes hidden file manifests without gluing queued messages', () => {
   const text = [
@@ -54,4 +54,19 @@ test('stripAugmentation collapses duplicate trailing file manifests from steered
 test('stripAugmentation removes agent experience as a paragraph boundary', () => {
   const text = 'before\n<agent_experience>hidden</agent_experience>\nafter'
   assert.equal(stripAugmentation(text), 'before\n\nafter')
+})
+
+test('augmentationSuffix returns the hidden file manifest so an edit can keep it', () => {
+  const suffix = '\n\n[Files in this session:\n- One.png → /p/One.png (image/png, 1 KB)]'
+  const content = 'please summarize this' + suffix
+  assert.equal(augmentationSuffix(content), suffix)
+  // The visible edit plus the preserved suffix reconstructs a manifest-bearing
+  // message; stripping it again yields just the new visible text.
+  const edited = 'summarize the attached file' + augmentationSuffix(content)
+  assert.equal(stripAugmentation(edited), 'summarize the attached file')
+})
+
+test('augmentationSuffix is empty when a queued message carries no manifest', () => {
+  assert.equal(augmentationSuffix('just plain queued text'), '')
+  assert.equal(augmentationSuffix(''), '')
 })

--- a/frontend/src/components/ChatView/msgText.js
+++ b/frontend/src/components/ChatView/msgText.js
@@ -9,3 +9,13 @@ export function stripAugmentation(text) {
   cleaned = cleaned.replace(/(?:\s*\[Files in this session:\n[\s\S]*?\]\s*)+/g, '\n')
   return cleaned.replace(/\n{3,}/g, '\n\n').trim()
 }
+
+// The hidden "Files in this session" manifest the server appends to a queued
+// message at compose time and stripAugmentation() hides for display. Editing a
+// queued row replaces only its visible text, so the editor re-attaches this
+// suffix to keep the row's file references intact — the same content force-steer
+// already resends verbatim. Empty when the message carries no such manifest.
+export function augmentationSuffix(text) {
+  const idx = (text || '').indexOf('\n\n[Files in this session:')
+  return idx === -1 ? '' : text.slice(idx)
+}


### PR DESCRIPTION
## Summary

Add an inline edit control to each queued follow-up message, so an owner can revise a message waiting behind the current turn without cancelling and retyping it. Editing changes only the visible text — the message keeps its place in the queue, its stable delivery identity, its attachments, and its hidden session-file references.

- A pencil action on each queued row opens an inline editor (save / discard, `Esc` to cancel, `Cmd/Ctrl+Enter` to save).
- Persistence goes through a new `UpdatePending` command on the `ChatWriter` actor — the single serialized mutator of `pending_messages` — so an edit that races a promotion or cancellation cannot lost-update. `PATCH /chats/{id}/pending/{cid}` returns `updated` plus the current queue.
- The client maps that outcome explicitly (`saved` / `gone` / `error`): an edit for a message that has already started running (or was cancelled) is surfaced to the owner instead of being reported as a phantom success.
- The hidden `[Files in this session: ...]` manifest is preserved across an edit, so editing a message that carries uploads keeps pointing the agent at those files.

## Relationship to #786

#786 bundles this queued-message editing together with a double-`Esc` stop shortcut and a stopped-turn continuation note. Following the review there asking to split those apart, this PR carries **only** the queued-message editing, so it can be reviewed and reverted on its own. It builds on @dzanahmed's implementation and additionally:

- fixes the QA finding that the edit reported success even when the backend applied nothing (`updated: false`);
- preserves the hidden upload manifest so editing an attachment-bearing message keeps its file references; and
- defines the request body in `app/schemas.py` rather than inline in the route.

The double-`Esc` shortcut and the interruption-presentation change are intentionally left out of this PR.

## Testing

- Backend `pytest`: `test_update_pending_message_preserves_identity_order_and_attachments`, `test_update_pending_message_reports_a_racing_promotion`, `test_update_pending_message_rejects_empty_content`, `test_update_pending_preserves_non_text_fields`, `test_update_pending_missing_cid_is_a_noop`, plus the full `test_augmentation.py` and `test_chat_writer_contention.py` files.
- Frontend: `npm test` (lib + hooks) and `npm run lint`.