### PR TITLE
Send on Enter in inline chat editors, matching the composer

### DIFF
--- a/frontend/src/components/ChatView/ChatInputBar.jsx
+++ b/frontend/src/components/ChatView/ChatInputBar.jsx
@@ -61,9 +61,9 @@
  * ║      synthesis. Don't remove either handler.                     ║
  * ║                                                                  ║
  * ║   7. ENTER / SHORTCUT SEND                                       ║
- * ║      `_isTouchPrimary` is detected once via                      ║
- * ║      `matchMedia('(hover: none) and (pointer: coarse)')` and     ║
- * ║      gates plain Enter. Touch devices: Enter inserts a           ║
+ * ║      `isTouchPrimary()` (shared lib/pointerPrimary.js, also used ║
+ * ║      by the inline QA + queued editors) gates plain Enter.        ║
+ * ║      Touch devices: Enter inserts a                              ║
  * ║      newline. Desktop: Enter sends or steers queued text.        ║
  * ║      Cmd/Ctrl+Enter fast-forwards composed text into a live      ║
  * ║      turn when possible, otherwise it sends normally.            ║
@@ -95,6 +95,7 @@ import {
   isPlainTextPasteShortcut,
   resolveComposerEnterAction,
 } from './composerShortcuts.js'
+import { isTouchPrimary } from '../../lib/pointerPrimary.js'
 import SlashMenu from './SlashMenu.jsx'
 import {
   applySlashCommand,
@@ -118,14 +119,6 @@ import {
   focusComposerElement,
   placeCaretAtTextEnd,
 } from './composerFocusPolicy.js'
-
-
-// Detect touch-primary once (same heuristic ChatView uses).
-const _touchMql = typeof matchMedia === 'function'
-  ? matchMedia('(hover: none) and (pointer: coarse)')
-  : null
-let _isTouchPrimary = _touchMql?.matches ?? false
-_touchMql?.addEventListener('change', (e) => { _isTouchPrimary = e.matches })
 
 
 /** The primary action button — Steer / Send / Stop / Mic —
@@ -801,7 +794,7 @@ export default function ChatInputBar({
       canSteer,
       canRequestSteer,
       canSubmitSteer,
-      isTouchPrimary: _isTouchPrimary,
+      isTouchPrimary: isTouchPrimary(),
     })
     if (!action) return
     e.preventDefault()

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -69,6 +69,7 @@ import {
 import { questionKey } from './questionKey.js'
 import { clearChatQuestionDrafts } from './questionDraft.js'
 import { captureLayoutSpace, clientLengthToLayout } from '../../lib/layoutSpace.js'
+import { isTouchPrimary } from '../../lib/pointerPrimary.js'
 import { resolveStopResend } from './resolveStopResend.js'
 import {
   focusComposerElement,
@@ -168,13 +169,6 @@ import {
 } from './goalProgress.js'
 import './ChatView.css'
 
-
-// Cache touch-primary detection. Updated dynamically if input devices change.
-const _touchMql = typeof matchMedia === 'function'
-  ? matchMedia('(hover: none) and (pointer: coarse)')
-  : null
-let _isTouchPrimary = _touchMql?.matches ?? false
-_touchMql?.addEventListener('change', (e) => { _isTouchPrimary = e.matches })
 
 const STOP_RETRY_DELAYS_MS = [0, 250, 700, 1200]
 const CHAT_FETCH_TIMEOUT_MS = 15000
@@ -2418,7 +2412,7 @@ export default function ChatView({
     // can be typed immediately. Fresh sends and explicit queue+steer submits
     // dismiss it; desktop retains its existing cursor-ready behaviour.
     if (shouldDismissComposerKeyboardOnSubmit({
-      isTouchPrimary: _isTouchPrimary,
+      isTouchPrimary: isTouchPrimary(),
       queuesBehindActiveTurn,
       directSteer,
     })) {
@@ -3586,7 +3580,7 @@ export default function ChatView({
       // changes. Both composer and per-row steer actions share this path.
       const inputEl = inputRef.current
       steerKeyboardDismissRequestRef.current = null
-      if (_isTouchPrimary && document.activeElement === inputEl) {
+      if (isTouchPrimary() && document.activeElement === inputEl) {
         steerKeyboardDismissRequestRef.current = {
           chatId: String(chatId),
           cid: steerCid,

--- a/frontend/src/components/ChatView/QuestionCard.jsx
+++ b/frontend/src/components/ChatView/QuestionCard.jsx
@@ -8,6 +8,8 @@ import {
 } from './questionDraft.js'
 import { textareaUsesNativeSizing } from './composerTextareaSizing.js'
 import { placeCaretAtTextEnd } from './composerFocusPolicy.js'
+import { isInlineEditorSubmit } from './composerShortcuts.js'
+import { isTouchPrimary } from '../../lib/pointerPrimary.js'
 import {
   pointerSelectionChangedWithin,
   textSelectionSnapshot,
@@ -41,6 +43,7 @@ function resizeCustomAnswer(textarea) {
 function CustomAnswerArea({
   active,
   answered,
+  canSubmit,
   disabled,
   onChange,
   onSubmitShortcut,
@@ -88,7 +91,10 @@ function CustomAnswerArea({
       readOnly={answered}
       disabled={disabled && !answered}
       onKeyDown={e => {
-        if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+        // Let Enter stay a newline until every question is answered, so a
+        // half-filled grouped card can still take multi-line custom text.
+        if (!canSubmit) return
+        if (isInlineEditorSubmit(e, { isTouchPrimary: isTouchPrimary() })) {
           e.preventDefault()
           onSubmitShortcut()
         }
@@ -362,6 +368,7 @@ export default function QuestionCard({
             <CustomAnswerArea
               active={isOtherSelected || answeredWithOther}
               answered={answered}
+              canSubmit={allAnswered}
               disabled={inactive}
               onChange={text => setOtherText(q.question, text)}
               onSubmitShortcut={() => {

--- a/frontend/src/components/ChatView/QueuedMessages.jsx
+++ b/frontend/src/components/ChatView/QueuedMessages.jsx
@@ -8,6 +8,8 @@ import {
 } from '@openai/apps-sdk-ui/components/Icon'
 import { stripAugmentation } from './msgText.js'
 import { cidOf } from './messageIdentity.js'
+import { isInlineEditorSubmit } from './composerShortcuts.js'
+import { isTouchPrimary } from '../../lib/pointerPrimary.js'
 import {
   pointerSelectionChangedWithin,
   textSelectionSnapshot,
@@ -184,9 +186,11 @@ export default function QueuedMessages({
                         if (event.key === 'Escape') {
                           event.preventDefault()
                           cancelEdit()
-                        } else if (
-                          event.key === 'Enter' && (event.metaKey || event.ctrlKey)
-                        ) {
+                          return
+                        }
+                        // Empty draft can't save, so leave Enter as a newline.
+                        if (!editDraft.trim()) return
+                        if (isInlineEditorSubmit(event, { isTouchPrimary: isTouchPrimary() })) {
                           event.preventDefault()
                           void saveEdit(msg)
                         }

--- a/frontend/src/components/ChatView/__tests__/composerShortcuts.test.js
+++ b/frontend/src/components/ChatView/__tests__/composerShortcuts.test.js
@@ -2,6 +2,7 @@ import { test } from 'node:test'
 import assert from 'node:assert/strict'
 
 import {
+  isInlineEditorSubmit,
   isPlainTextPasteShortcut,
   resolveComposerEnterAction,
 } from '../composerShortcuts.js'
@@ -137,6 +138,27 @@ test('non-Enter keys do not trigger composer shortcuts', () => {
     }),
     null,
   )
+})
+
+test('inline editor: plain Enter sends on desktop, matching the composer', () => {
+  assert.equal(isInlineEditorSubmit(enter(), { isTouchPrimary: false }), true)
+})
+
+test('inline editor: plain Enter stays a newline on touch', () => {
+  assert.equal(isInlineEditorSubmit(enter(), { isTouchPrimary: true }), false)
+})
+
+test('inline editor: Shift+Enter is always a newline', () => {
+  assert.equal(isInlineEditorSubmit(enter({ shiftKey: true }), { isTouchPrimary: false }), false)
+})
+
+test('inline editor: Cmd/Ctrl+Enter always sends, even on touch', () => {
+  assert.equal(isInlineEditorSubmit(enter({ metaKey: true }), { isTouchPrimary: true }), true)
+  assert.equal(isInlineEditorSubmit(enter({ ctrlKey: true }), { isTouchPrimary: false }), true)
+})
+
+test('inline editor: non-Enter keys never send', () => {
+  assert.equal(isInlineEditorSubmit({ key: 'a' }, { isTouchPrimary: false }), false)
 })
 
 test('Cmd/Ctrl+Shift+V requests paste without Markdown formatting', () => {

--- a/frontend/src/components/ChatView/__tests__/questionCardState.test.js
+++ b/frontend/src/components/ChatView/__tests__/questionCardState.test.js
@@ -46,8 +46,10 @@ test('unanswered question cards do not have a stale gray state', () => {
     'a submitted multiline answer should stay scrollable but not editable')
   assert.match(component, /resizeCustomAnswer|textareaUsesNativeSizing/,
     'older browsers should measure the growing answer when native sizing is unavailable')
-  assert.match(component, /e\.key === 'Enter' && \(e\.metaKey \|\| e\.ctrlKey\)/,
-    'plain Enter should create a new line while the explicit shortcut submits')
+  assert.match(component, /isInlineEditorSubmit\(e, \{ isTouchPrimary: isTouchPrimary\(\) \}\)/,
+    'the custom answer should send on the same Enter chord as the composer')
+  assert.match(component, /if \(!canSubmit\) return/,
+    'Enter should stay a newline until the card can actually be submitted')
   assert.match(component, /val\.replace\(\/\\n\/g, '\\n  '\)/,
     'multiline custom answers should keep their structure in the resumed turn')
   assert.match(component, /const next = arr\.includes\(label\)[\s\S]*?: \[\.\.\.arr, label\]/,

--- a/frontend/src/components/ChatView/composerShortcuts.js
+++ b/frontend/src/components/ChatView/composerShortcuts.js
@@ -18,6 +18,17 @@ export function resolveComposerEnterAction(event, {
   return 'noop'
 }
 
+/** Whether an inline chat editor (the QA card's custom answer, the queued-
+ * message editor) should treat this Enter as "send". Reuses the composer's own
+ * decision so every inline editor sends on the same chord: plain Enter on
+ * desktop, Shift+Enter always a newline, Enter a newline on touch, and
+ * Cmd/Ctrl+Enter always sends. These editors have no queued-steer affordance,
+ * so only a real submit counts. */
+export function isInlineEditorSubmit(event, { isTouchPrimary = false } = {}) {
+  const action = resolveComposerEnterAction(event, { hasInput: true, isTouchPrimary })
+  return action === 'submit' || action === 'submit-steer'
+}
+
 /** Paste-without-formatting chord. ClipboardEvent does not reliably retain
  * keyboard modifiers, so the composer snapshots this during keydown and lets
  * the subsequent paste event consume it. */

--- a/frontend/src/lib/pointerPrimary.js
+++ b/frontend/src/lib/pointerPrimary.js
@@ -1,0 +1,14 @@
+/* Live "is touch the primary pointer?" signal, shared by the composer and every
+ * inline chat editor so their Enter-to-send behavior agrees across devices. */
+
+export const TOUCH_PRIMARY_QUERY = '(hover: none) and (pointer: coarse)'
+
+const _mql = typeof matchMedia === 'function' ? matchMedia(TOUCH_PRIMARY_QUERY) : null
+let _touchPrimary = _mql?.matches ?? false
+_mql?.addEventListener('change', (e) => { _touchPrimary = e.matches })
+
+/** Whether touch is the primary pointer right now. Live: updates if the input
+ * mix changes (e.g. a tablet docking to a keyboard). */
+export function isTouchPrimary() {
+  return _touchPrimary
+}

--- a/tests/chat-redesign.spec.mjs
+++ b/tests/chat-redesign.spec.mjs
@@ -340,10 +340,12 @@ test.describe('Bug 1: AskUserQuestion', () => {
     })
 
     const before = await geometry()
+    // Plain Enter now sends in the inline answer editor (matches the composer),
+    // so a multi-line answer is built with Shift+Enter for each newline.
     await customAnswer.pressSequentially('First line')
-    await page.keyboard.press('Enter')
+    await page.keyboard.press('Shift+Enter')
     await customAnswer.pressSequentially('Second line')
-    await page.keyboard.press('Enter')
+    await page.keyboard.press('Shift+Enter')
     await customAnswer.pressSequentially('Third line')
     await page.evaluate(() => new Promise(resolve => (
       requestAnimationFrame(() => requestAnimationFrame(resolve))
@@ -360,7 +362,7 @@ test.describe('Bug 1: AskUserQuestion', () => {
     // Drive the real keyboard path so caret reveal, beforeinput, input, and the
     // chat scroll owner race exactly as they do for an owner writing an answer.
     for (let line = 4; line <= 14; line += 1) {
-      await page.keyboard.press('Enter')
+      await page.keyboard.press('Shift+Enter')
       await customAnswer.pressSequentially(`Line ${line}`)
     }
     await page.evaluate(() => new Promise(resolve => (


### PR DESCRIPTION
## What & why

The main composer sends a message on plain **Enter** (Shift+Enter inserts a newline; on touch-primary devices Enter stays a newline). Two smaller inline editors in the chat — the question card's custom-answer box and the queued-message editor — only submitted on **Cmd/Ctrl+Enter**, so plain Enter just inserted a newline. That inconsistency is easy to trip over.

This routes both inline editors through the composer's own Enter decision, so every text input in the chat behaves the same way.

## Changes

- Add `isInlineEditorSubmit()` to `composerShortcuts.js`, a thin wrapper over the existing `resolveComposerEnterAction` so inline editors share the composer's exact chord logic: plain Enter sends on desktop, Shift+Enter is always a newline, Enter stays a newline on touch-primary devices, and Cmd/Ctrl+Enter always sends.
- Use it in the question card's custom-answer textarea. Enter only submits once the card is actually answerable; until then it stays a newline, so a multi-question card can still take multi-line custom text.
- Use it in the queued-message editor. Escape still cancels; an empty draft leaves Enter as a newline.
- Extract the touch-primary detection that was duplicated in `ChatInputBar` and `ChatView` into a shared `lib/pointerPrimary.js` and point both at it, so the composer and the inline editors share one source of truth.

Single-line inputs (e.g. the secure-input card) already submit on Enter via native form submission and are unchanged.

## Tests

- New unit tests for `isInlineEditorSubmit` covering desktop send, touch newline, Shift+Enter, Cmd/Ctrl+Enter, and non-Enter keys.
- Updated the QuestionCard source-contract test to assert the new shared chord.