### PR TITLE
Fail app install loudly when a required capability is unsupported

### DIFF
--- a/backend/app/manifest_contract.py
+++ b/backend/app/manifest_contract.py
@@ -5,6 +5,20 @@ from urllib.parse import unquote, urlparse
 import re
 
 REQUIRED_STRING_FIELDS = ("id", "name", "version", "description", "entry")
+# Capability permissions this Möbius build recognizes. An app MAY list any of
+# these in `requires` to demand the platform actually provides them; requiring a
+# name absent here fails the install loudly instead of granting nothing in
+# silence. Extending a capability (e.g. the identity bridge) adds its name here.
+RECOGNIZED_CAPABILITIES = (
+  "manage_apps",
+  "manage_skills",
+  "github_access",
+  "github_connect",
+  "filesystem_access",
+  "connections_manage",
+  "identity_manage",
+  "railway_manage",
+)
 SOURCE_FILES_COUNT_MAX = 50
 SKILLS_COUNT_MAX = 5
 MANIFEST_MAX_BYTES = 64 * 1024
@@ -214,18 +228,26 @@ def validate_manifest_contract(manifest) -> None:
       f"Manifest permission {names} has been removed; server-side app jobs "
       "run as ordinary Möbius processes."
     )
-  for field in (
-    "manage_apps",
-    "manage_skills",
-    "github_access",
-    "github_connect",
-    "filesystem_access",
-    "connections_manage",
-    "identity_manage",
-    "railway_manage",
-  ):
+  for field in RECOGNIZED_CAPABILITIES:
     if field in permissions and not isinstance(permissions[field], bool):
       _fail(f"Manifest `permissions.{field}` must be a boolean.")
+
+  # An app declares the platform capabilities it cannot function without. A name
+  # this build does not recognize means the running Möbius predates the feature
+  # the app needs, so refuse the install loudly here rather than let it land in a
+  # permanently broken state where the capability is silently ungranted.
+  requires = manifest.get("requires", [])
+  if not isinstance(requires, list) or not all(
+    isinstance(name, str) for name in requires
+  ):
+    _fail("Manifest `requires` must be a list of capability names.")
+  unmet = [name for name in requires if name not in RECOGNIZED_CAPABILITIES]
+  if unmet:
+    _fail(
+      "This app requires capabilities this Möbius build does not provide: "
+      + ", ".join(sorted(set(unmet)))
+      + ". Update Möbius, then install."
+    )
 
   # Runtime capabilities are normalized by the same canonical registry used
   # to build the owner-reviewable install contract. Keep a single definition

--- a/backend/tests/test_validate_app_cli.py
+++ b/backend/tests/test_validate_app_cli.py
@@ -161,6 +161,36 @@ def test_removed_job_authority_permissions_fail_clearly(
     _validate_manifest(manifest)
 
 
+def test_requires_accepts_recognized_capabilities(tmp_path):
+  _write_app(tmp_path, "export default function App(){ return <div /> }")
+  manifest = json.loads((tmp_path / "mobius.json").read_text())
+  manifest["requires"] = ["identity_manage", "railway_manage"]
+  validate_manifest_contract(manifest)  # does not raise on a build that has them
+
+
+def test_requires_unrecognized_capability_fails_loudly(tmp_path):
+  _write_app(tmp_path, "export default function App(){ return <div /> }")
+  manifest = json.loads((tmp_path / "mobius.json").read_text())
+  manifest["requires"] = ["identity_manage", "does_not_exist"]
+  (tmp_path / "mobius.json").write_text(json.dumps(manifest))
+
+  result = _run(tmp_path)
+  assert result.returncode == 1
+  assert "does not provide" in result.stderr
+  with pytest.raises(ManifestContractError, match="Update Möbius"):
+    validate_manifest_contract(manifest)
+  with pytest.raises(HTTPException, match="does not provide"):
+    _validate_manifest(manifest)
+
+
+def test_requires_must_be_a_list_of_capability_names(tmp_path):
+  _write_app(tmp_path, "export default function App(){ return <div /> }")
+  manifest = json.loads((tmp_path / "mobius.json").read_text())
+  manifest["requires"] = "identity_manage"
+  with pytest.raises(ManifestContractError, match="must be a list"):
+    validate_manifest_contract(manifest)
+
+
 def test_validator_materializes_declared_static_asset_destinations(tmp_path):
   _write_app(
     tmp_path,


### PR DESCRIPTION
## Summary

Follow-up to the identity bridge (#849) and the report in
mobius-os/app-mobius-you#1. That app was declared with `identity_manage` /
`railway_manage`, but a platform that did not implement them accepted the
install and granted nothing — the owner landed in a permanently broken app with
no signal. This makes that failure mode loud.

## What this adds

An app declares the platform capabilities it cannot function without via a
manifest `requires` list:

```json
"requires": ["identity_manage", "railway_manage"]
```

`validate_manifest_contract` refuses the install when a required name is not in
this build's recognized capability set, with an actionable message ("… this
Möbius build does not provide: …. Update Möbius, then install."). Unknown
*optional* permission keys still pass, so forward-compatible manifests are
unaffected — only a capability the app says it truly needs, and the platform
does not provide, blocks the install.

Recognized capability names are consolidated into one `RECOGNIZED_CAPABILITIES`
constant, reused by both the boolean-permission check and the new gate, so
extending a capability (as the identity bridge did) adds its name in one place.

## Notes

- Scoped to capability permissions; data policies (`chat_log_access`,
  `cross_app_access`, …) are always present and are not gated.
- `mobius-os/app-mobius-you` will declare `requires: [identity_manage,
  railway_manage]` in a companion change so it now fails loudly on a
  pre-bridge Möbius instead of loading into the "Account unavailable" state.