### PR TITLE
Escalate a corroborated recall drop instead of deferring

### DIFF
--- a/backend/scripts/seed-skills/reflection.md
+++ b/backend/scripts/seed-skills/reflection.md
@@ -324,6 +324,18 @@ Then act on the **system** signal:
   runs alongside that work as optional durable context. When direct evidence
   contradicts a recalled claim, verify that the mismatch was surfaced for the
   next Memory maintenance run rather than silently following the stale claim.
+- A measured recall drop is partner-facing signal in its own right — do not
+  wait for the partner to notice it. On any comparable night, compare live
+  recall (recalling chats ÷ active cue-bearing chats) against its recent
+  baseline. On a material drop, first distinguish a genuinely cue-free workload
+  (correct, low recall) from over-skipping on cue-bearing chats (a regression)
+  by sampling a few no-recall chats. If it is over-skipping, surface a decisive
+  brief card with a concrete proposed trigger fix — even when the Memory app
+  owns the eventual change, and even if the partner has not raised it.
+  Fix-ownership by another surface, and "the partner is already iterating on
+  it," are never reasons to defer a drop to a silent "no action." Improve the
+  smallest owning instruction directly when it is a clear, reversible wording
+  fix; otherwise card it.
 - If Memory is healthy and no interview raised a memory-system issue, write one
   sentence in your run notes and move on. Empty phase 3 is fine.
 


### PR DESCRIPTION
## Problem

Reflection is meant to notice when Memory recall drops (added in #735). But it could measure a drop, explicitly match it to a concern the partner had already raised, and still record a silent "no action" — deferring the fix to the Memory app and assuming the partner was "already iterating on it." The safety net fired and stayed quiet, so the same recall regression could recur without ever reaching a brief card.

## Change

Adds one rule to Reflection's Memory-health phase: a measured recall drop is partner-facing signal in its own right. On any comparable night, compare live recall against its recent baseline; on a material drop, first distinguish a genuinely cue-free workload (correct, low recall) from over-skipping on cue-bearing chats (a regression) by sampling a few no-recall chats, then card the regression with a concrete proposed trigger fix — without waiting for the partner to raise it, and regardless of which surface owns the eventual fix.

## Relation to prior work

Extends #735 (assess Memory recall use and waste): #735 taught Reflection to *measure* recall use; this makes it *act* on a corroborated drop instead of deferring silently.