### PR TITLE
Runner-only concise register for the Claude runner

### DIFF
--- a/backend/app/claude_sdk_runner.py
+++ b/backend/app/claude_sdk_runner.py
@@ -103,6 +103,32 @@ from app.runtime_types import RunnerResult
 
 log = logging.getLogger(__name__)
 
+# --- Provider register (documented amendment to system_prompts.py's contract) ---
+# The per-chat snapshot in `system_prompts.py` is the identical behavioral
+# constitution handed to every provider. A runner MAY append its own small,
+# provider-authored behavioral register on top of that shared base — the narrow,
+# deliberate exception that module's contract now allows. The Codex runner
+# declares none, so it is unaffected. This is the Claude runner's concise
+# register: appended AFTER the constitution, never substituted for it.
+_CONCISE_REGISTER = r"""# Concise register
+
+Be concise by default: lead with the result, skip preamble and narration, keep only what the partner needs — full detail on request. Concision trims length and preamble, never substance: it never drops a required citation, the escaped `\$` for currency, a screenshot embedded before you describe it, the detail the platform summary or a future continuation needs, or the deliberate speech acts the constitution requires (the one-sentence intent opener, making non-obvious findings explicit, clarifying-question cards, destructive-op and restart confirmations, and the turn closeout)."""
+
+
+def _system_prompt_with_register(skill_text: str) -> str:
+  """Append this runner's provider-authored register to the shared constitution.
+
+  The SDK `system_prompt` is the shared per-chat snapshot (`skill_text`) plus the
+  Claude runner's own concise register. The register is appended, never
+  substituted, so the constitution the other provider receives is unchanged. An
+  empty register returns `skill_text` unchanged, keeping the seam behavior-neutral.
+  """
+  register = _CONCISE_REGISTER.strip()
+  if not register:
+    return skill_text
+  return skill_text.rstrip() + "\n\n" + register + "\n"
+
+
 _CLAUDE_CLI = "/usr/local/bin/claude"
 _ISOLATED_CLAUDE_CLI = "/app/scripts/claude-isolated"
 
@@ -1101,7 +1127,7 @@ async def run_claude_sdk_turn(
         stderr_tail.append(line.rstrip("\n")[:500])
 
     options_kwargs = {
-      "system_prompt": skill_text,
+      "system_prompt": _system_prompt_with_register(skill_text),
       "resume": session_id if session_id is not None else None,
       "cwd": cwd,
       "env": base_env,

--- a/backend/app/system_prompts.py
+++ b/backend/app/system_prompts.py
@@ -1,9 +1,13 @@
 """Capture immutable, provider-neutral per-chat prompts.
 
-The resulting snapshot is the complete behavioral constitution supplied to
-both Claude and Codex. Provider runners may add only the permission, tool, and
-runtime metadata their transports require; they must not substitute a
-provider-authored personality or behavioral prompt.
+The resulting snapshot is the shared behavioral constitution handed to every
+provider identically; keeping that base identical is what preserves consistent
+behavior no matter which provider backs a chat. A provider runner MAY append its
+own small, provider-authored behavioral register on top of that shared base — a
+narrow, deliberate exception (see the concise register in ``claude_sdk_runner``)
+— but it must not otherwise substitute or replace the shared constitution, and
+beyond that register it adds only the permission, tool, and runtime metadata its
+transport requires.
 
 An app opts into this privileged surface by declaring a root-level
 ``system_prompt`` markdown file in its manifest.  The installer stores only the

--- a/backend/tests/test_claude_sdk_runner.py
+++ b/backend/tests/test_claude_sdk_runner.py
@@ -1136,7 +1136,14 @@ async def test_run_claude_sdk_turn_requests_summarized_thinking(monkeypatch):
 
   assert captured["options"].model == "claude-opus-4-8"
   assert captured["options"].effort == "high"
-  assert captured["options"].system_prompt == "system"
+  # The Claude runner appends its provider-authored concise register on top of
+  # the shared base (documented amendment to system_prompts.py's contract): the
+  # shared base is preserved verbatim, with the register appended after it.
+  assert captured["options"].system_prompt == (
+    claude_sdk_runner._system_prompt_with_register("system")
+  )
+  assert captured["options"].system_prompt.startswith("system")
+  assert "# Concise register" in captured["options"].system_prompt
   assert captured["options"].max_buffer_size == 10 * 1024 * 1024
   assert captured["options"].thinking == {
     "type": "adaptive",

--- a/backend/tests/test_provider_register.py
+++ b/backend/tests/test_provider_register.py
@@ -1,0 +1,47 @@
+"""The Claude runner's provider-authored concise register.
+
+The shared per-chat snapshot (`system_prompts.py`) is identical for every
+provider. The Claude runner appends its own concise register on top; the Codex
+runner declares none. These tests pin that seam: the register is appended (never
+substituted), the shared base is preserved verbatim, an empty register is
+behavior-neutral, and the register never leaks into the other provider.
+"""
+
+from __future__ import annotations
+
+from app import claude_sdk_runner
+
+
+def test_register_is_appended_after_base():
+  out = claude_sdk_runner._system_prompt_with_register("SHARED CONSTITUTION")
+  assert out.startswith("SHARED CONSTITUTION")
+  assert "# Concise register" in out
+  # Register comes AFTER the shared constitution, never in front of it.
+  assert out.index("SHARED CONSTITUTION") < out.index("# Concise register")
+
+
+def test_register_protects_required_behaviors():
+  reg = claude_sdk_runner._CONCISE_REGISTER
+  assert reg.strip()
+  # Concision must not be allowed to suppress any of these.
+  for required in (
+    "lead with the result",
+    "the turn closeout",
+    "clarifying-question cards",
+    "making non-obvious findings explicit",
+    "citation",
+  ):
+    assert required in reg, f"register dropped protection for: {required!r}"
+
+
+def test_empty_register_is_behavior_neutral(monkeypatch):
+  monkeypatch.setattr(claude_sdk_runner, "_CONCISE_REGISTER", "   ")
+  assert claude_sdk_runner._system_prompt_with_register("BASE") == "BASE"
+
+
+def test_codex_runner_declares_no_register():
+  # The register lives only in the Claude runner; the other provider must not
+  # gain a behavioral addendum from this change.
+  from app import codex_sdk_runner
+
+  assert not hasattr(codex_sdk_runner, "_CONCISE_REGISTER")


### PR DESCRIPTION
## What
Adds a provider-authored **concise register** appended to the Claude runner's system prompt, on top of the shared per-chat snapshot. The other provider (Codex) is unchanged.

## Why
`system_prompts.py` composes one provider-neutral behavioral constitution handed to every provider. This introduces a narrow, documented exception: a runner MAY append its own small behavioral register. The Claude runner uses it for a concise voice — lead with the result, skip preamble/narration, full detail on request — without editing the shared constitution or touching the other provider.

## Contract change
Amends the `system_prompts.py` module docstring to legitimize the per-provider register: the "identical prompt for every provider" rule now documents this deliberate exception.

## Safety
The register never lets concision drop a required citation, currency `\$` escaping, screenshot-embed-first, the detail the summary/continuation needs, or the constitution's required speech acts (intent opener, non-obvious-findings surfacing, question cards, destructive-op/restart confirmations, closeout).

## Tests
Adds `test_provider_register.py` (register appended not substituted, base preserved verbatim, empty-register neutral, other provider declares none) and updates the runner test that pinned verbatim passthrough. Targeted backend suite: 101 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)