### PR TITLE
Keep the soft keyboard up and auto-size the queued-message editor

### DIFF
--- a/frontend/src/components/ChatView/ChatView.css
+++ b/frontend/src/components/ChatView/ChatView.css
@@ -3610,7 +3610,12 @@
   min-height: 56px;
   max-height: 160px;
   padding: 8px 10px;
-  resize: vertical;
+  /* Grow to fit the message being edited (capped by max-height, then scroll)
+     so a longer draft is visible instead of scrolling a cramped fixed box.
+     Browsers without field-sizing fall back to autoGrowTextarea's measurement. */
+  field-sizing: content;
+  overflow-y: auto;
+  resize: none;
   border: 1px solid var(--border);
   border-radius: 9px;
   outline: none;

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -4662,6 +4662,7 @@ export default function ChatView({
             onSteerOne={handleSteerOne}
             steerActive={turnActive && !hasPendingQuestion}
             steerBusy={steerBusy}
+            focusComposer={() => focusComposerElement(inputRef.current)}
           />
         )}
         <ChatInputBar

--- a/frontend/src/components/ChatView/QuestionCard.jsx
+++ b/frontend/src/components/ChatView/QuestionCard.jsx
@@ -6,7 +6,7 @@ import {
   readQuestionDraft,
   writeQuestionDraft,
 } from './questionDraft.js'
-import { textareaUsesNativeSizing } from './composerTextareaSizing.js'
+import { autoGrowTextarea, textareaUsesNativeSizing } from './composerTextareaSizing.js'
 import { placeCaretAtTextEnd } from './composerFocusPolicy.js'
 import { isInlineEditorSubmit } from './composerShortcuts.js'
 import { isTouchPrimary } from '../../lib/pointerPrimary.js'
@@ -30,13 +30,7 @@ const CUSTOM_ANSWER_MAX_HEIGHT = 180
 
 
 function resizeCustomAnswer(textarea) {
-  if (!textarea || textareaUsesNativeSizing()) return
-  textarea.style.height = 'auto'
-  const contentHeight = textarea.scrollHeight
-  textarea.style.height = `${Math.min(contentHeight, CUSTOM_ANSWER_MAX_HEIGHT)}px`
-  textarea.style.overflowY = contentHeight > CUSTOM_ANSWER_MAX_HEIGHT
-    ? 'auto'
-    : 'hidden'
+  autoGrowTextarea(textarea, CUSTOM_ANSWER_MAX_HEIGHT)
 }
 
 

