### PR TITLE
Keep app-owned skills current after local apply

### DIFF
--- a/backend/app/app_apply.py
+++ b/backend/app/app_apply.py
@@ -55,6 +55,32 @@ log = logging.getLogger("mobius.app_apply")
 class ApplyResult:
   app: models.App
   mode: Literal["created", "updated", "unchanged"]
+  warnings: tuple[str, ...] = ()
+
+
+async def _sync_accepted_app_skills(
+  db: Session, app: models.App, manifest: dict | None,
+) -> tuple[str, ...]:
+  """Refresh declared skills at the same acceptance boundary as app source."""
+  from app import install
+
+  if manifest is None:
+    contract = app.capability_contract or {}
+    agent = contract.get("agent") if isinstance(contract, dict) else None
+    skills = agent.get("skills") if isinstance(agent, dict) else None
+    manifest = {
+      # Store metadata remains authoritative for WHICH skills are approved;
+      # the accepted local source revision owns their current bytes.
+      "skills": skills if isinstance(skills, list) else [],
+      "version": "accepted-local-revision",
+    }
+  warnings: list[str] = []
+  try:
+    await install._sync_app_skills(db, app, manifest, warnings)
+  except Exception as exc:
+    log.exception("app apply: skill sync failed post-commit")
+    warnings.append(f"skills: sync failed — {exc!r}")
+  return tuple(warnings)
 
 
 async def _git_operation(label: str, fn, *args):
@@ -382,7 +408,8 @@ async def apply_source_revision(
       )
       if not changed:
         db.rollback()
-        return ApplyResult(app=app, mode="unchanged")
+        warnings = await _sync_accepted_app_skills(db, app, manifest)
+        return ApplyResult(app=app, mode="unchanged", warnings=warnings)
 
       app.jsx_source = source
       app.compiled_path = str(published)
@@ -397,7 +424,12 @@ async def apply_source_revision(
       if previous_bundle != published:
         unlink_app_bundle(app.id, previous_bundle)
       db.refresh(app)
-      return ApplyResult(app=app, mode="created" if created else "updated")
+      warnings = await _sync_accepted_app_skills(db, app, manifest)
+      return ApplyResult(
+        app=app,
+        mode="created" if created else "updated",
+        warnings=warnings,
+      )
   except Exception:
     db.rollback()
     if staged is not None:

--- a/backend/app/routes/apps.py
+++ b/backend/app/routes/apps.py
@@ -1521,7 +1521,9 @@ async def apply_app_source(
         "appId": str(result.app.id),
         "chatId": str(body.chat_id),
       })
-  return schemas.AppApplyOut(mode=result.mode, app=result.app)
+  return schemas.AppApplyOut(
+    mode=result.mode, app=result.app, warnings=list(result.warnings)
+  )
 
 
 def _pending_store_update_app(

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -339,6 +339,7 @@ class AppOut(BaseModel):
 class AppApplyOut(BaseModel):
   mode: Literal["created", "updated", "unchanged"]
   app: AppOut
+  warnings: list[str] = Field(default_factory=list)
 
 
 class AppInstall(BaseModel):

--- a/backend/scripts/apply_app.py
+++ b/backend/scripts/apply_app.py
@@ -27,6 +27,7 @@ def _receipt(result: dict) -> dict:
     "chat_id": app.get("chat_id"),
     "preview_path": f"/app/{app_id}",
     "open_path": f"/shell/?app={app_id}",
+    "warnings": result.get("warnings") or [],
   }
 
 

--- a/backend/tests/test_app_apply.py
+++ b/backend/tests/test_app_apply.py
@@ -114,6 +114,58 @@ def test_apply_updates_multifile_revision_once(client, auth, db):
   ]
 
 
