### PR TITLE
compose: fail loudly if SECRET_KEY/DOMAIN are unset

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,8 +34,12 @@ services:
     init: true
     restart: unless-stopped
     environment:
-      - SECRET_KEY=${SECRET_KEY}
-      - DOMAIN=${DOMAIN}
+      # Fail loudly instead of silently blanking these: a bare `docker compose
+      # up` (without deploy-prod.sh or --env-file) would default them to "",
+      # deriving FRONTEND_ORIGIN=https:// and crash-looping the app — and a
+      # changed SECRET_KEY would drift JWT/crypto. Refuse to start unless set.
+      - SECRET_KEY=${SECRET_KEY:?set SECRET_KEY — use scripts/deploy-prod.sh or docker compose --env-file <prod .env>, never a bare docker compose up}
+      - DOMAIN=${DOMAIN:?set DOMAIN — use scripts/deploy-prod.sh or docker compose --env-file <prod .env>, never a bare docker compose up}
       - FRONTEND_ORIGIN=https://${DOMAIN}
       # No application default: every public_surface fails closed unless the
       # operator explicitly configures the same shared origin consumed by


### PR DESCRIPTION
A bare `docker compose up` (without deploy-prod.sh or --env-file) silently defaults SECRET_KEY and DOMAIN to empty strings — deriving FRONTEND_ORIGIN=https:// and crash-looping the app; a changed SECRET_KEY also drifts JWT/crypto. This took prod down once. Compose's `${VAR:?err}` makes it refuse to start with a clear message instead of blanking. The sanctioned deploy-prod.sh / --env-file paths still pass (verified: config succeeds with the vars set, fails with a clear error when unset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)