### PR TITLE
Include parent chat title in delegation payload

### DIFF
--- a/backend/app/delegations.py
+++ b/backend/app/delegations.py
@@ -432,10 +432,16 @@ def serialize_delegation(
     db, row, load_result=include_result,
   )
   _record_lifecycle(db, row, status)
+  parent_chat_title = (
+    db.query(models.Chat.title)
+    .filter(models.Chat.id == row.parent_chat_id)
+    .scalar()
+  )
   return {
     "id": row.id,
     "app_id": row.app_id,
     "parent_chat_id": row.parent_chat_id,
+    "parent_chat_title": parent_chat_title,
     "parent_root_run_id": row.parent_root_run_id,
     "task_key": row.task_key,
     "child_chat_id": row.child_chat_id,


### PR DESCRIPTION
## What

Add `parent_chat_title` to the delegation payload (`serialize_delegation`), resolved from the parent chat's `title`.

## Why

Apps that surface delegated runs (e.g. the Subagents app) group runs by the chat that started them, but the payload only carries `parent_chat_id`. App principals can't read `/api/chats/<id>`, so there's no way to show a human-readable chat name. This adds the title alongside the id already present.

## Notes

- Additive, read-only field; existing fields and callers are unchanged.
- Resolved with a single scalar `Chat.title` lookup per row, consistent with the existing per-row work in `serialize_delegation`.