### PR TITLE
Add portable identity bridge for self-hosted Möbius · You

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,14 @@ SECRET_KEY=
 # Set to your server's IP and port: http://YOUR_SERVER_IP:8000
 # FRONTEND_ORIGIN=
 
+# Account service used when an ordinary self-hosted Möbius links a Möbius · You
+# identity. Change this when identity moves to an independent public host.
+MOBIUS_ACCOUNT_ORIGIN=https://www.mobius.you
+# Usually blank: the server derives the exact client origin from
+# FRONTEND_ORIGIN. Set an HTTPS origin here only when a reverse proxy makes the
+# browser-facing origin different.
+MOBIUS_ACCOUNT_CLIENT_ORIGIN=
+
 # Optional shared browser origin for owner-trusted full web services. Point one
 # DNS name at this Möbius host, then enable public_surface per service in
 # local-services.json. Every enabled service uses /services/<slug> below this

--- a/backend/app/app_apply.py
+++ b/backend/app/app_apply.py
@@ -362,6 +362,7 @@ async def apply_source_revision(
           app,
           capabilities=runtime_fields["capabilities"],
           public_access=runtime_fields["public_access"],
+          contract_permissions=manifest.get("permissions") or {},
         )
       if chat_id is not None:
         app.chat_id = chat_id

--- a/backend/app/app_capabilities.py
+++ b/backend/app/app_capabilities.py
@@ -432,6 +432,8 @@ def contract_from_manifest(manifest: dict[str, Any]) -> dict[str, Any]:
       "github_access": bool(perms.get("github_access", False)),
       "github_connect": bool(perms.get("github_connect", False)),
       "connections_manage": bool(perms.get("connections_manage", False)),