--- a/frontend/src/components/ChatView/QueuedMessages.jsx
+++ b/frontend/src/components/ChatView/QueuedMessages.jsx
@@ -132,14 +132,20 @@ export default function QueuedMessages({
     // reports an explicit outcome so a race can't read as success: 'saved'
     // applied, 'gone' already promoted/cancelled, 'error' transport.
     const outcome = await onEdit?.(cidOf(msg), visible)
-    setEditSaving(false)
-    if (outcome === 'saved') {
-      setEditingCid(null)
-      setEditDraft('')
-    } else if (outcome === 'gone') {
-      setEditError('This message already started — it can’t be edited now.')
-    } else {
-      setEditError('Couldn’t save this edit. Try again.')
+    flushSync(() => {
+      setEditSaving(false)
+      if (outcome === 'saved') {
+        setEditingCid(null)
+        setEditDraft('')
+      } else if (outcome === 'gone') {
+        setEditError('This message already started — it can’t be edited now.')
+      } else {
+        setEditError('Couldn’t save this edit. Try again.')
+      }
+    })
+    if (outcome !== 'saved') {
+      const el = editorRef.current
+      try { el?.focus({ preventScroll: true }) } catch { el?.focus() }
     }
   }
 

--- a/frontend/src/components/ChatView/QueuedMessages.jsx
+++ b/frontend/src/components/ChatView/QueuedMessages.jsx
@@ -1,4 +1,5 @@
 import { useRef, useState } from 'react'
+import { flushSync } from 'react-dom'
 import {
   Check,
   ChevronDown,
@@ -8,6 +9,8 @@ import {
 } from '@openai/apps-sdk-ui/components/Icon'
 import { stripAugmentation } from './msgText.js'
 import { cidOf } from './messageIdentity.js'
+import { placeCaretAtTextEnd } from './composerFocusPolicy.js'
+import { autoGrowTextarea } from './composerTextareaSizing.js'
 import { isInlineEditorSubmit } from './composerShortcuts.js'
 import { isTouchPrimary } from '../../lib/pointerPrimary.js'
 import {
@@ -16,6 +19,9 @@ import {
 } from '../../lib/selectableTextControl.js'
 
 const TRUNCATE_AT = 80
+// Matches .queued__editor-input max-height; the JS fallback caps growth here
+// for browsers without native field-sizing.
+const EDITOR_MAX_HEIGHT = 160
 
 /**
  * Queued-messages tray rendered above the chat input.
@@ -34,6 +40,7 @@ const TRUNCATE_AT = 80
  */
 export default function QueuedMessages({
   items, onCancel, onEdit, onSteerOne, steerActive, steerBusy = false,
+  focusComposer,
 }) {
   const [expanded, setExpanded] = useState(() => new Set())
   const [collapsed, setCollapsed] = useState(false)
@@ -42,6 +49,7 @@ export default function QueuedMessages({
   const [editSaving, setEditSaving] = useState(false)
   const [editError, setEditError] = useState('')
   const pointerSelectionRef = useRef(null)
+  const editorRef = useRef(null)
 
   if (!items || items.length === 0) return null
 
@@ -69,15 +77,33 @@ export default function QueuedMessages({
   function beginEdit(msg) {
     if (editSaving) return
     const cid = cidOf(msg)
-    setEditingCid(cid)
-    setEditDraft(stripAugmentation(msg.content || ''))
-    setEditError('')
-    // Expand so the whole message is visible while editing a truncated row.
-    setExpanded(prev => new Set(prev).add(cid))
+    // Reveal the editor synchronously so the textarea exists inside this tap's
+    // call stack (also expand, so the whole message is visible while editing a
+    // truncated row), then move focus to it before the gesture ends. iOS keeps
+    // the soft keyboard open only across a focus change that happens within the
+    // user gesture; autoFocus fires after the tapped pencil is already gone,
+    // which drops the keyboard mid-composition.
+    flushSync(() => {
+      setEditingCid(cid)
+      setEditDraft(stripAugmentation(msg.content || ''))
+      setEditError('')
+      setExpanded(prev => new Set(prev).add(cid))
+    })
+    const el = editorRef.current
+    if (el) {
+      try { el.focus({ preventScroll: true }) } catch { el.focus() }
+      placeCaretAtTextEnd(el)
+      // Reveal the whole message being edited (fallback for browsers without
+      // native field-sizing).
+      autoGrowTextarea(el, EDITOR_MAX_HEIGHT)
+    }
   }
 
   function cancelEdit() {
     if (editSaving) return
+    // Hand focus back to the composer so the soft keyboard stays up and the
+    // owner can keep typing, then tear the editor down.
+    focusComposer?.()
     setEditingCid(null)
     setEditDraft('')
     setEditError('')
@@ -94,6 +120,11 @@ export default function QueuedMessages({
       cancelEdit()
       return
     }
+    // Move focus to the composer now, inside this tap, before the textarea is
+    // disabled below. A disabled field blurs — on mobile that would drop the
+    // soft keyboard for the whole save round-trip. Handing focus to the
+    // composer keeps the keyboard up and leaves the owner ready to keep typing.
+    focusComposer?.()
     setEditSaving(true)
     setEditError('')
     // Send only the owner's visible text; the server re-derives the hidden
@@ -176,11 +207,13 @@ export default function QueuedMessages({
                 {isEditing ? (
                   <div className="queued__editor">
                     <textarea
+                      ref={editorRef}
                       className="queued__editor-input"
                       value={editDraft}
                       onChange={(event) => {
                         setEditDraft(event.target.value)
                         setEditError('')
+                        autoGrowTextarea(event.target, EDITOR_MAX_HEIGHT)
                       }}
                       onKeyDown={(event) => {
                         if (event.key === 'Escape') {
@@ -197,7 +230,6 @@ export default function QueuedMessages({
                       }}
                       aria-label="Edit queued message"
                       rows={2}
-                      autoFocus
                       disabled={editSaving}
                     />
                     <div className="queued__editor-actions">

--- a/frontend/src/components/ChatView/QueuedMessages.jsx
+++ b/frontend/src/components/ChatView/QueuedMessages.jsx
@@ -11,6 +11,7 @@ import { stripAugmentation } from './msgText.js'
 import { cidOf } from './messageIdentity.js'
 import { placeCaretAtTextEnd } from './composerFocusPolicy.js'
 import { autoGrowTextarea } from './composerTextareaSizing.js'
+import { restoreQueuedEditorAfterSave } from './queuedEditorFocus.js'
 import { isInlineEditorSubmit } from './composerShortcuts.js'
 import { isTouchPrimary } from '../../lib/pointerPrimary.js'
 import {
@@ -143,10 +144,7 @@ export default function QueuedMessages({
         setEditError('Couldn’t save this edit. Try again.')
       }
     })
-    if (outcome !== 'saved') {
-      const el = editorRef.current
-      try { el?.focus({ preventScroll: true }) } catch { el?.focus() }
-    }
+    restoreQueuedEditorAfterSave(outcome, editorRef.current)
   }
 
   function onHdrKeyDown(e) {

--- a/frontend/src/components/ChatView/__tests__/chatUiPolish.test.js
+++ b/frontend/src/components/ChatView/__tests__/chatUiPolish.test.js
@@ -81,14 +81,6 @@ test('mobile messages preserve native text selection and its action menu', () =>
     'messages must not suppress the native selection action menu')
 })
 
-test('a failed queued-message save returns focus to the active editor', () => {
-  assert.match(
-    queuedMessages,
-    /if \(outcome !== 'saved'\) \{[\s\S]*?editorRef\.current[\s\S]*?\.focus\(/,
-    'failure must not leave the next keystroke aimed at the main composer',
-  )
-})
-
 test('web tool activity uses the assistant reading width', () => {
   const css = stripComments(chatCss)
   const desktopRule = css.match(/@media\s*\(min-width:\s*720px\)\s*\{\s*\.chat__tools\s*\{[^}]*\}/)?.[0] || ''

--- a/frontend/src/components/ChatView/__tests__/chatUiPolish.test.js
+++ b/frontend/src/components/ChatView/__tests__/chatUiPolish.test.js
@@ -81,6 +81,14 @@ test('mobile messages preserve native text selection and its action menu', () =>
     'messages must not suppress the native selection action menu')
 })
 
+test('a failed queued-message save returns focus to the active editor', () => {
+  assert.match(
+    queuedMessages,
+    /if \(outcome !== 'saved'\) \{[\s\S]*?editorRef\.current[\s\S]*?\.focus\(/,
+    'failure must not leave the next keystroke aimed at the main composer',
+  )
+})
+
 test('web tool activity uses the assistant reading width', () => {
   const css = stripComments(chatCss)
   const desktopRule = css.match(/@media\s*\(min-width:\s*720px\)\s*\{\s*\.chat__tools\s*\{[^}]*\}/)?.[0] || ''

--- a/frontend/src/components/ChatView/__tests__/queuedMessages.test.js
+++ b/frontend/src/components/ChatView/__tests__/queuedMessages.test.js
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import { restoreQueuedEditorAfterSave } from '../queuedEditorFocus.js'
+
+
+test('a failed queued-message save returns focus to the active editor', () => {
+  const calls = []
+  const editor = { focus: options => calls.push(options) }
+
+  assert.equal(restoreQueuedEditorAfterSave('error', editor), true)
+  assert.deepEqual(calls, [{ preventScroll: true }])
+})
+
+
+test('a successful queued-message save does not refocus its removed editor', () => {
+  let focused = false
+  const editor = { focus: () => { focused = true } }
+
+  assert.equal(restoreQueuedEditorAfterSave('saved', editor), false)
+  assert.equal(focused, false)
+})
+
+
+test('queued-editor focus falls back for older browsers', () => {
+  let calls = 0
+  const editor = {
+    focus: options => {
+      calls += 1
+      if (options) throw new TypeError('focus options unsupported')
+    },
+  }
+
+  assert.equal(restoreQueuedEditorAfterSave('gone', editor), true)
+  assert.equal(calls, 2)
+})

--- a/frontend/src/components/ChatView/composerTextareaSizing.js
+++ b/frontend/src/components/ChatView/composerTextareaSizing.js
@@ -103,6 +103,27 @@ export function resizeComposerTextarea(textarea, value = textarea?.value) {
   return height
 }
 
+/**
+ * Grow an inline-editor textarea to fit its content, capped at `maxHeight`.
+ *
+ * For the small inline editors (the Q&A custom answer, the queued-message
+ * editor) that live outside the composer pill and want to reveal a longer
+ * draft instead of scrolling a cramped fixed box. Browsers with native
+ * `field-sizing: content` size from CSS, so this is a no-op there; this is the
+ * measurement fallback for the rest. Shared so a new inline editor reuses one
+ * sizing rule rather than copying the measure/cap/overflow dance.
+ */
+export function autoGrowTextarea(textarea, maxHeight) {
+  if (!textarea?.style || textareaUsesNativeSizing()) return
+  textarea.style.height = 'auto'
+  const contentHeight = Number(textarea.scrollHeight) || 0
+  // A display:none pane reports 0; leave the intrinsic height rather than
+  // collapsing the field to nothing.
+  if (contentHeight <= 0) return
+  textarea.style.height = `${Math.min(contentHeight, maxHeight)}px`
+  textarea.style.overflowY = contentHeight > maxHeight ? 'auto' : 'hidden'
+}
+
 /** Collapse immediately while React is still committing an empty value. */
 export function resetComposerTextarea(textarea) {
   if (!textarea?.style) return

--- a/frontend/src/components/ChatView/queuedEditorFocus.js
+++ b/frontend/src/components/ChatView/queuedEditorFocus.js
@@ -1,0 +1,5 @@
+export function restoreQueuedEditorAfterSave(outcome, editor) {
+  if (outcome === 'saved' || !editor) return false
+  try { editor.focus({ preventScroll: true }) } catch { editor.focus() }
+  return true
+}


### PR DESCRIPTION
## Problem

Editing a queued message dropped the mobile soft keyboard at three moments:

- **Opening the editor** — the pencil relied on `autoFocus`, which fires after the tapped button has already unmounted, so the browser treats the focus as detached and closes the keyboard.
- **Saving** — the textarea is `disabled` while the save is in flight, and disabling a focused field blurs it, dropping the keyboard for the whole round-trip.
- **Saving or discarding** — focus was lost entirely as the editor tore down.

The fixed-height edit box was also cramped: a longer queued message had to be scrolled inside a two-line field.

## Fix

Move focus deliberately, always inside the user's tap:

- On open, reveal the editor synchronously (`flushSync`) so the textarea exists in the tap's call stack, then focus it with the caret at the end. iOS keeps the keyboard across a focus change that happens within the gesture, where `autoFocus` did not.
- On save, hand focus to the composer *before* the textarea is disabled, so the keyboard rides through the save and lands ready for the next message.
- On discard, hand focus back to the composer as well.

Grow the editor to fit the message being edited — native `field-sizing: content`, capped by `max-height` then scroll — with a measurement fallback for browsers without it. That fallback is extracted into a shared `autoGrowTextarea`, and the Q&A custom-answer editor now uses the same helper instead of its own copy.

## Testing

- ChatView unit suites covering the queued editor, question card, and composer sizing pass on this branch; `vite build` succeeds.
- Auto-size is verified on desktop via native `field-sizing`. The soft-keyboard behavior is iOS-specific and is best confirmed on a device.