### PR TITLE
Add hierarchical Goal orchestration

### DIFF
--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -111,6 +111,9 @@ def create_app_token(
   app_nonce: str | None = None,
   *,
   expires_delta: timedelta = timedelta(hours=8),
+  delegation_id: str | None = None,
+  delegation_chat: str | None = None,
+  delegation_run: str | None = None,
 ) -> str:
   """Creates a short-lived JWT scoped to a specific mini-app.
 
@@ -128,8 +131,44 @@ def create_app_token(
   claims = {"sub": owner_username, "scope": "app", "app_id": app_id}
   if app_nonce is not None:
     claims["app_nonce"] = app_nonce
+  delegated_claims = (delegation_id, delegation_chat, delegation_run)
+  if any(value is not None for value in delegated_claims) and not all(
+    value is not None for value in delegated_claims
+  ):
+    raise ValueError(
+      "delegation identity, chat, and run must be supplied together"
+    )
+  if delegation_id is not None:
+    claims["delegation_id"] = delegation_id
+    claims["delegation_chat"] = delegation_chat
+    claims["delegation_run"] = delegation_run
   return create_access_token(
     claims,
+    expires_delta=expires_delta,
+    token_epoch=token_epoch,
+  )
+
+
+def create_delegation_token(
+  delegation_id: str,
+  app_id: int,
+  chat_id: str,
+  run_id: str,
+  owner_username: str,
+  token_epoch: int,
+  *,
+  expires_delta: timedelta = timedelta(hours=8),
+) -> str:
+  """Create a bearer confined to one delegated agent and direct children."""
+  return create_access_token(
+    {
+      "sub": owner_username,
+      "scope": "delegation",
+      "delegation_id": delegation_id,
+      "app_id": app_id,
+      "delegation_chat": chat_id,
+      "delegation_run": run_id,
+    },
     expires_delta=expires_delta,
     token_epoch=token_epoch,
   )

--- a/backend/app/chat.py
+++ b/backend/app/chat.py
@@ -4118,10 +4118,9 @@ async def _run_chat_impl_with_db(
 
   # A planned restart can replace the parent provider process while durable
   # child tasks keep running. Re-attach their immutable ids/statuses to every
-  # ordinary parent turn so a resumed agent waits on the existing child rather
-  # than launching a duplicate. Delegated children never receive this block,
-  # which also enforces the depth-one boundary.
-  if run_policy is None and chat_id and run_token:
+  # parent turn so both the root agent and a nested delegated owner wait on
+  # their existing direct children rather than launching duplicates.
+  if chat_id and run_token:
     from app.delegations import active_parent_context
     delegation_context = active_parent_context(db, chat_id, run_token)
     if delegation_context:
@@ -4174,8 +4173,8 @@ async def _run_chat_impl_with_db(
     return disposition
 
   if run_policy is not None:
-    from app.delegations import mint_app_token
-    agent_token = mint_app_token(db, run_policy)
+    from app.delegations import delegation_execution_token
+    agent_token = delegation_execution_token(db, run_policy, run_token or "")
   else:
     agent_token = auth.create_agent_token(
       chat_id, run_token, owner.username, owner.token_epoch,
@@ -4201,10 +4200,14 @@ async def _run_chat_impl_with_db(
     base_env["MOBIUS_RUN_TOKEN"] = run_token
   else:
     base_env.update({
-      "MOBIUS_SUBAGENT_DEPTH": "1",
+      "MOBIUS_SUBAGENT_DEPTH": str(run_policy.depth),
       "MOBIUS_DELEGATION_ID": run_policy.delegation_id,
       "MOBIUS_SUBAGENT_PROVIDER": run_policy.provider,
     })
+    if run_policy.provider == "claude":
+      base_env["MOBIUS_SUBAGENT_HELPER"] = (
+        "/data/apps/subagents/subagents.py"
+      )
   # Overrides any inherited TMPDIR from _safe_keys: agent scratch belongs on
   # the bounded data volume, never the container's unbounded overlay. TMP and
   # TEMP travel with it so a tool reading either does not escape back to /tmp.

--- a/backend/app/chat_context.py
+++ b/backend/app/chat_context.py
@@ -74,6 +74,7 @@ def _last_user_message_elapsed(db, chat_id: str) -> str | None:
       if (
         not isinstance(m, dict)
         or m.get("role") != "user"
+        or m.get("hidden")
         or is_continuation_message(m)
       ):
         continue
@@ -545,6 +546,8 @@ def _goal_resume_requested(chat_row, text: str) -> bool:
   # old goal that may already have finished before native goal storage existed.
   for message in reversed(durable[:-1]):
     if not isinstance(message, dict):
+      continue
+    if message.get("hidden"):
       continue
     if message.get("role") == "user":
       return False

--- a/backend/app/chat_start.py
+++ b/backend/app/chat_start.py
@@ -33,6 +33,9 @@ from app.chat_writer import (
 async def start_programmatic_chat_turn(
   *, chat_id: str, title: str, content: str, provider: str,
   initiated_by_app_id: int | None = None,
+  hidden: bool = False,
+  message_kind: str | None = None,
+  source_work_id: str | None = None,
 ) -> bool:
   """Durably start one system-initiated turn if the chat can be claimed.
 
@@ -57,6 +60,12 @@ async def start_programmatic_chat_turn(
       "content": content,
       "ts": int(time.time() * 1000),
     }
