### PR TITLE
Stop older-history auto-fill from hammering after a failed page

### DIFF
--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -2301,6 +2301,11 @@ export default function ChatView({
   useLayoutEffect(() => {
     const el = scrollRef.current
     if (!el || loadingOlder.current || loading || offset <= 0) return
+    // A failed page must hand control to the manual retry button, not auto-fill
+    // again: the failed fetch added no rows, so the surface is still
+    // non-scrollable and this dependency-less effect would otherwise re-fire and
+    // re-fetch on every render — an unbounded, backoff-free request storm.
+    if (olderHistoryError) return
     if (olderHistoryShouldLoad(el)) loadOlderMessages()
   })
 
@@ -2322,7 +2327,7 @@ export default function ChatView({
   function handleScroll() {
     updateJumpToLatest()
     const el = scrollRef.current
-    if (!el || loadingOlder.current || loading) return
+    if (!el || loadingOlder.current || loading || olderHistoryError) return
     // Programmatic scrolls can land near the top, so the shared gesture window
     // still owns intent. Prefetch before the loaded-page boundary can become a
     // visible interruption instead of waiting for the absolute top.


### PR DESCRIPTION
## Summary

The automatic older-history prefetch added in #752 can turn a single failed page load into an unbounded, backoff-free request storm.

The dependency-less auto-fill `useLayoutEffect` refetches older history whenever the scroll surface isn't yet scrollable and older history remains. Its guard ignored `olderHistoryError`, so a failed page — which adds no rows and leaves the surface non-scrollable — re-satisfies the guard on the very next render and refetches immediately. On offline / connection-refused / HTTP 500 the fetch rejects near-instantly, so requests fire back-to-back as fast as they can fail, and the `olderHistoryError` boolean toggles each cycle so the intended "Earlier messages didn't load — retry" button flickers and is effectively bypassed.

## Fix

- Skip the auto-fill effect while `olderHistoryError` is latched, so a failed page defers to the explicit retry button.
- Apply the same guard to the scroll-driven prefetch trigger for consistency.

A successful manual retry clears the flag (`loadOlderMessages` sets `olderHistoryError` false), which re-enables auto-fill — only persistent failures stop the retries.

## Testing

Frontend ChatView unit suite passes (1002 tests). The failure path is exercised end-to-end by the queue's e2e run.

Co-authored-by: Möbius Agent <mobius-agent@users.noreply.github.com>