### PR TITLE
Keep the soft keyboard up when dismissing the composer + popover

### DIFF
--- a/frontend/src/components/ChatView/ComposerPopover.jsx
+++ b/frontend/src/components/ChatView/ComposerPopover.jsx
@@ -157,6 +157,20 @@ export default function ComposerPopover({
     function onPointer(e) {
       if (!wrapRef.current) return
       if (wrapRef.current.contains(e.target)) return
+      // Dismissing by pressing outside must not drop the soft keyboard. If the
+      // textarea was focused when the popover opened, suppress the focus change
+      // this outside press would otherwise cause (which blurs the textarea and
+      // collapses the keyboard), then restore focus next frame only if a later
+      // click still steals it — mirroring the popover's own pointer boundary.
+      // preventDefault on pointerdown keeps focus and caret without blocking
+      // scrolling, which is governed by touch-action.
+      if (wasInputFocusedRef.current) {
+        e.preventDefault()
+        requestAnimationFrame(() => {
+          const el = composerInputRef?.current
+          if (el && document.activeElement !== el) focusComposerElement(el)
+        })
+      }
       setOpen(false)
     }
     function onKey(e) {


### PR DESCRIPTION
## Problem

With the composer's **+** popover open, pressing outside it dismissed the popover but also dropped the mobile soft keyboard. The document-level `pointerdown` that closes the popover let the outside press blur the focused textarea, collapsing the keyboard as a side effect of dismissal.

## Fix

When the textarea was focused at the moment the popover opened, suppress the focus change the outside press would otherwise cause (and restore focus on the next frame only if a later click still steals it) — mirroring the popover's own inside-pointer boundary (`preservePickerInputFocus`). `preventDefault()` on `pointerdown` keeps focus and caret intact without blocking scrolling, which is governed by `touch-action`.

## Testing

- ComposerPopover-related unit suites pass; `vite build` succeeds.
- The soft-keyboard behavior is iOS-specific and is best confirmed on a device.