+    if hidden:
+      user_msg["hidden"] = True
+    if message_kind is not None:
+      user_msg["kind"] = message_kind
+    if source_work_id is not None:
+      user_msg["source_work_id"] = source_work_id
     result = await await_ack(get_writer().submit(StartTurn(
       chat_id=chat_id,
       run_token=run_token,

--- a/backend/app/chat_writer.py
+++ b/backend/app/chat_writer.py
@@ -2205,8 +2205,8 @@ class ChatWriterActor:
     # so any still-running row is a prior run whose clear was dropped — mark it
     # interrupted before opening this one (at most one run is ever live).
     from app.models import ChatRun
-    from app.run_state import goal_objective_for_run_start
-    goal_objective = goal_objective_for_run_start(
+    from app.run_state import goal_identity_for_run_start
+    goal_objective, goal_id = goal_identity_for_run_start(
       db, cmd.chat_id, cmd.user_msg,
     )
     self._close_nonterminal_runs(db, cmd.chat_id, "interrupted")
@@ -2216,6 +2216,7 @@ class ChatWriterActor:
       provider=chat.provider, started_at=started_at,
       initiated_by_app_id=cmd.initiated_by_app_id,
       goal_objective=goal_objective,
+      goal_id=goal_id,
     ))
     if not _commit_or_rollback(db):
       raise _PersistFailed("StartTurn did not persist")
@@ -2670,10 +2671,15 @@ class ChatWriterActor:
     # SAME commit as the queue handoff.
     from app.models import ChatRun
     from app.continuations import is_continuation_message
-    from app.run_state import goal_objective_for_run_start
-    goal_objective = goal_objective_for_run_start(
+    from app.run_state import goal_identity_for_run_start
+    goal_objective, goal_id = goal_identity_for_run_start(
       db, cmd.chat_id, agent_pending,
     )
+    # This event-only metadata lets the mounted UI cross the physical-turn
+    # boundary without briefly clearing a Goal while the runtime refetch lands.
+    # It is not written into the transcript row.
+    returned_promoted["_goal_objective"] = goal_objective
+    returned_promoted["_goal_id"] = goal_id
     prior_run = (
       db.query(ChatRun)
       .filter(
@@ -2697,6 +2703,7 @@ class ChatWriterActor:
       provider=chat.provider, started_at=started_at,
       initiated_by_app_id=initiated_by_app_id,
       goal_objective=goal_objective,
+      goal_id=goal_id,
     ))
     if not _commit_or_rollback(db):
       raise _PersistFailed("PromotePending did not persist")

--- a/backend/app/claude_sdk_runner.py
+++ b/backend/app/claude_sdk_runner.py
@@ -63,6 +63,8 @@ import logging
 import os
 import signal
 import shutil
+import shlex
+import re
 from collections import deque
 from contextlib import ExitStack
 from typing import Any
@@ -103,6 +105,72 @@ log = logging.getLogger(__name__)
 
 _CLAUDE_CLI = "/usr/local/bin/claude"
 _ISOLATED_CLAUDE_CLI = "/app/scripts/claude-isolated"
+
+
+def _guarded_subagent_bash(
+  input_data: dict[str, Any],
+) -> dict[str, Any] | None:
+  """Return one canonical shell-safe durable-child invocation, or deny it."""
+  command = input_data.get("command")
+  if not isinstance(command, str) or len(command) > 24_000:
+    return None
+  try:
+    args = shlex.split(command, posix=True)
+  except ValueError:
+    return None
+  if len(args) < 9 or args[0] not in {"python", "python3"}:
+    return None
+  if args[1:3] != ["/data/apps/subagents/subagents.py", "run"]:
+    return None
+  valued = {
+    "--provider", "--name", "--scope", "--model", "--effort", "--cwd",
+    "--prompt",
+  }
+  # A delegated owner may choose blocking vs durable background execution,
+  # but it cannot claim the owner's explicit-provider override. A provider
+  # paused in Subagents remains paused for every descendant.
+  flags = {"--background"}
+  parsed: dict[str, str] = {}
+  index = 3
+  while index < len(args):
+    option = args[index]
+    if option in flags:
+      if option in parsed:
+        return None
+      parsed[option] = "true"
+      index += 1
+      continue
+    if option not in valued or option in parsed or index + 1 >= len(args):
+      return None
+    parsed[option] = args[index + 1]
+    index += 2
+  valid = bool(
+    parsed.get("--provider") in {"claude", "codex"}
+    and parsed.get("--scope") == "read"
+    and re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}", parsed.get("--name", ""))
+    and 0 < len(parsed.get("--prompt", "")) <= 20_000
+    and "\x00" not in parsed.get("--prompt", "")
+    and (
+      "--cwd" not in parsed
+      or (
+        (
+          parsed["--cwd"] == "/data"
+          or parsed["--cwd"].startswith("/data/")
+        )
+        and "\x00" not in parsed["--cwd"]
+      )
+    )
+    and all(
+      re.fullmatch(r"[A-Za-z0-9._:/+-]{1,256}", parsed[option])
+      for option in ("--model", "--effort") if option in parsed
+    )
+  )
+  if not valid:
+    return None
+  # Never execute the model-authored quoting. Rebuild the already-validated
+  # argv so command substitutions, redirects, and separators can only remain
+  # literal prompt/cwd text passed to the helper.
+  return {**input_data, "command": shlex.join(args)}
 
 
 def _claude_cli_path() -> str:
@@ -863,6 +931,11 @@ async def run_claude_sdk_turn(
       if run_policy.scope == "read" and tool_name in {
         "Bash", "Write", "Edit", "MultiEdit", "NotebookEdit",
       }:
+        guarded = (
+          _guarded_subagent_bash(input_data) if tool_name == "Bash" else None
+        )
+        if guarded is not None:
+          return PermissionResultAllow(updated_input=guarded)
         return PermissionResultDeny(
           message="This delegated task is read-only."
         )

--- a/backend/app/continuations.py
+++ b/backend/app/continuations.py
@@ -14,6 +14,12 @@ CONTINUATION_MESSAGE_KINDS = frozenset({
   "auto_continuation",
 })
 
+# Product-owned child results travel through the ordinary user-message slot so
+# both provider transports receive them without a second execution channel.
+# They are hidden from the owner transcript and carry their own semantic kind
+# so Goal identity, summaries, and recency never mistake them for owner speech.
+DELEGATION_RESULT_MESSAGE_KIND = "delegation_result"
+
 
 def is_continuation_message(message: Mapping[str, Any] | None) -> bool:
   return bool(

--- a/backend/app/delegations.py
+++ b/backend/app/delegations.py
@@ -15,7 +15,9 @@ import hashlib
 import json
 import logging
 from pathlib import Path
+import uuid
 
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app import auth, models
@@ -28,6 +30,7 @@ TERMINAL_DELEGATION_STATUSES = frozenset({
   "interrupted",
 })
 REVIEW_REQUIRED_MARKER = "DELEGATION_WRITE_REVIEW_REQUIRED"
+MAX_DELEGATION_DEPTH = 4
 
 
 @dataclass(frozen=True)
@@ -42,6 +45,7 @@ class RunPolicy:
   scope: str
   cwd: str
   max_budget_usd: float | None
+  depth: int = 1
 
   @property
   def delegated(self) -> bool:
@@ -64,11 +68,29 @@ class RunPolicy:
         "durable change that completes the bounded task."
       )
     )
+    child_work_rule = (
+      (
+        "You may use Möbius's installed Subagents capability for bounded "
+        "child work when parallelism or local decomposition materially helps; "
+        "you remain responsible for checking your own completion condition "
+        "after those children settle. Its guarded helper is "
+        "$MOBIUS_SUBAGENT_HELPER. Use: python3 "
+        "/data/apps/subagents/subagents.py run --provider claude|codex --name "
+        "stable-key --scope read|write --prompt 'one bounded contract'. A "
+        "read-only owner may create only read-only children. Use stable task "
+        "keys. Do not use any other agent CLI or recursive mechanism. "
+      )
+      if self.provider == "claude"
+      else (
+        "Nested delegated work is not available in this Codex child. Do not "
+        "launch, invoke, or delegate to another agent, provider, workflow, or "
+        "agent CLI. Complete the bounded task yourself. "
+      )
+    )
     return (
       "You are a delegated subagent running as a durable child task inside "
       "Möbius. Complete only the bounded user task in this child conversation "
-      "and return a clear result to the parent. Do not launch, invoke, consult, "
-      "or delegate to another agent, workflow, model, provider, or agent CLI. "
+      f"and return a clear result to the parent. {child_work_rule}"
       "Do not ask the owner an interactive question; if a required decision or "
       "credential is missing, stop and state the blocker precisely. Do not "
       "inspect unrelated chats, Memory, skills, or installed-app instructions. "
@@ -76,6 +98,116 @@ class RunPolicy:
       "Never read or write /data/cli-auth or /data/.secret-key. "
       f"Working directory: {self.cwd}. {scope_rule}"
     )
+
+
+@dataclass(frozen=True)
+class DelegationIntent:
+  """Validated immutable fields needed to create or attach one child task."""
+
+  app_id: int
+  parent_chat_id: str
+  parent_root_run_id: str
+  task_key: str
+  prompt: str
+  provider: str
+  model: str | None
+  effort: str | None
+  scope: str
+  cwd: str
+  max_budget_usd: float | None
+  notify_parent_on_complete: bool = True
+
+
+def same_delegation_intent(
+  row: models.Delegation, intent: DelegationIntent,
+) -> bool:
+  """Whether a durable row is the exact immutable task being retried."""
+  return all((
+    row.app_id == intent.app_id,
+    row.parent_chat_id == intent.parent_chat_id,
+    row.parent_root_run_id == intent.parent_root_run_id,
+    row.task_key == intent.task_key,
+    row.provider == intent.provider,
+    row.model == intent.model,
+    row.effort == intent.effort,
+    row.scope == intent.scope,
+    row.cwd == intent.cwd,
+    row.max_budget_usd == intent.max_budget_usd,
+    row.notify_parent_on_complete == intent.notify_parent_on_complete,
+    row.prompt_sha256 == hashlib.sha256(
+      intent.prompt.encode("utf-8")
+    ).hexdigest(),
+  ))
+
+
+def create_or_attach_delegation(
+  db: Session, intent: DelegationIntent,
+) -> tuple[models.Delegation, bool]:
+  """Persist one child intent idempotently under its parent logical run.
+
+  Execution is intentionally separate: callers commit the control/chat rows
+  here, then start the ordinary programmatic ChatRun.  A crash between those
+  steps leaves a discoverable ``starting`` delegation that reconciliation can
+  safely start with the same immutable prompt.
+  """
+  row = db.query(models.Delegation).filter(
+    models.Delegation.parent_root_run_id == intent.parent_root_run_id,
+    models.Delegation.task_key == intent.task_key,
+  ).first()
+  if row is not None:
+    if not same_delegation_intent(row, intent):
+      raise ValueError(
+        "task key is already attached to different immutable work"
+      )
+    return row, True
+
+  child_id = str(uuid.uuid4())
+  row = models.Delegation(
+    id=str(uuid.uuid4()),
+    app_id=intent.app_id,
+    parent_chat_id=intent.parent_chat_id,
+    parent_root_run_id=intent.parent_root_run_id,
+    task_key=intent.task_key,
+    child_chat_id=child_id,
+    provider=intent.provider,
+    model=intent.model,
+    effort=intent.effort,
+    scope=intent.scope,
+    cwd=intent.cwd,
+    prompt_sha256=hashlib.sha256(intent.prompt.encode("utf-8")).hexdigest(),
+    max_budget_usd=intent.max_budget_usd,
+    notify_parent_on_complete=intent.notify_parent_on_complete,
+  )
+  child = models.Chat(
+    id=child_id,
+    title=f"Delegation · {intent.task_key}",
+    messages=[],
+    provider=intent.provider,
+    agent_settings_json={
+      "model": intent.model,
+      "effort": intent.effort,
+      "drawer_hidden": True,
+      "owner_visible": False,
+    },
+    auto_resume_on_restart=True,
+    auto_resume_on_limit=False,
+    created_by_app_id=intent.app_id,
+  )
+  db.add_all((child, row))
+  try:
+    db.commit()
+  except IntegrityError:
+    db.rollback()
+    row = db.query(models.Delegation).filter(
+      models.Delegation.parent_root_run_id == intent.parent_root_run_id,
+      models.Delegation.task_key == intent.task_key,
+    ).first()
+    if row is None or not same_delegation_intent(row, intent):
+      raise ValueError(
+        "different delegation claimed the task key"
+      )
+    return row, True
+  return row, False
 
 
 def normalize_cwd(raw: str | None) -> str:
@@ -118,6 +250,15 @@ def policy_for_chat(db: Session, chat_id: str) -> RunPolicy | None:
     digest = hashlib.sha256(prompt.encode("utf-8")).hexdigest()
     if digest != row.prompt_sha256:
       raise RuntimeError("delegation prompt no longer matches immutable intent")
+  remaining_budget = row.max_budget_usd
+  if remaining_budget is not None:
+    known_prior_cost = float(sum(
+      float(value or 0.0) for (value,) in db.query(
+        models.ChatRun.cost_usd,
+      ).filter(models.ChatRun.chat_id == chat_id).all()
+    ))
+    remaining_budget = max(0.001, remaining_budget - known_prior_cost)
+  depth = delegation_depth(db, row)
   return RunPolicy(
     delegation_id=row.id,
     app_id=row.app_id,
@@ -126,8 +267,27 @@ def policy_for_chat(db: Session, chat_id: str) -> RunPolicy | None:
     effort=row.effort,
     scope=row.scope,
     cwd=row.cwd,
-    max_budget_usd=row.max_budget_usd,
+    max_budget_usd=remaining_budget,
+    depth=depth,
   )
+
+
+def delegation_depth(db: Session, row: models.Delegation) -> int:
+  """Return durable local-ownership depth by following parent child chats."""
+  depth = 1
+  parent_chat_id = row.parent_chat_id
+  seen = {row.id}
+  while True:
+    parent = db.query(models.Delegation).filter(
+      models.Delegation.child_chat_id == parent_chat_id,
+    ).first()
+    if parent is None:
+      return depth
+    if parent.id in seen:
+      raise RuntimeError("delegation parentage contains a cycle")
+    seen.add(parent.id)
+    depth += 1
+    parent_chat_id = parent.parent_chat_id
 
 
 def latest_run(db: Session, chat_id: str) -> models.ChatRun | None:
@@ -160,7 +320,17 @@ def parent_root_run_id(
       run = query.order_by(
         models.ChatRun.started_at.desc(), models.ChatRun.id.desc()
       ).first()
-  return (run.root_run_id or run.id) if run is not None else None
+  if run is None:
+    return None
+  # A delegated owner is one durable unit of work even when child-result wakes
+  # open fresh physical turns in its private chat. Key its direct children to
+  # that delegation, not to whichever physical attempt happened to spawn them.
+  owner = db.query(models.Delegation.id).filter(
+    models.Delegation.child_chat_id == parent_chat_id,
+  ).first()
+  if owner is not None:
+    return str(owner[0])
+  return str(run.goal_id or run.root_run_id or run.id)
 
 
 def _assistant_result(chat: models.Chat) -> str:
@@ -330,7 +500,21 @@ def active_parent_context(
   )
 
 
-def mint_app_token(db: Session, policy: RunPolicy) -> str:
+def delegation_execution_token(
+  db: Session, policy: RunPolicy, run_id: str,
+) -> str:
+  """Return the narrowest bearer that can fulfill the child contract.
+
+  A read delegation may still execute local inspection commands in the
+  provider sandbox. Giving that process a normal app bearer would let a
+  prompt-injected critic mutate app storage or call other app-owned write
+  routes over HTTP, bypassing the filesystem policy entirely. Read children
+  therefore receive a delegation-only bearer that can manage direct children
+  but cannot touch app storage. Write children retain the app-attributed
+  authority their contract promises.
+  """
+  if policy.scope not in {"read", "write"}:
+    raise RuntimeError(f"unknown delegation scope: {policy.scope}")
   owner = db.query(models.Owner).first()
   app = db.query(models.App).filter(
     models.App.id == policy.app_id,
@@ -338,29 +522,165 @@ def mint_app_token(db: Session, policy: RunPolicy) -> str:
   ).first()
   if owner is None or app is None:
     raise RuntimeError("delegation owner app is unavailable")
+  row = db.query(models.Delegation).filter(
+    models.Delegation.id == policy.delegation_id,
+  ).first()
+  if row is None or row.cancelled_at is not None:
+    raise RuntimeError("delegation is unavailable")
+  if any((
+    row.app_id != policy.app_id,
+    row.provider != policy.provider,
+    row.model != policy.model,
+    row.effort != policy.effort,
+    row.scope != policy.scope,
+    row.cwd != policy.cwd,
+  )):
+    raise RuntimeError("delegation policy no longer matches immutable intent")
+  physical = db.query(models.ChatRun.id).filter(
+    models.ChatRun.id == run_id,
+    models.ChatRun.chat_id == row.child_chat_id,
+    models.ChatRun.status == "running",
+  ).first()
+  if physical is None:
+    raise RuntimeError("delegation run is not active")
+  if policy.scope == "read":
+    return auth.create_delegation_token(
+      row.id, app.id, row.child_chat_id, run_id,
+      owner.username, owner.token_epoch,
+      expires_delta=timedelta(hours=2),
+    )
   return auth.create_app_token(
     app.id,
     owner.username,
     owner.token_epoch,
     app_nonce=app.token_nonce,
     expires_delta=timedelta(hours=2),
+    delegation_id=policy.delegation_id,
+    delegation_chat=row.child_chat_id,
+    delegation_run=run_id,
   )
 
 
 def mark_cancelled(db: Session, row: models.Delegation) -> None:
+  """Latch cancellation and its Workflows terminal projection idempotently."""
   child = db.query(models.Chat).filter(
     models.Chat.id == row.child_chat_id,
   ).first()
-  changed = False
   if child is not None:
     child.auto_resume_on_restart = False
     child.auto_resume_on_limit = False
-    changed = True
   if row.cancelled_at is None:
     row.cancelled_at = now_naive_utc()
-    changed = True
-  if changed:
-    db.commit()
+  # Stage cancellation before recording the terminal lifecycle fact.
+  # ``record_event`` commits both when the event is new; the explicit commit
+  # covers an idempotent replay where that deterministic event already exists.
+  _record_lifecycle(db, row, "cancelled")
+  db.commit()
+
+
+def _delegation_is_active(db: Session, row: models.Delegation) -> bool:
+  """Whether control/runtime state still reserves this delegated execution."""
+  from app.chat import is_chat_running
+
+  status, _physical, _result = derived_status(db, row, load_result=False)
+  return status in {"starting", "running", "resuming", "paused"} or (
+    is_chat_running(row.child_chat_id)
+  )
+
+
+def active_delegation_ids_for_app(db: Session, app_id: int) -> list[str]:
+  rows = db.query(models.Delegation).filter(
+    models.Delegation.app_id == app_id,
+  ).order_by(models.Delegation.created_at.asc()).all()
+  return [row.id for row in rows if _delegation_is_active(db, row)]
+
+
+def active_delegation_ids_for_chat(db: Session, chat_id: str) -> list[str]:
+  rows = db.query(models.Delegation).filter(
+    (models.Delegation.parent_chat_id == chat_id)
+    | (models.Delegation.child_chat_id == chat_id)
+  ).order_by(models.Delegation.created_at.asc()).all()
+  return [row.id for row in rows if _delegation_is_active(db, row)]
+
+
+async def cancel_delegation_execution(
+  delegation_id: str, *, _seen: frozenset[str] = frozenset(),
+) -> bool:
+  """Serialize cancellation against new direct-child admission."""
+  from app import chat_queue
+  from app.database import SessionLocal
+
+  if delegation_id in _seen:
+    return False
+  with SessionLocal() as db:
+    row = db.query(models.Delegation).filter(
+      models.Delegation.id == delegation_id,
+    ).first()
+    if row is None:
+      return True
+    child_id = row.child_chat_id
+  async with chat_queue.get_transition_lock(child_id):
+    return await _cancel_delegation_execution_locked(
+      delegation_id, _seen=_seen,
+    )
+
+
+async def _cancel_delegation_execution_locked(
+  delegation_id: str, *, _seen: frozenset[str],
+) -> bool:
+  """Stop one child and latch cancellation only after it is quiescent.
+
+  This owns the reusable cancellation boundary for the direct API, app/chat
+  deletion, and future lifecycle callers. A timed-out provider remains active
+  and returns ``False`` so no caller can tombstone or purge rows under it.
+  """
+  from app.chat import _finish_run, is_chat_running, stop_chat_for
+  from app.database import SessionLocal
+
+  seen = _seen | {delegation_id}
+
+  with SessionLocal() as db:
+    row = db.query(models.Delegation).filter(
+      models.Delegation.id == delegation_id,
+    ).first()
+    if row is None:
+      return True
+    child_id = row.child_chat_id
+    active = _delegation_is_active(db, row)
+    descendants = [
+      child.id for child in db.query(models.Delegation).filter(
+        models.Delegation.parent_chat_id == child_id,
+      ).all()
+    ]
+  # A parent cannot be quiescent while one of its locally-owned branches is
+  # still spending or writing. Settle leaves first, then their owner.
+  for descendant_id in descendants:
+    if not await cancel_delegation_execution(descendant_id, _seen=seen):
+      return False
+  if not active:
+    return True
+
+  if is_chat_running(child_id):
+    stopped, _ = await stop_chat_for(child_id)
+    if not stopped:
+      return False
+  if not is_chat_running(child_id):
+    await _finish_run(child_id, terminal_status="stopped")
+
+  with SessionLocal() as db:
+    row = db.query(models.Delegation).filter(
+      models.Delegation.id == delegation_id,
+    ).first()
+    if row is None:
+      return True
+    durable_active = db.query(models.ChatRun.id).filter(
+      models.ChatRun.chat_id == row.child_chat_id,
+      models.ChatRun.status.in_(models.NONTERMINAL_RUN_STATUSES),
+    ).first() is not None
+    if durable_active or is_chat_running(row.child_chat_id):
+      return False
+    mark_cancelled(db, row)
+  return True
 
 
 # --- Parent auto-wake on child completion ------------------------------------
@@ -376,7 +696,7 @@ _LOG = logging.getLogger("moebius.delegations")
 
 
 def _wake_eligible_rows_for_parent(
-  db: Session, parent_chat_id: str,
+  db: Session, parent_chat_id: str, source_work_id: str | None = None,
 ) -> list[models.Delegation]:
   """Opt-in, non-cancelled, un-woken delegations for this parent whose child
   reached a real terminal — the set a single wake coalesces."""
@@ -396,11 +716,17 @@ def _wake_eligible_rows_for_parent(
     status, _, _ = derived_status(db, row)
     if status in WAKE_ELIGIBLE_STATUSES:
       eligible.append(row)
-  return eligible
+  if not eligible:
+    return []
+  owner_id = source_work_id or eligible[0].parent_root_run_id
+  # Never attribute results from separate logical work to whichever Goal
+  # happened to create the newest row. Each hidden wake carries one exact
+  # owner identity so Goal recovery cannot fold old work into a newer Goal.
+  return [row for row in eligible if row.parent_root_run_id == owner_id]
 
 
 def _compose_wake_notice(db: Session, rows: list[models.Delegation]) -> str:
-  """One system-user message enumerating every finished child as runtime DATA.
+  """Provider-facing payload for one hidden child-completion product event.
 
   Uses `derived_status` directly rather than `serialize_delegation` so composing
   the notice has no lifecycle-event side effect.
@@ -433,11 +759,16 @@ def _compose_wake_notice(db: Session, rows: list[models.Delegation]) -> str:
   )
 
 
-async def _append_wake_pending(content: str, parent_chat_id: str) -> bool:
+async def _append_wake_pending(
+  content: str,
+  parent_chat_id: str,
+  source_work_id: str,
+) -> bool:
   """Queue the notice behind the parent's running turn (caller holds the lock)."""
   import time
 
   from app.chat_writer import AppendPending, await_ack, get_writer
+  from app.continuations import DELEGATION_RESULT_MESSAGE_KIND
 
   ack = get_writer().submit(AppendPending(
     chat_id=parent_chat_id,
@@ -446,6 +777,9 @@ async def _append_wake_pending(content: str, parent_chat_id: str) -> bool:
       "role": "user",
       "content": content,
       "ts": int(time.time() * 1000),
+      "hidden": True,
+      "kind": DELEGATION_RESULT_MESSAGE_KIND,
+      "source_work_id": source_work_id,
     },
     initiated_by_app_id=None,
   ))
@@ -460,7 +794,9 @@ async def _append_wake_pending(content: str, parent_chat_id: str) -> bool:
     return False
 
 
-async def _deliver_parent_wake(parent_chat_id: str) -> bool:
+async def _deliver_parent_wake(
+  parent_chat_id: str, source_work_id: str | None = None,
+) -> bool:
   """Coalesce every wake-eligible child for one parent into a single notice and
   deliver it under the parent's queue lock.
 
@@ -474,15 +810,19 @@ async def _deliver_parent_wake(parent_chat_id: str) -> bool:
   import app.chat_queue as chat_queue
   from app.chat import is_chat_running
   from app.chat_start import start_programmatic_chat_turn
+  from app.continuations import DELEGATION_RESULT_MESSAGE_KIND
   from app.database import SessionLocal
 
   async with chat_queue.get_lock(parent_chat_id):
     with SessionLocal() as db:
-      rows = _wake_eligible_rows_for_parent(db, parent_chat_id)
+      rows = _wake_eligible_rows_for_parent(
+        db, parent_chat_id, source_work_id,
+      )
       if not rows:
         return False
       ids = [row.id for row in rows]
       content = _compose_wake_notice(db, rows)
+      source_work_id = rows[0].parent_root_run_id
       parent_chat = (
         db.query(models.Chat)
         .filter(models.Chat.id == parent_chat_id)
@@ -494,7 +834,9 @@ async def _deliver_parent_wake(parent_chat_id: str) -> bool:
 
     delivered = False
     if is_chat_running(parent_chat_id):
-      delivered = await _append_wake_pending(content, parent_chat_id)
+      delivered = await _append_wake_pending(
+        content, parent_chat_id, source_work_id,
+      )
     else:
       delivered = await start_programmatic_chat_turn(
         chat_id=parent_chat_id,
@@ -502,11 +844,16 @@ async def _deliver_parent_wake(parent_chat_id: str) -> bool:
         content=content,
         provider=provider,
         initiated_by_app_id=None,
+        hidden=True,
+        message_kind=DELEGATION_RESULT_MESSAGE_KIND,
+        source_work_id=source_work_id,
       )
       if not delivered:
         # The actor refused the start (for example, an owner question opened or
         # a real turn claimed the parent); queue the notice instead.
-        delivered = await _append_wake_pending(content, parent_chat_id)
+        delivered = await _append_wake_pending(
+          content, parent_chat_id, source_work_id,
+        )
 
     if not delivered:
       return False
@@ -534,6 +881,9 @@ async def wake_parent_after_child_settled(child_chat_id: str) -> None:
         .filter(models.Delegation.child_chat_id == child_chat_id)
         .first()
       )
+      if row is not None:
+        from app.goal_plans import publish_plan_for_delegation
+        publish_plan_for_delegation(db, row)
       if (
         row is None
         or not row.notify_parent_on_complete
@@ -545,7 +895,7 @@ async def wake_parent_after_child_settled(child_chat_id: str) -> None:
       if status not in WAKE_ELIGIBLE_STATUSES:
         return
       parent_chat_id = row.parent_chat_id
-    await _deliver_parent_wake(parent_chat_id)
+    await _deliver_parent_wake(parent_chat_id, row.parent_root_run_id)
   except Exception:
     _LOG.debug(
       "delegation parent-wake hook failed child=%s",
@@ -558,7 +908,7 @@ async def wake_parents_for_completed_delegations() -> int:
   (latch still NULL). One coalesced wake per parent. Returns parents woken."""
   from app.database import SessionLocal
 
-  parent_ids: list[str] = []
+  wake_groups: list[tuple[str, str]] = []
   with SessionLocal() as db:
     rows = (
       db.query(models.Delegation)
@@ -570,23 +920,24 @@ async def wake_parents_for_completed_delegations() -> int:
       .order_by(models.Delegation.created_at.asc())
       .all()
     )
-    seen: set[str] = set()
+    seen: set[tuple[str, str]] = set()
     for row in rows:
-      if row.parent_chat_id in seen:
+      key = (row.parent_chat_id, row.parent_root_run_id)
+      if key in seen:
         continue
       status, _, _ = derived_status(db, row)
       if status in WAKE_ELIGIBLE_STATUSES:
-        seen.add(row.parent_chat_id)
-        parent_ids.append(row.parent_chat_id)
+        seen.add(key)
+        wake_groups.append(key)
 
-  woken = 0
-  for parent_chat_id in parent_ids:
+  woken_parents: set[str] = set()
+  for parent_chat_id, source_work_id in wake_groups:
     try:
-      if await _deliver_parent_wake(parent_chat_id):
-        woken += 1
+      if await _deliver_parent_wake(parent_chat_id, source_work_id):
+        woken_parents.add(parent_chat_id)
     except Exception:
       _LOG.warning(
         "boot delegation parent-wake failed parent=%s",
         parent_chat_id, exc_info=True,
       )
-  return woken
+  return len(woken_parents)

--- a/backend/app/delegations.py
+++ b/backend/app/delegations.py
@@ -605,8 +605,16 @@ def active_delegation_ids_for_chat(db: Session, chat_id: str) -> list[str]:
 
 async def cancel_delegation_execution(
   delegation_id: str, *, _seen: frozenset[str] = frozenset(),
+  held_chat_locks: frozenset[str] = frozenset(),
 ) -> bool:
-  """Serialize cancellation against new direct-child admission."""
+  """Serialize cancellation against new direct-child admission.
+
+  ``held_chat_locks`` names chats whose transition lock the caller already
+  holds (e.g. delete_chat locks the chat it is deleting). The per-chat
+  transition lock is not reentrant, so re-acquiring it for a delegation whose
+  child chat is the one already locked would deadlock; those are entered
+  directly under the caller's lock instead.
+  """
   from app import chat_queue
   from app.database import SessionLocal
 
@@ -619,14 +627,19 @@ async def cancel_delegation_execution(
     if row is None:
       return True
     child_id = row.child_chat_id
+  if child_id in held_chat_locks:
+    return await _cancel_delegation_execution_locked(
+      delegation_id, _seen=_seen, held_chat_locks=held_chat_locks,
+    )
   async with chat_queue.get_transition_lock(child_id):
     return await _cancel_delegation_execution_locked(
-      delegation_id, _seen=_seen,
+      delegation_id, _seen=_seen, held_chat_locks=held_chat_locks | {child_id},
     )
 
 
 async def _cancel_delegation_execution_locked(
   delegation_id: str, *, _seen: frozenset[str],
+  held_chat_locks: frozenset[str] = frozenset(),
 ) -> bool:
   """Stop one child and latch cancellation only after it is quiescent.
 
@@ -655,7 +668,9 @@ async def _cancel_delegation_execution_locked(
   # A parent cannot be quiescent while one of its locally-owned branches is
   # still spending or writing. Settle leaves first, then their owner.
   for descendant_id in descendants:
-    if not await cancel_delegation_execution(descendant_id, _seen=seen):
+    if not await cancel_delegation_execution(
+      descendant_id, _seen=seen, held_chat_locks=held_chat_locks,
+    ):
       return False
   if not active:
     return True

--- a/backend/app/deps.py
+++ b/backend/app/deps.py
@@ -589,28 +589,18 @@ def get_delegation_principal(
   db: Session = Depends(get_db),
 ) -> Principal:
   """Resolve owner/app plus the route-confined delegated-child bearer."""
-  owner, payload = _resolve_owner(token, db)
+  _owner, payload = _resolve_owner(token, db)
   if payload.get("scope") == "delegation":
     app_id = payload.get("app_id")
     delegation_id, chat_id = _enforce_delegation_claims(
       payload, db, app_id,
     )
     return Principal(
-      owner=owner, app_id=int(app_id), scope="delegation",
+      owner=_owner, app_id=int(app_id), scope="delegation",
       chat_id=str(chat_id), delegation_id=str(delegation_id),
     )
-  if payload.get("scope") not in (None, "app"):
-    raise HTTPException(status_code=403, detail="Token scope is not valid here.")
-  app_id = _enforce_app_scope(payload, db)
-  delegation_id = payload.get("delegation_id")
-  delegation_chat = payload.get("delegation_chat")
-  return Principal(
-    owner=owner, app_id=app_id,
-    app_instance_id=payload.get("app_nonce") if app_id is not None else None,
-    scope="app" if app_id is not None else "owner",
-    chat_id=delegation_chat,
-    delegation_id=delegation_id,
-  )
+  # Any non-delegation token resolves through the generic principal path.
+  return get_principal(token, db)
 
 
 def get_agent_run_principal(

--- a/backend/app/deps.py
+++ b/backend/app/deps.py
@@ -96,6 +96,7 @@ class Principal:
   embed_session_id: str | None = None
   embed_role: str | None = None
   operations: frozenset[str] = frozenset()
+  delegation_id: str | None = None
 
 
 @dataclass(frozen=True)
@@ -301,6 +302,42 @@ def get_current_owner(
   return resolve_owner_only(token, db)
 
 
+def _enforce_delegation_claims(
+  payload: dict, db: Session, app_id: int | None,
+) -> tuple[str, str]:
+  """Bind a delegated bearer to its exact currently-running child attempt."""
+  delegation_id = payload.get("delegation_id")
+  chat_id = payload.get("delegation_chat")
+  run_id = payload.get("delegation_run")
+  if not (
+    isinstance(app_id, int)
+    and isinstance(delegation_id, str)
+    and isinstance(chat_id, str)
+    and isinstance(run_id, str)
+  ):
+    raise HTTPException(status_code=401, detail="Malformed delegation token.")
+  active = (
+    db.query(models.Delegation.id)
+    .join(models.App, models.App.id == models.Delegation.app_id)
+    .join(models.ChatRun, models.ChatRun.chat_id == models.Delegation.child_chat_id)
+    .filter(
+      models.Delegation.id == delegation_id,
+      models.Delegation.child_chat_id == chat_id,
+      models.Delegation.app_id == app_id,
+      models.Delegation.cancelled_at.is_(None),
+      models.App.deleted_at.is_(None),
+      models.ChatRun.id == run_id,
+      models.ChatRun.status == "running",
+    )
+    .first()
+  )
+  if active is None:
+    raise HTTPException(
+      status_code=401, detail="Delegation token is no longer active.",
+    )
+  return delegation_id, chat_id
+
+
 def _enforce_app_scope(payload: dict, db: Session) -> int | None:
   """Validates an app-scoped token's app identity; returns its app_id.
 
@@ -341,6 +378,11 @@ def _enforce_app_scope(payload: dict, db: Session) -> int | None:
   stamped = payload.get("app_nonce")
   if stamped is not None and stamped != app.token_nonce:
     raise HTTPException(status_code=401, detail="App token no longer valid.")
+  if any(
+    payload.get(key) is not None
+    for key in ("delegation_id", "delegation_chat", "delegation_run")
+  ):
+    _enforce_delegation_claims(payload, db, app_id)
   return app_id
 
 
@@ -529,13 +571,45 @@ def get_principal(
   if payload.get("scope") not in (None, "app"):
     raise HTTPException(status_code=403, detail="Token scope is not valid here.")
   app_id = _enforce_app_scope(payload, db)
+  delegation_id = payload.get("delegation_id")
+  delegation_chat = payload.get("delegation_chat")
   return Principal(
     owner=owner,
     app_id=app_id,
     app_instance_id=payload.get("app_nonce") if app_id is not None else None,
     scope="app" if app_id is not None else "owner",
-    chat_id=payload.get("agent_chat"),
+    chat_id=payload.get("agent_chat") or delegation_chat,
     run_id=payload.get("agent_run"),
+    delegation_id=delegation_id,
+  )
+
+
+def get_delegation_principal(
+  token: str = Depends(_oauth2),
+  db: Session = Depends(get_db),
+) -> Principal:
+  """Resolve owner/app plus the route-confined delegated-child bearer."""
+  owner, payload = _resolve_owner(token, db)
+  if payload.get("scope") == "delegation":
+    app_id = payload.get("app_id")
+    delegation_id, chat_id = _enforce_delegation_claims(
+      payload, db, app_id,
+    )
+    return Principal(
+      owner=owner, app_id=int(app_id), scope="delegation",
+      chat_id=str(chat_id), delegation_id=str(delegation_id),
+    )
+  if payload.get("scope") not in (None, "app"):
+    raise HTTPException(status_code=403, detail="Token scope is not valid here.")
+  app_id = _enforce_app_scope(payload, db)
+  delegation_id = payload.get("delegation_id")
+  delegation_chat = payload.get("delegation_chat")
+  return Principal(
+    owner=owner, app_id=app_id,
+    app_instance_id=payload.get("app_nonce") if app_id is not None else None,
+    scope="app" if app_id is not None else "owner",
+    chat_id=delegation_chat,
+    delegation_id=delegation_id,
   )
 
 

--- a/backend/app/goal_plans.py
+++ b/backend/app/goal_plans.py
@@ -22,6 +22,7 @@ MAX_TASKS = 64
 MAX_DEPENDENCIES = 16
 MAX_TITLE = 160
 MAX_NOTE = 500
+MAX_RESULT = 1000
 
 
 class GoalPlanError(ValueError):
@@ -48,10 +49,11 @@ def _clean_text(value: Any, *, field: str, maximum: int, required: bool) -> str:
 def normalize_tasks(raw_tasks: Any) -> list[dict[str, Any]]:
   """Validate and normalize one complete plan snapshot.
 
-  Dependencies form a DAG. A task may run or complete only after every
-  dependency has completed, and repeated progress cannot claim completion
-  before its total has been reached. Those are orchestration invariants, not
-  UI hints, so every write path shares this function.
+  Explicit dependencies and implicit child-before-parent completion edges form
+  one DAG. A task may run or complete only after every dependency has
+  completed, and repeated progress cannot claim completion before its total has
+  been reached. Those are orchestration invariants, not UI hints, so every
+  write path shares this function.
   """
   if not isinstance(raw_tasks, list) or not raw_tasks:
     raise GoalPlanError("a goal plan needs at least one task")
@@ -110,18 +112,41 @@ def normalize_tasks(raw_tasks: Any) -> list[dict[str, Any]]:
       "status": status,
       "depends_on": depends_on,
     }
+    parent_id = raw.get("parent_id")
+    if parent_id is not None:
+      if not isinstance(parent_id, str) or not TASK_ID_RE.fullmatch(parent_id):
+        raise GoalPlanError(f"parent_id for {task_id} must be a valid task id")
+      task["parent_id"] = parent_id
+    completion_condition = _clean_text(
+      raw.get("completion_condition"),
+      field=f"completion_condition for {task_id}",
+      maximum=MAX_NOTE, required=False,
+    )
+    if completion_condition:
+      task["completion_condition"] = completion_condition
     note = _clean_text(
       raw.get("note"), field=f"note for {task_id}",
       maximum=MAX_NOTE, required=False,
     )
     if note:
       task["note"] = note
+    result = _clean_text(
+      raw.get("result"), field=f"result for {task_id}",
+      maximum=MAX_RESULT, required=False,
+    )
+    if result:
+      task["result"] = result
     if normalized_progress is not None:
       task["progress"] = normalized_progress
     tasks.append(task)
 
   by_id = {task["id"]: task for task in tasks}
   for task in tasks:
+    parent_id = task.get("parent_id")
+    if parent_id == task["id"]:
+      raise GoalPlanError(f"{task['id']} cannot be its own parent")
+    if parent_id is not None and parent_id not in by_id:
+      raise GoalPlanError(f"{task['id']} has missing parent {parent_id}")
     for dependency in task["depends_on"]:
       if dependency == task["id"]:
         raise GoalPlanError(f"{task['id']} cannot depend on itself")
@@ -130,22 +155,33 @@ def normalize_tasks(raw_tasks: Any) -> list[dict[str, Any]]:
           f"{task['id']} depends on missing task {dependency}"
         )
 
+  children_by_parent: dict[str, list[str]] = {}
+  for task in tasks:
+    parent_id = task.get("parent_id")
+    if parent_id is not None:
+      children_by_parent.setdefault(parent_id, []).append(task["id"])
+
   visiting: set[str] = set()
   visited: set[str] = set()
 
-  def visit(task_id: str) -> None:
+  def visit_completion_prerequisites(task_id: str) -> None:
     if task_id in visited:
       return
     if task_id in visiting:
-      raise GoalPlanError("goal-plan dependencies must not contain a cycle")
+      raise GoalPlanError(
+        "goal-plan dependencies and parentage must not form a completion cycle"
+      )
     visiting.add(task_id)
-    for dependency in by_id[task_id]["depends_on"]:
-      visit(dependency)
+    prerequisites = (
+      by_id[task_id]["depends_on"] + children_by_parent.get(task_id, [])
+    )
+    for prerequisite in prerequisites:
+      visit_completion_prerequisites(prerequisite)
     visiting.remove(task_id)
     visited.add(task_id)
 
   for task in tasks:
-    visit(task["id"])
+    visit_completion_prerequisites(task["id"])
 
   for task in tasks:
     incomplete = [
@@ -156,6 +192,16 @@ def normalize_tasks(raw_tasks: Any) -> list[dict[str, Any]]:
       raise GoalPlanError(
         f"{task['id']} cannot be {task['status']} until these dependencies "
         f"complete: {', '.join(incomplete)}"
+      )
+    unfinished_children = [
+      child["id"] for child in tasks
+      if child.get("parent_id") == task["id"]
+      and child["status"] not in {"completed", "cancelled"}
+    ]
+    if task["status"] == "completed" and unfinished_children:
+      raise GoalPlanError(
+        f"{task['id']} cannot complete before its children settle: "
+        f"{', '.join(unfinished_children)}"
       )
     progress = task.get("progress")
     if (
@@ -171,7 +217,7 @@ def normalize_tasks(raw_tasks: Any) -> list[dict[str, Any]]:
 def active_goal_rows(
   db: Session, chat_id: str,
 ) -> tuple[models.ChatRun, models.ChatRun] | None:
-  """Return (active physical row, logical root row) for this chat's Goal."""
+  """Return the currently executing or delegated Goal and its plan owner."""
   physical = (
     db.query(models.ChatRun)
     .filter(
@@ -183,7 +229,44 @@ def active_goal_rows(
     .first()
   )
   if physical is None:
-    return None
+    # A parent provider turn may finish after launching durable background
+    # children. Keep that latest Goal visible while its plan or delegation tree
+    # still owns unsettled work, but never reach past a newer ordinary turn.
+    physical = (
+      db.query(models.ChatRun)
+      .filter(models.ChatRun.chat_id == chat_id)
+      .order_by(models.ChatRun.started_at.desc(), models.ChatRun.id.desc())
+      .first()
+    )
+    if physical is None or physical.goal_objective is None:
+      return None
+  if physical.goal_id:
+    plan_owner = (
+      db.query(models.ChatRun)
+      .filter(
+        models.ChatRun.chat_id == chat_id,
+        models.ChatRun.goal_id == physical.goal_id,
+        models.ChatRun.goal_plan_json.isnot(None),
+      )
+      .order_by(models.ChatRun.started_at.asc(), models.ChatRun.id.asc())
+      .first()
+    )
+    if plan_owner is not None:
+      rows = (physical, plan_owner)
+      if physical.status in models.NONTERMINAL_RUN_STATUSES:
+        return rows
+      document = plan_owner.goal_plan_json
+      tasks = document.get("tasks") if isinstance(document, dict) else None
+      unfinished_plan = bool(tasks) and any(
+        isinstance(task, dict)
+        and task.get("status") not in {"completed", "cancelled"}
+        for task in tasks
+      )
+      if unfinished_plan or _delegation_tree_has_active_work(
+        _delegation_tree(db, *rows),
+      ):
+        return rows
+      return None
   root_id = physical.root_run_id or physical.id
   root = db.query(models.ChatRun).filter(
     models.ChatRun.id == root_id,
@@ -191,40 +274,203 @@ def active_goal_rows(
   ).first()
   if root is None:
     raise RuntimeError("active Goal refers to a missing logical root run")
+  if physical.status not in models.NONTERMINAL_RUN_STATUSES:
+    document = root.goal_plan_json
+    tasks = document.get("tasks") if isinstance(document, dict) else None
+    unfinished_plan = bool(tasks) and any(
+      isinstance(task, dict)
+      and task.get("status") not in {"completed", "cancelled"}
+      for task in tasks
+    )
+    if not unfinished_plan and not _delegation_tree_has_active_work(
+      _delegation_tree(db, physical, root),
+    ):
+      return None
   return physical, root
 
 
+def _delegation_tree(
+  db: Session, physical: models.ChatRun, root: models.ChatRun,
+) -> list[dict[str, Any]]:
+  """Project durable immediate-child ownership without copying transcripts."""
+  from app.delegations import MAX_DELEGATION_DEPTH, derived_status
+
+  run_ids = {root.id}
+  if physical.goal_id:
+    run_ids.add(physical.goal_id)
+    run_ids.update(
+      str(value) for (value,) in db.query(models.ChatRun.root_run_id).filter(
+        models.ChatRun.chat_id == physical.chat_id,
+        models.ChatRun.goal_id == physical.goal_id,
+      ).all() if value
+    )
+  root_rows = db.query(models.Delegation).filter(
+    models.Delegation.parent_chat_id == physical.chat_id,
+    models.Delegation.parent_root_run_id.in_(run_ids),
+  ).order_by(models.Delegation.created_at.asc()).all()
+  # A resumed Goal may delegate the same plan task again from a newer physical
+  # run. Only the latest attempt is current execution; older attempts remain in
+  # Workflows history rather than appearing twice (or disagreeing with the
+  # compact rail) in the Goal tree.
+  roots_by_task = {row.task_key: row for row in root_rows}
+  roots = list(roots_by_task.values())
+  children_by_parent: dict[str, list[models.Delegation]] = {}
+  frontier = [row.child_chat_id for row in roots]
+  seen_rows = {row.id for row in roots}
+  for _depth in range(1, MAX_DELEGATION_DEPTH):
+    if not frontier:
+      break
+    child_rows = db.query(models.Delegation).filter(
+      models.Delegation.parent_chat_id.in_(frontier),
+    ).order_by(models.Delegation.created_at.asc()).all()
+    frontier = []
+    latest_by_owner_and_task = {
+      (child.parent_chat_id, child.task_key): child for child in child_rows
+    }
+    for child in latest_by_owner_and_task.values():
+      if child.id in seen_rows:
+        continue
+      seen_rows.add(child.id)
+      children_by_parent.setdefault(child.parent_chat_id, []).append(child)
+      frontier.append(child.child_chat_id)
+
+  def project(row: models.Delegation, seen: set[str]) -> dict[str, Any]:
+    if row.id in seen:
+      return {"id": row.id, "task_key": row.task_key, "status": "failed", "children": []}
+    status, _run, _result = derived_status(db, row, load_result=False)
+    children = children_by_parent.get(row.child_chat_id, [])
+    return {
+      "id": row.id,
+      "task_key": row.task_key,
+      "provider": row.provider,
+      "status": status,
+      "children": [project(child, seen | {row.id}) for child in children],
+    }
+
+  return [project(row, set()) for row in roots]
+
+
+def _delegation_tree_has_active_work(nodes: list[dict[str, Any]]) -> bool:
+  from app.delegations import TERMINAL_DELEGATION_STATUSES
+
+  return any(
+    node.get("status") not in TERMINAL_DELEGATION_STATUSES
+    or _delegation_tree_has_active_work(node.get("children") or [])
+    for node in nodes
+  )
+
+
+def publish_plan_for_delegation(
+  db: Session, row: models.Delegation,
+) -> None:
+  """Refresh the root Goal when any locally-owned descendant changes state."""
+  top = row
+  seen = {row.id}
+  while True:
+    parent = db.query(models.Delegation).filter(
+      models.Delegation.child_chat_id == top.parent_chat_id,
+    ).first()
+    if parent is None:
+      break
+    if parent.id in seen:
+      return
+    seen.add(parent.id)
+    top = parent
+  rows = active_goal_rows(db, top.parent_chat_id)
+  if rows is None:
+    return
+  plan = serialize_plan(db, *rows)
+  if plan is None:
+    return
+  from app.broadcast import get_broadcast
+  broadcast = get_broadcast(top.parent_chat_id)
+  if broadcast is not None and broadcast.running:
+    broadcast.publish({"type": "goal_plan_updated", "plan": plan})
+
+
 def serialize_plan(
-  physical: models.ChatRun, root: models.ChatRun,
+  db: Session, physical: models.ChatRun, root: models.ChatRun,
 ) -> dict[str, Any] | None:
   raw = root.goal_plan_json
   if not isinstance(raw, dict) or not isinstance(raw.get("tasks"), list):
     return None
   tasks = deepcopy(raw["tasks"])
   by_id = {task["id"]: task for task in tasks}
-  completed = sum(task.get("status") == "completed" for task in tasks)
+  delegations = _delegation_tree(db, physical, root)
+  from app.delegations import TERMINAL_DELEGATION_STATUSES
+
+  active_execution_keys: list[str] = []
+
+  def collect_active_execution(nodes: list[dict[str, Any]]) -> bool:
+    any_active = False
+    for node in nodes:
+      branch_start = len(active_execution_keys)
+      descendant_active = collect_active_execution(node.get("children") or [])
+      subtree_active = (
+        node.get("status") not in TERMINAL_DELEGATION_STATUSES
+        or descendant_active
+      )
+      if subtree_active:
+        active_execution_keys.insert(
+          branch_start, str(node.get("task_key") or node["id"]),
+        )
+        any_active = True
+    return any_active
+
+  collect_active_execution(delegations)
+  active_execution = set(active_execution_keys)
+  completed = sum(
+    task.get("status") == "completed" and task["id"] not in active_execution
+    for task in tasks
+  )
   running = [task["id"] for task in tasks if task.get("status") == "running"]
-  completion_blockers = [
+  task_blockers = [
     task["id"] for task in tasks
     if task.get("status") not in {"completed", "cancelled"}
   ]
+  completion_blockers = list(dict.fromkeys(
+    task_blockers + active_execution_keys
+  ))
   ready: list[str] = []
   for task in tasks:
     waiting_on = [
       dep for dep in task.get("depends_on", [])
       if by_id.get(dep, {}).get("status") != "completed"
     ]
+    children = [
+      child["id"] for child in tasks
+      if child.get("parent_id") == task["id"]
+    ]
     task["waiting_on"] = waiting_on
-    task["ready"] = task.get("status") == "pending" and not waiting_on
+    task["children"] = children
+    # Once a task has children, its next executable step is owned by the
+    # deepest ready leaves. The parent returns only as a verification step
+    # after every child settles; it must not also appear in the ordinary ready
+    # set and invite duplicate top-level work.
+    task["ready"] = (
+      task.get("status") == "pending"
+      and not waiting_on
+      and not children
+    )
+    task["ready_to_verify"] = (
+      task.get("status") in {"pending", "running"}
+      and not waiting_on
+      and bool(children) and all(
+        by_id[child_id].get("status") in {"completed", "cancelled"}
+        for child_id in children
+      )
+    )
     if task["ready"]:
       ready.append(task["id"])
   return {
     "version": 1,
+    "goal_id": physical.goal_id,
     "root_run_id": root.id,
     "objective": physical.goal_objective,
     "revision": int(root.goal_plan_revision or 0),
     "updated_at": raw.get("updated_at"),
     "tasks": tasks,
+    "delegations": delegations,
     "summary": {
       "completed": completed,
       "total": len(tasks),
@@ -266,7 +512,7 @@ def replace_plan(
     raise GoalPlanConflict("goal plan changed; fetch it and retry")
   db.commit()
   db.refresh(root)
-  plan = serialize_plan(physical, root)
+  plan = serialize_plan(db, physical, root)
   if plan is None:  # pragma: no cover - the write above guarantees a document
     raise RuntimeError("goal plan disappeared after commit")
   return plan
@@ -281,15 +527,13 @@ def update_task(
   task_id: str,
   changes: dict[str, Any],
 ) -> dict[str, Any]:
-  existing = serialize_plan(physical, root)
+  existing = serialize_plan(db, physical, root)
   if existing is None:
     raise GoalPlanError("this Goal does not have a plan yet")
   tasks = existing["tasks"]
   target = next((task for task in tasks if task["id"] == task_id), None)
   if target is None:
     raise GoalPlanError(f"unknown task id: {task_id}")
-  target.pop("ready", None)
-  target.pop("waiting_on", None)
   for key, value in changes.items():
     if value is not None:
       target[key] = value

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -247,6 +247,11 @@ class ChatRun(Base):
   # questions are steered into the same run and must not make the goal vanish
   # after a reload. NULL is an ordinary non-goal run.
   goal_objective = Column(Text, nullable=True, default=None)
+  # Stable identity for one native Goal across physical/logical run recovery.
+  # Unlike root_run_id this survives a fresh provider turn after a restart or
+  # question checkpoint. Explicit /goal starts mint a new identity; genuine
+  # continuations inherit it.
+  goal_id = Column(String(64), nullable=True, index=True, default=None)
   # Optional agent-authored execution plan for the logical goal rooted at this
   # run. Only the root row stores the snapshot; continuation rows resolve it
   # through root_run_id. The JSON document is intentionally small and bounded

--- a/backend/app/routes/apps.py
+++ b/backend/app/routes/apps.py
@@ -2534,7 +2534,9 @@ async def delete_app(
   tombstone against a concurrent install of the same app, and the per-app
   storage lock matches the order the purge (which DOES rmtree) takes them.
   """
+  from app import chat_queue
   async with (
+    chat_queue.get_transition_lock(f"app-lifecycle:{app_id}"),
     fs_locks.install_uninstall_lock(),
     fs_locks.app_storage_lock(app_id),
   ):
@@ -2544,6 +2546,29 @@ async def delete_app(
       .first()
     )
     if not app:
+      raise HTTPException(status_code=404, detail="App not found.")
+
+    # An app-owned delegated process can keep spending or writing after its
+    # frame disappears. Settle every child (and its descendants) before the
+    # app authority is tombstoned; a provider that will not stop makes the
+    # uninstall retryable rather than orphaning live work.
+    from app.delegations import (
+      active_delegation_ids_for_app,
+      cancel_delegation_execution,
+    )
+    for delegation_id in active_delegation_ids_for_app(db, app_id):
+      if not await cancel_delegation_execution(delegation_id):
+        raise HTTPException(
+          status_code=409,
+          detail="Could not stop active delegated work; retry",
+        )
+    db.rollback()
+    app = (
+      db.query(models.App)
+      .filter(models.App.id == app_id, models.App.deleted_at.is_(None))
+      .first()
+    )
+    if app is None:
       raise HTTPException(status_code=404, detail="App not found.")
 
     await _revoke_app_publish_tokens(

--- a/backend/app/routes/chats.py
+++ b/backend/app/routes/chats.py
@@ -511,9 +511,7 @@ def _chat_detail_response(
 
   provider = chat.provider or "claude"
   settings_obj = _coerce_agent_settings(chat.agent_settings_json) or None
-  active_goal_objective = (
-    running_goal_objective(db, chat.id) if running else None
-  )
+  active_goal_objective = running_goal_objective(db, chat.id)
   response = {
     "id": chat.id,
     "title": chat.title,
@@ -1772,6 +1770,14 @@ async def delete_chat(
   _: models.Owner = Depends(get_current_owner),
   db: Session = Depends(get_db),
 ):
+  """Soft-deletes a chat under its send/delegation admission gate."""
+  from app.chat_queue import get_transition_lock
+
+  async with get_transition_lock(chat_id):
+    await _delete_chat_locked(chat_id, db)
+
+
+async def _delete_chat_locked(chat_id: str, db: Session) -> None:
   """Soft-deletes a chat and stops any running agent for it."""
   # Only attempt to stop if the chat is actually running. An idle chat
   # has no proc/SDK client/session to interrupt, so calling
@@ -1791,6 +1797,17 @@ async def delete_chat(
         status_code=409,
         detail="Could not stop active agent; retry",
       )
+  from app.delegations import (
+    active_delegation_ids_for_chat,
+    cancel_delegation_execution,
+  )
+  for delegation_id in active_delegation_ids_for_chat(db, chat_id):
+    if not await cancel_delegation_execution(delegation_id):
+      raise HTTPException(
+        status_code=409,
+        detail="Could not stop active delegated work; retry",
+      )
+  db.rollback()
   # Bump generation BEFORE the soft-delete commit so that any run
   # that started in the TOCTOU window between the is_chat_running
   # check above and now sees `we_own_gen == False` on its next gen

--- a/backend/app/routes/chats.py
+++ b/backend/app/routes/chats.py
@@ -1802,7 +1802,11 @@ async def _delete_chat_locked(chat_id: str, db: Session) -> None:
     cancel_delegation_execution,
   )
   for delegation_id in active_delegation_ids_for_chat(db, chat_id):
-    if not await cancel_delegation_execution(delegation_id):
+    # This runs under get_transition_lock(chat_id); a delegation whose child
+    # chat IS this chat must not try to re-acquire that same non-reentrant lock.
+    if not await cancel_delegation_execution(
+      delegation_id, held_chat_locks=frozenset({chat_id}),
+    ):
       raise HTTPException(
         status_code=409,
         detail="Could not stop active delegated work; retry",

--- a/backend/app/routes/chats_stream.py
+++ b/backend/app/routes/chats_stream.py
@@ -57,6 +57,14 @@ router = APIRouter(prefix="/api/chats", tags=["chats"])
 
 log = logging.getLogger(__name__)
 
+
+def _delegation_manages_chat(db: Session, chat_id: str) -> bool:
+  """Whether a parent delegation owns this chat's send lifecycle."""
+  return db.query(models.Delegation.id).filter(
+    models.Delegation.child_chat_id == chat_id,
+  ).first() is not None
+
+
 def _pending_question_open_conflict() -> HTTPException:
   return HTTPException(
     status_code=409,
@@ -540,6 +548,14 @@ async def send_message(
   """
   require_chat_embed_operation(principal, "chat:send")
   chat = get_active_chat_for_principal(db, chat_id, principal)
+  if _delegation_manages_chat(db, chat_id):
+    raise HTTPException(
+      status_code=409,
+      detail={
+        "code": "delegation_managed",
+        "message": "This evaluator chat is managed by its parent workflow.",
+      },
+    )
 
   # AskUserQuestion answer delivery. If a live SDK turn is blocked waiting for
   # the answer (held in `questions._pending[chat_id]`), persist through the
@@ -788,6 +804,16 @@ async def _send_message_locked(
   duplicate = _duplicate_send_response(chat_id, chat, body.cid)
   if duplicate is not None:
     return duplicate
+  # Re-check after acquiring the transition lock: creation may have attached
+  # this chat to a delegation after the request's initial admission read.
+  if _delegation_manages_chat(db, chat_id):
+    raise HTTPException(
+      status_code=409,
+      detail={
+        "code": "delegation_managed",
+        "message": "This evaluator chat is managed by its parent workflow.",
+      },
+    )
   if body.continuation == "manual" and principal.app_id is not None:
     raise HTTPException(
       status_code=403,

--- a/backend/app/routes/delegations.py
+++ b/backend/app/routes/delegations.py
@@ -2,32 +2,67 @@
 
 from __future__ import annotations
 
-import hashlib
 import re
-import uuid
+import json
+import os
+import stat
+from pathlib import Path
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field, field_validator
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app import models, providers
-from app.chat import _finish_run, is_chat_running, stop_chat_for
 from app.chat_start import start_programmatic_chat_turn
 from app.database import get_db
+from app.config import get_settings
 from app.delegations import (
+  DelegationIntent,
+  cancel_delegation_execution,
+  create_or_attach_delegation,
   derived_status,
-  mark_cancelled,
+  MAX_DELEGATION_DEPTH,
   normalize_cwd,
   parent_root_run_id,
   serialize_delegation,
 )
-from app.deps import Principal, get_principal, reject_cross_site
+from app.deps import Principal, get_delegation_principal, reject_cross_site
 from app.resource_access import get_active_chat_or_404
 
 
 router = APIRouter(prefix="/api/delegations", tags=["delegations"])
 _TASK_KEY_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+_CAPABILITY_FILES = frozenset({"config.json", "status.json"})
+_CAPABILITY_FILE_MAX = 256 * 1024
+
+
+def _read_delegation_storage_json(
+  data_dir: str, app_id: int, name: str,
+) -> dict:
+  """Read one small app-owned JSON file without following storage symlinks."""
+  if name not in _CAPABILITY_FILES:
+    return {}
+  base = Path(data_dir) / "apps" / str(app_id)
+  directory_fd = file_fd = None
+  try:
+    directory_fd = os.open(
+      base, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+    )
+    file_fd = os.open(name, os.O_RDONLY | os.O_NOFOLLOW, dir_fd=directory_fd)
+    info = os.fstat(file_fd)
+    if not stat.S_ISREG(info.st_mode) or info.st_size > _CAPABILITY_FILE_MAX:
+      return {}
+    with os.fdopen(file_fd, "r", encoding="utf-8") as handle:
+      file_fd = None
+      value = json.load(handle)
+  except (OSError, UnicodeError, ValueError):
+    return {}
+  finally:
+    if file_fd is not None:
+      os.close(file_fd)
+    if directory_fd is not None:
+      os.close(directory_fd)
+  return value if isinstance(value, dict) else {}
 
 
 class DelegationSubmit(BaseModel):
@@ -77,14 +112,51 @@ class DelegationSubmit(BaseModel):
     return value
 
 
-def _require_owner_submit(principal: Principal) -> None:
-  # App frames may observe and cancel their own children, but only the owner
-  # agent's token may authorize a new provider spend.
-  if principal.app_id is not None or principal.scope != "owner":
+def _require_submitter(
+  db: Session, principal: Principal, body: DelegationSubmit,
+) -> models.Delegation | None:
+  if principal.scope == "owner" and principal.app_id is None:
+    return None
+  if (
+    principal.scope not in {"app", "delegation"}
+    or principal.app_id != body.app_id
+    or principal.delegation_id is None
+  ):
     raise HTTPException(
       status_code=403,
-      detail="Only the owner agent may submit delegated work.",
+      detail="Only the owner agent or an attached delegated agent may submit work.",
     )
+  parent = db.query(models.Delegation).filter(
+    models.Delegation.child_chat_id == body.parent_chat_id,
+    models.Delegation.app_id == principal.app_id,
+  ).first()
+  if parent is None:
+    raise HTTPException(status_code=403, detail="Delegated work must stay under its parent child chat.")
+  if parent.provider == "codex":
+    raise HTTPException(
+      status_code=409,
+      detail=(
+        "Nested Codex delegation requires a narrow local bridge and is not "
+        "available yet."
+      ),
+    )
+  if parent.scope == "read" and body.scope != "read":
+    raise HTTPException(
+      status_code=403,
+      detail="A read-only delegated owner cannot create write-capable children.",
+    )
+  if principal.delegation_id is not None and (
+    principal.delegation_id != parent.id
+    or principal.chat_id != body.parent_chat_id
+  ):
+    raise HTTPException(
+      status_code=403,
+      detail="Delegation token may only create direct children.",
+    )
+  from app.delegations import delegation_depth
+  if delegation_depth(db, parent) >= MAX_DELEGATION_DEPTH:
+    raise HTTPException(status_code=409, detail=f"Delegation depth reached the maximum ({MAX_DELEGATION_DEPTH}).")
+  return parent
 
 
 def _row_for_principal(
@@ -93,26 +165,17 @@ def _row_for_principal(
   query = db.query(models.Delegation).filter(
     models.Delegation.id == delegation_id,
   )
-  if principal.app_id is not None:
+  if principal.delegation_id is not None:
+    query = query.filter(
+      models.Delegation.parent_chat_id == principal.chat_id,
+      models.Delegation.app_id == principal.app_id,
+    )
+  elif principal.app_id is not None:
     query = query.filter(models.Delegation.app_id == principal.app_id)
   row = query.first()
   if row is None:
     raise HTTPException(status_code=404, detail="Delegation not found.")
   return row
-
-
-def _same_intent(row: models.Delegation, body: DelegationSubmit, cwd: str) -> bool:
-  return all((
-    row.app_id == body.app_id,
-    row.parent_chat_id == body.parent_chat_id,
-    row.provider == body.provider,
-    row.model == body.model,
-    row.effort == body.effort,
-    row.scope == body.scope,
-    row.cwd == cwd,
-    row.notify_parent_on_complete == body.notify_parent_on_complete,
-    row.prompt_sha256 == hashlib.sha256(body.prompt.encode("utf-8")).hexdigest(),
-  ))
 
 
 async def _ensure_started(
@@ -148,11 +211,11 @@ async def _ensure_started(
 @router.post("", status_code=201, dependencies=[Depends(reject_cross_site)])
 async def submit_or_attach(
   body: DelegationSubmit,
-  principal: Principal = Depends(get_principal),
+  principal: Principal = Depends(get_delegation_principal),
   db: Session = Depends(get_db),
 ):
   """Create once per (parent logical run, task key), otherwise attach."""
-  _require_owner_submit(principal)
+  _require_submitter(db, principal, body)
   parent = get_active_chat_or_404(db, body.parent_chat_id)
   root_id = parent_root_run_id(db, parent.id, require_active=True)
   if root_id is None:
@@ -178,75 +241,105 @@ async def submit_or_attach(
   except ValueError as exc:
     raise HTTPException(status_code=422, detail=str(exc)) from exc
 
-  row = db.query(models.Delegation).filter(
-    models.Delegation.parent_root_run_id == root_id,
-    models.Delegation.task_key == body.task_key,
-  ).first()
-  attached = row is not None
-  if row is not None:
-    if not _same_intent(row, body, cwd):
+  from app import chat_queue
+  async with (
+    chat_queue.get_transition_lock(f"app-lifecycle:{body.app_id}"),
+    chat_queue.get_transition_lock(parent.id),
+  ):
+    # App/chat deletion uses these same gates. End the authentication/read
+    # snapshot and re-establish every admission fact under the locks so a
+    # child cannot start after either owner has begun tombstoning.
+    db.rollback()
+    app = db.query(models.App).filter(
+      models.App.id == body.app_id,
+      models.App.deleted_at.is_(None),
+    ).first()
+    if app is None:
+      raise HTTPException(
+        status_code=404, detail="Delegation owner app not found.",
+      )
+    parent = get_active_chat_or_404(db, body.parent_chat_id)
+    root_id = parent_root_run_id(db, parent.id, require_active=True)
+    if root_id is None:
+      raise HTTPException(
+        status_code=409,
+        detail="Delegation requires an active parent chat run.",
+      )
+    intent = DelegationIntent(
+      app_id=body.app_id,
+      parent_chat_id=parent.id,
+      parent_root_run_id=root_id,
+      task_key=body.task_key,
+      prompt=body.prompt,
+      provider=body.provider,
+      model=body.model,
+      effort=body.effort,
+      scope=body.scope,
+      cwd=cwd,
+      max_budget_usd=5.0 if body.provider == "claude" else None,
+      notify_parent_on_complete=body.notify_parent_on_complete,
+    )
+    try:
+      row, attached = create_or_attach_delegation(db, intent)
+    except ValueError as exc:
       raise HTTPException(
         status_code=409,
         detail=(
           "That task key is already attached to different immutable work. "
           "Reuse the original prompt/policy or choose a new task key."
         ),
-      )
-  else:
-    child_id = str(uuid.uuid4())
-    delegation_id = str(uuid.uuid4())
-    row = models.Delegation(
-      id=delegation_id,
-      app_id=body.app_id,
-      parent_chat_id=parent.id,
-      parent_root_run_id=root_id,
-      task_key=body.task_key,
-      child_chat_id=child_id,
-      provider=body.provider,
-      model=body.model,
-      effort=body.effort,
-      scope=body.scope,
-      cwd=cwd,
-      prompt_sha256=hashlib.sha256(body.prompt.encode("utf-8")).hexdigest(),
-      max_budget_usd=5.0 if body.provider == "claude" else None,
-      notify_parent_on_complete=body.notify_parent_on_complete,
-    )
-    child = models.Chat(
-      id=child_id,
-      title=f"Delegation · {body.task_key}",
-      messages=[],
-      provider=body.provider,
-      agent_settings_json={
-        "model": body.model,
-        "effort": body.effort,
-        "drawer_hidden": True,
-        "owner_visible": False,
-      },
-      auto_resume_on_restart=True,
-      # Provider-limit retries can incur additional spend and remain opt-in.
-      auto_resume_on_limit=False,
-      created_by_app_id=body.app_id,
-    )
-    db.add_all((child, row))
-    try:
-      db.commit()
-    except IntegrityError:
-      db.rollback()
-      row = db.query(models.Delegation).filter(
-        models.Delegation.parent_root_run_id == root_id,
-        models.Delegation.task_key == body.task_key,
-      ).first()
-      if row is None or not _same_intent(row, body, cwd):
-        raise HTTPException(
-          status_code=409,
-          detail="A different delegation claimed that task key.",
-        )
-      attached = True
+      ) from exc
 
-  await _ensure_started(db, row, body.prompt)
+    await _ensure_started(db, row, body.prompt)
+    from app.goal_plans import publish_plan_for_delegation
+    publish_plan_for_delegation(db, row)
   payload = serialize_delegation(db, row)
   payload["attached"] = attached
   return payload
+
+
+@router.get("/capabilities")
+async def delegation_capabilities(
+  principal: Principal = Depends(get_delegation_principal),
+  db: Session = Depends(get_db),
+):
+  """Read-only Subagents configuration for a confined delegated owner."""
+  if principal.delegation_id is None or principal.app_id is None:
+    raise HTTPException(status_code=403, detail="Delegated child token required.")
+  app = db.query(models.App).filter(
+    models.App.id == principal.app_id,
+    models.App.deleted_at.is_(None),
+  ).first()
+  if app is None:
+    raise HTTPException(status_code=403, detail="Delegation owner app is unavailable.")
+
+  connections = {}
+  for provider_id, provider in providers.PROVIDERS.items():
+    error = provider.check_auth(get_settings().data_dir)
+    connections[provider_id] = {
+      "configured": error is None,
+      "authenticated": error is None,
+      "error": error,
+    }
+  registry = await providers.list_models(get_settings().data_dir)
+  models_by_provider = {
+    provider_id: [
+      {"id": entry["id"], "name": entry["label"]}
+      for entry in entries
+    ]
+    for provider_id, entries in registry.items()
+  }
+  return {
+    "app_id": app.id,
+    "config": _read_delegation_storage_json(
+      get_settings().data_dir, app.id, "config.json",
+    ),
+    "runtime": _read_delegation_storage_json(
+      get_settings().data_dir, app.id, "status.json",
+    ),
+    "connections": connections,
+    "models": models_by_provider,
+  }
 
 
 @router.get("")
@@ -255,11 +348,16 @@ def list_delegations(
   parent_chat_id: str | None = Query(default=None, min_length=1, max_length=64),
   limit: int = Query(default=100, ge=1, le=500),
   offset: int = Query(default=0, ge=0),
-  principal: Principal = Depends(get_principal),
+  principal: Principal = Depends(get_delegation_principal),
   db: Session = Depends(get_db),
 ):
   query = db.query(models.Delegation)
-  if principal.app_id is not None:
+  if principal.delegation_id is not None:
+    query = query.filter(
+      models.Delegation.parent_chat_id == principal.chat_id,
+      models.Delegation.app_id == principal.app_id,
+    )
+  elif principal.app_id is not None:
     query = query.filter(models.Delegation.app_id == principal.app_id)
   elif app_id is not None:
     query = query.filter(models.Delegation.app_id == app_id)
@@ -277,7 +375,7 @@ def list_delegations(
 def get_delegation(
   delegation_id: str,
   include_history: bool = Query(default=False),
-  principal: Principal = Depends(get_principal),
+  principal: Principal = Depends(get_delegation_principal),
   db: Session = Depends(get_db),
 ):
   row = _row_for_principal(db, delegation_id, principal)
@@ -294,23 +392,22 @@ def get_delegation(
 )
 async def cancel_delegation(
   delegation_id: str,
-  principal: Principal = Depends(get_principal),
+  principal: Principal = Depends(get_delegation_principal),
   db: Session = Depends(get_db),
 ):
   row = _row_for_principal(db, delegation_id, principal)
   status, _, _ = derived_status(db, row)
   if status in ("running", "resuming", "paused", "starting"):
-    if is_chat_running(row.child_chat_id):
-      stopped, _ = await stop_chat_for(row.child_chat_id, db=db)
-      if not stopped:
-        raise HTTPException(
-          status_code=409,
-          detail="The child is still stopping; retry cancellation shortly.",
-        )
-    else:
-      await _finish_run(row.child_chat_id, terminal_status="stopped")
-    mark_cancelled(db, row)
+    if not await cancel_delegation_execution(row.id):
+      raise HTTPException(
+        status_code=409,
+        detail="The child is still stopping; retry cancellation shortly.",
+      )
+    db.rollback()
+    row = _row_for_principal(db, delegation_id, principal)
   payload = serialize_delegation(db, row)
+  from app.goal_plans import publish_plan_for_delegation
+  publish_plan_for_delegation(db, row)
   return payload
 
 
@@ -325,12 +422,7 @@ async def cancel_active_for_parent(db: Session, parent_chat_id: str) -> list[str
     status, _, _ = derived_status(db, row)
     if status not in ("running", "resuming", "paused", "starting"):
       continue
-    if is_chat_running(row.child_chat_id):
-      stopped, _ = await stop_chat_for(row.child_chat_id, db=db)
-      if not stopped:
-        continue
-    else:
-      await _finish_run(row.child_chat_id, terminal_status="stopped")
-    mark_cancelled(db, row)
-    cancelled.append(row.id)
+    if await cancel_delegation_execution(row.id):
+      cancelled.append(row.id)
+  db.rollback()
   return cancelled

--- a/backend/app/routes/goal_plans.py
+++ b/backend/app/routes/goal_plans.py
@@ -58,12 +58,16 @@ class GoalTaskUpdate(BaseModel):
   expected_revision: int = Field(ge=0)
   status: str | None = None
   note: str | None = None
+  result: str | None = None
   progress: dict[str, Any] | None = None
 
   @model_validator(mode="after")
   def require_change(self) -> "GoalTaskUpdate":
-    if self.status is None and self.note is None and self.progress is None:
-      raise ValueError("provide status, note, or progress")
+    if (
+      self.status is None and self.note is None and self.result is None
+      and self.progress is None
+    ):
+      raise ValueError("provide status, note, result, or progress")
     return self
 
 
@@ -99,7 +103,7 @@ def get_goal_plan(
   require_chat_embed_operation(principal, "chat:read")
   get_active_chat_for_principal(db, chat_id, principal)
   rows = active_goal_rows(db, chat_id)
-  return {"plan": serialize_plan(*rows) if rows is not None else None}
+  return {"plan": serialize_plan(db, *rows) if rows is not None else None}
 
 
 @router.post(
@@ -206,6 +210,7 @@ async def patch_goal_task(
         changes={
           "status": body.status,
           "note": body.note,
+          "result": body.result,
           "progress": body.progress,
         },
       )

--- a/backend/app/run_state.py
+++ b/backend/app/run_state.py
@@ -8,39 +8,124 @@ reconstructed from a second per-chat marker.
 
 from collections.abc import Iterable, Mapping
 from typing import Any
+import json
+import uuid
 
 from sqlalchemy.orm import Session
 
 from app import models
 
 
-def goal_objective_for_run_start(
+def goal_identity_for_run_start(
   db: Session,
   chat_id: str,
   message: Mapping[str, Any] | None,
-) -> str | None:
-  """Resolve the goal metadata for a newly opened durable run.
-
-  Explicit ``/goal`` commands start a new objective. A real continuation may
-  inherit only from the immediately preceding unfinished/interrupted run; an
-  ordinary turn after a completed goal therefore cannot revive stale UI state.
-  """
+) -> tuple[str | None, str | None]:
+  """Resolve objective + stable Goal identity before prior runs are closed."""
   from app.chat_context import _goal_objective
   from app.continuations import is_continuation_message
 
   content = message.get("content") if message is not None else ""
   objective = _goal_objective(content if isinstance(content, str) else "")
   if objective is not None:
-    return objective
-  if not is_continuation_message(message):
-    return None
-  previous = latest_run(db, chat_id)
-  if previous is None or previous.status not in (
-    *models.NONTERMINAL_RUN_STATUSES,
-    "interrupted",
+    return objective, str(uuid.uuid4())
+  from app.continuations import DELEGATION_RESULT_MESSAGE_KIND
+  if (
+    isinstance(message, Mapping)
+    and message.get("kind") == DELEGATION_RESULT_MESSAGE_KIND
   ):
-    return None
-  return previous.goal_objective
+    source_work_id = message.get("source_work_id")
+    if isinstance(source_work_id, str) and source_work_id:
+      source = (
+        db.query(models.ChatRun)
+        .filter(
+          models.ChatRun.chat_id == chat_id,
+          models.ChatRun.goal_id == source_work_id,
+          models.ChatRun.goal_objective.isnot(None),
+        )
+        .order_by(models.ChatRun.started_at.desc(), models.ChatRun.id.desc())
+        .first()
+      )
+      if source is not None:
+        return source.goal_objective, source.goal_id
+    return None, None
+  previous = latest_run(db, chat_id)
+  semantic_continuation = is_continuation_message(message)
+  literal_continue = str(content or "").strip().lower() == "continue"
+  if not semantic_continuation and not literal_continue:
+    return None, None
+  if (
+    previous is not None
+    and previous.goal_objective is not None
+  ):
+    if (
+      semantic_continuation
+      and previous.status in (
+        *models.NONTERMINAL_RUN_STATUSES, "interrupted",
+      )
+    ):
+      # Pre-identity Goal rows can still exist in backups and fixtures. Keep
+      # their objective through an explicit semantic continuation; the normal
+      # migration supplies a stable id for current production rows.
+      return previous.goal_objective, previous.goal_id
+    if (
+      previous.goal_id is not None
+      and _goal_plan_is_unfinished(db, chat_id, previous.goal_id)
+    ):
+      return previous.goal_objective, previous.goal_id
+  if not semantic_continuation:
+    return None, None
+
+  # A restart can interrupt a physical continuation after its provider turn
+  # has already closed, leaving one no-goal recovery row between the new
+  # continuation marker and the logical Goal. Follow only an explicitly
+  # unfinished visible plan; completed or unplanned historical Goals never
+  # revive through this recovery path.
+  candidates = (
+    db.query(models.ChatRun)
+    .filter(
+      models.ChatRun.chat_id == chat_id,
+      models.ChatRun.goal_id.isnot(None),
+      models.ChatRun.goal_objective.isnot(None),
+    )
+    .order_by(models.ChatRun.started_at.desc(), models.ChatRun.id.desc())
+    .all()
+  )
+  seen: set[str] = set()
+  for candidate in candidates:
+    if candidate.goal_id in seen:
+      continue
+    seen.add(candidate.goal_id)
+    if _goal_plan_is_unfinished(db, chat_id, candidate.goal_id):
+      return candidate.goal_objective, candidate.goal_id
+  return None, None
+
+
+def _goal_plan_is_unfinished(db: Session, chat_id: str, goal_id: str) -> bool:
+  """Whether a stable Goal identity owns a plan with unsettled work."""
+  owner = (
+    db.query(models.ChatRun.goal_plan_json)
+    .filter(
+      models.ChatRun.chat_id == chat_id,
+      models.ChatRun.goal_id == goal_id,
+      models.ChatRun.goal_plan_json.isnot(None),
+    )
+    .order_by(models.ChatRun.started_at.asc(), models.ChatRun.id.asc())
+    .first()
+  )
+  if owner is None:
+    return False
+  raw = owner[0]
+  try:
+    plan = json.loads(raw) if isinstance(raw, str) else raw
+  except (TypeError, json.JSONDecodeError):
+    return False
+  tasks = (plan or {}).get("tasks") if isinstance(plan, dict) else None
+  return bool(tasks) and any(
+    isinstance(task, dict)
+    and task.get("status") not in ("completed", "cancelled")
+    for task in tasks
+  )
 
 
 def latest_run(db: Session, chat_id: str) -> models.ChatRun | None:
@@ -102,20 +187,11 @@ def running_run(db: Session, chat_id: str) -> models.ChatRun | None:
 
 
 def running_goal_objective(db: Session, chat_id: str) -> str | None:
-  """Return only the active run's goal label for lightweight UI reads."""
-  row = (
-    db.query(models.ChatRun.goal_objective)
-    .filter(
-      models.ChatRun.chat_id == chat_id,
-      models.ChatRun.status == "running",
-    )
-    .order_by(
-      models.ChatRun.started_at.desc(),
-      models.ChatRun.id.desc(),
-    )
-    .first()
-  )
-  return row[0] if row is not None else None
+  """Return the live or latest still-unsettled Goal label for UI reads."""
+  from app.goal_plans import active_goal_rows
+
+  rows = active_goal_rows(db, chat_id)
+  return rows[0].goal_objective if rows is not None else None
 
 
 def running_chat_ids(

--- a/backend/app/schema_migrations.py
+++ b/backend/app/schema_migrations.py
@@ -837,6 +837,39 @@ def _add_chat_run_goal_plan(eng) -> None:
       ))
 
 
+def _add_chat_run_goal_identity(eng) -> None:
+  """Give a native Goal identity that survives logical-run recovery."""
+  from sqlalchemy import inspect as sa_inspect, text
+
+  inspector = sa_inspect(eng)
+  if "chat_runs" not in inspector.get_table_names():
+    return
+  columns = {column["name"] for column in inspector.get_columns("chat_runs")}
+  with eng.begin() as conn:
+    if "goal_id" not in columns:
+      conn.execute(text("ALTER TABLE chat_runs ADD COLUMN goal_id VARCHAR(64) NULL"))
+    required = {"id", "root_run_id", "goal_objective"}
+    if not required.issubset(columns):
+      return
+    rows = conn.execute(text(
+      "SELECT id, root_run_id FROM chat_runs "
+      "WHERE goal_objective IS NOT NULL"
+    )).mappings().all()
+    for row in rows:
+      # Historical logical roots are the only identity the old schema proves.
+      # Never merge two Goals merely because their objective text matches: an
+      # owner may deliberately start the same Goal again. Future recovery rows
+      # inherit the stable id through goal_identity_for_run_start.
+      identity = str(row["root_run_id"] or row["id"])
+      conn.execute(text(
+        "UPDATE chat_runs SET goal_id = :goal_id WHERE id = :run_id "
+        "AND goal_id IS NULL"
+      ), {"goal_id": identity, "run_id": row["id"]})
+    conn.execute(text(
+      "CREATE INDEX IF NOT EXISTS ix_chat_runs_goal_id ON chat_runs (goal_id)"
+    ))
+
+
 def _add_chat_run_root_identity(eng) -> None:
   """Give every physical run a stable logical identity across continuations."""
   from sqlalchemy import inspect as sa_inspect, text
@@ -1609,6 +1642,7 @@ _SCHEMA_MIGRATIONS = (
   ("0012_connector_oauth_gcloud", _add_connector_oauth_gcloud_fields),
   ("0013_app_hosted_publication", _add_app_hosted_publication),
   ("0014_chat_run_goal_plan", _add_chat_run_goal_plan),
+  ("0015_chat_run_goal_identity", _add_chat_run_goal_identity),
 )
 
 

--- a/backend/scripts/goal_plan.py
+++ b/backend/scripts/goal_plan.py
@@ -89,6 +89,17 @@ def _completion_blockers(plan: dict | None) -> list[str]:
     task for task in plan.get("tasks") or []
     if isinstance(task, dict)
   ]
+  by_id = {str(task.get("id")): task for task in tasks if task.get("id")}
+  summary_blockers = (plan.get("summary") or {}).get("completion_blockers")
+  if isinstance(summary_blockers, list):
+    return [
+      str(
+        by_id.get(str(blocker), {}).get("title")
+        or blocker
+        or "Unnamed task"
+      )
+      for blocker in summary_blockers
+    ]
   return [
     str(task.get("title") or task.get("id") or "Unnamed task")
     for task in tasks
@@ -112,6 +123,12 @@ def main() -> int:
     "--task", action="append", type=_parse_task, default=[],
     metavar="ID|Title|DEP1,DEP2",
   )
+  add_parser = sub.add_parser("add", help="append a newly discovered subgoal")
+  add_parser.add_argument("task_id")
+  add_parser.add_argument("title")
+  add_parser.add_argument("--parent")
+  add_parser.add_argument("--depends-on", action="append", default=[])
+  add_parser.add_argument("--completion-condition")
   set_parser.add_argument(
     "--tasks-json", help="JSON array alternative to repeated --task",
   )
@@ -122,6 +139,7 @@ def main() -> int:
     choices=("pending", "running", "completed", "blocked", "failed", "cancelled"),
   )
   update_parser.add_argument("--note")
+  update_parser.add_argument("--result")
   update_parser.add_argument("--progress", type=_progress, metavar="CURRENT/TOTAL")
   args = parser.parse_args()
 
@@ -160,12 +178,34 @@ def main() -> int:
       "PUT", f"/api/chats/{chat_id}/goal-plan",
       {"expected_revision": revision, "tasks": tasks},
     )
+  elif args.command == "add":
+    tasks = list((current or {}).get("tasks") or [])
+    for task in tasks:
+      for transient in ("ready", "waiting_on", "children", "ready_to_verify"):
+        task.pop(transient, None)
+    added = {
+      "id": args.task_id,
+      "title": args.title,
+      "status": "pending",
+      "depends_on": args.depends_on,
+    }
+    if args.parent:
+      added["parent_id"] = args.parent
+    if args.completion_condition:
+      added["completion_condition"] = args.completion_condition
+    tasks.append(added)
+    result = _request(
+      "PUT", f"/api/chats/{chat_id}/goal-plan",
+      {"expected_revision": revision, "tasks": tasks},
+    )
   else:
     changes = {"expected_revision": revision}
     if args.status is not None:
       changes["status"] = args.status
     if args.note is not None:
       changes["note"] = args.note
+    if args.result is not None:
+      changes["result"] = args.result
     if args.progress is not None:
       changes["progress"] = args.progress
     if len(changes) == 1:

--- a/backend/scripts/seed-skills/goal-planning.md
+++ b/backend/scripts/seed-skills/goal-planning.md
@@ -84,6 +84,31 @@ Translate common shapes directly:
   `"progress":{"current":0,"total":3}` and advance it after each run. Do
   not mark it complete until progress is `3/3`.
 
+## Grow the route as the work teaches you more
+
+The initial plan is a useful route, not a prediction ritual. When completing a
+task reveals substantial independently verifiable work, add it as a child of
+the task that owns the newly discovered requirement:
+
+```bash
+python3 /data/platform/backend/scripts/goal_plan.py add inspect-auth \
+  'Inspect the authentication boundary' \
+  --parent audit \
+  --completion-condition 'The owner and child authority paths are verified'
+```
+
+Children may themselves gain children. The deepest ready leaves are the work
+that can run now; safe independent leaves may run in parallel. After all direct
+children settle, their parent becomes **Ready to verify** rather than
+auto-completing. Verify the parent's own completion condition, record the
+concise result, and only then complete it. This repeats upward until the root
+outcome is proved.
+
+A parent owns coordination, not descendant transcripts. Pass each child only
+the bounded contract and context it needs. Fold its concise result into its
+immediate parent; the top-level agent needs the status and verified result of
+its direct children, not every lower-level implementation detail.
+
 ## Keep the visible state truthful
 
 Before starting a task, mark it running; after evidence proves its outcome,
@@ -104,24 +129,21 @@ do not duplicate that scheduler with prose or timers.
 
 When several ready tasks are independent, run them in parallel only when the
 available delegation capability and write isolation make that safe. Shared
-live writes still need one serialized integrator; parallel read/review work is
-the easy case. When a delegated task settles, fold its evidence into the parent,
-update the matching task, and start newly ready work. Ordinary in-turn fleets
-still die with the turn; use a capability that explicitly owns durable child
-work when the task must survive a restart.
+live writes—including Goal-plan revisions—still need one serialized integrator;
+parallel read/review work is the easy case. When a delegated task settles, fold
+its evidence into the parent, update the matching task, and start newly ready
+work. Ordinary in-turn fleets still die with the turn; use a capability that
+explicitly owns durable child work when the task must survive a restart.
 
-Immediately before marking the native Goal complete, run the mediated
-completion preflight as its own command:
+Immediately before completing the native Goal, run the mediated completion
+preflight as its own command:
 
 ```bash
 python3 /data/platform/backend/scripts/goal_plan.py check-complete
 ```
 
-Only finish the Goal when that command exits zero and the actual requested
-outcome has been achieved. Where an explicit provider Goal exposes mediated
-`update_goal`, call it with `status: complete` only after this check; otherwise
-the verified end of the agent turn completes the Goal. The preflight allows a
-deliberately unplanned one-step Goal; for a planned Goal it rejects pending,
-running, blocked, or failed tasks. Cancelled tasks are treated as deliberately
-removed from the route. A green todo list supports the completion audit; it
-never replaces checking the actual result.
+For a planned Goal it rejects unfinished tasks and active mapped delegations.
+A green todo list supports the completion audit; it never replaces checking the
+actual result. Where an explicit provider Goal exposes mediated `update_goal`,
+call it with `status: complete` only after the preflight and real completion
+audit pass; otherwise the verified end of the agent turn completes the Goal.

--- a/backend/tests/fixtures/migration_history.json
+++ b/backend/tests/fixtures/migration_history.json
@@ -14,6 +14,7 @@
     "0011_delegation_parent_wake": "beaf17a1887c950209fa8e695d5ba66dbd544db881b2c888e80a1a926fe41709",
     "0012_connector_oauth_gcloud": "cc0f805478540ee55fd927786f10e03a020873f349cc3b0ee99a7b741cff45f1",
     "0013_app_hosted_publication": "62d7ff873ded24c52da4031684ca5fd95ed244f416345ae1dcbae9cf880025ae",
-    "0014_chat_run_goal_plan": "28a1e1a60164ae48845a9cfb4227e7d8c58655852caed6b95e1e1725dd12a217"
+    "0014_chat_run_goal_plan": "28a1e1a60164ae48845a9cfb4227e7d8c58655852caed6b95e1e1725dd12a217",
+    "0015_chat_run_goal_identity": "aa63ad39a2b55b364b97c950f912041ff88cd59ebf315218a824bb567bc6bf77"
   }
 }

--- a/backend/tests/test_chat_start.py
+++ b/backend/tests/test_chat_start.py
@@ -152,6 +152,33 @@ async def test_programmatic_start_does_nothing_when_claim_is_busy(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_programmatic_start_preserves_hidden_product_event_identity(
+  monkeypatch,
+):
+  state = _install_start_fakes(monkeypatch)
+  monkeypatch.setattr(chat_start.time, "time", lambda: 123.456)
+
+  assert await chat_start.start_programmatic_chat_turn(
+    chat_id="parent",
+    title="Delegation results",
+    content="child completed",
+    provider="codex",
+    hidden=True,
+    message_kind="delegation_result",
+    source_work_id="goal-1",
+  ) is True
+
+  assert state.writer.commands[0].user_msg == {
+    "role": "user",
+    "content": "child completed",
+    "ts": 123456,
+    "hidden": True,
+    "kind": "delegation_result",
+    "source_work_id": "goal-1",
+  }
+
+
+@pytest.mark.asyncio
 async def test_programmatic_start_yields_to_pending_owner_question(monkeypatch):
   state = _install_start_fakes(
     monkeypatch,

--- a/backend/tests/test_db_migrations.py
+++ b/backend/tests/test_db_migrations.py
@@ -1059,6 +1059,7 @@ def test_run_migrations_records_an_inspectable_append_only_history(tmp_path):
     "0012_connector_oauth_gcloud",
     "0013_app_hosted_publication",
     "0014_chat_run_goal_plan",
+    "0015_chat_run_goal_identity",
   ]
   assert second == first
 
@@ -1693,6 +1694,53 @@ def test_goal_plan_migration_adds_snapshot_and_revision_to_existing_runs(
       "SELECT COUNT(*) FROM schema_migrations "
       "WHERE version = '0014_chat_run_goal_plan'"
     )).scalar_one() == 1
+
+
+def test_goal_identity_migration_preserves_distinct_historical_roots_and_index(
+  tmp_path,
+):
+  eng = create_engine(f"sqlite:///{tmp_path / 'goal-identity.db'}")
+  models.Base.metadata.create_all(eng)
+  with Session(eng) as session:
+    session.add(models.Chat(id="goal-chat", title="Goal", messages=[]))
+    session.add_all([
+      models.ChatRun(
+        id="planned", root_run_id="planned", chat_id="goal-chat",
+        status="interrupted", provider="codex", goal_objective="Ship",
+        goal_plan_json={"version": 1, "tasks": []},
+        started_at=datetime(2026, 8, 18, 10),
+      ),
+      models.ChatRun(
+        id="recovered", root_run_id="recovered", chat_id="goal-chat",
+        status="running", provider="codex", goal_objective="Ship",
+        started_at=datetime(2026, 8, 18, 11),
+      ),
+    ])
+    session.commit()
+  with eng.begin() as conn:
+    conn.execute(text("DROP INDEX ix_chat_runs_goal_id"))
+    conn.execute(text("ALTER TABLE chat_runs DROP COLUMN goal_id"))
+    conn.execute(text(
+      "CREATE TABLE IF NOT EXISTS schema_migrations ("
+      "version VARCHAR(128) PRIMARY KEY, applied_at TIMESTAMP NOT NULL)"
+    ))
+    for version, _migration in migrations._SCHEMA_MIGRATIONS[:-1]:
+      conn.execute(text(
+        "INSERT INTO schema_migrations (version, applied_at) "
+        "VALUES (:version, :at)"
+      ), {"version": version, "at": datetime(2026, 8, 18)})
+
+  run_migrations(eng)
+
+  with eng.connect() as conn:
+    rows = conn.execute(text(
+      "SELECT id, goal_id FROM chat_runs ORDER BY started_at"
+    )).all()
+  assert rows == [("planned", "planned"), ("recovered", "recovered")]
+  assert any(
+    index["name"] == "ix_chat_runs_goal_id"
+    for index in inspect(eng).get_indexes("chat_runs")
+  )
 
 
 def test_published_schema_migration_history_is_unique_ordered_and_immutable():

--- a/backend/tests/test_delegations.py
+++ b/backend/tests/test_delegations.py
@@ -7,7 +7,15 @@ from app.chat_writer import (
   AppendPending, Barrier, PromotePending, StartTurn, get_writer,
 )
 from app.codex_sdk_runner import _codex_config_overrides
-from app.delegations import derived_status, mark_cancelled, policy_for_chat
+from app.claude_sdk_runner import _guarded_subagent_bash
+from app.delegations import (
+  RunPolicy,
+  delegation_execution_token,
+  derived_status,
+  mark_cancelled,
+  parent_root_run_id,
+  policy_for_chat,
+)
 from test_app_fixtures import create_local_app
 
 
@@ -25,6 +33,81 @@ def _parent_with_run(client, owner_token, db):
   ))
   db.commit()
   return chat_id
+
+
+def test_read_delegation_receives_only_a_delegation_scoped_bearer(
+  client, owner_token, db,
+):
+  auth = {"Authorization": f"Bearer {owner_token}"}
+  app_id = create_local_app(client, auth, name="Read policy")['id']
+  db.add_all([
+    models.Chat(id="parent", title="Parent", messages=[]),
+    models.Chat(id="read-child", title="Child", messages=[], created_by_app_id=app_id),
+    models.Chat(id="write-child", title="Child", messages=[], created_by_app_id=app_id),
+  ])
+  db.add_all([
+    models.Delegation(
+      id="read-policy", app_id=app_id, parent_chat_id="parent",
+      parent_root_run_id="parent-root", task_key="read",
+      child_chat_id="read-child", provider="codex", model=None, effort=None,
+      scope="read", cwd="/data/platform",
+      prompt_sha256=hashlib.sha256(b"read").hexdigest(),
+    ),
+    models.Delegation(
+      id="write-policy", app_id=app_id, parent_chat_id="parent",
+      parent_root_run_id="parent-root", task_key="write",
+      child_chat_id="write-child", provider="codex", model=None, effort=None,
+      scope="write", cwd="/data/platform",
+      prompt_sha256=hashlib.sha256(b"write").hexdigest(),
+    ),
+    models.ChatRun(
+      id="read-run", root_run_id="read-run", chat_id="read-child",
+      status="running", provider="codex",
+    ),
+    models.ChatRun(
+      id="write-run", root_run_id="write-run", chat_id="write-child",
+      status="running", provider="codex",
+    ),
+  ])
+  db.commit()
+  base = dict(
+    delegation_id="read-policy",
+    app_id=app_id,
+    provider="codex",
+    model=None,
+    effort=None,
+    cwd="/data/platform",
+    max_budget_usd=None,
+  )
+
+  read_token = delegation_execution_token(
+    db, RunPolicy(scope="read", **base), "read-run",
+  )
+  write_token = delegation_execution_token(
+    db, RunPolicy(
+      scope="write", **{**base, "delegation_id": "write-policy"},
+    ),
+    "write-run",
+  )
+  assert read_token and write_token
+  active_write = client.get(
+    "/api/delegations", headers={"Authorization": f"Bearer {write_token}"},
+  )
+  assert active_write.status_code == 200
+
+  db.get(models.ChatRun, "read-run").status = "completed"
+  db.commit()
+  stale = client.get(
+    "/api/delegations/capabilities",
+    headers={"Authorization": f"Bearer {read_token}"},
+  )
+  assert stale.status_code == 401
+  db.get(models.ChatRun, "write-run").status = "completed"
+  db.commit()
+  stale_write = client.get(
+    "/api/delegations", headers={"Authorization": f"Bearer {write_token}"},
+  )
+  assert stale_write.status_code == 401
 
 
 def test_submit_is_idempotent_per_parent_root_and_task_key(
@@ -82,7 +165,17 @@ def test_submit_is_idempotent_per_parent_root_and_task_key(
   assert wake_policy_conflict.status_code == 409
 
 
-def test_app_token_can_observe_own_work_but_cannot_submit_spend(
+def test_goal_identity_is_the_delegation_idempotency_parent(db, chat):
+  db.add(models.ChatRun(
+    id="goal-physical", root_run_id="logical-before-restart",
+    chat_id=chat.id, status="running", provider="codex",
+    goal_objective="Ship", goal_id="stable-goal",
+  ))
+  db.commit()
+  assert parent_root_run_id(db, chat.id, require_active=True) == "stable-goal"
+
+
+def test_app_token_can_only_submit_bounded_work_under_its_own_child(
   client, owner_token, db, monkeypatch,
 ):
   owner_auth = {"Authorization": f"Bearer {owner_token}"}
@@ -117,6 +210,139 @@ def test_app_token_can_observe_own_work_but_cannot_submit_spend(
 
   rejected = client.post("/api/delegations", json=body, headers=app_auth)
   assert rejected.status_code == 403
+
+  child_id = created.json()["child_chat_id"]
+  db.add(models.ChatRun(
+    id="child-parent-run", root_run_id="child-parent-run",
+    chat_id=child_id, status="running", provider="claude",
+  ))
+  db.commit()
+  child_policy = policy_for_chat(db, child_id)
+  assert child_policy is not None and child_policy.depth == 1
+  plain_app_nested = client.post("/api/delegations", json={
+    **body,
+    "parent_chat_id": child_id,
+    "task_key": "app-frame-cannot-spend",
+    "prompt": "Try to spend from an app frame.",
+  }, headers=app_auth)
+  assert plain_app_nested.status_code == 403
+  child_auth = {
+    "Authorization": (
+      f"Bearer {delegation_execution_token(db, child_policy, 'child-parent-run')}"
+    )
+  }
+  parent_delegation = db.get(models.Delegation, created.json()["id"])
+  parent_delegation.provider = "codex"
+  db.commit()
+  codex_nested = client.post("/api/delegations", json={
+    **body,
+    "parent_chat_id": child_id,
+    "task_key": "codex-needs-local-bridge",
+    "prompt": "Try to create a nested child without the local bridge.",
+  }, headers=child_auth)
+  assert codex_nested.status_code == 409
+  assert "narrow local bridge" in codex_nested.json()["detail"]
+  parent_delegation.provider = "claude"
+  db.commit()
+  other_app_id = create_local_app(client, owner_auth, name="Other delegates")['id']
+  foreign_nested = client.post("/api/delegations", json={
+    **body,
+    "app_id": other_app_id,
+    "parent_chat_id": child_id,
+    "task_key": "other-app-child",
+    "prompt": "Owner-authorized work from another app.",
+  }, headers=owner_auth)
+  assert foreign_nested.status_code == 201, foreign_nested.text
+  child_listing = client.get("/api/delegations", headers=child_auth)
+  assert child_listing.status_code == 200, child_listing.text
+  assert child_listing.json()["items"] == []
+  async def fake_models(_data_dir):
+    return {
+      "claude": [{"id": "claude-sonnet-4-6", "label": "Sonnet"}],
+      "codex": [{"id": "gpt-5.6-sol", "label": "Sol"}],
+    }
+  monkeypatch.setattr(
+    "app.routes.delegations.providers.list_models", fake_models,
+  )
+  capabilities = client.get(
+    "/api/delegations/capabilities", headers=child_auth,
+  )
+  assert capabilities.status_code == 200, capabilities.text
+  assert capabilities.json()["app_id"] == app_id
+  assert capabilities.json()["models"]["codex"][0]["id"] == "gpt-5.6-sol"
+  nested = client.post("/api/delegations", json={
+    **body,
+    "parent_chat_id": child_id,
+    "task_key": "nested-check",
+    "prompt": "Check one bounded detail.",
+  }, headers=child_auth)
+  assert nested.status_code == 201, nested.text
+  nested_policy = policy_for_chat(db, nested.json()["child_chat_id"])
+  assert nested_policy is not None and nested_policy.depth == 2
+  escalated = client.post("/api/delegations", json={
+    **body,
+    "parent_chat_id": child_id,
+    "task_key": "nested-write",
+    "prompt": "Try to write.",
+    "scope": "write",
+  }, headers=child_auth)
+  assert escalated.status_code == 403
+  assert "read-only" in escalated.json()["detail"]
+
+  # The backend is the single recursion-policy owner. Descendants may use the
+  # same guarded helper until the fourth level, where another child is refused
+  # regardless of what an installed helper or its documentation claims.
+  nested_parent = nested.json()["child_chat_id"]
+  for depth in (3, 4):
+    nested_run_id = f"depth-{depth}-parent-run"
+    db.add(models.ChatRun(
+      id=nested_run_id,
+      root_run_id=nested_run_id,
+      chat_id=nested_parent,
+      status="running",
+      provider="claude",
+    ))
+    db.commit()
+    nested_parent_policy = policy_for_chat(db, nested_parent)
+    assert nested_parent_policy is not None
+    nested_auth = {
+      "Authorization": (
+        f"Bearer {delegation_execution_token(db, nested_parent_policy, nested_run_id)}"
+      )
+    }
+    deeper = client.post("/api/delegations", json={
+      **body,
+      "parent_chat_id": nested_parent,
+      "task_key": f"depth-{depth}",
+      "prompt": f"Check depth {depth}.",
+    }, headers=nested_auth)
+    assert deeper.status_code == 201, deeper.text
+    nested_parent = deeper.json()["child_chat_id"]
+
+  db.add(models.ChatRun(
+    id="depth-limit-parent-run",
+    root_run_id="depth-limit-parent-run",
+    chat_id=nested_parent,
+    status="running",
+    provider="claude",
+  ))
+  db.commit()
+  depth_limit_policy = policy_for_chat(db, nested_parent)
+  assert depth_limit_policy is not None and depth_limit_policy.depth == 4
+  depth_limit_auth = {
+    "Authorization": (
+      "Bearer "
+      f"{delegation_execution_token(db, depth_limit_policy, 'depth-limit-parent-run')}"
+    )
+  }
+  rejected_depth = client.post("/api/delegations", json={
+    **body,
+    "parent_chat_id": nested_parent,
+    "task_key": "depth-5",
+    "prompt": "Exceed the recursion limit.",
+  }, headers=depth_limit_auth)
+  assert rejected_depth.status_code == 409
+  assert "maximum (4)" in rejected_depth.json()["detail"]
 
 
 def test_delegation_listing_exposes_run_usage_without_loading_result(
@@ -209,7 +435,18 @@ def test_child_policy_is_integrity_checked_and_write_loss_needs_review(db):
   assert policy is not None
   assert policy.allow_session_reseed is False
   assert policy.max_budget_usd == 5.0
-  assert "Do not launch" in policy.system_prompt
+  assert "$MOBIUS_SUBAGENT_HELPER" in policy.system_prompt
+  assert "Do not use any other agent CLI" in policy.system_prompt
+
+  codex_policy = RunPolicy(
+    delegation_id="codex-child", app_id=app.id, provider="codex",
+    model=None, effort=None, scope="read", cwd="/data/platform",
+    max_budget_usd=None,
+  )
+  assert (
+    "Nested delegated work is not available" in codex_policy.system_prompt
+  )
+  assert "$MOBIUS_SUBAGENT_HELPER" not in codex_policy.system_prompt
 
   child.messages = [
     {"role": "user", "content": "Make the bounded edit."},
@@ -234,9 +471,18 @@ def test_child_policy_is_integrity_checked_and_write_loss_needs_review(db):
   assert result == "Review before replaying."
 
   mark_cancelled(db, row)
+  mark_cancelled(db, row)
   db.expire_all()
   assert db.get(models.Chat, child.id).auto_resume_on_restart is False
   assert db.get(models.Chat, child.id).auto_resume_on_limit is False
+  lifecycle = db.query(models.AgentLifecycleEvent).filter(
+    models.AgentLifecycleEvent.provider_agent_id == row.id,
+    models.AgentLifecycleEvent.source_event_id
+      == f"delegation:{row.id}:terminal:cancelled",
+  ).all()
+  assert len(lifecycle) == 1
+  assert lifecycle[0].event_type == "agent_terminal"
+  assert lifecycle[0].state == "stopped"
 
 
 def test_continuation_physical_runs_inherit_one_logical_root(db):
@@ -293,6 +539,47 @@ def test_delegated_codex_config_has_no_questions_or_nested_agents():
   assert "features.goals=true" not in overrides
 
 
+def test_read_only_claude_admits_only_the_guarded_read_child_command():
+  admitted = _guarded_subagent_bash({"command": (
+    "python3 /data/apps/subagents/subagents.py run --provider codex "
+    "--name audit-x --scope read --prompt 'Check migration X.\nReport evidence.'"
+  )})
+  assert admitted
+  assert "'Check migration X.\nReport evidence.'" in admitted["command"]
+  assert not _guarded_subagent_bash({"command": (
+    "python3 /data/apps/subagents/subagents.py run --provider codex "
+    "--name audit-x --scope write --prompt 'Change X.'"
+  )})
+  assert not _guarded_subagent_bash({"command": (
+    "python3 /data/apps/subagents/subagents.py run --provider codex "
+    "--name audit-x --scope read --explicit --prompt 'Bypass a paused provider.'"
+  )})
+  assert not _guarded_subagent_bash({"command": (
+    "python3 /data/apps/subagents/subagents.py run --provider codex "
+    "--name audit-x --scope read --prompt 'Check X.'; rm -rf /data"
+  )})
+  substitution = _guarded_subagent_bash({"command": (
+    "python3 /data/apps/subagents/subagents.py run --provider codex "
+    '--name audit-x --scope read --prompt "Report $(touch /data/pwned)."'
+  )})
+  assert substitution
+  assert "'Report $(touch /data/pwned).'" in substitution["command"]
+
+
+def test_delegated_capability_read_refuses_symlinked_storage(tmp_path):
+  from app.routes.delegations import _read_delegation_storage_json
+
+  storage = tmp_path / "apps" / "7"
+  storage.mkdir(parents=True)
+  victim = tmp_path / "victim.json"
+  victim.write_text('{"secret":"must-not-follow"}', encoding="utf-8")
+  (storage / "config.json").symlink_to(victim)
+
+  assert _read_delegation_storage_json(
+    str(tmp_path), 7, "config.json",
+  ) == {}
+
+
 # --- Parent auto-wake on child completion ------------------------------------
 
 import asyncio
@@ -315,6 +602,7 @@ def _seed_delegation(
   cancelled=False,
   parent_messages=None,
   parent_pending_question_id=None,
+  parent_root_id=None,
 ):
   """Create a parent chat, a child chat (+ its ChatRun at child_status), and a
   Delegation row. Returns (parent_id, child_id, delegation_id)."""
@@ -346,7 +634,7 @@ def _seed_delegation(
     id=delegation_id,
     app_id=app.id,
     parent_chat_id=parent_id,
-    parent_root_run_id=f"root-{suffix}",
+    parent_root_run_id=parent_root_id or f"root-{suffix}",
     task_key=f"task-{suffix}",
     child_chat_id=child_id,
     provider="claude",
@@ -383,6 +671,21 @@ def _capture_starts(monkeypatch, *, running=False):
   return starts
 
 
+def test_direct_send_to_delegation_child_is_rejected(
+  client, owner_token, db,
+):
+  _, child_id, _ = _seed_delegation(db, suffix="send-gate")
+
+  response = client.post(
+    f"/api/chats/{child_id}/messages",
+    json={"content": "Bypass the parent workflow."},
+    headers={"Authorization": f"Bearer {owner_token}"},
+  )
+
+  assert response.status_code == 409, response.text
+  assert response.json()["detail"]["code"] == "delegation_managed"
+
+
 def test_child_completion_wakes_idle_parent_once(db, monkeypatch):
   parent_id, child_id, delegation_id = _seed_delegation(
     db, suffix="idle",
@@ -397,6 +700,9 @@ def test_child_completion_wakes_idle_parent_once(db, monkeypatch):
   assert "task-idle" in starts[0]["content"]
   assert "All 3 checks passed." in starts[0]["content"]
   assert starts[0]["initiated_by_app_id"] is None
+  assert starts[0]["hidden"] is True
+  assert starts[0]["message_kind"] == "delegation_result"
+  assert starts[0]["source_work_id"] == "root-idle"
   db.expire_all()
   assert db.get(models.Delegation, delegation_id).parent_woken_at is not None
 
@@ -407,11 +713,13 @@ def test_child_completion_wakes_idle_parent_once(db, monkeypatch):
 
 def test_two_finishes_coalesce_into_one_wake(db, monkeypatch):
   parent_id, child_a, del_a = _seed_delegation(
-    db, suffix="coa", result_blocks=[{"type": "text", "content": "A done"}],
+    db, suffix="coa", parent_root_id="shared-root",
+    result_blocks=[{"type": "text", "content": "A done"}],
   )
   # Second delegation shares the same parent chat.
   _, child_b, del_b = _seed_delegation(
     db, suffix="cob", parent_id=parent_id,
+    parent_root_id="shared-root",
     result_blocks=[{"type": "text", "content": "B done"}],
   )
   starts = _capture_starts(monkeypatch, running=False)
@@ -430,6 +738,61 @@ def test_two_finishes_coalesce_into_one_wake(db, monkeypatch):
   assert len(starts) == 1
 
 
+def test_finishes_from_different_logical_work_never_share_a_wake(
+  db, monkeypatch,
+):
+  parent_id, child_a, del_a = _seed_delegation(
+    db, suffix="goal-a", parent_root_id="goal-a",
+    result_blocks=[{"type": "text", "content": "A done"}],
+  )
+  _, child_b, del_b = _seed_delegation(
+    db, suffix="goal-b", parent_id=parent_id, parent_root_id="goal-b",
+    result_blocks=[{"type": "text", "content": "B done"}],
+  )
+  starts = _capture_starts(monkeypatch, running=False)
+
+  asyncio.run(delegations_mod.wake_parent_after_child_settled(child_a))
+
+  assert len(starts) == 1
+  assert "task-goal-a" in starts[0]["content"]
+  assert "task-goal-b" not in starts[0]["content"]
+  assert starts[0]["source_work_id"] == "goal-a"
+  db.expire_all()
+  assert db.get(models.Delegation, del_a).parent_woken_at is not None
+  assert db.get(models.Delegation, del_b).parent_woken_at is None
+
+  asyncio.run(delegations_mod.wake_parent_after_child_settled(child_b))
+
+  assert len(starts) == 2
+  assert "task-goal-b" in starts[1]["content"]
+  assert starts[1]["source_work_id"] == "goal-b"
+
+
+def test_nested_owner_keeps_direct_child_roster_across_physical_turns(db):
+  _root, child_owner, owner_id = _seed_delegation(
+    db, suffix="owner-roster", child_status="interrupted",
+  )
+  _same_parent, _leaf, _leaf_id = _seed_delegation(
+    db, suffix="leaf-roster", parent_id=child_owner,
+    parent_root_id=owner_id, child_status="running",
+  )
+  db.add(models.ChatRun(
+    id="owner-recovery", root_run_id="owner-recovery",
+    chat_id=child_owner, status="running", provider="claude",
+    started_at=now_naive_utc(),
+  ))
+  db.commit()
+
+  assert delegations_mod.parent_root_run_id(
+    db, child_owner, physical_run_id="owner-recovery",
+  ) == owner_id
+  context = delegations_mod.active_parent_context(
+    db, child_owner, "owner-recovery",
+  )
+  assert "task-leaf-roster" in context
+  assert '"status":"running"' in context
+
+
 def test_running_parent_gets_appended_not_started(db, monkeypatch):
   parent_id, child_id, delegation_id = _seed_delegation(
     db, suffix="run",
@@ -443,9 +806,12 @@ def test_running_parent_gets_appended_not_started(db, monkeypatch):
   db.expire_all()
   parent = db.get(models.Chat, parent_id)
   pending = parent.pending_messages or []
-  assert any(
-    "task-run" in (m.get("content") or "") for m in pending
-  ), pending
+  wake = next(
+    m for m in pending if "task-run" in (m.get("content") or "")
+  )
+  assert wake["hidden"] is True
+  assert wake["kind"] == "delegation_result"
+  assert wake["source_work_id"] == "root-run"
   assert db.get(models.Delegation, delegation_id).parent_woken_at is not None
 
   # The queued notice survives the parent's own drain into a continuation.
@@ -459,6 +825,12 @@ def test_running_parent_gets_appended_not_started(db, monkeypatch):
     (m.get("content") or "") for m in (parent.messages or [])
   )
   assert "task-run" in promoted
+  promoted_wake = next(
+    m for m in (parent.messages or [])
+    if "task-run" in (m.get("content") or "")
+  )
+  assert promoted_wake["hidden"] is True
+  assert promoted_wake["kind"] == "delegation_result"
 
 
 def test_question_blocked_parent_gets_appended_not_started(db, monkeypatch):
@@ -477,8 +849,8 @@ def test_question_blocked_parent_gets_appended_not_started(db, monkeypatch):
     starts.append(kwargs)
     return False
 
-  async def append_pending(content, chat_id):
-    queued.append((content, chat_id))
+  async def append_pending(content, chat_id, source_work_id=None):
+    queued.append((content, chat_id, source_work_id))
     return True
 
   monkeypatch.setattr(chat_start_mod, "start_programmatic_chat_turn", blocked_start)
@@ -490,6 +862,7 @@ def test_question_blocked_parent_gets_appended_not_started(db, monkeypatch):
   assert len(queued) == 1
   assert queued[0][1] == parent_id
   assert "task-question" in queued[0][0]
+  assert queued[0][2] == "root-question"
   db.expire_all()
   parent = db.get(models.Chat, parent_id)
   assert parent.pending_question_id == "owner-decision"
@@ -512,6 +885,78 @@ def test_stopped_and_cancelled_children_do_not_wake(db, monkeypatch):
   db.expire_all()
   assert db.get(models.Delegation, stopped_id).parent_woken_at is None
   assert db.get(models.Delegation, cancelled_id).parent_woken_at is None
+
+
+def test_cancelling_an_owner_settles_descendants_before_the_parent(db):
+  _parent, child_owner, owner_id = _seed_delegation(
+    db, suffix="cancel-owner", child_status="running",
+  )
+  _same_parent, child_leaf, leaf_id = _seed_delegation(
+    db,
+    suffix="cancel-leaf",
+    parent_id=child_owner,
+    child_status="running",
+  )
+
+  assert asyncio.run(
+    delegations_mod.cancel_delegation_execution(owner_id)
+  ) is True
+
+  db.expire_all()
+  owner = db.get(models.Delegation, owner_id)
+  leaf = db.get(models.Delegation, leaf_id)
+  assert owner.cancelled_at is not None
+  assert leaf.cancelled_at is not None
+  owner_run = db.query(models.ChatRun).filter(
+    models.ChatRun.chat_id == child_owner,
+  ).first()
+  leaf_run = db.query(models.ChatRun).filter(
+    models.ChatRun.chat_id == child_leaf,
+  ).first()
+  assert owner_run.status == "stopped"
+  assert leaf_run.status == "stopped"
+  assert leaf.cancelled_at <= owner.cancelled_at
+
+
+def test_chat_delete_settles_owned_delegations(client, owner_token, db):
+  parent_id, child_id, delegation_id = _seed_delegation(
+    db, suffix="delete-chat", child_status="running",
+  )
+
+  response = client.delete(
+    f"/api/chats/{parent_id}",
+    headers={"Authorization": f"Bearer {owner_token}"},
+  )
+
+  assert response.status_code == 204, response.text
+  db.expire_all()
+  assert db.get(models.Chat, parent_id).deleted_at is not None
+  assert db.get(models.Delegation, delegation_id).cancelled_at is not None
+  run = db.query(models.ChatRun).filter(
+    models.ChatRun.chat_id == child_id,
+  ).first()
+  assert run.status == "stopped"
+
+
+def test_app_delete_settles_owned_delegations(client, owner_token, db):
+  _parent_id, child_id, delegation_id = _seed_delegation(
+    db, suffix="delete-app", child_status="running",
+  )
+  app_id = db.get(models.Delegation, delegation_id).app_id
+
+  response = client.delete(
+    f"/api/apps/{app_id}",
+    headers={"Authorization": f"Bearer {owner_token}"},
+  )
+
+  assert response.status_code == 204, response.text
+  db.expire_all()
+  assert db.get(models.App, app_id).deleted_at is not None
+  assert db.get(models.Delegation, delegation_id).cancelled_at is not None
+  run = db.query(models.ChatRun).filter(
+    models.ChatRun.chat_id == child_id,
+  ).first()
+  assert run.status == "stopped"
 
 
 def test_interrupted_child_does_not_wake_it_resumes(db, monkeypatch):

--- a/backend/tests/test_delegations.py
+++ b/backend/tests/test_delegations.py
@@ -959,6 +959,30 @@ def test_app_delete_settles_owned_delegations(client, owner_token, db):
   assert run.status == "stopped"
 
 
+def test_child_chat_delete_settles_its_own_delegation(client, owner_token, db):
+  # Deleting the delegated CHILD chat runs under get_transition_lock(child_id).
+  # active_delegation_ids_for_chat returns the delegation whose child IS this
+  # chat, so the cancellation path must settle it WITHOUT re-acquiring that same
+  # non-reentrant lock — otherwise the delete deadlocks and wedges the chat.
+  _parent_id, child_id, delegation_id = _seed_delegation(
+    db, suffix="delete-child", child_status="running",
+  )
+
+  response = client.delete(
+    f"/api/chats/{child_id}",
+    headers={"Authorization": f"Bearer {owner_token}"},
+  )
+
+  assert response.status_code == 204, response.text
+  db.expire_all()
+  assert db.get(models.Chat, child_id).deleted_at is not None
+  assert db.get(models.Delegation, delegation_id).cancelled_at is not None
+  run = db.query(models.ChatRun).filter(
+    models.ChatRun.chat_id == child_id,
+  ).first()
+  assert run.status == "stopped"
+
+
 def test_interrupted_child_does_not_wake_it_resumes(db, monkeypatch):
   _, child_id, delegation_id = _seed_delegation(
     db, suffix="intr", child_status="interrupted",

--- a/backend/tests/test_goal_identity.py
+++ b/backend/tests/test_goal_identity.py
@@ -1,0 +1,167 @@
+"""A native Goal keeps one identity across physical recovery, not new Goals."""
+
+from app import models
+from app.chat_writer import AppendPending, Barrier, PromotePending, get_writer
+from app.run_state import goal_identity_for_run_start
+
+
+def test_explicit_goals_mint_identity_and_continuations_inherit_it(db, chat):
+  objective, first_id = goal_identity_for_run_start(
+    db, chat.id, {"content": "/goal Ship it"},
+  )
+  assert objective == "Ship it"
+  assert first_id
+  db.add(models.ChatRun(
+    id="first-run", root_run_id="first-run", chat_id=chat.id,
+    status="interrupted", provider="codex", goal_objective=objective,
+    goal_id=first_id,
+  ))
+  db.commit()
+
+  resumed_objective, resumed_id = goal_identity_for_run_start(
+    db, chat.id, {
+      "content": "continue", "kind": "continuation",
+      "continuation_reason": "restart",
+    },
+  )
+  assert resumed_objective == objective
+  assert resumed_id == first_id
+
+  repeated_objective, repeated_id = goal_identity_for_run_start(
+    db, chat.id, {"content": "/goal Ship it"},
+  )
+  assert repeated_objective == objective
+  assert repeated_id != first_id
+
+
+def test_ordinary_turn_does_not_revive_the_previous_goal(db, chat):
+  db.add(models.ChatRun(
+    id="old-goal", root_run_id="old-goal", chat_id=chat.id,
+    status="interrupted", provider="claude", goal_objective="Old",
+    goal_id="old-id",
+  ))
+  db.commit()
+  assert goal_identity_for_run_start(
+    db, chat.id, {"content": "unrelated follow-up"},
+  ) == (None, None)
+
+
+def test_plain_continue_keeps_a_completed_physical_run_with_unfinished_plan(
+  db, chat,
+):
+  db.add(models.ChatRun(
+    id="planned-goal", root_run_id="planned-goal", chat_id=chat.id,
+    status="completed", provider="codex", goal_objective="Ship it",
+    goal_id="stable-goal", goal_plan_json={
+      "tasks": [{"id": "verify", "status": "running"}],
+    },
+  ))
+  db.commit()
+
+  assert goal_identity_for_run_start(
+    db, chat.id, {"content": "continue"},
+  ) == ("Ship it", "stable-goal")
+
+
+def test_semantic_recovery_skips_intervening_no_goal_run_for_unfinished_plan(
+  db, chat,
+):
+  db.add_all([
+    models.ChatRun(
+      id="planned-goal", root_run_id="planned-goal", chat_id=chat.id,
+      status="completed", provider="codex", goal_objective="Ship it",
+      goal_id="stable-goal", goal_plan_json={
+        "tasks": [{"id": "verify", "status": "running"}],
+      },
+    ),
+    models.ChatRun(
+      id="intervening", root_run_id="intervening", chat_id=chat.id,
+      status="interrupted", provider="codex",
+    ),
+  ])
+  db.commit()
+
+  assert goal_identity_for_run_start(db, chat.id, {
+    "content": "continue", "kind": "continuation",
+    "continuation_reason": "restart",
+  }) == ("Ship it", "stable-goal")
+
+
+def test_continue_does_not_revive_a_settled_plan(db, chat):
+  db.add(models.ChatRun(
+    id="settled-goal", root_run_id="settled-goal", chat_id=chat.id,
+    status="completed", provider="codex", goal_objective="Done",
+    goal_id="settled-id", goal_plan_json={
+      "tasks": [{"id": "verify", "status": "completed"}],
+    },
+  ))
+  db.commit()
+
+  assert goal_identity_for_run_start(
+    db, chat.id, {"content": "continue"},
+  ) == (None, None)
+
+
+def test_delegation_result_inherits_only_its_originating_goal(db, chat):
+  db.add_all([
+    models.ChatRun(
+      id="origin", root_run_id="origin", chat_id=chat.id,
+      status="completed", provider="codex", goal_objective="Ship it",
+      goal_id="origin-goal",
+    ),
+    models.ChatRun(
+      id="later", root_run_id="later", chat_id=chat.id,
+      status="completed", provider="codex", goal_objective="Different",
+      goal_id="later-goal",
+    ),
+  ])
+  db.commit()
+
+  assert goal_identity_for_run_start(db, chat.id, {
+    "content": "<delegation_results>[]</delegation_results>",
+    "kind": "delegation_result",
+    "hidden": True,
+    "source_work_id": "origin-goal",
+  }) == ("Ship it", "origin-goal")
+
+
+def test_delegation_result_without_a_goal_origin_stays_non_goal(db, chat):
+  db.add(models.ChatRun(
+    id="old", root_run_id="old", chat_id=chat.id,
+    status="completed", provider="codex", goal_objective="Old",
+    goal_id="old-goal",
+  ))
+  db.commit()
+
+  assert goal_identity_for_run_start(db, chat.id, {
+    "content": "result",
+    "kind": "delegation_result",
+    "hidden": True,
+    "source_work_id": "ordinary-root",
+  }) == (None, None)
+
+
+def test_promoted_child_result_exposes_committed_goal_to_the_live_event(db, chat):
+  db.add(models.ChatRun(
+    id="origin", root_run_id="origin", chat_id=chat.id,
+    status="completed", provider="codex", goal_objective="Ship it",
+    goal_id="origin-goal", goal_plan_json={
+      "tasks": [{"id": "verify", "status": "running"}],
+    },
+  ))
+  db.commit()
+  get_writer().submit(AppendPending(
+    chat_id=chat.id,
+    user_msg={
+      "role": "user", "content": "child result", "ts": 1,
+      "hidden": True, "kind": "delegation_result",
+      "source_work_id": "origin-goal",
+    },
+  )).result(timeout=5)
+  result = get_writer().submit(PromotePending(
+    chat_id=chat.id, run_token="result-run",
+  )).result(timeout=5)
+  get_writer().submit(Barrier()).result(timeout=5)
+
+  assert result["promoted"]["_goal_objective"] == "Ship it"
+  assert result["promoted"]["_goal_id"] == "origin-goal"

--- a/backend/tests/test_goal_plans.py
+++ b/backend/tests/test_goal_plans.py
@@ -2,6 +2,8 @@
 
 from datetime import timedelta
 import importlib.util
+import hashlib
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import pytest
@@ -30,6 +32,7 @@ def _active_goal(client, owner_token, db):
     status="running",
     provider="codex",
     goal_objective="Ship the release",
+    goal_id="goal-1",
   ))
   db.commit()
   return auth, chat_id
@@ -369,6 +372,270 @@ def test_cancelled_work_is_removed_from_the_completion_route(
   assert summary["completion_blockers"] == []
 
 
+def test_nested_children_settle_before_parent_becomes_ready_to_verify(
+  client, owner_token, db,
+):
+  auth, chat_id = _active_goal(client, owner_token, db)
+  created = client.put(
+    f"/api/chats/{chat_id}/goal-plan",
+    json={"expected_revision": 0, "tasks": [
+      {"id": "b", "title": "Deliver B", "status": "running"},
+      {"id": "x", "title": "Do X", "parent_id": "b"},
+      {"id": "y", "title": "Do Y", "parent_id": "b"},
+    ]}, headers=auth,
+  )
+  assert created.status_code == 200, created.text
+  initial_tasks = {
+    task["id"]: task for task in created.json()["plan"]["tasks"]
+  }
+  assert initial_tasks["b"]["ready"] is False
+  assert initial_tasks["b"]["ready_to_verify"] is False
+  assert initial_tasks["x"]["ready"] is True
+  assert initial_tasks["y"]["ready"] is True
+  revision = 1
+  for task_id, status in (("x", "completed"), ("y", "completed")):
+    response = client.patch(
+      f"/api/chats/{chat_id}/goal-plan/tasks/{task_id}",
+      json={"expected_revision": revision, "status": status}, headers=auth,
+    )
+    assert response.status_code == 200, response.text
+    revision += 1
+  tasks = {task["id"]: task for task in response.json()["plan"]["tasks"]}
+  assert tasks["b"]["children"] == ["x", "y"]
+  assert tasks["b"]["ready"] is False
+  assert tasks["b"]["ready_to_verify"] is True
+
+  incomplete_parent = client.put(
+    f"/api/chats/{chat_id}/goal-plan",
+    json={"expected_revision": revision, "tasks": [
+      {"id": "b", "title": "Deliver B", "status": "completed"},
+      {"id": "x", "title": "Do X", "parent_id": "b"},
+    ]}, headers=auth,
+  )
+  assert incomplete_parent.status_code == 422
+  assert "children settle" in incomplete_parent.json()["detail"]
+
+
+def test_mixed_parent_dependency_cycle_is_rejected_before_it_can_deadlock(
+  client, owner_token, db,
+):
+  auth, chat_id = _active_goal(client, owner_token, db)
+  response = client.put(
+    f"/api/chats/{chat_id}/goal-plan",
+    json={"expected_revision": 0, "tasks": [
+      {"id": "parent", "title": "Parent", "status": "running"},
+      {
+        "id": "child", "title": "Child", "parent_id": "parent",
+        "depends_on": ["parent"],
+      },
+    ]}, headers=auth,
+  )
+  assert response.status_code == 422
+  assert "completion cycle" in response.json()["detail"]
+
+
+def test_failed_parent_never_masquerades_as_ready_to_verify(
+  client, owner_token, db,
+):
+  auth, chat_id = _active_goal(client, owner_token, db)
+  response = client.put(
+    f"/api/chats/{chat_id}/goal-plan",
+    json={"expected_revision": 0, "tasks": [
+      {"id": "parent", "title": "Parent", "status": "failed"},
+      {
+        "id": "child", "title": "Child", "parent_id": "parent",
+        "status": "completed",
+      },
+    ]}, headers=auth,
+  )
+  assert response.status_code == 200, response.text
+  tasks = {task["id"]: task for task in response.json()["plan"]["tasks"]}
+  assert tasks["parent"]["ready_to_verify"] is False
+
+
+def test_plan_follows_stable_goal_identity_across_a_new_logical_run(
+  client, owner_token, db,
+):
+  auth, chat_id = _active_goal(client, owner_token, db)
+  created = client.put(
+    f"/api/chats/{chat_id}/goal-plan",
+    json={"expected_revision": 0, "tasks": [{"id": "a", "title": "A"}]},
+    headers=auth,
+  )
+  assert created.status_code == 200, created.text
+  db.query(models.ChatRun).filter(models.ChatRun.id == "goal-root").update({
+    models.ChatRun.status: "interrupted",
+  })
+  db.add(models.ChatRun(
+    id="recovered-root", root_run_id="recovered-root", chat_id=chat_id,
+    status="running", provider="codex", goal_objective="Ship the release",
+    goal_id="goal-1",
+  ))
+  db.commit()
+  recovered = client.get(f"/api/chats/{chat_id}/goal-plan", headers=auth)
+  assert recovered.status_code == 200, recovered.text
+  assert recovered.json()["plan"]["revision"] == 1
+  assert recovered.json()["plan"]["goal_id"] == "goal-1"
+
+
+def test_plan_projects_recursive_delegation_ownership_without_transcripts(
+  client, owner_token, db,
+):
+  auth, chat_id = _active_goal(client, owner_token, db)
+  created = client.put(
+    f"/api/chats/{chat_id}/goal-plan",
+    json={"expected_revision": 0, "tasks": [{
+      "id": "b", "title": "Do B", "status": "completed",
+    }]},
+    headers=auth,
+  )
+  assert created.status_code == 200, created.text
+  app = models.App(
+    slug="goal-tree-subagents", source_dir="/tmp/goal-tree-subagents",
+    name="Subagents", description="", jsx_source="",
+  )
+  db.add(app)
+  db.flush()
+  child_b = models.Chat(
+    id="child-b", title="B", messages=[], created_by_app_id=app.id,
+  )
+  child_x = models.Chat(
+    id="child-x", title="X", messages=[], created_by_app_id=app.id,
+  )
+  db.add_all([child_b, child_x])
+  db.flush()
+  common = {
+    "app_id": app.id, "provider": "codex", "model": None,
+    "effort": None, "scope": "read", "cwd": "/data",
+    "prompt_sha256": hashlib.sha256(b"").hexdigest(),
+  }
+  db.add_all([
+    models.Delegation(
+      id="delegation-b", parent_chat_id=chat_id,
+      parent_root_run_id="goal-root", task_key="b", child_chat_id="child-b",
+      **common,
+    ),
+    models.Delegation(
+      id="delegation-x", parent_chat_id="child-b",
+      parent_root_run_id="child-b-run", task_key="x", child_chat_id="child-x",
+      **common,
+    ),
+    models.ChatRun(
+      id="child-b-run", root_run_id="child-b-run", chat_id="child-b",
+      status="running", provider="codex",
+    ),
+    models.ChatRun(
+      id="child-x-run", root_run_id="child-x-run", chat_id="child-x",
+      status="running", provider="codex",
+    ),
+  ])
+  db.commit()
+
+  plan = client.get(f"/api/chats/{chat_id}/goal-plan", headers=auth).json()["plan"]
+  assert plan["delegations"] == [{
+    "id": "delegation-b", "task_key": "b", "provider": "codex",
+    "status": "running", "children": [{
+      "id": "delegation-x", "task_key": "x", "provider": "codex",
+      "status": "running", "children": [],
+    }],
+  }]
+  assert plan["summary"]["completed"] == 0
+  assert plan["summary"]["can_complete"] is False
+  assert plan["summary"]["completion_blockers"] == ["b", "x"]
+
+  db.query(models.ChatRun).filter(models.ChatRun.id.in_([
+    "goal-root", "child-b-run",
+  ])).update({"status": "completed"}, synchronize_session=False)
+  db.commit()
+  descendant_plan = client.get(
+    f"/api/chats/{chat_id}/goal-plan", headers=auth,
+  ).json()["plan"]
+  assert descendant_plan["delegations"][0]["status"] == "completed"
+  assert descendant_plan["delegations"][0]["children"][0]["status"] == "running"
+  assert descendant_plan["summary"]["completed"] == 0
+  assert descendant_plan["summary"]["completion_blockers"] == ["b", "x"]
+  runtime = client.get(f"/api/chats/{chat_id}/runtime", headers=auth).json()
+  assert runtime["running"] is False
+  assert runtime["active_goal_objective"] == "Ship the release"
+
+  db.query(models.ChatRun).filter(models.ChatRun.id == "child-x-run").update({
+    "status": "completed",
+  })
+  db.commit()
+  assert client.get(
+    f"/api/chats/{chat_id}/goal-plan", headers=auth,
+  ).json()["plan"] is None
+  assert client.get(
+    f"/api/chats/{chat_id}/runtime", headers=auth,
+  ).json()["active_goal_objective"] is None
+
+
+def test_resumed_goal_projects_only_latest_delegation_attempt_per_task(
+  client, owner_token, db,
+):
+  auth, chat_id = _active_goal(client, owner_token, db)
+  created = client.put(
+    f"/api/chats/{chat_id}/goal-plan",
+    json={"expected_revision": 0, "tasks": [{
+      "id": "audit", "title": "Audit", "status": "completed",
+    }]}, headers=auth,
+  )
+  assert created.status_code == 200, created.text
+  app = models.App(
+    slug="goal-retry-subagents", source_dir="/tmp/goal-retry-subagents",
+    name="Subagents", description="", jsx_source="",
+  )
+  db.add(app)
+  db.flush()
+  old_child = models.Chat(
+    id="goal-old-child", title="Old", messages=[], created_by_app_id=app.id,
+  )
+  new_child = models.Chat(
+    id="goal-new-child", title="New", messages=[], created_by_app_id=app.id,
+  )
+  db.add_all([old_child, new_child])
+  db.flush()
+  common = {
+    "app_id": app.id, "provider": "codex", "model": None,
+    "effort": None, "scope": "read", "cwd": "/data",
+    "prompt_sha256": hashlib.sha256(b"").hexdigest(),
+  }
+  now = datetime.now(UTC).replace(tzinfo=None)
+  db.add_all([
+    models.ChatRun(
+      id="resumed-goal-run", root_run_id="resumed-goal-run", chat_id=chat_id,
+      status="interrupted", provider="codex", goal_objective="Ship the release",
+      goal_id="goal-1",
+    ),
+    models.Delegation(
+      id="old-attempt", parent_chat_id=chat_id,
+      parent_root_run_id="goal-root", task_key="audit",
+      child_chat_id=old_child.id, created_at=now - timedelta(minutes=1),
+      **common,
+    ),
+    models.Delegation(
+      id="new-attempt", parent_chat_id=chat_id,
+      parent_root_run_id="resumed-goal-run", task_key="audit",
+      child_chat_id=new_child.id, created_at=now,
+      **common,
+    ),
+    models.ChatRun(
+      id="old-attempt-run", root_run_id="old-attempt-run",
+      chat_id=old_child.id, status="completed", provider="codex",
+    ),
+    models.ChatRun(
+      id="new-attempt-run", root_run_id="new-attempt-run",
+      chat_id=new_child.id, status="running", provider="codex",
+    ),
+  ])
+  db.commit()
+
+  plan = client.get(f"/api/chats/{chat_id}/goal-plan", headers=auth).json()["plan"]
+  assert [node["id"] for node in plan["delegations"]] == ["new-attempt"]
+  assert plan["summary"]["completed"] == 0
+  assert plan["summary"]["completion_blockers"] == ["audit"]
+
+
 def test_completion_preflight_names_only_unfinished_required_work():
   helper = _goal_plan_script()
   plan = {
@@ -382,6 +649,10 @@ def test_completion_preflight_names_only_unfinished_required_work():
   assert helper._completion_blockers(None) == []
   assert helper._completion_blockers(plan) == [
     "Run final audit", "Resolve blocker",
+  ]
+  plan["summary"] = {"completion_blockers": ["next", "live-child"]}
+  assert helper._completion_blockers(plan) == [
+    "Run final audit", "live-child",
   ]
 
 

--- a/backend/tests/test_time_context.py
+++ b/backend/tests/test_time_context.py
@@ -103,6 +103,12 @@ def test_elapsed_ignores_automatic_continuation_marker(monkeypatch):
           "ts": (now - 5 * 60) * 1000,
         },
         {"role": "assistant", "content": "automatic reply"},
+        {
+          "role": "user", "content": "internal child result",
+          "kind": "delegation_result", "hidden": True,
+          "ts": (now - 60) * 1000,
+        },
+        {"role": "assistant", "content": "internal result folded"},
         {"role": "user", "content": "current owner message", "ts": now * 1000},
       ],
     ))

--- a/frontend/src/components/ChatView/ChatView.css
+++ b/frontend/src/components/ChatView/ChatView.css
@@ -3260,11 +3260,16 @@
 
 .chat__progress-step--button {
   appearance: none;
-  padding: 0;
+  flex: 1 0 100%;
+  width: 100%;
+  margin: -3px -4px;
+  padding: 3px 4px;
   border: 0;
+  border-radius: 7px;
   background: transparent;
   font: inherit;
   text-align: left;
+  justify-content: space-between;
   -webkit-tap-highlight-color: transparent;
 }
 
@@ -3274,21 +3279,7 @@
 
 .chat__progress-step--toggle:focus-visible {
   outline: 2px solid var(--accent);
-  outline-offset: 3px;
-  border-radius: 3px;
-}
-
-.chat__progress-step-action {
-  flex: 0 0 auto;
-  margin-left: 2px;
-  color: var(--accent);
-  font-weight: 650;
-  white-space: nowrap;
-}
-
-.chat__progress-step--toggle:hover .chat__progress-step-action {
-  text-decoration: underline;
-  text-underline-offset: 2px;
+  outline-offset: 2px;
 }
 
 .chat__progress-step--expanded {
@@ -3356,7 +3347,11 @@
 }
 
 .chat__goal-task--running,
-.chat__goal-task--ready {
+.chat__goal-task--starting,
+.chat__goal-task--resuming,
+.chat__goal-task--paused,
+.chat__goal-task--ready,
+.chat__goal-task--verify {
   color: var(--text);
   background: color-mix(in srgb, var(--accent) 7%, transparent);
 }
@@ -3373,6 +3368,13 @@
 .chat__goal-task--running .chat__goal-task-marker {
   border-color: var(--accent);
   box-shadow: inset 0 0 0 3px color-mix(in srgb, var(--accent) 24%, transparent);
+}
+
+.chat__goal-task--starting .chat__goal-task-marker,
+.chat__goal-task--resuming .chat__goal-task-marker,
+.chat__goal-task--paused .chat__goal-task-marker {
+  border-color: var(--accent);
+  box-shadow: inset 0 0 0 3px color-mix(in srgb, var(--accent) 18%, transparent);
 }
 
 .chat__goal-task--ready .chat__goal-task-marker {

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -158,6 +158,8 @@ import {
   railAtRunStart,
 } from './buildPhaseRail.js'
 import {
+  compactGoalObjective,
+  goalObjectiveForQueuedStart,
   goalObjectiveAtRunStart,
   goalObjectiveFromRuntime,
   latestGoalObjective,
@@ -536,15 +538,16 @@ export default function ChatView({
   // real run-start seam and left intact across mid-turn steers; a fresh mount
   // can recover it from the visible run-start message once liveness is known.
   const [activeGoalObjective, setActiveGoalObjective] = useState(
-    () => cached?.running ? (cached?.activeGoalObjective ?? '') : '',
+    () => compactGoalObjective(cached?.activeGoalObjective),
   )
   const [activeGoalPlan, setActiveGoalPlan] = useState(null)
   const setActiveGoalState = useCallback((objective) => {
-    setActiveGoalObjective(objective)
+    const compactObjective = compactGoalObjective(objective)
+    setActiveGoalObjective(compactObjective)
     updateChatRuntimeCache(
       queryClient,
       chatMessagesQueryKey(chatId),
-      { activeGoalObjective: objective },
+      { activeGoalObjective: compactObjective },
     )
   }, [chatId, queryClient])
 
@@ -565,7 +568,9 @@ export default function ChatView({
   }, [])
   useEffect(() => {
     const runtime = queryClient.getQueryData(chatMessagesQueryKey(chatId))
-    setActiveGoalObjective(runtime?.running ? (runtime.activeGoalObjective ?? '') : '')
+    setActiveGoalObjective(
+      compactGoalObjective(runtime?.activeGoalObjective),
+    )
   }, [chatId, queryClient])
 
   useEffect(() => {
@@ -1293,7 +1298,9 @@ export default function ChatView({
         setSending(false)
         sendingRef.current = false
         setServerRunningState(false)
-        setActiveGoalState('')
+        if (activeGoalPlan?.summary?.can_complete !== false) {
+          setActiveGoalState('')
+        }
         // Stream ended without continuation. If we have local pending
         // entries, server may have cleared them (auth fail, error) —
         // refetch to reconcile. Skip when pending empty.
@@ -1332,9 +1339,8 @@ export default function ChatView({
       // position the live stream did (old-run phases, then reset) and the
       // rail always lands on the run being displayed.
       setBuildPhases(railAtRunStart())
-      setActiveGoalState(goalObjectiveAtRunStart(
-        message?.content,
-        messagesRef.current,
+      setActiveGoalState(goalObjectiveForQueuedStart(
+        message, messagesRef.current,
       ))
       const consumedCids = message?._consumed_cids
       const serverRows = Array.isArray(message?._messages)
@@ -4641,7 +4647,7 @@ export default function ChatView({
         </div>
         <ProgressRail
           items={progressRail}
-          key={activeGoalPlan?.root_run_id || visibleGoalObjective || 'build-progress'}
+          resetKey={activeGoalPlan?.root_run_id || visibleGoalObjective || 'build-progress'}
           ariaLabel={visibleGoalObjective ? 'Goal progress' : 'Build progress'}
         />
         <ConnectionStatus

--- a/frontend/src/components/ChatView/GoalPlanDetails.jsx
+++ b/frontend/src/components/ChatView/GoalPlanDetails.jsx
@@ -1,5 +1,7 @@
 /* GoalPlanDetails renders the expanded dependency-aware todo list. */
 
+import { goalTaskDisplayStatus } from './goalProgress'
+
 function taskMeta(task, tasksById) {
   if (task.status === 'running') {
     const progress = task.progress
@@ -17,29 +19,111 @@ function taskMeta(task, tasksById) {
   return waiting.length ? `Waiting for ${waiting.join(' + ')}` : 'Pending'
 }
 
+function delegationMeta(node) {
+  const provider = node.provider === 'claude'
+    ? 'Claude'
+    : node.provider === 'codex'
+      ? 'Codex'
+      : null
+  const state = node.status === 'completed'
+    ? 'Complete'
+    : node.status === 'paused'
+      ? 'Paused'
+      : ['starting', 'running', 'resuming'].includes(node.status)
+        ? 'In progress'
+        : node.status === 'cancelled'
+          ? 'Cancelled'
+          : node.status === 'stopped'
+            ? 'Stopped'
+            : 'Needs review'
+  return [provider, state].filter(Boolean).join(' · ')
+}
+
+function delegationTitle(node) {
+  return String(node.task_key || '')
+    .replace(/[._-]+/g, ' ')
+    .replace(/^./, letter => letter.toUpperCase())
+}
+
+function GoalPlanRow({ title, status, meta, depth, emphasized, children }) {
+  const hasChildren = Array.isArray(children) ? children.length > 0 : !!children
+  return (
+    <div className="chat__goal-branch" role="listitem">
+      <div
+        style={{ paddingLeft: `${4 + Math.min(depth, 6) * 18}px` }}
+        className={`chat__goal-task chat__goal-task--${status}${
+          emphasized ? ` chat__goal-task--${emphasized}` : ''
+        }`}
+      >
+        <span className="chat__goal-task-marker" aria-hidden="true" />
+        <span className="chat__goal-task-copy">
+          <span className="chat__goal-task-title">{title}</span>
+          <span className="chat__goal-task-meta">{meta}</span>
+        </span>
+      </div>
+      {hasChildren && <div className="chat__goal-children" role="list">{children}</div>}
+    </div>
+  )
+}
+
 export default function GoalPlanDetails({ plan }) {
   const tasks = Array.isArray(plan?.tasks) ? plan.tasks : []
   if (!tasks.length) return null
   const tasksById = new Map(tasks.map(task => [task.id, task]))
+  const delegations = Array.isArray(plan?.delegations) ? plan.delegations : []
+  const delegatedByTask = new Map(delegations.map(node => [node.task_key, node]))
+  const childrenByParent = new Map()
+  for (const task of tasks) {
+    const parent = tasksById.has(task.parent_id) ? task.parent_id : null
+    childrenByParent.set(parent, [...(childrenByParent.get(parent) || []), task])
+  }
+  const renderBranch = (
+    task,
+    depth = 0,
+    execution = delegatedByTask.get(task.id),
+  ) => {
+    const planChildren = childrenByParent.get(task.id) || []
+    const executionChildren = execution?.children || []
+    const children = planChildren.map(child => renderBranch(
+        child,
+        depth + 1,
+        executionChildren.find(node => node.task_key === child.id),
+      ))
+    children.push(...executionChildren
+        .filter(node => !planChildren.some(child => child.id === node.task_key))
+        .map(node => renderDelegation(node, depth + 1)))
+    return <GoalPlanRow
+      key={task.id}
+      title={task.title}
+      status={goalTaskDisplayStatus(task, execution)}
+      depth={depth}
+      emphasized={task.ready_to_verify ? 'verify' : task.ready ? 'ready' : ''}
+      meta={task.ready_to_verify
+        ? 'Ready to verify'
+        : execution
+          ? delegationMeta(execution)
+          : taskMeta(task, tasksById)}
+    >
+      {children}
+    </GoalPlanRow>
+  }
+  const renderDelegation = (node, depth = 0) => (
+    <GoalPlanRow
+      key={node.id}
+      title={delegationTitle(node)}
+      status={node.status}
+      depth={depth}
+      meta={delegationMeta(node)}
+    >
+      {(node.children || []).map(child => renderDelegation(child, depth + 1))}
+    </GoalPlanRow>
+  )
   return (
     <div className="chat__goal-plan" role="list" aria-label="Full goal todo list">
-      {tasks.map(task => (
-        <div
-          key={task.id}
-          role="listitem"
-          className={`chat__goal-task chat__goal-task--${task.status}${
-            task.ready ? ' chat__goal-task--ready' : ''
-          }`}
-        >
-          <span className="chat__goal-task-marker" aria-hidden="true" />
-          <span className="chat__goal-task-copy">
-            <span className="chat__goal-task-title">{task.title}</span>
-            <span className="chat__goal-task-meta">
-              {taskMeta(task, tasksById)}
-            </span>
-          </span>
-        </div>
-      ))}
+      {(childrenByParent.get(null) || []).map(task => renderBranch(task))}
+      {delegations
+        .filter(node => !tasksById.has(node.task_key))
+        .map(node => renderDelegation(node))}
     </div>
   )
 }

--- a/frontend/src/components/ChatView/ProgressRail.jsx
+++ b/frontend/src/components/ChatView/ProgressRail.jsx
@@ -1,49 +1,22 @@
 /* ProgressRail renders the shared compact status sequence above the composer. */
 
-import { useLayoutEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 
 function ProgressStep({ item, detailsExpanded, onDetailsToggle }) {
-  const stepRef = useRef(null)
-  const labelRef = useRef(null)
   const [labelExpanded, setLabelExpanded] = useState(false)
-  const [canExpand, setCanExpand] = useState(false)
-
-  useLayoutEffect(() => {
-    setLabelExpanded(false)
-    setCanExpand(false)
-  }, [item.label])
-
-  useLayoutEffect(() => {
-    const step = stepRef.current
-    const label = labelRef.current
-    if (!step || !label || labelExpanded || !item.expandable) return undefined
-
-    const measure = () => {
-      setCanExpand(label.scrollWidth > step.clientWidth + 1)
-    }
-    measure()
-
-    if (typeof ResizeObserver === 'undefined') return undefined
-    const observer = new ResizeObserver(measure)
-    observer.observe(step)
-    return () => observer.disconnect()
-  }, [labelExpanded, item.expandable, item.label])
+  useEffect(() => setLabelExpanded(false), [item.label])
 
   const hasDetails = !!item.details
   const expanded = hasDetails ? detailsExpanded : labelExpanded
-  const toggleable = item.expandable && (hasDetails || canExpand || expanded)
-  const actionLabel = expanded
-    ? item.expandedActionLabel
-    : item.actionLabel
   const accessibleLabel = item.ariaLabel || item.label
   const title = item.title || item.label
   const className = `chat__progress-step${
     item.current ? ' chat__progress-step--current' : ''
-  }${toggleable ? ' chat__progress-step--toggle' : ''}${
+  }${item.expandable ? ' chat__progress-step--toggle' : ''}${
     labelExpanded ? ' chat__progress-step--expanded' : ''
   }`
   const label = (
-    <span ref={labelRef} className="chat__progress-step-label">
+    <span className="chat__progress-step-label">
       {item.label}
     </span>
   )
@@ -51,7 +24,6 @@ function ProgressStep({ item, detailsExpanded, onDetailsToggle }) {
   if (!item.expandable) {
     return (
       <span
-        ref={stepRef}
         className={className}
         aria-current={item.current ? 'step' : undefined}
         title={title}
@@ -63,16 +35,12 @@ function ProgressStep({ item, detailsExpanded, onDetailsToggle }) {
 
   return (
     <button
-      ref={stepRef}
       type="button"
       className={`${className} chat__progress-step--button`}
       aria-current={item.current ? 'step' : undefined}
       aria-expanded={expanded}
-      aria-label={toggleable
-        ? `${actionLabel || (expanded ? 'Collapse' : 'Expand')}: ${accessibleLabel}`
-        : accessibleLabel}
-      title={toggleable ? (actionLabel || (expanded ? 'Collapse' : title)) : title}
-      disabled={!toggleable}
+      aria-label={`${expanded ? 'Collapse' : 'Expand'}: ${accessibleLabel}`}
+      title={expanded ? 'Collapse' : title}
       onClick={() => {
         if (hasDetails) onDetailsToggle?.()
         else setLabelExpanded(value => !value)
@@ -80,21 +48,15 @@ function ProgressStep({ item, detailsExpanded, onDetailsToggle }) {
     >
       {label}
       {hasDetails && (
-        <>
-          {actionLabel && (
-            <span className="chat__progress-step-action" aria-hidden="true">
-              {actionLabel}
-            </span>
-          )}
-          <span className="chat__progress-toggle-mark" aria-hidden="true" />
-        </>
+        <span className="chat__progress-toggle-mark" aria-hidden="true" />
       )}
     </button>
   )
 }
 
-export default function ProgressRail({ items, ariaLabel }) {
+export default function ProgressRail({ items, ariaLabel, resetKey }) {
   const [detailsKey, setDetailsKey] = useState(null)
+  useEffect(() => setDetailsKey(null), [resetKey])
   if (!items.length) return null
   const detailItem = items.find(item => item.key === detailsKey && item.details)
   return (

--- a/frontend/src/components/ChatView/__tests__/goalProgress.test.js
+++ b/frontend/src/components/ChatView/__tests__/goalProgress.test.js
@@ -3,10 +3,13 @@ import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
 
 import {
+  compactGoalObjective,
+  goalObjectiveForQueuedStart,
   goalObjectiveAtRunStart,
   goalObjectiveFromText,
   goalObjectiveFromRuntime,
   goalMessageObjectiveFromText,
+  goalTaskDisplayStatus,
   latestGoalObjective,
   newestGoalPlan,
   progressRailViewModel,
@@ -19,6 +22,10 @@ const streamConnection = readFileSync(
   'utf8',
 )
 const progressRail = readFileSync(new URL('../ProgressRail.jsx', import.meta.url), 'utf8')
+const goalPlanDetails = readFileSync(
+  new URL('../GoalPlanDetails.jsx', import.meta.url),
+  'utf8',
+)
 const msgContent = readFileSync(new URL('../MsgContent.jsx', import.meta.url), 'utf8')
 const chatCss = readFileSync(new URL('../ChatView.css', import.meta.url), 'utf8')
 
@@ -83,6 +90,14 @@ test('latestGoalObjective recovers only the current visible owner turn', () => {
   ]), 'build the indicator')
 })
 
+test('compact Goal objectives are canonical before the first paint', () => {
+  assert.equal(
+    compactGoalObjective('Review every issue\nthen verify the result'),
+    'Review every issue then verify the result',
+  )
+  assert.equal(compactGoalObjective(null), '')
+})
+
 test('a resumable continue keeps the same goal through live start and cold attach', () => {
   const interruptedGoal = [
     { role: 'user', content: '/goal finish the migration' },
@@ -108,6 +123,15 @@ test('a resumable continue keeps the same goal through live start and cold attac
     ]),
     'finish the migration',
   )
+})
+
+test('a queued child-result continuation keeps the committed Goal without jitter', () => {
+  assert.equal(goalObjectiveForQueuedStart({
+    content: '<delegation_results>[]</delegation_results>',
+    hidden: true,
+    kind: 'delegation_result',
+    _goal_objective: 'Ship the audited result',
+  }, []), 'Ship the audited result')
 })
 
 test('continuation recovery preserves only an active goal', () => {
@@ -138,9 +162,17 @@ test('continuation recovery preserves only an active goal', () => {
     active_goal_objective: 'authoritative goal',
   }, 'stale goal'), 'authoritative goal')
   assert.equal(goalObjectiveFromRuntime({
+    running: true,
+    active_goal_objective: 'Review every issue\nthen verify the result',
+  }), 'Review every issue then verify the result')
+  assert.equal(goalObjectiveFromRuntime({
     running: false,
     active_goal_objective: null,
   }, 'finished goal'), '')
+  assert.equal(goalObjectiveFromRuntime({
+    running: false,
+    active_goal_objective: 'Waiting for delegated checks',
+  }, 'stale goal'), 'Waiting for delegated checks')
 })
 
 test('the goal reuses the progress rail and stays as context for build phases', () => {
@@ -192,25 +224,10 @@ test('a planned goal shows every running branch and dependency progress', () => 
   assert.deepEqual(progressRailViewModel('Ship it', [], plan), [
     {
       key: 'goal',
-      label: 'Goal plan · 1 of 4',
+      label: 'Goal · 1/4 · Run A · 2/3 + Run B',
       expandable: true,
-      hasDetails: true,
       title: 'Goal: Ship it',
-      ariaLabel: 'Goal plan for Ship it; 1 of 4 tasks complete',
-      actionLabel: 'View tasks',
-      expandedActionLabel: 'Hide tasks',
-      current: false,
-    },
-    {
-      key: 'goal-task-a',
-      label: 'Now · Run A · 2/3',
-      goalTask: true,
-      current: true,
-    },
-    {
-      key: 'goal-task-b',
-      label: 'Now · Run B',
-      goalTask: true,
+      ariaLabel: 'Goal for Ship it; 1 of 4 complete',
       current: true,
     },
   ])
@@ -226,9 +243,103 @@ test('a plan with no running work presents every independent ready task', () => 
     ],
   }
   assert.deepEqual(
-    visibleGoalTasks(plan).map(task => [task.id, task.activity]),
-    [['a', 'Next'], ['b', 'Next']],
+    visibleGoalTasks(plan).map(task => task.id),
+    ['a', 'b'],
   )
+})
+
+test('the deepest live delegated owners replace their parent in the collapsed label', () => {
+  const plan = {
+    tasks: [{ id: 'b', title: 'Do B', status: 'running' }],
+    delegations: [{
+      id: 'delegation-b', task_key: 'b', status: 'running', children: [
+        { id: 'delegation-x', task_key: 'x', status: 'running', children: [] },
+        { id: 'delegation-y', task_key: 'y', status: 'running', children: [] },
+      ],
+    }],
+  }
+  assert.deepEqual(
+    visibleGoalTasks(plan).map(task => task.title),
+    ['X', 'Y'],
+  )
+})
+
+test('delegated leaves stay beside independent local running work', () => {
+  const plan = {
+    tasks: [
+      { id: 'a', title: 'Delegated A', status: 'running' },
+      { id: 'b', title: 'Local B', status: 'running' },
+    ],
+    delegations: [{
+      id: 'delegation-a', task_key: 'a', status: 'running', children: [
+        { id: 'delegation-x', task_key: 'x', status: 'running', children: [] },
+      ],
+    }],
+  }
+  assert.deepEqual(
+    visibleGoalTasks(plan).map(task => task.title),
+    ['Local B', 'X'],
+  )
+  const completedAncestors = {
+    tasks: [
+      { id: 'audit', title: 'Audit', status: 'running' },
+      { id: 'other', title: 'Other', status: 'running' },
+    ],
+    delegations: [{
+      id: 'delegation-audit', task_key: 'audit', status: 'completed', children: [{
+        id: 'delegation-detail', task_key: 'detail', status: 'completed', children: [{
+          id: 'delegation-leaf', task_key: 'leaf-check', status: 'running', children: [],
+        }],
+      }],
+    }],
+  }
+  assert.deepEqual(
+    visibleGoalTasks(completedAncestors).map(task => task.title),
+    ['Other', 'Leaf check'],
+  )
+})
+
+test('the deepest running plan nodes replace coordinating parents', () => {
+  const plan = {
+    tasks: [
+      { id: 'root', title: 'Coordinate', status: 'running' },
+      { id: 'branch', parent_id: 'root', title: 'Inspect branch', status: 'running' },
+      { id: 'leaf', parent_id: 'branch', title: 'Verify leaf', status: 'running' },
+      { id: 'parallel', parent_id: 'root', title: 'Check parallel path', status: 'running' },
+    ],
+  }
+  assert.deepEqual(
+    visibleGoalTasks(plan).map(task => task.id),
+    ['leaf', 'parallel'],
+  )
+})
+
+test('malformed parent cycles cannot hang current-work selection', () => {
+  const plan = {
+    tasks: [
+      { id: 'a', parent_id: 'b', title: 'A', status: 'running' },
+      { id: 'b', parent_id: 'a', title: 'B', status: 'running' },
+    ],
+  }
+  assert.deepEqual(visibleGoalTasks(plan), [])
+})
+
+test('malformed delegation cycles cannot recurse forever', () => {
+  const a = { id: 'a', task_key: 'a', status: 'running', children: [] }
+  const b = { id: 'b', task_key: 'b', status: 'running', children: [a] }
+  a.children = [b]
+  assert.deepEqual(
+    visibleGoalTasks({ delegations: [a] }).map(task => task.id),
+    ['b'],
+  )
+})
+
+test('live delegated execution outranks a stale completed task presentation', () => {
+  const task = { id: 'audit', status: 'completed' }
+  assert.equal(goalTaskDisplayStatus(task, { status: 'running' }), 'running')
+  assert.equal(goalTaskDisplayStatus(task, { status: 'paused' }), 'running')
+  assert.equal(goalTaskDisplayStatus(task, { status: 'needs_review' }), 'failed')
+  assert.equal(goalTaskDisplayStatus(task, { status: 'completed' }), 'completed')
 })
 
 test('ChatView binds goal state to explicit run boundaries, not transport liveness', () => {
@@ -250,7 +361,7 @@ test('ChatView binds goal state to explicit run boundaries, not transport livene
   for (const suffix of runStarts) {
     assert.match(
       suffix.slice(0, 380),
-      /setActiveGoalState\(goalObjectiveAtRunStart\(/,
+      /setActiveGoalState\(goalObjective(?:AtRunStart|ForQueuedStart)\(/,
       'goal and build progress must reset together at each run boundary',
     )
   }
@@ -261,8 +372,8 @@ test('ChatView binds goal state to explicit run boundaries, not transport livene
   )
   assert.match(
     chatView,
-    /setServerRunningState\(false\)\s*setActiveGoalState\(''\)\s*\/\/ Stream ended without continuation/,
-    'a terminal stream boundary must retire its goal indication',
+    /setServerRunningState\(false\)[\s\S]{0,180}activeGoalPlan\?\.summary\?\.can_complete !== false[\s\S]{0,100}setActiveGoalState\(''\)/,
+    'a terminal stream should retain an unfinished delegated Goal but retire a settled one',
   )
   assert.match(
     chatView,
@@ -286,7 +397,7 @@ test('ChatView binds goal state to explicit run boundaries, not transport livene
   )
   assert.match(
     chatView,
-    /activeGoalObjective: objective/,
+    /activeGoalObjective: compactObjective/,
     'the existing chat cache should retain a goal across chat switches and steers',
   )
   assert.match(
@@ -299,6 +410,12 @@ test('ChatView binds goal state to explicit run boundaries, not transport livene
     /<ProgressRail\s+items=\{progressRail\}/,
     'the goal should render through the shared progress rail',
   )
+  assert.doesNotMatch(
+    chatView,
+    /<ProgressRail[\s\S]{0,160}\skey=/,
+    'late plan data must not remount the rail and replay its entrance animation',
+  )
+  assert.match(progressRail, /useEffect\(\(\) => setDetailsKey\(null\), \[resetKey\]\)/)
   assert.match(
     chatView,
     /`Following goal: \$\{activeGoalObjective\}\.`/,
@@ -306,9 +423,15 @@ test('ChatView binds goal state to explicit run boundaries, not transport livene
   )
   assert.match(progressRail, /chat__progress-rail/)
   assert.match(progressRail, /aria-expanded=\{expanded\}/)
-  assert.match(progressRail, /chat__progress-step-action/)
-  assert.match(progressRail, /expandedActionLabel/)
-  assert.match(progressRail, /label\.scrollWidth > step\.clientWidth/)
+  assert.doesNotMatch(progressRail, /chat__progress-step-action/)
+  assert.doesNotMatch(progressRail, /expandedActionLabel/)
+  assert.doesNotMatch(progressRail, /ResizeObserver|scrollWidth|clientWidth/)
+  assert.doesNotMatch(
+    chatCss,
+    /\.chat__progress-step--button:hover/,
+    'the Goal header should toggle without a selected-looking hover fill',
+  )
+  assert.match(progressRail, /aria-label=\{`\$\{expanded \? 'Collapse' : 'Expand'\}/)
   assert.match(
     chatCss,
     /\.chat__foot \.chat__progress-step--toggle[\s\S]*?\{ pointer-events: auto; \}/,
@@ -316,4 +439,19 @@ test('ChatView binds goal state to explicit run boundaries, not transport livene
   )
   assert.doesNotMatch(progressRail, /goal|build/i,
     'the shared rail should not encode one producer’s domain')
+  assert.match(
+    goalPlanDetails,
+    /className="chat__goal-branch" role="listitem"[\s\S]*?role="list"/,
+    'expanded Goal hierarchy should expose nested list semantics',
+  )
+  assert.match(
+    goalPlanDetails,
+    /execution = delegatedByTask\.get\(task\.id\)/,
+    'a nested plan task without a child-local match should retain root execution fallback',
+  )
+  assert.match(
+    goalPlanDetails,
+    /status=\{goalTaskDisplayStatus\(task, execution\)\}/,
+    'live delegated execution should own the row presentation state',
+  )
 })

--- a/frontend/src/components/ChatView/goalProgress.js
+++ b/frontend/src/components/ChatView/goalProgress.js
@@ -19,8 +19,13 @@ function goalCommandObjective(text) {
   return objective
 }
 
+/** Canonical one-line objective used by every compact Goal surface. */
+export function compactGoalObjective(objective) {
+  return String(objective || '').replace(/\s+/g, ' ').trim()
+}
+
 export function goalObjectiveFromText(text) {
-  return goalCommandObjective(text).replace(/\s+/g, ' ')
+  return compactGoalObjective(goalCommandObjective(text))
 }
 
 /** Keep the owner's formatting while hiding the command token in the bubble. */
@@ -110,10 +115,21 @@ export function goalObjectiveAtRunStart(text, messages) {
   return priorGoalObjective(messages, tailIndex)
 }
 
+/** Prefer the ChatRun identity committed with a queue promotion over parsing. */
+export function goalObjectiveForQueuedStart(message, messages) {
+  if (message && Object.hasOwn(message, '_goal_objective')) {
+    return compactGoalObjective(message._goal_objective)
+  }
+  return goalObjectiveAtRunStart(message?.content, messages)
+}
+
 /** Keep a known goal through a rolling/recovered active runtime; idle ends it. */
 export function goalObjectiveFromRuntime(runtime, fallbackObjective = '') {
+  if (runtime?.active_goal_objective) {
+    return compactGoalObjective(runtime.active_goal_objective)
+  }
   if (!runtime?.running) return ''
-  return runtime.active_goal_objective || fallbackObjective || ''
+  return compactGoalObjective(fallbackObjective)
 }
 
 /**
@@ -131,14 +147,67 @@ function progressLabel(task) {
   return task?.title || ''
 }
 
+/** Present the live execution owner rather than a stale optimistic task state. */
+export function goalTaskDisplayStatus(task, execution) {
+  if (!execution || execution.status === 'completed') return task?.status
+  if (['starting', 'running', 'resuming', 'paused'].includes(execution.status)) {
+    return 'running'
+  }
+  if (['failed', 'needs_review', 'interrupted'].includes(execution.status)) {
+    return 'failed'
+  }
+  return execution.status
+}
+
+function deepestPlanTasks(tasks, candidates) {
+  const byId = new Map(tasks.map(task => [task.id, task]))
+  const candidateIds = new Set(candidates.map(task => task.id))
+  const shadowedAncestors = new Set()
+  for (const task of candidates) {
+    let parent = byId.get(task.parent_id)
+    const visited = new Set()
+    while (parent && !visited.has(parent.id)) {
+      visited.add(parent.id)
+      if (candidateIds.has(parent.id)) shadowedAncestors.add(parent.id)
+      parent = byId.get(parent.parent_id)
+    }
+  }
+  return candidates.filter(task => !shadowedAncestors.has(task.id))
+}
+
 /** Active work first; when nothing is running, expose every newly ready task. */
 export function visibleGoalTasks(goalPlan) {
+  const activeStatuses = new Set(['starting', 'running', 'resuming', 'paused'])
+  const delegatedLeaves = []
+  const delegatedTaskKeys = new Set()
+  const collectDelegatedLeaves = (node, ancestors = new Set()) => {
+    if (!node || ancestors.has(node.id)) return false
+    const branch = new Set(ancestors).add(node.id)
+    let childActive = false
+    for (const child of node?.children || []) {
+      childActive = collectDelegatedLeaves(child, branch) || childActive
+    }
+    const ownActive = activeStatuses.has(node?.status)
+    const subtreeActive = ownActive || childActive
+    if (subtreeActive && node?.task_key) delegatedTaskKeys.add(node.task_key)
+    if (ownActive && !childActive) {
+      const title = String(node.task_key || '')
+        .replace(/[._-]+/g, ' ')
+        .replace(/^./, letter => letter.toUpperCase())
+      delegatedLeaves.push({ id: node.id, title, status: 'running' })
+    }
+    return subtreeActive
+  }
+  ;(goalPlan?.delegations || []).forEach(node => collectDelegatedLeaves(node))
   const tasks = Array.isArray(goalPlan?.tasks) ? goalPlan.tasks : []
-  const running = tasks.filter(task => task?.status === 'running')
-  if (running.length) return running.map(task => ({ ...task, activity: 'Now' }))
-  return tasks
-    .filter(task => task?.ready === true)
-    .map(task => ({ ...task, activity: 'Next' }))
+  const running = deepestPlanTasks(
+    tasks,
+    tasks.filter(task => task?.status === 'running'),
+  ).filter(task => !delegatedTaskKeys.has(task.id))
+  if (running.length || delegatedLeaves.length) {
+    return [...running, ...delegatedLeaves]
+  }
+  return deepestPlanTasks(tasks, tasks.filter(task => task?.ready === true))
 }
 
 export function progressRailViewModel(goalObjective, buildPhases, goalPlan = null) {
@@ -147,27 +216,20 @@ export function progressRailViewModel(goalObjective, buildPhases, goalPlan = nul
     const completed = goalPlan?.summary?.completed
     const total = goalPlan?.summary?.total
     const planned = Number.isInteger(completed) && Number.isInteger(total)
+    const activeTasks = visibleGoalTasks(goalPlan)
+    const activeLabels = activeTasks.map(progressLabel).filter(Boolean)
     items.push({
       key: 'goal',
       label: planned
-        ? `Goal plan · ${completed} of ${total}`
+        ? `Goal · ${completed}/${total}${
+          activeLabels.length ? ` · ${activeLabels.join(' + ')}` : ''
+        }`
         : `Goal · ${goalObjective}`,
       expandable: true,
       ...(goalPlan ? {
-        hasDetails: true,
         title: `Goal: ${goalObjective}`,
-        ariaLabel: `Goal plan for ${goalObjective}; ${completed} of ${total} tasks complete`,
-        actionLabel: 'View tasks',
-        expandedActionLabel: 'Hide tasks',
+        ariaLabel: `Goal for ${goalObjective}; ${completed} of ${total} complete`,
       } : {}),
-    })
-  }
-  const activeTasks = goalObjective ? visibleGoalTasks(goalPlan) : []
-  for (const task of activeTasks) {
-    items.push({
-      key: `goal-task-${task.id}`,
-      label: `${task.activity} · ${progressLabel(task)}`,
-      goalTask: true,
     })
   }
   const phases = Array.isArray(buildPhases) ? buildPhases : []
@@ -178,14 +240,8 @@ export function progressRailViewModel(goalObjective, buildPhases, goalPlan = nul
       label: phase.label,
     })
   }
-  const hasPhases = phases.some(phase => phase?.label)
-  const hasActiveTasks = activeTasks.length > 0
   return items.map((item, index) => ({
     ...item,
-    current: hasPhases
-      ? index === items.length - 1
-      : hasActiveTasks
-        ? item.goalTask === true
-        : index === items.length - 1,
+    current: index === items.length - 1,
   }))
 }

--- a/frontend/src/components/ChatView/hooks/__tests__/usePendingQueue.test.js
+++ b/frontend/src/components/ChatView/hooks/__tests__/usePendingQueue.test.js
@@ -88,6 +88,29 @@ test('a steer reservation hides a row without removing its durable queue record'
   )
 })
 
+test('hidden product events remain durable but never enter the owner queue tray', () => {
+  const { result } = renderHook(() => usePendingQueue([
+    { role: 'user', content: 'owner follow-up', ts: 1, cid: 'owner' },
+    {
+      role: 'user', content: 'internal child result', ts: 2, cid: 'product',
+      hidden: true, kind: 'delegation_result',
+    },
+  ]))
+
+  assert.deepEqual(
+    result.current.pendingMessagesRef.current.map(m => m.cid),
+    ['owner', 'product'],
+  )
+  assert.deepEqual(
+    result.current.visiblePendingMessages.map(m => m.cid),
+    ['owner'],
+  )
+  assert.deepEqual(
+    result.current.getVisiblePendingMessages().map(m => m.cid),
+    ['owner'],
+  )
+})
+
 test('a deferred-cut hydrate keeps a reserved row hidden until its cut', () => {
   const { result } = renderHook(() => usePendingQueue([
     { role: 'user', content: 'first', ts: 1, cid: 'a' },

--- a/frontend/src/components/ChatView/hooks/usePendingQueue.js
+++ b/frontend/src/components/ChatView/hooks/usePendingQueue.js
@@ -171,12 +171,12 @@ export default function usePendingQueue(initialServerList = []) {
 
   const getVisiblePendingMessages = useCallback(
     () => pendingMessagesRef.current.filter(
-      msg => !steerReservedCidsRef.current.has(cidOf(msg)),
+      msg => !msg.hidden && !steerReservedCidsRef.current.has(cidOf(msg)),
     ),
     [],
   )
   const visiblePendingMessages = pendingMessages.filter(
-    msg => !steerReservedCids.has(cidOf(msg)),
+    msg => !msg.hidden && !steerReservedCids.has(cidOf(msg)),
   )
 
   // Internal helper: synchronously update both the ref and React state. Every


### PR DESCRIPTION
## Summary

- let agents grow an active Goal with nested, dependency-aware subgoals as substantial work is discovered
- show the deepest live branches in the compact Goal header and the complete hierarchy when it is expanded
- allow bounded Claude delegated children to create read-only descendants while preserving immediate-parent ownership across restarts
- keep child-completion events out of the owner transcript while they update the Goal and wake the correct parent work
- keep an idle parent Goal visible until its plan and delegated descendants settle, then require parent verification before completion
- bind delegated authority to the exact child run and settle descendants before chat or app deletion
- compact multiline Goal labels before first paint and make the full Goal header the expand/collapse target

## Safety boundaries

- nested Claude delegation is capped at four levels
- read-only parents cannot create write-capable children
- delegated tokens are limited to one delegation, child chat, app, and active physical run
- a nested child cannot bypass a provider paused in the Subagents app
- nested Codex delegation is rejected until a narrow local-only bridge exists; ordinary parent Goals can still delegate directly to Codex
- cancellation and deletion settle deepest descendants before their owners

## Prior work

Builds on #807, which introduced dependency-aware Goal plans. #824 introduced conservative routing, and #827 corrects that routing through a provider-neutral platform transition. This PR keeps promotion policy separate and focuses on dynamic hierarchy, durable delegation ownership, and the Goal UI; #827 should land first.

## Verification

- targeted Goal, delegation, migration, and wake backend tests: 119 passed
- broader affected auth, lifecycle, provider-runner, and app backend tests: 344 passed
- hermetic fast backend suite: 83 passed
- full frontend unit suite: 2,613 passed
- frontend lint: 0 errors (44 pre-existing warnings remain)
- migration history guard: 15 immutable migrations verified

The complete Docker backend suite and isolated browser suite were not available in this runtime and remain CI gates.
