### PR TITLE
Keep composer focus when expanding a progress-rail step

### DIFF
--- a/frontend/src/components/ChatView/ProgressRail.jsx
+++ b/frontend/src/components/ChatView/ProgressRail.jsx
@@ -41,6 +41,8 @@ function ProgressStep({ item, detailsExpanded, onDetailsToggle }) {
       aria-expanded={expanded}
       aria-label={`${expanded ? 'Collapse' : 'Expand'}: ${accessibleLabel}`}
       title={expanded ? 'Collapse' : title}
+      // Keep composer focus (and the soft keyboard) put when expanding.
+      onPointerDown={(event) => event.preventDefault()}
       onClick={() => {
         if (hasDetails) onDetailsToggle?.()
         else setLabelExpanded(value => !value)


### PR DESCRIPTION
## Problem

Tapping a progress-rail step (such as a goal) to expand its details moves keyboard focus onto the toggle button. On touch devices this dismisses the soft keyboard while the user is typing in the composer, interrupting them and making them lose their place.

## Fix

Call `preventDefault()` on the toggle's `pointerdown` so tapping to expand or collapse no longer pulls focus off the composer, and the soft keyboard stays open. Keyboard activation is unaffected: `preventDefault` on `pointerdown` only suppresses the pointer-driven focus change, so Tab/Enter still focus and toggle the control normally.

## Testing

- ChatView progress-rail unit suites pass.
- Confirmed the built shell serves the pointer-down guard on the expand toggle.
- On a touch device, expanding a step should now keep the soft keyboard open while composing (previously it was dismissed).