+      "identity_manage": bool(perms.get("identity_manage", False)),
+      "railway_manage": bool(perms.get("railway_manage", False)),
     },
     "background": (
       {
@@ -482,6 +484,7 @@ def contract_from_app_state(
   *,
   capabilities: dict[str, Any] | None = None,
   public_access: dict[str, Any] | None = None,
+  contract_permissions: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
   """Build an accurate contract for an owner-authored local app.
 
@@ -512,6 +515,15 @@ def contract_from_app_state(
       "github_access": bool(getattr(app, "github_access", False)),
       "github_connect": bool(getattr(app, "github_connect", False)),
       "connections_manage": bool(getattr(app, "connections_manage", False)),
+      # Contract-only grants are declared by a local package on every apply.
+      # Store installs build straight from their manifest and never enter this
+      # projection. Do not inherit an older accepted value: omission revokes.
+      "identity_manage": bool(
+        (contract_permissions or {}).get("identity_manage", False)
+      ),
+      "railway_manage": bool(
+        (contract_permissions or {}).get("railway_manage", False)
+      ),
     },
     "offline_capable": bool(getattr(app, "offline_capable", False)),
     "offline": getattr(app, "offline_contract", None),

--- a/backend/app/bootstrap.py
+++ b/backend/app/bootstrap.py
@@ -1,4 +1,4 @@
-"""First-boot bootstrap for the App Store, Memory, and Reflection apps.
+"""First-boot bootstrap for the core and managed-account apps.
 
 Called from the FastAPI lifespan handler once the server is up and the
 DB is migrated. Calls `install_from_manifest()` directly (in-process)
@@ -21,6 +21,7 @@ from dataclasses import dataclass
 from sqlalchemy.orm import Session
 
 from app import models
+from app.config import get_settings
 from app.install import install_from_manifest
 
 log = logging.getLogger("mobius.bootstrap")
@@ -56,6 +57,9 @@ BOOTSTRAP_REFLECTION_MANIFEST_URL = (
 BOOTSTRAP_CONNECTIONS_MANIFEST_URL = (
   "https://raw.githubusercontent.com/mobius-os/app-connections/main/mobius.json"
 )
+BOOTSTRAP_IDENTITY_MANIFEST_URL = (
+  "https://raw.githubusercontent.com/mobius-os/app-mobius-you/main/mobius.json"
+)
 
 
 @dataclass(frozen=True)
@@ -79,6 +83,12 @@ _BOOTSTRAP_APPS = (
   # respected; the Store remains the way back.
   _BootstrapApp(
     "connections", BOOTSTRAP_CONNECTIONS_MANIFEST_URL, False,
+  ),
+  # Managed Railway owners have already authenticated with mobius.you. Their
+  # identity surface is therefore useful immediately, but it must not appear
+  # on ordinary self-hosted instances where no launcher account exists.
+  _BootstrapApp(
+    "identity", BOOTSTRAP_IDENTITY_MANIFEST_URL, False,
   ),
 )
 
@@ -113,6 +123,9 @@ async def ensure_bootstrap_apps_installed(db: Session) -> None:
   from app.install import _find_install_identity_row
 
   for bootstrap_app in _BOOTSTRAP_APPS:
+    if bootstrap_app.name == "identity" and not get_settings().mobius_sso_enabled:
+      log.info("bootstrap: identity skipped for local-account deployment")
+      continue
     # Use the installer's identity resolver here too: bootstrap and an explicit
     # Store action must agree across ref moves and legacy rows whose matching
     # catalog origin predates persisted manifest identity.

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -14,7 +14,7 @@ import os
 import re
 from functools import lru_cache
 from pathlib import Path
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urlunsplit
 
 from pydantic import model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -33,6 +33,32 @@ def _read_build_info() -> dict:
   except Exception:
     return {}
   return data if isinstance(data, dict) else {}
+
+
+def _validated_origin(value: str, setting_name: str) -> str:
+  """Return a normalized HTTPS origin (HTTP is allowed only on loopback)."""
+  normalized = value.strip().rstrip("/")
+  parsed = urlparse(normalized)
+  is_local_http = (
+    parsed.scheme == "http"
+    and parsed.hostname in {"localhost", "127.0.0.1", "::1"}
+  )
+  try:
+    parsed.port
+  except ValueError as exc:
+    raise ValueError(f"{setting_name} must be an HTTPS origin.") from exc
+  if (
+    (parsed.scheme != "https" and not is_local_http)
+    or not parsed.hostname
+    or parsed.username is not None
+    or parsed.password is not None
+    or parsed.path not in {"", "/"}
+    or parsed.params
+    or parsed.query
+    or parsed.fragment
+  ):
+    raise ValueError(f"{setting_name} must be an HTTPS origin.")
+  return urlunsplit((parsed.scheme.lower(), parsed.netloc.lower(), "", "", ""))
 
 
 class Settings(BaseSettings):
@@ -82,6 +108,14 @@ class Settings(BaseSettings):
   mobius_sso_issuer: str = ""
   mobius_sso_instance_id: str = ""
   mobius_sso_client_secret: str = ""
+  # Authoritative account service used by ordinary self-hosted installations
+  # when their owner links a mobius.you identity. Keep this independent from
+  # the managed-deployment SSO issuer so the account service can move hosts
+  # without a code change or an implicit coupling between the two protocols.
+  mobius_account_origin: str = "https://www.mobius.you"
+  # Public origin of this installation, bound into self-hosted account grants.
+  # Empty derives from FRONTEND_ORIGIN when that is HTTPS or loopback HTTP.
+  mobius_account_client_origin: str = ""
 
   model_config = SettingsConfigDict(env_file=".env")
 
@@ -140,26 +174,31 @@ class Settings(BaseSettings):
         "MOBIUS_SSO_CLIENT_SECRET must be configured together."
       )
     if all(sso_values):
-      issuer = urlparse(sso_values[0])
-      is_local_http = (
-        issuer.scheme == "http"
-        and issuer.hostname in {"localhost", "127.0.0.1", "::1"}
+      self.mobius_sso_issuer = _validated_origin(
+        sso_values[0], "MOBIUS_SSO_ISSUER",
       )
-      if (
-        (issuer.scheme != "https" and not is_local_http)
-        or not issuer.netloc
-        or issuer.path not in {"", "/"}
-        or issuer.params
-        or issuer.query
-        or issuer.fragment
-      ):
-        raise ValueError("MOBIUS_SSO_ISSUER must be an HTTPS origin.")
       if not re.fullmatch(r"mob_[A-Za-z0-9_-]{3,80}", sso_values[1]):
         raise ValueError("MOBIUS_SSO_INSTANCE_ID is invalid.")
       if len(sso_values[2]) < 32:
         raise ValueError("MOBIUS_SSO_CLIENT_SECRET must be at least 32 characters.")
-      self.mobius_sso_issuer = sso_values[0].rstrip("/")
       self.mobius_sso_instance_id = sso_values[1]
+    self.mobius_account_origin = _validated_origin(
+      self.mobius_account_origin, "MOBIUS_ACCOUNT_ORIGIN",
+    )
+    client_origin = self.mobius_account_client_origin.strip()
+    if client_origin:
+      self.mobius_account_client_origin = _validated_origin(
+        client_origin, "MOBIUS_ACCOUNT_CLIENT_ORIGIN",
+      )
+    else:
+      try:
+        self.mobius_account_client_origin = _validated_origin(
+          self.frontend_origin, "FRONTEND_ORIGIN",
+        )
+      except ValueError:
+        # Non-loopback HTTP remains supported for an entirely local Möbius,
+        # but it cannot be entrusted with a cross-origin account grant.
+        self.mobius_account_client_origin = ""
     return self
 
   @property

--- a/backend/app/deps.py
+++ b/backend/app/deps.py
@@ -927,6 +927,60 @@ def get_owner_or_app_with_connections_manage(
   )
 
 
+def get_owner_or_app_with_identity_manage(
+  principal: Principal = Depends(get_principal),
+  db: Session = Depends(get_db),
+) -> models.Owner:
+  """Owner JWT, or an app with the reviewed identity-management grant.
+
+  This grant lives in the accepted capability contract rather than a second
+  model column: identity is a package-owned system integration, and every
+  install/update already replaces that contract atomically. Omission on a
+  later app version therefore revokes access on the next request.
+  """
+  owner = principal.owner
+  if principal.app_id is None:
+    return owner
+  app = db.query(models.App).filter(models.App.id == principal.app_id).first()
+  if not app:
+    raise HTTPException(status_code=401, detail="App not found.")
+  contract = app.capability_contract if isinstance(app.capability_contract, dict) else {}
+  data = contract.get("data") if isinstance(contract.get("data"), dict) else {}
+  if data.get("identity_manage") is True:
+    return owner
+  raise HTTPException(
+    status_code=403,
+    detail=(
+      "This app needs permissions.identity_manage=true in its manifest "
+      "to read or update your Möbius identity."
+    ),
+  )
+
+
+def get_owner_or_app_with_railway_manage(
+  principal: Principal = Depends(get_principal),
+  db: Session = Depends(get_db),
+) -> models.Owner:
+  """Owner JWT, or an app with reviewed Railway deployment authority."""
+  owner = principal.owner
+  if principal.app_id is None:
+    return owner
+  app = db.query(models.App).filter(models.App.id == principal.app_id).first()
+  if not app:
+    raise HTTPException(status_code=401, detail="App not found.")
+  contract = app.capability_contract if isinstance(app.capability_contract, dict) else {}
+  data = contract.get("data") if isinstance(contract.get("data"), dict) else {}
+  if data.get("railway_manage") is True:
+    return owner
+  raise HTTPException(
+    status_code=403,
+    detail=(
+      "This app needs permissions.railway_manage=true in its manifest "
+      "to manage Railway deployments on your behalf."
+    ),
+  )
+
+
 def get_owner_or_app_with_github_connect(
   principal: Principal = Depends(get_principal),
   db: Session = Depends(get_db),

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -70,6 +70,7 @@ from app.routes import (
   secure_inputs_router,
   connectors_router, connectors_public_router,
   debug_router, delegations_router, fs_router, goal_plans_router, github_router, media_router,
+  identity_router,
   local_services_router, notifications_router, notify_router, proxy_router, push_router,
   public_apps_router,
   secrets_router, self_reminders_router, settings_router, skills_router,
@@ -751,6 +752,7 @@ app.include_router(uploads_router)
 app.include_router(media_router)
 app.include_router(secrets_router)
 app.include_router(github_router)
+app.include_router(identity_router)
 app.include_router(push_router)
 app.include_router(notifications_router)
 app.include_router(debug_router)

--- a/backend/app/manifest_contract.py
+++ b/backend/app/manifest_contract.py
@@ -221,6 +221,8 @@ def validate_manifest_contract(manifest) -> None:
     "github_connect",
     "filesystem_access",
     "connections_manage",
+    "identity_manage",
+    "railway_manage",
   ):
     if field in permissions and not isinstance(permissions[field], bool):
       _fail(f"Manifest `permissions.{field}` must be a boolean.")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -91,6 +91,38 @@ class Owner(Base):
   created_at = Column(DateTime, default=lambda: datetime.now(UTC))
 
 
+class IdentityLinkAttempt(Base):
+  """Single outstanding PKCE account-link attempt for the local owner.
+
+  A new start replaces the previous row, so only the most recent browser
+  window can complete. The verifier is encrypted and never enters app code.
+  """
+
+  __tablename__ = "identity_link_attempts"
+
+  owner_id = Column(
+    Integer, ForeignKey("owner.id", ondelete="CASCADE"), primary_key=True,
+  )
+  attempt_id = Column(String(64), nullable=False, unique=True, index=True)
+  state_digest = Column(String(64), nullable=False)
+  verifier_encrypted = Column(Text, nullable=False)
+  expires_at = Column(DateTime, nullable=False, index=True)
+  created_at = Column(DateTime, nullable=False, default=now_naive_utc)
+
+
+class IdentityAccountLink(Base):
+  """Revocable, encrypted mobius.you grant for a self-hosted owner."""
+
+  __tablename__ = "identity_account_links"
+
+  owner_id = Column(
+    Integer, ForeignKey("owner.id", ondelete="CASCADE"), primary_key=True,
+  )
+  access_token_encrypted = Column(Text, nullable=False)
+  scopes_json = Column(JSON, nullable=False, default=list)
+  linked_at = Column(DateTime, nullable=False, default=now_naive_utc)
+
+
 class SystemPromptSnapshot(Base):
   """Deduplicated immutable prompt bytes captured at a chat's first turn."""
 

--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -75,6 +75,7 @@ uploads_router = _load("uploads")
 media_router = _load("media")
 secrets_router = _load("secrets")
 github_router = _load("github")
+identity_router = _load("identity")
 push_router = _load("push")
 notifications_router = _load("notifications")
 debug_router = _load("debug")
@@ -112,6 +113,7 @@ __all__ = [
   "media_router",
   "secrets_router",
   "github_router",
+  "identity_router",
   "push_router",
   "notifications_router",
   "debug_router",

--- a/backend/app/routes/identity.py
+++ b/backend/app/routes/identity.py
@@ -1,0 +1,1090 @@
+"""Narrow deployment-to-account-service bridge for the Identity system app.
+
+The mini-app receives only its ordinary scoped bearer. This route owns the
+managed instance credential and forwards a deliberately small profile contract
+to the configured account service, which remains authoritative for globally
+unique handles, avatar storage, and the cross-deployment inventory.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import re
+import secrets
+from datetime import timedelta
+from urllib.parse import urlencode, urlparse
+
+import httpx
+from cryptography.fernet import Fernet, InvalidToken
+from fastapi import APIRouter, Depends, File, HTTPException, Response, UploadFile
+from pydantic import BaseModel
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app import models
+from app.config import get_settings
+from app.database import get_db
+from app.deps import (
+  get_owner_or_app_with_identity_manage,
+  get_owner_or_app_with_railway_manage,
+  reject_cross_site,
+)
+from app.timeutil import now_naive_utc
+
+router = APIRouter(
+  prefix="/api/identity",
+  tags=["identity"],
+  dependencies=[Depends(reject_cross_site)],
+)
+
+_REMOTE_PATH = "/api/instance/v1/identity"
+_ACCOUNT_PATH = "/api/account/v1/identity"
+_LINK_SCOPES = {
+  "deployments:delete",
+  "deployments:read",
+  "identity:read",
+  "identity:write",
+  "railway:read",
+  "railway:write",
+}
+_LINK_SCOPE = " ".join(sorted(_LINK_SCOPES))
+_LINK_TTL = timedelta(minutes=10)
+_AVATAR_MAX_BYTES = 5 * 1024 * 1024
+_AVATAR_TYPES = {"image/jpeg", "image/png", "image/webp"}
+
+
+class ProfilePatch(BaseModel):
+  handle: str
+
+
+class LinkStart(BaseModel):
+  provider: str
+
+
+class LinkComplete(BaseModel):
+  code: str
+  state: str
+  attempt: str
+
+
+class RailwayCreate(BaseModel):
+  name: str
+  managed_auth: bool = True
+  cpu: int | None = None
+  memory_mb: int | None = None
+  volume_mb: int | None = None
+
+
+class RailwayCompute(BaseModel):
+  cpu: int | None = None
+  memory_mb: int | None = None
+
+
+class RailwayStorage(BaseModel):
+  volume_mb: int
+
+
+class RailwaySelectWorkspace(BaseModel):
+  workspace_id: str
+
+
+class RailwayConnectStart(BaseModel):
+  replace: bool = False
+
+
+def _link_fernet() -> Fernet:
+  material = f"mobius-identity-link-v1:{get_settings().secret_key}".encode()
+  key = base64.urlsafe_b64encode(hashlib.sha256(material).digest())
+  return Fernet(key)
+
+
+def _seal(value: str) -> str:
+  return _link_fernet().encrypt(value.encode()).decode()
+
+
+def _open(value: str) -> str:
+  try:
+    return _link_fernet().decrypt(value.encode()).decode()
+  except (InvalidToken, ValueError) as exc:
+    raise HTTPException(409, "Sign in again to reconnect your account.") from exc
+
+
+def _digest(value: str) -> str:
+  return hashlib.sha256(value.encode()).hexdigest()
+
+
+def _local_payload(
+  *, account_mode: str = "signed_out", account_unavailable: bool = False,
+) -> dict:
+  settings = get_settings()
+  current = {
+    "id": settings.mobius_sso_instance_id or "local",
+    "name": "This Möbius",
+    "status": "Active",
+    "current": True,
+    "url": settings.frontend_origin.rstrip("/"),
+  }
+  return {
+    "account_mode": account_mode,
+    "account_unavailable": account_unavailable,
+    "instance_id": settings.mobius_sso_instance_id or None,
+    # A local owner is not a mobius.you identity. A null profile makes the
+    # signed-out privacy boundary explicit instead of encoding it as null
+    # fields that clients must infer.
+    "profile": None,
+    "deployments": [current],
+  }
+
+
+def _remote_headers() -> dict[str, str]:
+  settings = get_settings()
+  return {
+    "Authorization": f"Bearer {settings.mobius_sso_client_secret}",
+    "X-Mobius-Instance-Id": settings.mobius_sso_instance_id,
+    "Accept": "application/json",
+  }
+
+
+def _identity_contract(payload: object) -> dict:
+  if not isinstance(payload, dict):
+    raise HTTPException(502, "The Möbius account service returned an invalid response.")
+  if not isinstance(payload.get("profile"), dict):
+    raise HTTPException(502, "The Möbius account service returned an invalid profile.")
+  deployments = payload.get("deployments")
+  if not isinstance(deployments, list) or not all(
+    isinstance(item, dict) for item in deployments
+  ):
+    raise HTTPException(502, "The Möbius account service returned an invalid deployment list.")
+  return payload
+
+
+def _railway_contract(payload: object) -> dict:
+  if not isinstance(payload, dict) or set(payload) != {"connection", "instances"}:
+    raise HTTPException(502, "The Möbius account service returned invalid Railway state.")
+  connection = payload.get("connection")
+  instances = payload.get("instances")
+  if connection is not None and not isinstance(connection, dict):
+    raise HTTPException(502, "The Möbius account service returned an invalid Railway connection.")
+  if (
+    not isinstance(instances, list)
+    or len(instances) > 100
+    or not all(isinstance(item, dict) for item in instances)
+  ):
+    raise HTTPException(502, "The Möbius account service returned invalid Railway deployments.")
+  return payload
+
+
+def _remote_avatar_url(payload: dict | None) -> str | None:
+  """Return one safe HTTPS avatar URL from the trusted account response.
+
+  Mini-app CSP intentionally disallows arbitrary external images. The bridge
+  fetches the account host's selected avatar server-side instead, so moving the
+  account service does not require weakening every app frame's browser policy.
+  """
+  profile = payload.get("profile") if isinstance(payload, dict) else None
+  value = profile.get("avatar_url") if isinstance(profile, dict) else None
+  if not isinstance(value, str) or len(value) > 2048:
+    return None
+  try:
+    parsed = urlparse(value)
+    port = parsed.port
+  except ValueError:
+    return None
+  if (
+    parsed.scheme != "https"
+    or not parsed.hostname
+    or parsed.username is not None
+    or parsed.password is not None
+    or port not in (None, 443)
+    or parsed.fragment
+  ):
+    return None
+  origin = f"https://{parsed.hostname}"
+  account_origins = {
+    str(get_settings().mobius_account_origin).rstrip("/"),
+    str(get_settings().mobius_sso_issuer).rstrip("/"),
+  }
+  google_avatar = parsed.hostname == "googleusercontent.com" or (
+    parsed.hostname.endswith(".googleusercontent.com")
+  )
+  if origin not in account_origins and not google_avatar:
+    return None
+  return value
+
+
+async def _avatar_bytes(url: str) -> tuple[bytes, str]:
+  try:
+    async with httpx.AsyncClient(timeout=15.0, follow_redirects=False) as client:
+      async with client.stream(
+        "GET", url, headers={"Accept": ", ".join(sorted(_AVATAR_TYPES))},
+      ) as response:
+        content_type = response.headers.get("content-type", "").split(";", 1)[0].lower()
+        if response.status_code != 200 or content_type not in _AVATAR_TYPES:
+          raise HTTPException(502, "The Möbius account avatar is unavailable.")
+        chunks: list[bytes] = []
+        size = 0
+        async for chunk in response.aiter_bytes():
+          size += len(chunk)
+          if size > _AVATAR_MAX_BYTES:
+            raise HTTPException(502, "The Möbius account avatar is too large.")
+          chunks.append(chunk)
+  except HTTPException:
+    raise
+  except httpx.HTTPError:
+    raise HTTPException(502, "The Möbius account avatar could not be reached.")
+  if not chunks:
+    raise HTTPException(502, "The Möbius account avatar is empty.")
+  return b"".join(chunks), content_type
+
+
+async def _managed_remote(method: str, suffix: str = "", **kwargs) -> dict:
+  settings = get_settings()
+  if not settings.mobius_sso_enabled:
+    raise HTTPException(409, "This Möbius uses a local account.")
+  try:
+    async with httpx.AsyncClient(timeout=15.0, follow_redirects=False) as client:
+      response = await client.request(
+        method,
+        settings.mobius_sso_issuer + _REMOTE_PATH + suffix,
+        headers=_remote_headers(),
+        **kwargs,
+      )
+  except httpx.HTTPError:
+    raise HTTPException(502, "The Möbius account service could not be reached.")
+  if response.status_code == 409:
+    detail = "That handle is already taken."
+    try:
+      detail = response.json().get("detail") or detail
+    except ValueError:
+      pass
+    raise HTTPException(409, detail)
+  if response.status_code not in (200, 201):
+    raise HTTPException(502, "The Möbius account service could not complete that request.")
+  try:
+    payload = response.json()
+  except ValueError:
+    raise HTTPException(502, "The Möbius account service returned an invalid response.")
+  return _identity_contract(payload)
+
+
+def _linked_row(db: Session, owner_id: int) -> models.IdentityAccountLink | None:
+  return db.query(models.IdentityAccountLink).filter(
+    models.IdentityAccountLink.owner_id == owner_id,
+  ).one_or_none()
+
+
+async def _linked_remote(
+  db: Session,
+  owner_id: int,
+  method: str,
+  suffix: str = "",
+  **kwargs,
+) -> dict | None:
+  link = _linked_row(db, owner_id)
+  if link is None:
+    return None
+  try:
+    token = _open(link.access_token_encrypted)
+  except HTTPException:
+    # A rotated SECRET_KEY or damaged ciphertext cannot be recovered and must
+    # not strand the owner behind an unlink operation that also cannot decrypt.
+    db.delete(link)
+    db.commit()
+    return None
+  try:
+    async with httpx.AsyncClient(timeout=15.0, follow_redirects=False) as client:
+      response = await client.request(
+        method,
+        get_settings().mobius_account_origin + _ACCOUNT_PATH + suffix,
+        headers={"Authorization": f"Bearer {token}", "Accept": "application/json"},
+        **kwargs,
+      )
+  except httpx.HTTPError:
+    raise HTTPException(502, "The Möbius account service could not be reached.")
+  if response.status_code == 401:
+    db.delete(link)
+    db.commit()
+    return None
+  if response.status_code == 409:
+    detail = "That handle is already taken."
+    try:
+      detail = response.json().get("detail") or detail
+    except ValueError:
+      pass
+    raise HTTPException(409, detail)
+  if response.status_code not in (200, 201):
+    raise HTTPException(502, "The Möbius account service could not complete that request.")
+  try:
+    payload = response.json()
+  except ValueError:
+    raise HTTPException(502, "The Möbius account service returned an invalid response.")
+  return _identity_contract(payload)
+
+
+def _merge_local_deployment(payload: dict) -> dict:
+  local = _local_payload()
+  remote_deployments = payload.get("deployments")
+  deployments = list(remote_deployments) if isinstance(remote_deployments, list) else []
+  deployments = [item for item in deployments if isinstance(item, dict)]
+  local_deployment = local["deployments"][0]
+  local_url = local_deployment["url"].rstrip("/")
+  deployments = [
+    item for item in deployments
+    if str(item.get("url") or "").rstrip("/") != local_url
+  ]
+  deployments.append(local_deployment)
+  return {
+    "account_mode": "linked",
+    "account_unavailable": False,
+    "instance_id": None,
+    "profile": (
+      payload.get("profile") if isinstance(payload.get("profile"), dict) else None
+    ),
+    "deployments": deployments,
+  }
+
+
+def _managed_payload(payload: dict, owner: models.Owner) -> dict:
+  # The local SSO binding is authoritative for the user and instance. Copy the
+  # remote profile before adding those fields so response objects are never
+  # mutated in place and can be reused safely by tests/adapters.
+  profile = dict(payload["profile"])
+  profile["user_id"] = owner.sso_subject
+  profile["email"] = owner.sso_email
+  return {
+    "account_mode": "managed",
+    "account_unavailable": False,
+    "instance_id": get_settings().mobius_sso_instance_id,
+    "profile": profile,
+    "deployments": list(payload["deployments"]),
+  }
+
+
+@router.get("")
+async def read_identity(
+  owner: models.Owner = Depends(get_owner_or_app_with_identity_manage),
+  db: Session = Depends(get_db),
+):
+  local = _local_payload()
+  if not get_settings().mobius_sso_enabled:
+    had_link = _linked_row(db, owner.id) is not None
+    try:
+      linked = await _linked_remote(db, owner.id, "GET")
+    except HTTPException as exc:
+      if exc.status_code == 502 and had_link:
+        return _local_payload(
+          account_mode="linked", account_unavailable=True,
+        )
+      raise
+    return _merge_local_deployment(linked) if linked is not None else local
+  try:
+    remote = await _managed_remote("GET")
+  except HTTPException as exc:
+    if exc.status_code != 502:
+      raise
+    degraded = _local_payload(
+      account_mode="managed", account_unavailable=True,
+    )
+    degraded["profile"] = {
+      "user_id": owner.sso_subject,
+      "email": owner.sso_email,
+      "display_name": None,
+      "handle": None,
+      "avatar_url": None,
+    }
+    return degraded
+  return _managed_payload(remote, owner)
+
+
+@router.patch("/profile")
+async def update_profile(
+  body: ProfilePatch,
+  owner: models.Owner = Depends(get_owner_or_app_with_identity_manage),
+  db: Session = Depends(get_db),
+):
+  handle = body.handle.strip().lower()
+  if not re.fullmatch(r"[a-z0-9_]{3,30}", handle):
+    raise HTTPException(422, "Use 3–30 letters, numbers, or underscores.")
+  if get_settings().mobius_sso_enabled:
+    remote = await _managed_remote("PATCH", "/profile", json={"handle": handle})
+    return _managed_payload(remote, owner)
+  remote = await _linked_remote(
+    db, owner.id, "PATCH", "/profile", json={"handle": handle},
+  )
+  if remote is None:
+    raise HTTPException(409, "Sign in to edit your Möbius profile.")
+  return _merge_local_deployment(remote)
+
+
+@router.post("/avatar")
+async def update_avatar(
+  avatar: UploadFile = File(...),
+  owner: models.Owner = Depends(get_owner_or_app_with_identity_manage),
+  db: Session = Depends(get_db),
+):
+  content_type = (avatar.content_type or "").lower()
+  if content_type not in _AVATAR_TYPES:
+    raise HTTPException(415, "Choose a JPEG, PNG, or WebP image.")
+  content = await avatar.read(_AVATAR_MAX_BYTES + 1)
+  if not content or len(content) > _AVATAR_MAX_BYTES:
+    raise HTTPException(413, "Profile pictures must be 5 MB or smaller.")
+  files = {"avatar": (avatar.filename or "avatar", content, content_type)}
+  if get_settings().mobius_sso_enabled:
+    remote = await _managed_remote("POST", "/avatar", files=files)
+    return _managed_payload(remote, owner)
+  remote = await _linked_remote(db, owner.id, "POST", "/avatar", files=files)
+  if remote is None:
+    raise HTTPException(409, "Sign in to edit your Möbius profile.")
+  return _merge_local_deployment(remote)
+
+
+@router.get("/avatar")
+async def read_avatar(
+  owner: models.Owner = Depends(get_owner_or_app_with_identity_manage),
+  db: Session = Depends(get_db),
+):
+  if get_settings().mobius_sso_enabled:
+    remote = await _managed_remote("GET")
+  else:
+    remote = await _linked_remote(db, owner.id, "GET")
+  url = _remote_avatar_url(remote)
+  if url is None:
+    raise HTTPException(404, "This Möbius account has no profile picture.")
+  content, content_type = await _avatar_bytes(url)
+  return Response(
+    content=content,
+    media_type=content_type,
+    headers={
+      "Cache-Control": "private, max-age=300",
+      "X-Content-Type-Options": "nosniff",
+    },
+  )
+
+
+async def _managed_railway_remote() -> dict:
+  settings = get_settings()
+  if not settings.mobius_sso_enabled:
+    raise HTTPException(409, "This Möbius uses a linked account.")
+  try:
+    async with httpx.AsyncClient(timeout=15.0, follow_redirects=False) as client:
+      response = await client.get(
+        settings.mobius_sso_issuer + "/api/instance/v1/railway",
+        headers=_remote_headers(),
+      )
+  except httpx.HTTPError:
+    raise HTTPException(502, "The Möbius account service could not be reached.")
+  if response.status_code != 200:
+    raise HTTPException(502, "The Möbius account service could not read Railway state.")
+  try:
+    return _railway_contract(response.json())
+  except ValueError:
+    raise HTTPException(502, "The Möbius account service returned invalid Railway state.")
+
+
+async def _linked_railway_remote(
+  db: Session, owner_id: int,
+) -> tuple[str, dict | None]:
+  link = _linked_row(db, owner_id)
+  if link is None:
+    return "signed_out", None
+  if not _LINK_SCOPES.issubset(set(link.scopes_json or [])):
+    return "reconnect", None
+  try:
+    token = _open(link.access_token_encrypted)
+  except HTTPException:
+    db.delete(link)
+    db.commit()
+    return "signed_out", None
+  try:
+    async with httpx.AsyncClient(timeout=15.0, follow_redirects=False) as client:
+      response = await client.get(
+        get_settings().mobius_account_origin + "/api/account/v1/railway",
+        headers={"Authorization": f"Bearer {token}", "Accept": "application/json"},
+      )
+  except httpx.HTTPError:
+    return "unavailable", None
+  if response.status_code == 401:
+    db.delete(link)
+    db.commit()
+    return "signed_out", None
+  if response.status_code == 403:
+    return "reconnect", None
+  if response.status_code != 200:
+    return "unavailable", None
+  try:
+    return "available", _railway_contract(response.json())
+  except ValueError:
+    raise HTTPException(502, "The Möbius account service returned invalid Railway state.")
+
+
+@router.get("/railway")
+async def read_railway(
+  owner: models.Owner = Depends(get_owner_or_app_with_railway_manage),
+  db: Session = Depends(get_db),
+):
+  if get_settings().mobius_sso_enabled:
+    try:
+      payload = await _managed_railway_remote()
+    except HTTPException as exc:
+      if exc.status_code == 502:
+        return {"railway_access": "unavailable", "connection": None, "instances": []}
+      raise
+    return {"railway_access": "available", **payload}
+  access, payload = await _linked_railway_remote(db, owner.id)
+  return {
+    "railway_access": access,
+    "connection": payload.get("connection") if payload else None,
+    "instances": payload.get("instances", []) if payload else [],
+  }
+
+
+def _railway_instance_id(value: str) -> str:
+  if not re.fullmatch(r"mob_[A-Za-z0-9_-]{3,80}", value):
+    raise HTTPException(404, "That deployment was not found.")
+  return value
+
+
+async def _railway_proxy(
+  db: Session,
+  owner_id: int,
+  method: str,
+  suffix: str,
+  *,
+  json: dict | None = None,
+) -> dict:
+  """Proxy one Railway call to the account/instance host and return its JSON.
+
+  Shared by every Railway mutation and connection-management route so the auth
+  routing, scope gate, dropped-link recovery, and error mapping live in one
+  place. Callers that expect a specific shape validate the returned dict.
+  """
+  settings = get_settings()
+  if settings.mobius_sso_enabled:
+    url = settings.mobius_sso_issuer + "/api/instance/v1/railway" + suffix
+    headers = _remote_headers()
+  else:
+    link = _linked_row(db, owner_id)
+    if link is None:
+      raise HTTPException(409, "Sign in to manage Railway deployments.")
+    if not _LINK_SCOPES.issubset(set(link.scopes_json or [])):
+      raise HTTPException(
+        409, "Reconnect this Möbius to approve Railway deployment access."
+      )
+    try:
+      token = _open(link.access_token_encrypted)
+    except HTTPException:
+      # A link whose token can no longer be decrypted (e.g. SECRET_KEY drift) is
+      # unusable; drop it so write paths self-heal like the read/401 paths do.
+      db.delete(link)
+      db.commit()
+      raise HTTPException(409, "Sign in again to manage Railway deployments.")
+    url = settings.mobius_account_origin + "/api/account/v1/railway" + suffix
+    headers = {"Authorization": f"Bearer {token}", "Accept": "application/json"}
+  try:
+    async with httpx.AsyncClient(timeout=30.0, follow_redirects=False) as client:
+      response = await client.request(method, url, headers=headers, json=json)
+  except httpx.HTTPError:
+    raise HTTPException(502, "The Möbius account service could not be reached.")
+  if response.status_code == 401 and not settings.mobius_sso_enabled:
+    link = _linked_row(db, owner_id)
+    if link is not None:
+      db.delete(link)
+      db.commit()
+    raise HTTPException(409, "Sign in again to manage Railway deployments.")
+  detail = "The Möbius account service could not complete that Railway action."
+  try:
+    payload = response.json()
+    if isinstance(payload, dict) and isinstance(payload.get("detail"), str):
+      detail = payload["detail"]
+  except ValueError:
+    payload = None
+  if response.status_code not in (200, 202):
+    status = response.status_code if response.status_code in {404, 409, 422} else 502
+    raise HTTPException(status, detail)
+  if not isinstance(payload, dict):
+    raise HTTPException(502, "The Möbius account service returned invalid Railway state.")
+  return payload
+
+
+async def _railway_mutation(
+  db: Session,
+  owner_id: int,
+  method: str,
+  suffix: str,
+  *,
+  json: dict | None = None,
+) -> dict:
+  payload = await _railway_proxy(db, owner_id, method, suffix, json=json)
+  instance = payload.get("instance")
+  if not isinstance(instance, dict):
+    raise HTTPException(502, "The Möbius account service returned invalid Railway state.")
+  return {"instance": instance}
+
+
+def _railway_workspaces_contract(payload: object) -> dict:
+  if not isinstance(payload, dict) or set(payload) != {"workspaces", "current"}:
+    raise HTTPException(502, "The Möbius account service returned invalid workspaces.")
+  workspaces = payload.get("workspaces")
+  current = payload.get("current")
+  if (
+    not isinstance(workspaces, list)
+    or len(workspaces) > 100
+    or any(
+      not isinstance(item, dict)
+      or set(item) != {"id", "name"}
+      or not isinstance(item.get("id"), str)
+      or not isinstance(item.get("name"), str)
+      or len(item["id"]) > 128
+      or len(item["name"]) > 128
+      for item in workspaces
+    )
+    or (current is not None and (not isinstance(current, str) or len(current) > 128))
+  ):
+    raise HTTPException(502, "The Möbius account service returned invalid workspaces.")
+  return payload
+
+
+def _railway_metrics_contract(payload: object) -> dict:
+  invalid = HTTPException(502, "The Möbius account service returned invalid Railway metrics.")
+  if not isinstance(payload, dict) or set(payload) != {
+    "runtime", "cpu", "memory", "volume", "network"
+  }:
+    raise invalid
+
+  def _strings(source: object, keys: set[str], limit: int) -> None:
+    if (
+      not isinstance(source, dict)
+      or set(source) != keys
+      or any(not isinstance(source[key], str) or len(source[key]) > limit for key in keys)
+    ):
+      raise invalid
+
+  _strings(
+    payload["runtime"],
+    {"status_label", "region_label", "latest_deployment_at", "data_status"},
+    200,
+  )
+  _strings(payload["cpu"], {"label", "limit_label", "percent"}, 40)
+  _strings(payload["memory"], {"label", "limit_label", "percent"}, 40)
+  _strings(payload["volume"], {"used_label", "allocated_label", "percent"}, 40)
+  _strings(payload["network"], {"rx_label", "tx_label", "percent"}, 40)
+  return payload
+
+
+def _railway_recovery_status_contract(payload: object) -> dict:
+  invalid = HTTPException(502, "The Möbius account service returned invalid Recovery state.")
+  if not isinstance(payload, dict) or set(payload) - {"state", "message", "error", "open_url"}:
+    raise invalid
+  state = payload.get("state")
+  message = payload.get("message")
+  error = payload.get("error")
+  if (
+    not isinstance(state, str) or len(state) > 32
+    or not isinstance(message, str) or len(message) > 200
+    or not isinstance(error, str) or len(error) > 360
+  ):
+    raise invalid
+  open_url = payload.get("open_url")
+  if open_url is not None:
+    # The app opens this in a popup, so pin it to the account origin's exact
+    # recovery-open path — never let the account host redirect us elsewhere.
+    if not isinstance(open_url, str) or len(open_url) > 2048:
+      raise invalid
+    parsed = urlparse(open_url)
+    if (
+      parsed.scheme != "https"
+      or parsed.fragment
+      or f"{parsed.scheme}://{parsed.netloc}" != get_settings().mobius_account_origin
+      or not parsed.path.endswith("/account/recovery/open")
+    ):
+      raise invalid
+  return payload
+
+
+async def _railway_connect_start(
+  db: Session, owner_id: int, *, replace: bool = False
+) -> dict:
+  settings = get_settings()
+  if settings.mobius_sso_enabled:
+    url = settings.mobius_sso_issuer + "/api/instance/v1/railway/connect/start"
+    headers = _remote_headers()
+  else:
+    link = _linked_row(db, owner_id)
+    if link is None or not _LINK_SCOPES.issubset(set(link.scopes_json or [])):
+      raise HTTPException(
+        409, "Reconnect this Möbius to approve Railway deployment access."
+      )
+    try:
+      token = _open(link.access_token_encrypted)
+    except HTTPException:
+      db.delete(link)
+      db.commit()
+      raise HTTPException(409, "Sign in again to reconnect Railway.")
+    url = settings.mobius_account_origin + "/api/account/v1/railway/connect/start"
+    headers = {"Authorization": f"Bearer {token}", "Accept": "application/json"}
+  try:
+    async with httpx.AsyncClient(timeout=15.0, follow_redirects=False) as client:
+      response = await client.post(url, headers=headers, json={"replace": replace})
+  except httpx.HTTPError:
+    raise HTTPException(502, "The Möbius account service could not be reached.")
+  if response.status_code != 200:
+    raise HTTPException(502, "The Möbius account service could not start Railway sign-in.")
+  try:
+    authorization_url = response.json().get("authorization_url")
+    parsed = urlparse(authorization_url)
+  except (AttributeError, TypeError, ValueError):
+    raise HTTPException(502, "The Möbius account service returned an invalid Railway address.")
+  if (
+    parsed.scheme != "https"
+    or parsed.fragment
+    or f"{parsed.scheme}://{parsed.netloc}" != settings.mobius_account_origin
+    or not parsed.path.endswith("/railway/connect")
+  ):
+    raise HTTPException(502, "The Möbius account service returned an invalid Railway address.")
+  return {"authorization_url": authorization_url}
+
+
+@router.post("/railway/deployments", status_code=202)
+async def create_railway_deployment(
+  body: RailwayCreate,
+  owner: models.Owner = Depends(get_owner_or_app_with_railway_manage),
+  db: Session = Depends(get_db),
+):
+  name = body.name.strip()
+  if not name or len(name) > 80:
+    raise HTTPException(422, "Use a deployment name between 1 and 80 characters.")
+  return await _railway_mutation(
+    db,
+    owner.id,
+    "POST",
+    "/instances",
+    json={
+      "name": name,
+      "managed_auth": body.managed_auth,
+      "cpu": body.cpu,
+      "memory_mb": body.memory_mb,
+      "volume_mb": body.volume_mb,
+    },
+  )
+
+
+@router.post("/railway/connect/start")
+async def start_railway_connection(
+  body: RailwayConnectStart | None = None,
+  owner: models.Owner = Depends(get_owner_or_app_with_railway_manage),
+  db: Session = Depends(get_db),
+):
+  return await _railway_connect_start(
+    db, owner.id, replace=bool(body and body.replace)
+  )
+
+
+@router.get("/railway/workspaces")
+async def read_railway_workspaces(
+  owner: models.Owner = Depends(get_owner_or_app_with_railway_manage),
+  db: Session = Depends(get_db),
+):
+  return _railway_workspaces_contract(
+    await _railway_proxy(db, owner.id, "GET", "/workspaces")
+  )
+
+
+@router.post("/railway/workspace")
+async def select_railway_workspace(
+  body: RailwaySelectWorkspace,
+  owner: models.Owner = Depends(get_owner_or_app_with_railway_manage),
+  db: Session = Depends(get_db),
+):
+  workspace_id = body.workspace_id.strip()
+  if not workspace_id or len(workspace_id) > 128:
+    raise HTTPException(422, "Choose a Railway workspace.")
+  await _railway_proxy(
+    db, owner.id, "POST", "/workspace", json={"workspace_id": workspace_id}
+  )
+  return {"ok": True}
+
+
+@router.post("/railway/plan/refresh")
+async def refresh_railway_plan(
+  owner: models.Owner = Depends(get_owner_or_app_with_railway_manage),
+  db: Session = Depends(get_db),
+):
+  await _railway_proxy(db, owner.id, "POST", "/plan/refresh")
+  return {"ok": True}
+
+
+@router.post("/railway/disconnect")
+async def disconnect_railway(
+  owner: models.Owner = Depends(get_owner_or_app_with_railway_manage),
+  db: Session = Depends(get_db),
+):
+  await _railway_proxy(db, owner.id, "POST", "/disconnect")
+  return {"ok": True}
+
+
+@router.get("/railway/deployments/{instance_id}/metrics")
+async def read_railway_metrics(
+  instance_id: str,
+  owner: models.Owner = Depends(get_owner_or_app_with_railway_manage),
+  db: Session = Depends(get_db),
+):
+  return _railway_metrics_contract(
+    await _railway_proxy(
+      db, owner.id, "GET", f"/instances/{_railway_instance_id(instance_id)}/metrics"
+    )
+  )
+
+
+@router.post("/railway/deployments/{instance_id}/recovery", status_code=202)
+async def open_railway_recovery(
+  instance_id: str,
+  owner: models.Owner = Depends(get_owner_or_app_with_railway_manage),
+  db: Session = Depends(get_db),
+):
+  payload = await _railway_proxy(
+    db, owner.id, "POST", f"/instances/{_railway_instance_id(instance_id)}/recovery"
+  )
+  return {"state": str(payload.get("state") or "starting")}
+
+
+@router.get("/railway/deployments/{instance_id}/recovery/status")
+async def read_railway_recovery_status(
+  instance_id: str,
+  owner: models.Owner = Depends(get_owner_or_app_with_railway_manage),
+  db: Session = Depends(get_db),
+):
+  return _railway_recovery_status_contract(
+    await _railway_proxy(
+      db, owner.id, "GET", f"/instances/{_railway_instance_id(instance_id)}/recovery/status"
+    )
+  )
+
+
+@router.post("/railway/deployments/{instance_id}/retry", status_code=202)
+async def retry_railway_deployment(
+  instance_id: str,
+  owner: models.Owner = Depends(get_owner_or_app_with_railway_manage),
+  db: Session = Depends(get_db),
+):
+  return await _railway_mutation(
+    db, owner.id, "POST", f"/instances/{_railway_instance_id(instance_id)}/retry"
+  )
+
+
+@router.patch("/railway/deployments/{instance_id}/compute")
+async def update_railway_compute(
+  instance_id: str,
+  body: RailwayCompute,
+  owner: models.Owner = Depends(get_owner_or_app_with_railway_manage),
+  db: Session = Depends(get_db),
+):
+  return await _railway_mutation(
+    db,
+    owner.id,
+    "PATCH",
+    f"/instances/{_railway_instance_id(instance_id)}/compute",
+    json={"cpu": body.cpu, "memory_mb": body.memory_mb},
+  )
+
+
+@router.patch("/railway/deployments/{instance_id}/storage")
+async def update_railway_storage(
+  instance_id: str,
+  body: RailwayStorage,
+  owner: models.Owner = Depends(get_owner_or_app_with_railway_manage),
+  db: Session = Depends(get_db),
+):
+  return await _railway_mutation(
+    db,
+    owner.id,
+    "PATCH",
+    f"/instances/{_railway_instance_id(instance_id)}/storage",
+    json={"volume_mb": body.volume_mb},
+  )
+
+
+@router.delete("/railway/deployments/{instance_id}", status_code=202)
+async def delete_railway_deployment(
+  instance_id: str,
+  owner: models.Owner = Depends(get_owner_or_app_with_railway_manage),
+  db: Session = Depends(get_db),
+):
+  return await _railway_mutation(
+    db, owner.id, "DELETE", f"/instances/{_railway_instance_id(instance_id)}"
+  )
+
+
+@router.post("/link/start")
+async def start_link(
+  body: LinkStart,
+  owner: models.Owner = Depends(get_owner_or_app_with_identity_manage),
+  db: Session = Depends(get_db),
+):
+  if get_settings().mobius_sso_enabled:
+    raise HTTPException(409, "This Möbius is already connected.")
+  if _linked_row(db, owner.id) is not None:
+    raise HTTPException(409, "Disconnect the current account before linking another.")
+  client_origin = get_settings().mobius_account_client_origin
+  if not client_origin:
+    raise HTTPException(
+      409,
+      "Set MOBIUS_ACCOUNT_CLIENT_ORIGIN to this Möbius's public HTTPS origin.",
+    )
+  provider = body.provider.strip().lower()
+  if provider not in {"google", "apple"}:
+    raise HTTPException(422, "Choose Google or Apple.")
+  attempt_id = secrets.token_urlsafe(24)
+  state = secrets.token_urlsafe(32)
+  verifier = secrets.token_urlsafe(64)
+  challenge = base64.urlsafe_b64encode(
+    hashlib.sha256(verifier.encode()).digest(),
+  ).rstrip(b"=").decode()
+  expires_at = now_naive_utc() + _LINK_TTL
+  query = urlencode({
+    "state": state,
+    "code_challenge": challenge,
+    "code_challenge_method": "S256",
+    "provider": provider,
+    "client_origin": client_origin,
+  })
+  authorization_url = f"{get_settings().mobius_account_origin}/connect/mobius?{query}"
+  verifier_encrypted = _seal(verifier)
+  created_at = now_naive_utc()
+  statement = sqlite_insert(models.IdentityLinkAttempt).values(
+    owner_id=owner.id,
+    attempt_id=attempt_id,
+    state_digest=_digest(state),
+    verifier_encrypted=verifier_encrypted,
+    expires_at=expires_at,
+    created_at=created_at,
+  ).on_conflict_do_update(
+    index_elements=[models.IdentityLinkAttempt.owner_id],
+    set_={
+      "attempt_id": attempt_id,
+      "state_digest": _digest(state),
+      "verifier_encrypted": verifier_encrypted,
+      "expires_at": expires_at,
+      "created_at": created_at,
+    },
+  )
+  db.execute(statement)
+  db.commit()
+  return {
+    "authorization_url": authorization_url,
+    "attempt": attempt_id,
+    "state": state,
+    "expires_at": expires_at.isoformat() + "Z",
+  }
+
+
+@router.post("/link/complete")
+async def complete_link(
+  body: LinkComplete,
+  owner: models.Owner = Depends(get_owner_or_app_with_identity_manage),
+  db: Session = Depends(get_db),
+):
+  if get_settings().mobius_sso_enabled:
+    raise HTTPException(409, "This Möbius is already connected.")
+  attempt = db.query(models.IdentityLinkAttempt).filter(
+    models.IdentityLinkAttempt.owner_id == owner.id,
+    models.IdentityLinkAttempt.attempt_id == body.attempt,
+  ).one_or_none()
+  valid = bool(
+    attempt
+    and attempt.expires_at >= now_naive_utc()
+    and hmac.compare_digest(attempt.state_digest, _digest(body.state))
+  )
+  if not valid:
+    raise HTTPException(400, "That sign-in attempt expired. Please try again.")
+  if _linked_row(db, owner.id) is not None:
+    raise HTTPException(409, "Disconnect the current account before linking another.")
+  try:
+    verifier = _open(attempt.verifier_encrypted)
+  except HTTPException:
+    db.delete(attempt)
+    db.commit()
+    raise
+  try:
+    async with httpx.AsyncClient(timeout=15.0, follow_redirects=False) as client:
+      response = await client.post(
+        get_settings().mobius_account_origin + "/api/account-links/token",
+        json={"code": body.code, "code_verifier": verifier},
+        headers={"Accept": "application/json"},
+      )
+  except httpx.HTTPError:
+    raise HTTPException(
+      502, "The Möbius account service could not be reached. Try completion again."
+    )
+  if response.status_code != 200:
+    if response.status_code == 400:
+      db.delete(attempt)
+      db.commit()
+    raise HTTPException(400, "That sign-in could not be completed. Please try again.")
+  try:
+    grant = response.json()
+  except ValueError:
+    raise HTTPException(502, "The Möbius account service returned an invalid response.")
+  token = grant.get("access_token") if isinstance(grant, dict) else None
+  scope = grant.get("scope") if isinstance(grant, dict) else None
+  identity = grant.get("identity") if isinstance(grant, dict) else None
+  if (
+    not isinstance(token, str)
+    or len(token) < 32
+    or scope != _LINK_SCOPE
+  ):
+    raise HTTPException(502, "The Möbius account service returned an invalid account grant.")
+  identity = _identity_contract(identity)
+  link = models.IdentityAccountLink(owner_id=owner.id)
+  db.add(link)
+  link.access_token_encrypted = _seal(token)
+  link.scopes_json = scope.split()
+  link.linked_at = now_naive_utc()
+  db.delete(attempt)
+  try:
+    db.commit()
+  except IntegrityError:
+    # A duplicate completion can race after the remote idempotent exchange.
+    # It is successful only when the winner stored the exact same grant.
+    db.rollback()
+    winner = _linked_row(db, owner.id)
+    if winner is None or not hmac.compare_digest(
+      _open(winner.access_token_encrypted), token,
+    ):
+      raise HTTPException(409, "Another account link completed first.")
+  return _merge_local_deployment(identity)
+
+
+@router.delete("/link", status_code=204)
+async def delete_link(
+  owner: models.Owner = Depends(get_owner_or_app_with_identity_manage),
+  db: Session = Depends(get_db),
+):
+  if get_settings().mobius_sso_enabled:
+    raise HTTPException(409, "Managed Möbius accounts cannot be unlinked here.")
+  link = _linked_row(db, owner.id)
+  if link is None:
+    return Response(status_code=204)
+  try:
+    token = _open(link.access_token_encrypted)
+  except HTTPException:
+    db.delete(link)
+    db.commit()
+    return Response(status_code=204)
+  try:
+    async with httpx.AsyncClient(timeout=15.0, follow_redirects=False) as client:
+      response = await client.post(
+        get_settings().mobius_account_origin + "/api/account-links/revoke",
+        headers={"Authorization": f"Bearer {token}"},
+      )
+  except httpx.HTTPError:
+    raise HTTPException(
+      502, "The Möbius account service could not be reached; your link was kept."
+    )
+  if response.status_code not in (204, 401):
+    raise HTTPException(502, "The Möbius account service could not revoke this link.")
+  db.delete(link)
+  db.commit()
+  return Response(status_code=204)

--- a/backend/scripts/check-schema-migrations.py
+++ b/backend/scripts/check-schema-migrations.py
@@ -1,18 +1,30 @@
 #!/usr/bin/env python3
-"""Dependency-free guard for published schema-migration history."""
+"""Dependency-free guard for append-only schema-migration history."""
 
 from __future__ import annotations
 
+import argparse
 import ast
 import hashlib
-import json
+import os
+import subprocess
 import sys
-from dataclasses import dataclass
 from pathlib import Path
+
 
 ROOT = Path(__file__).resolve().parents[2]
 SOURCE = ROOT / "backend" / "app" / "schema_migrations.py"
-HISTORY = ROOT / "backend" / "tests" / "fixtures" / "migration_history.json"
+SOURCE_REPO_PATH = SOURCE.relative_to(ROOT)
+
+# These migrations shipped before the repository required migration code to
+# be self-contained. Their source remains immutable, but their historical
+# runtime imports are deliberately not fingerprinted: doing so froze unrelated
+# app_git/model/compiler work and still did not prove history was append-only.
+LEGACY_APP_DEPENDENCIES = frozenset({
+  "0004_app_identity_required",
+  "0005_connectors",
+  "0013_app_hosted_publication",
+})
 
 
 def fail(message: str) -> None:
@@ -20,28 +32,8 @@ def fail(message: str) -> None:
   raise SystemExit(1)
 
 
-@dataclass(frozen=True)
-class ModuleSymbols:
-  path: Path
-  definitions: dict[str, ast.AST]
-  imports: dict[str, tuple[str, str]]
-
-
-def _module_path(module: str) -> Path | None:
-  if module != "app" and not module.startswith("app."):
-    return None
-  candidate = ROOT / "backend" / Path(*module.split("."))
-  path = candidate.with_suffix(".py")
-  if path.is_file():
-    return path
-  package = candidate / "__init__.py"
-  return package if package.is_file() else None
-
-
-def _symbols(path: Path) -> ModuleSymbols:
-  module = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+def _definitions(module: ast.Module) -> dict[str, ast.AST]:
   definitions: dict[str, ast.AST] = {}
-  imports: dict[str, tuple[str, str]] = {}
   for node in module.body:
     if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
       definitions[node.name] = node
@@ -50,95 +42,10 @@ def _symbols(path: Path) -> ModuleSymbols:
       for target in targets:
         if isinstance(target, ast.Name):
           definitions[target.id] = node
-    elif isinstance(node, ast.ImportFrom) and node.module:
-      for alias in node.names:
-        if alias.name != "*":
-          imports[alias.asname or alias.name] = (node.module, alias.name)
-    elif isinstance(node, ast.Import):
-      for alias in node.names:
-        imports[alias.asname or alias.name] = (alias.name, "")
-  return ModuleSymbols(path, definitions, imports)
+  return definitions
 
 
-def semantic_hash(source: Path, function_name: str) -> str:
-  """Hash a migration plus transitive local and imported ``app`` symbols."""
-  modules: dict[Path, ModuleSymbols] = {}
-
-  def load(path: Path) -> ModuleSymbols:
-    resolved = path.resolve()
-    if resolved not in modules:
-      modules[resolved] = _symbols(resolved)
-    return modules[resolved]
-
-  dependencies: dict[str, ast.AST] = {}
-  pending: list[tuple[ModuleSymbols, str]] = [(load(source), function_name)]
-  while pending:
-    owner, name = pending.pop()
-    key = f"{owner.path.relative_to(ROOT)}:{name}"
-    if key in dependencies:
-      continue
-    current = owner.definitions.get(name)
-    if current is None:
-      fail(f"migration dependency {key!r} does not exist")
-    dependencies[key] = current
-
-    scoped_imports = dict(owner.imports)
-    for node in ast.walk(current):
-      if isinstance(node, ast.ImportFrom) and node.module:
-        for alias in node.names:
-          if alias.name != "*":
-            scoped_imports[alias.asname or alias.name] = (node.module, alias.name)
-      elif isinstance(node, ast.Import):
-        for alias in node.names:
-          scoped_imports[alias.asname or alias.name] = (alias.name, "")
-    referenced = {
-      node.id for node in ast.walk(current) if isinstance(node, ast.Name)
-    }
-    for referenced_name in sorted(referenced):
-      if referenced_name in owner.definitions:
-        pending.append((owner, referenced_name))
-        continue
-      imported = scoped_imports.get(referenced_name)
-      if imported is None:
-        continue
-      if imported[1] and _module_path(f"{imported[0]}.{imported[1]}") is not None:
-        # ``from app import helper`` binds the helper module. Attribute reads
-        # below select the exact symbols whose semantics the migration uses.
-        continue
-      imported_path = _module_path(imported[0])
-      if imported_path is not None and imported[1]:
-        pending.append((load(imported_path), imported[1]))
-    # ``from app import helper`` and ``import app.helper as helper`` bind a
-    # module rather than one symbol. Fingerprint only the attributes this
-    # dependency actually reads, preserving a deep guard without coupling a
-    # migration to unrelated edits elsewhere in that module.
-    for node in ast.walk(current):
-      if not isinstance(node, ast.Attribute) or not isinstance(node.value, ast.Name):
-        continue
-      imported = scoped_imports.get(node.value.id)
-      if imported is None:
-        continue
-      module_name, imported_name = imported
-      module_target = (
-        f"{module_name}.{imported_name}" if imported_name else module_name
-      )
-      imported_path = _module_path(module_target)
-      if imported_path is not None:
-        pending.append((load(imported_path), node.attr))
-  shape = "\n".join(
-    f"{key}\n{ast.dump(dependencies[key], include_attributes=False)}"
-    for key in sorted(dependencies)
-  ).encode()
-  return hashlib.sha256(shape).hexdigest()
-
-
-def main() -> None:
-  module = ast.parse(SOURCE.read_text(encoding="utf-8"), filename=str(SOURCE))
-  functions = {
-    node.name: node
-    for node in module.body
-    if isinstance(node, ast.FunctionDef)
-  }
+def _registry(module: ast.Module) -> list[tuple[str, str]]:
   registry = next((
     node.value
     for node in module.body
@@ -162,7 +69,83 @@ def main() -> None:
     ):
       fail("each registry entry must be a literal (version, function) pair")
     entries.append((item.elts[0].value, item.elts[1].id))
+  return entries
 
+
+def _dependency_nodes(
+  definitions: dict[str, ast.AST], root_name: str,
+) -> dict[str, ast.AST]:
+  dependencies: dict[str, ast.AST] = {}
+  pending = [root_name]
+  while pending:
+    name = pending.pop()
+    if name in dependencies:
+      continue
+    node = definitions.get(name)
+    if node is None:
+      fail(f"registered migration function {name!r} does not exist")
+    dependencies[name] = node
+    referenced = {
+      child.id for child in ast.walk(node) if isinstance(child, ast.Name)
+    }
+    pending.extend(sorted(referenced & definitions.keys()))
+  return dependencies
+
+
+def _migration_hash(dependencies: dict[str, ast.AST]) -> str:
+  """Fingerprint migration-owned code without freezing runtime modules."""
+  shape = "\n".join(
+    f"{name}\n{ast.dump(dependencies[name], include_attributes=False)}"
+    for name in sorted(dependencies)
+  ).encode()
+  return hashlib.sha256(shape).hexdigest()
+
+
+def _app_imports(
+  module: ast.Module, dependencies: dict[str, ast.AST],
+) -> set[str]:
+  """Return runtime ``app`` modules used by one migration dependency set."""
+  bound_imports: dict[str, str] = {}
+  import_nodes = [
+    node for node in module.body
+    if isinstance(node, (ast.Import, ast.ImportFrom))
+  ]
+  for dependency in dependencies.values():
+    import_nodes.extend(
+      node for node in ast.walk(dependency)
+      if isinstance(node, (ast.Import, ast.ImportFrom))
+    )
+  for node in import_nodes:
+    if isinstance(node, ast.ImportFrom) and node.module:
+      for alias in node.names:
+        target = f"{node.module}.{alias.name}"
+        bound_imports[alias.asname or alias.name] = target
+    elif isinstance(node, ast.Import):
+      for alias in node.names:
+        bound_imports[alias.asname or alias.name] = alias.name
+
+  referenced = {
+    child.id
+    for dependency in dependencies.values()
+    for child in ast.walk(dependency)
+    if isinstance(child, ast.Name)
+  }
+  return {
+    module_name
+    for name, module_name in bound_imports.items()
+    if name in referenced
+    and (module_name == "app" or module_name.startswith("app."))
+  }
+
+
+def inspect_history(raw: str, *, source: str) -> dict[str, tuple[str, str]]:
+  """Validate one source revision and return version -> (function, hash)."""
+  try:
+    module = ast.parse(raw, filename=source)
+  except SyntaxError as exc:
+    fail(f"cannot parse {source}: {exc}")
+  definitions = _definitions(module)
+  entries = _registry(module)
   versions = [version for version, _name in entries]
   function_names = [name for _version, name in entries]
   try:
@@ -176,33 +159,86 @@ def main() -> None:
   if len(function_names) != len(set(function_names)):
     fail("one migration function cannot own multiple ledger entries")
 
-  frozen = json.loads(HISTORY.read_text(encoding="utf-8"))
-  if frozen.get("format") != 2 or not isinstance(frozen.get("migrations"), dict):
-    fail("migration_history.json has an unsupported shape")
-  expected = frozen["migrations"]
-  if list(expected) != versions:
-    fail(
-      "registry and frozen history differ; append the new version and its "
-      "semantic hash without editing or renumbering prior entries"
-    )
-
-  actual = {}
+  history: dict[str, tuple[str, str]] = {}
   for version, function_name in entries:
-    function = functions.get(function_name)
-    if function is None:
-      fail(f"registered function {function_name!r} does not exist")
-    actual[version] = semantic_hash(SOURCE, function_name)
-  if actual != expected:
-    changed = [
-      version for version in versions
-      if actual.get(version) != expected.get(version)
-    ]
-    fail(
-      "published migration code changed for " + ", ".join(changed)
-      + "; restore it and append a new migration"
-    )
+    dependencies = _dependency_nodes(definitions, function_name)
+    runtime_imports = _app_imports(module, dependencies)
+    if runtime_imports and version not in LEGACY_APP_DEPENDENCIES:
+      fail(
+        f"new migration {version} depends on mutable runtime module(s): "
+        + ", ".join(sorted(runtime_imports))
+        + "; keep migration code self-contained"
+      )
+    history[version] = (function_name, _migration_hash(dependencies))
+  return history
 
-  print(f"schema-migrations: {len(entries)} immutable migrations verified")
+
+def append_only_error(
+  published: dict[str, object], candidate: dict[str, object],
+) -> str | None:
+  """Explain how candidate rewrites published history, or return ``None``."""
+  published_entries = list(published.items())
+  candidate_entries = list(candidate.items())
+  if candidate_entries[:len(published_entries)] == published_entries:
+    return None
+  for index, (version, identity) in enumerate(published_entries):
+    if index >= len(candidate_entries):
+      return f"published migration {version} was removed"
+    candidate_version, candidate_identity = candidate_entries[index]
+    if candidate_version != version:
+      return (
+        f"published migration {version} was reordered, removed, or renamed "
+        f"to {candidate_version}"
+      )
+    if candidate_identity != identity:
+      return f"published migration {version} changed"
+  return "published migration history changed"
+
+
+def _published_source(ref: str) -> str:
+  try:
+    completed = subprocess.run(
+      ["git", "show", f"{ref}:{SOURCE_REPO_PATH.as_posix()}"],
+      cwd=ROOT,
+      text=True,
+      capture_output=True,
+      check=True,
+    )
+  except subprocess.CalledProcessError as exc:
+    detail = exc.stderr.strip() or exc.stdout.strip() or "not found"
+    fail(f"cannot read published migration source at {ref!r}: {detail}")
+  return completed.stdout
+
+
+def main() -> None:
+  parser = argparse.ArgumentParser(
+    description="Verify current and already-published schema migration history.",
+  )
+  parser.add_argument(
+    "--against",
+    default=os.environ.get("SCHEMA_MIGRATION_BASE_REF"),
+    help="Git revision whose migration source is the immutable prefix",
+  )
+  args = parser.parse_args()
+
+  candidate = inspect_history(
+    SOURCE.read_text(encoding="utf-8"), source=str(SOURCE_REPO_PATH),
+  )
+  if args.against:
+    published = inspect_history(
+      _published_source(args.against),
+      source=f"{args.against}:{SOURCE_REPO_PATH}",
+    )
+    regression = append_only_error(published, candidate)
+    if regression:
+      fail(regression + "; restore it and append a new migration")
+    suffix = f" against {args.against}"
+  else:
+    suffix = " (no published baseline supplied)"
+  print(
+    f"schema-migrations: {len(candidate)} append-only migrations verified"
+    f"{suffix}"
+  )
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_bootstrap.py
+++ b/backend/tests/test_bootstrap.py
@@ -14,6 +14,7 @@ from fastapi import HTTPException
 from app import app_git, models
 from app.bootstrap import (
   BOOTSTRAP_CONNECTIONS_MANIFEST_URL,
+  BOOTSTRAP_IDENTITY_MANIFEST_URL,
   BOOTSTRAP_MEMORY_MANIFEST_URL,
   BOOTSTRAP_REFLECTION_MANIFEST_URL,
   BOOTSTRAP_SKILLS_MANIFEST_URL,
@@ -77,6 +78,23 @@ async def test_bootstrap_installs_all_apps_in_order_when_absent(db, monkeypatch)
     assert call.kwargs["manifest"] is None
     assert call.kwargs["raw_base"] is None
     assert call.kwargs["source"] == "bootstrap"
+
+
+@pytest.mark.asyncio
+async def test_managed_deployment_also_bootstraps_identity(db, monkeypatch):
+  """Railway SSO is the install condition; local owners do not get the app."""
+  monkeypatch.delenv("MOEBIUS_SKIP_BOOTSTRAP", raising=False)
+  install_mock = AsyncMock(return_value=_install_result())
+
+  class ManagedSettings:
+    mobius_sso_enabled = True
+
+  monkeypatch.setattr("app.bootstrap.get_settings", lambda: ManagedSettings())
+  with patch("app.bootstrap.install_from_manifest", install_mock):
+    await ensure_bootstrap_apps_installed(db)
+
+  urls = [call.kwargs["manifest_url"] for call in install_mock.await_args_list]
+  assert urls == _bootstrap_urls() + [BOOTSTRAP_IDENTITY_MANIFEST_URL]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_db_migrations.py
+++ b/backend/tests/test_db_migrations.py
@@ -1753,65 +1753,7 @@ def test_published_schema_migration_history_is_unique_ordered_and_immutable():
     check=False,
   )
   assert completed.returncode == 0, completed.stderr
-  assert "immutable migrations verified" in completed.stdout
-
-
-def test_migration_hash_includes_imported_app_helper(tmp_path, monkeypatch):
-  """Changing live in-repository helper semantics must invalidate history."""
-  script = Path(__file__).parents[1] / "scripts" / "check-schema-migrations.py"
-  spec = importlib.util.spec_from_file_location("migration_guard", script)
-  assert spec and spec.loader
-  guard = importlib.util.module_from_spec(spec)
-  sys.modules[spec.name] = guard
-  spec.loader.exec_module(guard)
-
-  root = tmp_path
-  app = root / "backend" / "app"
-  app.mkdir(parents=True)
-  migration = app / "schema_migrations.py"
-  helper = app / "helper.py"
-  migration.write_text(
-    "def migrate(db):\n"
-    "  from app.helper import normalize\n"
-    "  return normalize(db)\n",
-    encoding="utf-8",
-  )
-  helper.write_text("def normalize(value):\n  return value\n", encoding="utf-8")
-  monkeypatch.setattr(guard, "ROOT", root)
-  first = guard.semantic_hash(migration, "migrate")
-
-  helper.write_text("def normalize(value):\n  return str(value)\n", encoding="utf-8")
-  second = guard.semantic_hash(migration, "migrate")
-
-  assert first != second
-
-
-def test_migration_hash_includes_imported_app_module_attribute(tmp_path, monkeypatch):
-  script = Path(__file__).parents[1] / "scripts" / "check-schema-migrations.py"
-  spec = importlib.util.spec_from_file_location("migration_guard_module", script)
-  assert spec and spec.loader
-  guard = importlib.util.module_from_spec(spec)
-  sys.modules[spec.name] = guard
-  spec.loader.exec_module(guard)
-
-  root = tmp_path
-  app = root / "backend" / "app"
-  app.mkdir(parents=True)
-  (app / "__init__.py").write_text("", encoding="utf-8")
-  migration = app / "schema_migrations.py"
-  helper = app / "helper.py"
-  migration.write_text(
-    "def migrate(db):\n"
-    "  from app import helper\n"
-    "  return helper.normalize(db)\n",
-    encoding="utf-8",
-  )
-  helper.write_text("def normalize(value):\n  return value\n", encoding="utf-8")
-  monkeypatch.setattr(guard, "ROOT", root)
-  first = guard.semantic_hash(migration, "migrate")
-  helper.write_text("def normalize(value):\n  return str(value)\n", encoding="utf-8")
-
-  assert first != guard.semantic_hash(migration, "migrate")
+  assert "append-only migrations verified" in completed.stdout
 
 
 def test_failed_migration_is_not_recorded_and_can_retry(tmp_path, monkeypatch):

--- a/backend/tests/test_identity.py
+++ b/backend/tests/test_identity.py
@@ -1,0 +1,707 @@
+"""Identity app authorization and local-account behavior."""
+
+import httpx
+
+from urllib.parse import parse_qs, urlparse
+
+from app import models
+from app.database import SessionLocal
+from test_app_fixtures import create_local_app
+
+
+def _app_auth(client, auth, *, granted: bool, railway_granted: bool = False):
+  app_id = create_local_app(client, auth, name="identity-test", description="t")["id"]
+  with SessionLocal() as session:
+    app = session.query(models.App).filter(models.App.id == app_id).one()
+    app.capability_contract = {
+      "schema": 1,
+      "data": {
+        "identity_manage": granted,
+        "railway_manage": railway_granted,
+      },
+    }
+    session.commit()
+  minted = client.post("/api/auth/app-token", json={"app_id": app_id}, headers=auth)
+  assert minted.status_code == 200, minted.text
+  return {"Authorization": f"Bearer {minted.json()['token']}"}
+
+
+def test_identity_app_requires_reviewed_capability(client, auth):
+  denied = _app_auth(client, auth, granted=False)
+  assert client.get("/api/identity", headers=denied).status_code == 403
+
+  granted = _app_auth(client, auth, granted=True)
+  response = client.get("/api/identity", headers=granted)
+  assert response.status_code == 200, response.text
+  body = response.json()
+  assert body["account_mode"] == "signed_out"
+  assert body["account_unavailable"] is False
+  assert body["profile"] is None
+  assert "test" not in response.text
+  assert body["deployments"][0]["current"] is True
+
+
+def test_identity_permission_is_part_of_review_contract():
+  from app.app_capabilities import contract_from_app_state, contract_from_manifest
+
+  contract = contract_from_manifest({
+    "permissions": {"identity_manage": True},
+  })
+  assert contract["data"]["identity_manage"] is True
+  local = contract_from_app_state(
+    models.App(name="Identity", slug="identity", source_dir="/tmp/identity"),
+    contract_permissions={"identity_manage": True},
+  )
+  assert local["data"]["identity_manage"] is True
+
+
+def test_railway_permission_is_separate_from_identity_management(client, auth):
+  identity_only = _app_auth(client, auth, granted=True)
+  assert client.get("/api/identity/railway", headers=identity_only).status_code == 403
+
+  railway = _app_auth(
+    client, auth, granted=True, railway_granted=True,
+  )
+  response = client.get("/api/identity/railway", headers=railway)
+  assert response.status_code == 200, response.text
+  assert response.json() == {
+    "railway_access": "signed_out",
+    "connection": None,
+    "instances": [],
+  }
+
+
+def test_linked_railway_inventory_requires_reconsent_for_legacy_grants(
+  client, auth,
+):
+  from app.routes.identity import _seal
+
+  granted = _app_auth(
+    client, auth, granted=True, railway_granted=True,
+  )
+  with SessionLocal() as session:
+    owner = session.query(models.Owner).one()
+    session.add(models.IdentityAccountLink(
+      owner_id=owner.id,
+      access_token_encrypted=_seal("legacy-token-" + "x" * 40),
+      scopes_json=["identity:read", "identity:write", "deployments:read"],
+    ))
+    session.commit()
+
+  response = client.get("/api/identity/railway", headers=granted)
+
+  assert response.status_code == 200
+  assert response.json() == {
+    "railway_access": "reconnect",
+    "connection": None,
+    "instances": [],
+  }
+
+
+def test_linked_railway_inventory_is_proxied_without_credentials(
+  client, auth, monkeypatch,
+):
+  from app.routes.identity import _seal
+
+  granted = _app_auth(
+    client, auth, granted=True, railway_granted=True,
+  )
+  with SessionLocal() as session:
+    owner = session.query(models.Owner).one()
+    session.add(models.IdentityAccountLink(
+      owner_id=owner.id,
+      access_token_encrypted=_seal("railway-token-" + "x" * 40),
+      scopes_json=[
+        "deployments:delete", "deployments:read", "identity:read",
+        "identity:write", "railway:read", "railway:write",
+      ],
+    ))
+    session.commit()
+
+  class Response:
+    status_code = 200
+
+    @staticmethod
+    def json():
+      return {
+        "connection": {
+          "connected": True,
+          "account": "owner@example.com",
+          "workspace": "Personal",
+          "plan": "hobby",
+          "deploy_blocked": "",
+        },
+        "instances": [{"id": "mob_one"}],
+      }
+
+  class Client:
+    def __init__(self, *args, **kwargs):
+      assert kwargs.get("follow_redirects") is False
+
+    async def __aenter__(self):
+      return self
+
+    async def __aexit__(self, *args):
+      return None
+
+    async def get(self, url, **kwargs):
+      assert url == "https://www.mobius.you/api/account/v1/railway"
+      assert kwargs["headers"]["Authorization"].startswith("Bearer railway-token-")
+      return Response()
+
+  monkeypatch.setattr("app.routes.identity.httpx.AsyncClient", Client)
+  response = client.get("/api/identity/railway", headers=granted)
+
+  assert response.status_code == 200
+  assert response.json()["railway_access"] == "available"
+  assert response.json()["instances"] == [{"id": "mob_one"}]
+  assert "token" not in response.text
+
+
+def test_linked_railway_mutations_use_the_scoped_server_bridge(
+  client, auth, monkeypatch,
+):
+  from app.routes.identity import _seal
+
+  granted = _app_auth(
+    client, auth, granted=True, railway_granted=True,
+  )
+  with SessionLocal() as session:
+    owner = session.query(models.Owner).one()
+    session.add(models.IdentityAccountLink(
+      owner_id=owner.id,
+      access_token_encrypted=_seal("railway-token-" + "x" * 40),
+      scopes_json=[
+        "deployments:delete", "deployments:read", "identity:read",
+        "identity:write", "railway:read", "railway:write",
+      ],
+    ))
+    session.commit()
+
+  calls = []
+
+  class Response:
+    status_code = 202
+
+    @staticmethod
+    def json():
+      return {"instance": {"id": "mob_example", "status": "queued"}}
+
+  class ConnectResponse:
+    status_code = 200
+
+    @staticmethod
+    def json():
+      return {
+        "authorization_url": (
+          "https://www.mobius.you/railway/connect?popup=1&account_request=signed"
+        ),
+      }
+
+  class Client:
+    def __init__(self, *args, **kwargs):
+      assert kwargs.get("follow_redirects") is False
+
+    async def __aenter__(self):
+      return self
+
+    async def __aexit__(self, *args):
+      return None
+
+    async def request(self, method, url, **kwargs):
+      calls.append((method, url, kwargs.get("json")))
+      assert kwargs["headers"]["Authorization"].startswith("Bearer railway-token-")
+      return Response()
+
+    async def post(self, url, **kwargs):
+      assert url == "https://www.mobius.you/api/account/v1/railway/connect/start"
+      assert kwargs["headers"]["Authorization"].startswith("Bearer railway-token-")
+      return ConnectResponse()
+
+  monkeypatch.setattr("app.routes.identity.httpx.AsyncClient", Client)
+  connect = client.post("/api/identity/railway/connect/start", headers=granted)
+  created = client.post(
+    "/api/identity/railway/deployments",
+    json={
+      "name": "Writing room",
+      "managed_auth": True,
+      "cpu": None,
+      "memory_mb": None,
+      "volume_mb": None,
+    },
+    headers=granted,
+  )
+  deleted = client.delete(
+    "/api/identity/railway/deployments/mob_example", headers=granted,
+  )
+  storage = client.patch(
+    "/api/identity/railway/deployments/mob_example/storage",
+    json={"volume_mb": 2048},
+    headers=granted,
+  )
+
+  assert connect.status_code == 200
+  assert connect.json()["authorization_url"].startswith("https://www.mobius.you/")
+  assert created.status_code == 202
+  assert deleted.status_code == 202
+  assert storage.status_code == 200
+  assert calls == [
+    (
+      "POST",
+      "https://www.mobius.you/api/account/v1/railway/instances",
+      {
+        "name": "Writing room",
+        "managed_auth": True,
+        "cpu": None,
+        "memory_mb": None,
+        "volume_mb": None,
+      },
+    ),
+    (
+      "DELETE",
+      "https://www.mobius.you/api/account/v1/railway/instances/mob_example",
+      None,
+    ),
+    (
+      "PATCH",
+      "https://www.mobius.you/api/account/v1/railway/instances/mob_example/storage",
+      {"volume_mb": 2048},
+    ),
+  ]
+
+
+def test_link_start_keeps_pkce_verifier_server_side_and_supersedes(
+  client, auth,
+):
+  granted = _app_auth(client, auth, granted=True)
+
+  first = client.post(
+    "/api/identity/link/start", json={"provider": "google"}, headers=granted,
+  )
+  assert first.status_code == 200, first.text
+  first_body = first.json()
+  query = parse_qs(urlparse(first_body["authorization_url"]).query)
+  assert query["provider"] == ["google"]
+  assert query["code_challenge_method"] == ["S256"]
+  assert query["state"] == [first_body["state"]]
+  assert query["client_origin"] == ["http://localhost:5173"]
+  assert "code_verifier" not in first.text
+
+  second = client.post(
+    "/api/identity/link/start", json={"provider": "apple"}, headers=granted,
+  )
+  assert second.status_code == 200, second.text
+  with SessionLocal() as session:
+    rows = session.query(models.IdentityLinkAttempt).all()
+    assert len(rows) == 1
+    assert rows[0].attempt_id == second.json()["attempt"]
+    assert first_body["state"] not in rows[0].state_digest
+    assert "code_verifier" not in rows[0].verifier_encrypted
+
+
+def test_link_start_does_not_create_a_throwaway_server_side_oauth_flow(
+  client, auth, monkeypatch,
+):
+  class UnexpectedAuthorizationClient:
+    def __init__(self, *args, **kwargs):
+      raise AssertionError("link start must not call the authorization URL")
+
+  monkeypatch.setattr(
+    "app.routes.identity.httpx.AsyncClient", UnexpectedAuthorizationClient,
+  )
+  granted = _app_auth(client, auth, granted=True)
+  response = client.post(
+    "/api/identity/link/start", json={"provider": "google"}, headers=granted,
+  )
+  assert response.status_code == 200
+  with SessionLocal() as session:
+    assert session.query(models.IdentityLinkAttempt).count() == 1
+
+
+def test_link_complete_consumes_attempt_and_stores_encrypted_grant(
+  client, auth, monkeypatch,
+):
+  granted = _app_auth(client, auth, granted=True)
+  plain_token = "account-token-" + "x" * 40
+
+  class Response:
+    def __init__(self, status_code, body=None):
+      self.status_code = status_code
+      self._body = body
+
+    def json(self):
+      return self._body
+
+  class Client:
+    def __init__(self, *args, **kwargs):
+      pass
+
+    async def __aenter__(self):
+      return self
+
+    async def __aexit__(self, *args):
+      return None
+
+    async def post(self, url, **kwargs):
+      assert url.endswith("/api/account-links/token")
+      assert len(kwargs["json"]["code_verifier"]) >= 43
+      return Response(200, {
+        "access_token": plain_token,
+        "token_type": "Bearer",
+        "scope": (
+          "deployments:delete deployments:read identity:read identity:write "
+          "railway:read railway:write"
+        ),
+        "identity": {
+          "profile": {
+            "user_id": "usr_123",
+            "email": "owner@example.com",
+            "display_name": "Owner",
+            "handle": "owner",
+            "avatar_url": None,
+          },
+          "deployments": [{
+            "id": "remote", "name": "Production", "status": "Active",
+            "url": "https://example.com", "current": False,
+          }],
+        },
+      })
+
+    async def get(self, url, **kwargs):
+      assert url.startswith("https://www.mobius.you/connect/mobius?")
+      return Response(200)
+
+    async def request(self, method, url, **kwargs):
+      raise AssertionError("completion must not need a second remote request")
+
+  monkeypatch.setattr("app.routes.identity.httpx.AsyncClient", Client)
+  started = client.post(
+    "/api/identity/link/start", json={"provider": "google"}, headers=granted,
+  ).json()
+  completed = client.post("/api/identity/link/complete", json={
+    "code": "one-use-code-" + "c" * 32,
+    "state": started["state"],
+    "attempt": started["attempt"],
+  }, headers=granted)
+  assert completed.status_code == 200, completed.text
+  body = completed.json()
+  assert body["account_mode"] == "linked"
+  assert body["profile"]["user_id"] == "usr_123"
+  assert [item["id"] for item in body["deployments"]] == ["remote", "local"]
+
+  with SessionLocal() as session:
+    assert session.query(models.IdentityLinkAttempt).count() == 0
+    link = session.query(models.IdentityAccountLink).one()
+    assert plain_token not in link.access_token_encrypted
+    assert link.scopes_json == [
+      "deployments:delete", "deployments:read", "identity:read",
+      "identity:write", "railway:read", "railway:write",
+    ]
+
+  replacement = client.post(
+    "/api/identity/link/start", json={"provider": "apple"}, headers=granted,
+  )
+  assert replacement.status_code == 409
+  assert replacement.json()["detail"] == (
+    "Disconnect the current account before linking another."
+  )
+
+  replay = client.post("/api/identity/link/complete", json={
+    "code": "one-use-code-" + "c" * 32,
+    "state": started["state"],
+    "attempt": started["attempt"],
+  }, headers=granted)
+  assert replay.status_code == 400
+
+
+def test_unlink_removes_local_link_when_remote_grant_is_already_gone(
+  client, auth, monkeypatch,
+):
+  from app.routes.identity import _seal
+
+  granted = _app_auth(client, auth, granted=True)
+  with SessionLocal() as session:
+    owner = session.query(models.Owner).one()
+    session.add(models.IdentityAccountLink(
+      owner_id=owner.id,
+      access_token_encrypted=_seal("expired-token-" + "x" * 40),
+      scopes_json=["identity:read", "identity:write", "deployments:read"],
+    ))
+    session.commit()
+
+  class Client:
+    def __init__(self, *args, **kwargs):
+      pass
+
+    async def __aenter__(self):
+      return self
+
+    async def __aexit__(self, *args):
+      return None
+
+    async def post(self, url, **kwargs):
+      assert url == "https://www.mobius.you/api/account-links/revoke"
+      return type("Response", (), {"status_code": 401})()
+
+  monkeypatch.setattr("app.routes.identity.httpx.AsyncClient", Client)
+  response = client.delete("/api/identity/link", headers=granted)
+
+  assert response.status_code == 204
+  with SessionLocal() as session:
+    assert session.query(models.IdentityAccountLink).count() == 0
+
+
+def test_link_completion_keeps_retry_state_when_host_response_is_lost(
+  client, auth, monkeypatch,
+):
+  granted = _app_auth(client, auth, granted=True)
+
+  class Client:
+    def __init__(self, *args, **kwargs):
+      pass
+
+    async def __aenter__(self):
+      return self
+
+    async def __aexit__(self, *args):
+      return None
+
+    async def get(self, url, **kwargs):
+      return type("Response", (), {"status_code": 200})()
+
+    async def post(self, url, **kwargs):
+      raise httpx.ConnectError("response lost")
+
+  monkeypatch.setattr("app.routes.identity.httpx.AsyncClient", Client)
+  started = client.post(
+    "/api/identity/link/start", json={"provider": "google"}, headers=granted,
+  ).json()
+  response = client.post("/api/identity/link/complete", json={
+    "code": "one-use-code-" + "c" * 32,
+    "state": started["state"],
+    "attempt": started["attempt"],
+  }, headers=granted)
+
+  assert response.status_code == 502
+  with SessionLocal() as session:
+    assert session.query(models.IdentityLinkAttempt).count() == 1
+    assert session.query(models.IdentityAccountLink).count() == 0
+
+
+def test_corrupt_local_grant_self_heals_to_signed_out(client, auth):
+  granted = _app_auth(client, auth, granted=True)
+  with SessionLocal() as session:
+    owner = session.query(models.Owner).one()
+    session.add(models.IdentityAccountLink(
+      owner_id=owner.id,
+      access_token_encrypted="not-a-fernet-token",
+      scopes_json=["identity:read"],
+    ))
+    session.commit()
+
+  response = client.get("/api/identity", headers=granted)
+
+  assert response.status_code == 200
+  assert response.json()["account_mode"] == "signed_out"
+  with SessionLocal() as session:
+    assert session.query(models.IdentityAccountLink).count() == 0
+
+
+def test_linked_host_outage_preserves_local_deployment(client, auth, monkeypatch):
+  from app.routes.identity import _seal
+
+  granted = _app_auth(client, auth, granted=True)
+  with SessionLocal() as session:
+    owner = session.query(models.Owner).one()
+    session.add(models.IdentityAccountLink(
+      owner_id=owner.id,
+      access_token_encrypted=_seal("linked-token-" + "x" * 40),
+      scopes_json=["identity:read", "identity:write", "deployments:read"],
+    ))
+    session.commit()
+
+  class Client:
+    def __init__(self, *args, **kwargs):
+      pass
+
+    async def __aenter__(self):
+      return self
+
+    async def __aexit__(self, *args):
+      return None
+
+    async def request(self, method, url, **kwargs):
+      raise httpx.ConnectError("account host unavailable")
+
+  monkeypatch.setattr("app.routes.identity.httpx.AsyncClient", Client)
+  response = client.get("/api/identity", headers=granted)
+
+  assert response.status_code == 200
+  body = response.json()
+  assert body["account_mode"] == "linked"
+  assert body["account_unavailable"] is True
+  assert body["profile"] is None
+  assert body["deployments"] == [{
+    "id": "local",
+    "name": "This Möbius",
+    "status": "Active",
+    "current": True,
+    "url": "http://localhost:5173",
+  }]
+
+
+def test_linked_avatar_is_proxied_through_the_authenticated_bridge(
+  client, auth, monkeypatch,
+):
+  from app.routes.identity import _seal
+
+  granted = _app_auth(client, auth, granted=True)
+  with SessionLocal() as session:
+    owner = session.query(models.Owner).one()
+    session.add(models.IdentityAccountLink(
+      owner_id=owner.id,
+      access_token_encrypted=_seal("linked-token-" + "x" * 40),
+      scopes_json=["identity:read", "identity:write", "deployments:read"],
+    ))
+    session.commit()
+
+  class IdentityResponse:
+    status_code = 200
+
+    @staticmethod
+    def json():
+      return {
+        "profile": {
+          "user_id": "usr_123",
+          "email": "owner@example.com",
+          "display_name": "Owner",
+          "handle": "owner",
+          "avatar_url": "https://www.mobius.you/api/account/v1/avatars/key/256.webp",
+        },
+        "deployments": [],
+      }
+
+  class AvatarResponse:
+    status_code = 200
+    headers = {"content-type": "image/png"}
+
+    async def __aenter__(self):
+      return self
+
+    async def __aexit__(self, *args):
+      return None
+
+    async def aiter_bytes(self):
+      yield b"safe-avatar-bytes"
+
+  class Client:
+    def __init__(self, *args, **kwargs):
+      assert kwargs.get("follow_redirects") is False
+
+    async def __aenter__(self):
+      return self
+
+    async def __aexit__(self, *args):
+      return None
+
+    async def request(self, method, url, **kwargs):
+      assert method == "GET"
+      assert url.endswith("/api/account/v1/identity")
+      return IdentityResponse()
+
+    def stream(self, method, url, **kwargs):
+      assert method == "GET"
+      assert url == "https://www.mobius.you/api/account/v1/avatars/key/256.webp"
+      return AvatarResponse()
+
+  monkeypatch.setattr("app.routes.identity.httpx.AsyncClient", Client)
+  response = client.get("/api/identity/avatar", headers=granted)
+
+  assert response.status_code == 200
+  assert response.content == b"safe-avatar-bytes"
+  assert response.headers["content-type"] == "image/png"
+  assert response.headers["cache-control"] == "private, max-age=300"
+  assert response.headers["x-content-type-options"] == "nosniff"
+
+
+def test_avatar_proxy_rejects_unsafe_remote_urls():
+  from app.routes.identity import _remote_avatar_url
+
+  assert _remote_avatar_url({
+    "profile": {"avatar_url": "https://www.mobius.you/avatar.webp"},
+  }) == "https://www.mobius.you/avatar.webp"
+  assert _remote_avatar_url({
+    "profile": {"avatar_url": "https://lh3.googleusercontent.com/avatar"},
+  }) == "https://lh3.googleusercontent.com/avatar"
+  for value in (
+    "http://images.example/avatar.webp",
+    "https://user:pass@images.example/avatar.webp",
+    "https://images.example:444/avatar.webp",
+    "https://images.example/avatar.webp#fragment",
+    "https://private.example/avatar.webp",
+  ):
+    assert _remote_avatar_url({"profile": {"avatar_url": value}}) is None
+
+
+def test_linked_profile_mutation_uses_the_authoritative_response_once(
+  client, auth, monkeypatch,
+):
+  from app.routes.identity import _seal
+
+  granted = _app_auth(client, auth, granted=True)
+  with SessionLocal() as session:
+    owner = session.query(models.Owner).one()
+    session.add(models.IdentityAccountLink(
+      owner_id=owner.id,
+      access_token_encrypted=_seal("linked-token-" + "x" * 40),
+      scopes_json=["identity:read", "identity:write", "deployments:read"],
+    ))
+    session.commit()
+
+  calls = []
+
+  class Response:
+    status_code = 200
+
+    @staticmethod
+    def json():
+      return {
+        "profile": {
+          "user_id": "usr_123",
+          "email": "owner@example.com",
+          "display_name": "Owner",
+          "handle": "new_handle",
+          "avatar_url": None,
+        },
+        "deployments": [],
+      }
+
+  class Client:
+    def __init__(self, *args, **kwargs):
+      pass
+
+    async def __aenter__(self):
+      return self
+
+    async def __aexit__(self, *args):
+      return None
+
+    async def request(self, method, url, **kwargs):
+      calls.append((method, url, kwargs.get("json")))
+      return Response()
+
+  monkeypatch.setattr("app.routes.identity.httpx.AsyncClient", Client)
+  response = client.patch(
+    "/api/identity/profile",
+    json={"handle": "NEW_HANDLE"},
+    headers=granted,
+  )
+
+  assert response.status_code == 200, response.text
+  assert response.json()["account_mode"] == "linked"
+  assert response.json()["profile"]["handle"] == "new_handle"
+  assert calls == [(
+    "PATCH",
+    "https://www.mobius.you/api/account/v1/identity/profile",
+    {"handle": "new_handle"},
+  )]

--- a/backend/tests/test_schema_migration_history.py
+++ b/backend/tests/test_schema_migration_history.py
@@ -1,0 +1,110 @@
+"""Build-time contracts for immutable, self-contained migration history."""
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _migration_guard():
+  script = Path(__file__).parents[1] / "scripts" / "check-schema-migrations.py"
+  spec = importlib.util.spec_from_file_location("migration_guard", script)
+  assert spec and spec.loader
+  guard = importlib.util.module_from_spec(spec)
+  sys.modules[spec.name] = guard
+  spec.loader.exec_module(guard)
+  return guard
+
+
+def test_current_schema_migration_history_is_unique_ordered_and_self_contained():
+  """The checkout is internally valid even when no target ref is available."""
+  script = Path(__file__).parents[1] / "scripts" / "check-schema-migrations.py"
+  completed = subprocess.run(
+    [sys.executable, str(script)],
+    text=True,
+    capture_output=True,
+    check=False,
+  )
+  assert completed.returncode == 0, completed.stderr
+  assert "append-only migrations verified" in completed.stdout
+
+
+def test_published_history_cannot_be_rehashed_in_place():
+  """Changing a published function remains a rewrite without a manifest."""
+  guard = _migration_guard()
+  published = guard.inspect_history(
+    "def initial(db):\n  return db\n"
+    "_SCHEMA_MIGRATIONS = ((\"0001_initial\", initial),)\n",
+    source="published.py",
+  )
+  rewritten = guard.inspect_history(
+    "def initial(db):\n  return str(db)\n"
+    "_SCHEMA_MIGRATIONS = ((\"0001_initial\", initial),)\n",
+    source="rewritten.py",
+  )
+  appended = guard.inspect_history(
+    "def initial(db):\n  return db\n"
+    "def next_step(db):\n  return db\n"
+    "_SCHEMA_MIGRATIONS = ("
+    "(\"0001_initial\", initial), (\"0002_next\", next_step))\n",
+    source="appended.py",
+  )
+
+  assert guard.append_only_error(published, rewritten) == (
+    "published migration 0001_initial changed"
+  )
+  assert guard.append_only_error(published, appended) is None
+
+
+def test_published_history_cannot_be_removed_or_reordered():
+  guard = _migration_guard()
+
+  published = {"0001_initial": "one", "0002_next": "two"}
+  removed = guard.append_only_error(published, {"0001_initial": "one"})
+  reordered = guard.append_only_error(published, {
+    "0002_next": "two",
+    "0001_initial": "one",
+  })
+  assert removed == "published migration 0002_next was removed"
+  assert reordered == (
+    "published migration 0001_initial was reordered, removed, or renamed "
+    "to 0002_next"
+  )
+
+
+def test_new_migration_cannot_import_mutable_runtime_helpers():
+  """Published migrations own their behavior instead of freezing app code."""
+  guard = _migration_guard()
+  source = (
+    "def migrate(db):\n"
+    "  from app.helper import normalize\n"
+    "  return normalize(db)\n"
+    "_SCHEMA_MIGRATIONS = ((\"0016_new\", migrate),)\n"
+  )
+
+  with pytest.raises(SystemExit):
+    guard.inspect_history(source, source="candidate.py")
+
+
+def test_migration_hash_includes_migration_owned_helpers():
+  guard = _migration_guard()
+  first = guard.inspect_history(
+    "def normalize(value):\n"
+    "  return value\n"
+    "def migrate(db):\n"
+    "  return normalize(db)\n"
+    "_SCHEMA_MIGRATIONS = ((\"0016_new\", migrate),)\n",
+    source="first.py",
+  )
+  second = guard.inspect_history(
+    "def normalize(value):\n"
+    "  return str(value)\n"
+    "def migrate(db):\n"
+    "  return normalize(db)\n"
+    "_SCHEMA_MIGRATIONS = ((\"0016_new\", migrate),)\n",
+    source="second.py",
+  )
+
+  assert first["0016_new"] != second["0016_new"]

--- a/backend/tests/test_sso_config.py
+++ b/backend/tests/test_sso_config.py
@@ -37,6 +37,42 @@ def test_managed_sign_in_accepts_launcher_origin_and_normalizes_it():
   assert config.mobius_sso_issuer == "https://www.mobius.you"
 
 
+def test_account_service_origin_is_independently_configurable():
+  config = settings(mobius_account_origin="https://accounts.mobius.example/")
+
+  assert config.mobius_sso_enabled is False
+  assert config.mobius_account_origin == "https://accounts.mobius.example"
+  assert config.mobius_account_client_origin == "http://localhost:5173"
+
+
+def test_account_client_origin_is_normalized_when_explicit():
+  config = settings(
+    frontend_origin="http://private-lan:8000",
+    mobius_account_client_origin="https://my.mobius.example/",
+  )
+
+  assert config.mobius_account_client_origin == "https://my.mobius.example"
+
+
+def test_insecure_non_loopback_frontend_does_not_become_a_grant_origin():
+  config = settings(frontend_origin="http://private-lan:8000")
+
+  assert config.mobius_account_client_origin == ""
+
+
+@pytest.mark.parametrize(
+  "origin",
+  [
+    "http://accounts.mobius.example",
+    "https://accounts.mobius.example/path",
+    "https://user:password@accounts.mobius.example",
+  ],
+)
+def test_account_service_origin_rejects_non_origins(origin):
+  with pytest.raises(ValidationError, match="MOBIUS_ACCOUNT_ORIGIN"):
+    settings(mobius_account_origin=origin)
+
+
 @pytest.mark.parametrize(
   ("issuer", "message"),
   [

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,11 @@ services:
       - SECRET_KEY=${SECRET_KEY:?set SECRET_KEY — use scripts/deploy-prod.sh or docker compose --env-file <prod .env>, never a bare docker compose up}
       - DOMAIN=${DOMAIN:?set DOMAIN — use scripts/deploy-prod.sh or docker compose --env-file <prod .env>, never a bare docker compose up}
       - FRONTEND_ORIGIN=https://${DOMAIN}
+      # Ordinary self-hosted account linking follows this service origin. The
+      # client origin normally derives from FRONTEND_ORIGIN; set it explicitly
+      # only when the browser-facing origin differs from DOMAIN.
+      - MOBIUS_ACCOUNT_ORIGIN=${MOBIUS_ACCOUNT_ORIGIN:-https://www.mobius.you}
+      - MOBIUS_ACCOUNT_CLIENT_ORIGIN=${MOBIUS_ACCOUNT_CLIENT_ORIGIN:-}
       # No application default: every public_surface fails closed unless the
       # operator explicitly configures the same shared origin consumed by
       # Caddy above. One gateway serves all owner-trusted service slugs.

--- a/frontend/src/components/AppCanvas/AppCanvas.jsx
+++ b/frontend/src/components/AppCanvas/AppCanvas.jsx
@@ -22,6 +22,12 @@ import { builtInCapabilityProviders } from '../../lib/capabilityProviders.js'
 import { requestAppCodeWarm } from '../../lib/appPrecache.js'
 import { appHostRequest } from '../../lib/appHostRequest.js'
 import {
+  accountLinkCompletion,
+  accountLinkRegistration,
+  accountLinkUnregistration,
+  identityLinkBrokerAllowed,
+} from '../../lib/accountLinkBroker.js'
+import {
   appMediaSessionEvent,
   applyVirtualStorageMutation,
   attributedFrameVersion,
@@ -147,6 +153,17 @@ function appFrameRequestUrl(appId, version, frameRev) {
 //      Pointer input inside an opaque iframe cannot bubble into its positioned
 //      shell wrapper. The live frame signals the parent so its pane becomes the
 //      focused owner of keyboard and immersive state.
+//
+//   9. moebius:account-link-*                               three-party broker
+//      The CSP-sandboxed app frame has an opaque origin, so an external OAuth
+//      completion page cannot safely target it by the shell's concrete origin.
+//      A live, visible frame with the reviewed identity_manage grant registers
+//      one unpredictable state + exact authorization origin here. The external
+//      page posts to window.opener.top at the exact shell origin; the shell
+//      accepts only that origin/state/shape and forwards the one-time result to
+//      the exact registered contentWindow. `"*"` is required only on that last
+//      hop because the target is opaque; frame identity and parent-origin
+//      validation provide the trust boundary.
 //
 // Host-level messages (attributed and narrowed here, outcomes owned by the
 // `onHostRequest` callback):
@@ -362,6 +379,16 @@ const AppCanvas = forwardRef(function AppCanvas({
   // VERSION — a Map, not a single ref, because two iframes are alive during the
   // swap window and each must be addressable independently.
   const framesRef = useRef(new Map())
+  // At most one short-lived external account-link result may be routed to this
+  // app canvas. The registration binds the result to an exact mounted frame;
+  // it is retired on unregister, timeout, document removal, reload, or unmount.
+  const accountLinkRef = useRef(null)
+  function clearAccountLinkRegistration(expected = null) {
+    const current = accountLinkRef.current
+    if (!current || (expected && current !== expected)) return
+    clearTimeout(current.timeoutId)
+    accountLinkRef.current = null
+  }
   // Playback remains inside the app frame. This map only binds the shell's
   // small metadata/control surface to the exact document that owns it.
   const frameMediaSessionRef = useRef(new Map())
@@ -443,6 +470,9 @@ const AppCanvas = forwardRef(function AppCanvas({
             framesRef.current.get(v)?.contentWindow,
           )
           storageHostRef.current.detachSource(framesRef.current.get(v)?.contentWindow)
+          if (accountLinkRef.current?.source === framesRef.current.get(v)?.contentWindow) {
+            clearAccountLinkRegistration()
+          }
           retireFrameMediaSession(v)
           // A service-surface takeover can remove the live iframe without
           // unmounting AppCanvas or advancing the buffered version. Retire its
@@ -637,6 +667,28 @@ const AppCanvas = forwardRef(function AppCanvas({
   useEffect(() => {
     if (!appId) return
     function onMessage(e) {
+      // The external completion page talks to the concrete top-level shell,
+      // not to the opaque app frame. Consume this before the frame-origin gate,
+      // then forward only to the still-mounted document that registered it.
+      const registered = accountLinkRef.current
+      const completion = accountLinkCompletion(e, registered)
+      if (completion) {
+        const registeredVersion = attributedFrameVersion(
+          framesRef.current,
+          registered.source,
+        )
+        if (
+          registeredVersion === registered.frameVersion
+          && registeredVersion === liveVersionRef.current
+          && identityLinkBrokerAllowed(capabilityContractRef.current)
+        ) {
+          clearAccountLinkRegistration(registered)
+          try { registered.source.postMessage(completion, '*') } catch { /* frame retired */ }
+        } else {
+          clearAccountLinkRegistration(registered)
+        }
+        return
+      }
       if (e.origin !== 'null' && e.origin !== window.location.origin) return
       const msg = e.data
       if (!msg || typeof msg !== 'object') return
@@ -746,6 +798,45 @@ const AppCanvas = forwardRef(function AppCanvas({
       // browsing context). Route acks back to the source frame via e.source
       // directly — it is the verified sender window.
       if (srcVersion !== liveVersionRef.current) return
+
+      if (msg.type === 'moebius:account-link-register') {
+        if (!visibleRef.current || !identityLinkBrokerAllowed(capabilityContractRef.current)) {
+          return
+        }
+        const parsed = accountLinkRegistration(msg)
+        if (!parsed) return
+        clearAccountLinkRegistration()
+        const registration = {
+          ...parsed,
+          source: e.source,
+          frameVersion: srcVersion,
+          timeoutId: null,
+        }
+        registration.timeoutId = setTimeout(() => {
+          clearAccountLinkRegistration(registration)
+        }, Math.max(0, registration.deadline - Date.now()))
+        accountLinkRef.current = registration
+        try {
+          e.source.postMessage({
+            type: 'moebius:account-link-registered',
+            state: registration.state,
+          }, '*')
+        } catch {
+          clearAccountLinkRegistration(registration)
+        }
+        return
+      }
+
+      if (msg.type === 'moebius:account-link-unregister') {
+        const registration = accountLinkRef.current
+        if (
+          registration?.source === e.source
+          && accountLinkUnregistration(msg, registration)
+        ) {
+          clearAccountLinkRegistration(registration)
+        }
+        return
+      }
 
       // App-owned playback may continue while its warm frame is hidden, so its
       // drawer control surface is live-frame-scoped rather than visibility-
@@ -889,6 +980,13 @@ const AppCanvas = forwardRef(function AppCanvas({
     onAppFocus, onImmersive, onIntentDelivered, onAppError, onHostRequest,
     queryClient,
   ])
+
+  // The listener above may be refreshed when callback props change. Keep the
+  // short-lived registration across those harmless refreshes, but never across
+  // an AppCanvas unmount or a different app taking over this component.
+  useEffect(() => () => {
+    clearAccountLinkRegistration()
+  }, [appId])
 
   // Capabilities belong to a visible workspace pane, not merely the focused
   // pane. Finish/cancel active-frame work before a cached app becomes hidden.
@@ -1320,6 +1418,9 @@ const AppCanvas = forwardRef(function AppCanvas({
     // why the parent never dedups frame-init).
     if (loadedDocsRef.current.has(v)) {
       retireFrameMediaSession(v)
+      if (accountLinkRef.current?.source === framesRef.current.get(v)?.contentWindow) {
+        clearAccountLinkRegistration()
+      }
       capabilityHostRef.current.detachSource(
         framesRef.current.get(v)?.contentWindow,
       )

--- a/frontend/src/lib/__tests__/accountLinkBroker.test.js
+++ b/frontend/src/lib/__tests__/accountLinkBroker.test.js
@@ -1,0 +1,99 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  accountLinkCompletion,
+  accountLinkRegistration,
+  accountLinkUnregistration,
+  identityLinkBrokerAllowed,
+} from '../accountLinkBroker.js'
+
+const state = 's'.repeat(43)
+const expiresAt = '2026-08-20T03:00:00Z'
+
+test('account-link broker requires the reviewed identity capability', () => {
+  assert.equal(identityLinkBrokerAllowed({ data: { identity_manage: true } }), true)
+  assert.equal(identityLinkBrokerAllowed({ data: { identity_manage: false } }), false)
+  assert.equal(identityLinkBrokerAllowed(null), false)
+})
+
+test('account-link registration accepts only an exact secure or loopback origin', () => {
+  const valid = accountLinkRegistration({
+    type: 'moebius:account-link-register',
+    state,
+    authorizationOrigin: 'https://www.mobius.you',
+    expiresAt,
+  }, () => 1_000)
+  assert.deepEqual(valid, {
+    state,
+    authorizationOrigin: 'https://www.mobius.you',
+    deadline: 601_000,
+  })
+  assert.ok(accountLinkRegistration({
+    type: 'moebius:account-link-register',
+    state,
+    authorizationOrigin: 'http://127.0.0.1:8080',
+    expiresAt,
+  }))
+  for (const authorizationOrigin of (
+    [
+      'http://account.example',
+      'https://account.example/path',
+      'https://u:p@account.example',
+      'http://192.168.1.2:8080',
+    ]
+  )) {
+    assert.equal(accountLinkRegistration({
+      type: 'moebius:account-link-register',
+      state,
+      authorizationOrigin,
+      expiresAt,
+    }), null)
+  }
+  assert.equal(accountLinkRegistration({
+    type: 'moebius:account-link-register',
+    state,
+    authorizationOrigin: 'https://www.mobius.you',
+    expiresAt,
+    extra: true,
+  }), null)
+})
+
+test('account-link unregistration is exact and state-bound', () => {
+  const registration = { state }
+  assert.equal(accountLinkUnregistration({
+    type: 'moebius:account-link-unregister', state,
+  }, registration), true)
+  assert.equal(accountLinkUnregistration({
+    type: 'moebius:account-link-unregister', state: 'x'.repeat(43),
+  }, registration), false)
+  assert.equal(accountLinkUnregistration({
+    type: 'moebius:account-link-unregister', state, extra: true,
+  }, registration), false)
+})
+
+test('account-link completion consumes only the exact origin, state and shape', () => {
+  const registration = {
+    state,
+    authorizationOrigin: 'https://www.mobius.you',
+    deadline: 10_000,
+  }
+  const event = {
+    origin: registration.authorizationOrigin,
+    data: { type: 'mobius-account-link', state, code: 'c'.repeat(32) },
+  }
+  assert.deepEqual(accountLinkCompletion(event, registration, () => 9_000), {
+    type: 'moebius:account-link-result',
+    state,
+    code: 'c'.repeat(32),
+    authorizationOrigin: registration.authorizationOrigin,
+  })
+  assert.equal(accountLinkCompletion({ ...event, origin: 'https://evil.example' }, registration), null)
+  assert.equal(accountLinkCompletion({
+    ...event, data: { ...event.data, state: 'x'.repeat(43) },
+  }, registration), null)
+  assert.equal(accountLinkCompletion({
+    ...event, data: { ...event.data, extra: true },
+  }, registration), null)
+  assert.equal(accountLinkCompletion(event, registration, () => 10_001), null)
+})

--- a/frontend/src/lib/accountLinkBroker.js
+++ b/frontend/src/lib/accountLinkBroker.js
@@ -1,0 +1,89 @@
+const ACCOUNT_LINK_WINDOW_MS = 10 * 60 * 1000
+const ACCOUNT_LINK_STATE = /^[A-Za-z0-9_-]{32,512}$/
+
+function loopback(hostname) {
+  const host = hostname.toLowerCase()
+  return host === 'localhost'
+    || host.endsWith('.localhost')
+    || host === '[::1]'
+    || /^127(?:\.\d{1,3}){3}$/.test(host)
+}
+
+export function identityLinkBrokerAllowed(capabilityContract) {
+  return capabilityContract?.data?.identity_manage === true
+}
+
+export function accountLinkRegistration(message, now = Date.now) {
+  if (
+    !message
+    || typeof message !== 'object'
+    || Array.isArray(message)
+    || Object.keys(message).sort().join(',') !== 'authorizationOrigin,expiresAt,state,type'
+    || message.type !== 'moebius:account-link-register'
+  ) return null
+  const state = typeof message.state === 'string' ? message.state : ''
+  const authorizationOrigin = typeof message.authorizationOrigin === 'string'
+    ? message.authorizationOrigin
+    : ''
+  const expiresAt = typeof message.expiresAt === 'string' ? message.expiresAt : ''
+  if (!ACCOUNT_LINK_STATE.test(state) || !Number.isFinite(Date.parse(expiresAt))) {
+    return null
+  }
+  let parsed
+  try {
+    parsed = new URL(authorizationOrigin)
+  } catch {
+    return null
+  }
+  if (
+    parsed.origin !== authorizationOrigin
+    || parsed.username
+    || parsed.password
+    || parsed.pathname !== '/'
+    || parsed.search
+    || parsed.hash
+    || (parsed.protocol !== 'https:' && !(parsed.protocol === 'http:' && loopback(parsed.hostname)))
+  ) {
+    return null
+  }
+  return {
+    state,
+    authorizationOrigin,
+    // The account backend enforces its own absolute expiry. Use a local bounded
+    // lifetime here so a badly skewed browser clock cannot make a valid broker
+    // registration vanish immediately or keep one alive indefinitely.
+    deadline: now() + ACCOUNT_LINK_WINDOW_MS,
+  }
+}
+
+export function accountLinkUnregistration(message, registration) {
+  if (!registration || !message || typeof message !== 'object' || Array.isArray(message)) {
+    return false
+  }
+  return Object.keys(message).sort().join(',') === 'state,type'
+    && message.type === 'moebius:account-link-unregister'
+    && message.state === registration.state
+}
+
+export function accountLinkCompletion(event, registration, now = Date.now) {
+  if (!registration || now() > registration.deadline) return null
+  if (event?.origin !== registration.authorizationOrigin) return null
+  const message = event?.data
+  if (!message || typeof message !== 'object' || Array.isArray(message)) return null
+  if (
+    Object.keys(message).sort().join(',') !== 'code,state,type'
+    || message.type !== 'mobius-account-link'
+    || message.state !== registration.state
+    || typeof message.code !== 'string'
+    || message.code.length < 16
+    || message.code.length > 2048
+  ) {
+    return null
+  }
+  return {
+    type: 'moebius:account-link-result',
+    code: message.code,
+    state: registration.state,
+    authorizationOrigin: registration.authorizationOrigin,
+  }
+}


### PR DESCRIPTION
## Summary

Self-hosted Möbius · You (`mobius-os/app-mobius-you`) is unusable on a stock
`mobius-os/mobius`: its first call, `GET /api/identity`, returns
`404 {"detail":"Not found."}`, so the app never renders past its error card.
The platform has no identity router, and the `identity_manage` / `railway_manage`
capabilities the app declares are unrecognized, so the install succeeds while
granting nothing. Reported in mobius-os/app-mobius-you#1.

This adds the portable identity bridge the app consumes, so it renders and
functions on an ordinary self-hosted deployment.

## Commits

**1. Decouple the schema-migration history gate from mutable runtime helpers.**
The append-only gate fingerprinted the transitive `app.*` helper source that each
legacy migration imports, so an unrelated change to any referenced runtime helper
falsely tripped "published migration changed". This bridge edits
`app_capabilities` helpers that legacy migrations reach, so the fix is a
prerequisite: fingerprint only migration-owned code (self-contained, with the
existing legacy exemption) and move the guard's unit tests into their own module.

**2. Add the portable identity bridge.**
- `/api/identity` router (`GET /api/identity`, `PATCH /api/identity/profile`,
  avatar read/write, scoped Railway routes) behind two reviewed capabilities.
  `signed_out` / `linked` / `managed` account modes are all served; a self-hosted
  owner with no launcher account gets the local deployment view and can link a
  Möbius · You account.
- Capability recognition for `identity_manage` and `railway_manage` in the
  manifest and install/app-state contract, so declaring them grants (or, on
  omission, revokes) access instead of being silently dropped.
- Account-link broker in the shell so an external OAuth completion page can hand
  a one-time result to the opaque, CSP-sandboxed app frame safely.
- Encrypted, revocable link storage (`identity_link_attempts`,
  `identity_account_links`); the PKCE verifier and access token never enter app
  code.
- Bootstrap fix: the managed-deployment bootstrap constant pointed at
  `mobius-os/app-identity`, which 404s; corrected to `mobius-os/app-mobius-you`.
  Bootstrap stays skipped on self-hosted (non-managed) deployments.

## Notes

- Account-service origin is configurable and independent of the managed SSO
  issuer (`MOBIUS_ACCOUNT_ORIGIN`, default `https://www.mobius.you`), documented
  in `.env.example` and `docker-compose.yml`.
- Thanks to @eldarkurtic for the precise root-cause report and the offer to test
  on a current self-hosted deployment.

A follow-up will make a declared-but-unrecognized required capability fail the
install loudly, so this "installed successfully, silently broken" class cannot
recur.