### PR TITLE
Release the launch cover if a restored chat crashes on mount

### DIFF
--- a/frontend/src/components/Shell/PaneChatView.jsx
+++ b/frontend/src/components/Shell/PaneChatView.jsx
@@ -50,6 +50,7 @@ function PaneChatView({
   onChatMissing,
   onFirstMessage,
   onDisplayReady,
+  onChatBoundaryError,
 }) {
   // builtApps is derived PER chatId, memoized on the same signature Shell uses
   // for the primary chat — an unrelated app's refetch is a no-op for this pane.
@@ -128,6 +129,7 @@ function PaneChatView({
       variant="inline"
       label="chat"
       recoveryKey={`chat:${chatId}`}
+      onError={onChatBoundaryError}
     >
       <ChatView
         key={chatId}

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -3999,6 +3999,7 @@ export default function Shell({ onInitialVisualReady }) {
                 onDisplayReady={role === 'held' || !surfaceVisible
                   ? null
                   : handlePaneChatDisplayReady}
+                onChatBoundaryError={markInitialVisualReady}
               />
             </div>
           )


### PR DESCRIPTION
## Summary

The visual-ready handoff added in #756 can leave the app **permanently wedged behind the opaque launch cover** if the restored active chat throws during its initial render.

The cover is released only by the chat's display-ready callback, and the fallback effect deliberately waits when `activeView === 'chat' && activeChatId`. But `ChatView` is wrapped in an inline `ErrorBoundary` with **no `onError`**. So a render-time crash on cold launch (a corrupt cached transcript/message/draft) is caught by that inner boundary: `onDisplayReady` never fires, the top-level `onError={removeSplash}` never runs, and index.html's timed recovery is skipped because `#root` already has children. The result is a blank full-viewport cover that stays up forever, hiding the inline retry UI — strictly worse than the pre-#756 behavior.

## Fix

Thread the idempotent `markInitialVisualReady` into the inline chat `ErrorBoundary`'s `onError`, so a contained ChatView crash releases the cover and reveals its own recovery UI (mirroring `App.jsx`'s top-level `onError={removeSplash}`).

## Follow-up (not in this PR)

A restored chat that never reaches display-ready *without* crashing (a stalled stream, or a surface that never becomes the visible owner) has the same wedge and no timeout backstop; a bounded safety-net timer that restores the removed index.html recovery would close that gap.

## Testing

Shell unit suite passes (589 tests). The crash-release path is exercised by the queue's e2e run.

Co-authored-by: Möbius Agent <mobius-agent@users.noreply.github.com>