+def test_apply_refreshes_manifest_declared_skill_on_create_and_update(
+  client, auth,
+):
+  source = _source()
+  manifest = json.loads((source / "mobius.json").read_text())
+  manifest["skills"] = ["guide.md"]
+  manifest["source_files"] = ["guide.md"]
+  (source / "mobius.json").write_text(json.dumps(manifest))
+  (source / "guide.md").write_text("# First guidance\n")
+
+  created = _apply(client, auth, source)
+
+  assert created.status_code == 200, created.text
+  shared = Path(get_settings().data_dir) / "shared" / "skills" / "guide.md"
+  assert shared.read_text() == "# First guidance\n"
+  assert created.json()["warnings"] == []
+
+  (source / "guide.md").write_text("# Revised guidance\n")
+  updated = _apply(client, auth, source)
+
+  assert updated.status_code == 200, updated.text
+  assert shared.read_text() == "# Revised guidance\n"
+  assert updated.json()["warnings"] == []
+
+
+def test_store_managed_apply_refreshes_only_previously_approved_skills(
+  client, auth, db,
+):
+  source = _source()
+  manifest = json.loads((source / "mobius.json").read_text())
+  manifest["skills"] = ["guide.md"]
+  manifest["source_files"] = ["guide.md"]
+  (source / "mobius.json").write_text(json.dumps(manifest))
+  (source / "guide.md").write_text("# Installed guidance\n")
+  created = _apply(client, auth, source)
+  app_id = created.json()["app"]["id"]
+  row = db.query(models.App).populate_existing().filter_by(id=app_id).one()
+  row.manifest_url = "https://example.test/demo/mobius.json"
+  contract = dict(row.capability_contract or {})
+  contract["agent"] = {**(contract.get("agent") or {}), "skills": ["guide.md"]}
+  row.capability_contract = contract
+  db.commit()
+  (source / "guide.md").write_text("# Locally revised guidance\n")
+
+  updated = _apply(client, auth, source)
+
+  assert updated.status_code == 200, updated.text
+  shared = Path(get_settings().data_dir) / "shared" / "skills" / "guide.md"
+  assert shared.read_text() == "# Locally revised guidance\n"
+  assert updated.json()["warnings"] == []
+
+
 def test_startup_retires_integrated_app_provenance(client, auth, db):
   source = _source()
   created = _apply(client, auth, source)

--- a/backend/tests/test_app_apply.py
+++ b/backend/tests/test_app_apply.py
@@ -166,6 +166,26 @@ def test_store_managed_apply_refreshes_only_previously_approved_skills(
   assert updated.json()["warnings"] == []
 
 
+def test_apply_route_forwards_skill_sync_warnings(client, auth, monkeypatch):
+  # A partial skill sync (oversize skill, snapshot failure, ownership conflict)
+  # is non-fatal but must reach the apply receipt, not be silently dropped at
+  # the HTTP boundary — that silent staleness is exactly what this path fixes.
+  from app import install
+
+  async def _warn(_db, _app, _manifest, warnings):
+    warnings.append("skill guide.md: exceeds 262144 bytes — skipped")
+
+  monkeypatch.setattr(install, "_sync_app_skills", _warn)
+
+  created = _apply(client, auth, _source())
+
+  assert created.status_code == 200, created.text
+  assert (
+    "skill guide.md: exceeds 262144 bytes — skipped"
+    in created.json()["warnings"]
+  )
+
+
 def test_startup_retires_integrated_app_provenance(client, auth, db):
   source = _source()
   created = _apply(client, auth, source)

--- a/backend/tests/test_apply_app_script.py
+++ b/backend/tests/test_apply_app_script.py
@@ -47,6 +47,7 @@ def test_apply_prints_compact_reusable_identity_receipt(
     "urlopen",
     lambda request, timeout: _Response({
       "mode": "created",
+      "warnings": ["skill guide.md: left unchanged"],
       "app": {
         "id": 73,
         "name": "Same name",
@@ -70,6 +71,7 @@ def test_apply_prints_compact_reusable_identity_receipt(
     "chat_id": "building-chat",
     "preview_path": "/app/73",
     "open_path": "/shell/?app=73",
+    "warnings": ["skill guide.md: left unchanged"],
   }
 
 


### PR DESCRIPTION
## Summary
- refresh manifest-declared skills whenever a local app revision is accepted
- let unchanged re-applies repair a stale installed skill copy
- for Store-managed apps, update only the skill files already approved by the installed capability contract
- return best-effort synchronization warnings in the app-apply receipt

## Why
Applying an app source revision updated its code but not the shared skill files agents actually read. An app could therefore run new behavior while continuing to teach agents an obsolete contract.

The accepted app revision now owns the bytes at the same boundary as its code. Store metadata remains authoritative for which skills are allowed, so a local edit cannot add a new skill or widen capability scope.

## Prior work
[#146](https://github.com/mobius-os/mobius/pull/146) established the shared skill installation and synchronization layer. This change connects the local app-apply path to that existing owner rather than creating another copy mechanism.

## Verification
- 83 hermetic backend contract tests passed on the current upstream base
- focused app-apply, helper-receipt, and app-skill tests passed
- live Store-managed re-apply updated both the shared skill and Codex-native cache without warnings
- `git diff --check`

The full containerized backend suite was not available in this runtime because Docker is unavailable; hosted checks remain the complete gate.