### PR TITLE
Add secure external machine pairing

### DIFF
--- a/backend/app/app_capabilities.py
+++ b/backend/app/app_capabilities.py
@@ -432,6 +432,7 @@ def contract_from_manifest(manifest: dict[str, Any]) -> dict[str, Any]:
       "github_access": bool(perms.get("github_access", False)),
       "github_connect": bool(perms.get("github_connect", False)),
       "connections_manage": bool(perms.get("connections_manage", False)),
+      "connect_manage": bool(perms.get("connect_manage", False)),
       "identity_manage": bool(perms.get("identity_manage", False)),
       "railway_manage": bool(perms.get("railway_manage", False)),
     },
@@ -515,6 +516,7 @@ def contract_from_app_state(
       "github_access": bool(getattr(app, "github_access", False)),
       "github_connect": bool(getattr(app, "github_connect", False)),
       "connections_manage": bool(getattr(app, "connections_manage", False)),
+      "connect_manage": bool(getattr(app, "connect_manage", False)),
       # Contract-only grants are declared by a local package on every apply.
       # Store installs build straight from their manifest and never enter this
       # projection. Do not inherit an older accepted value: omission revokes.

--- a/backend/app/connect_runner.py
+++ b/backend/app/connect_runner.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+"""Mobius Connect runner.
+
+Dials OUT to your Mobius instance and lets it run commands on this machine.
+It only makes OUTBOUND HTTPS requests (no open ports), and it runs commands as
+YOU, in your own environment -- the same trust model as running a coding CLI
+locally. Remove the machine in the Connect app to revoke its token.
+
+Pair AND install as a background service that survives reboots (recommended):
+    curl -fsSL "https://YOUR-INSTANCE/api/connect/runner" | python3 - \
+        --pair ABCD-EFGH --url "https://YOUR-INSTANCE" --install
+
+Just try it in this terminal (stops on Ctrl-C):
+    curl -fsSL "https://YOUR-INSTANCE/api/connect/runner" | python3 - \
+        --pair ABCD-EFGH --url "https://YOUR-INSTANCE"
+
+Manage the installed service:
+    python3 ~/.mobius-connect/runner.py --uninstall
+"""
+import argparse
+import json
+import os
+import platform
+import ssl
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+CONFIG_DIR = os.path.expanduser("~/.mobius-connect")
+CONFIG_PATH = os.path.join(CONFIG_DIR, "config.json")
+RUNNER_PATH = os.path.join(CONFIG_DIR, "runner.py")
+LOG_PATH = os.path.join(CONFIG_DIR, "service.log")
+LAUNCHD_LABEL = "sh.mobius.connect"
+LAUNCHD_PLIST = os.path.expanduser("~/Library/LaunchAgents/%s.plist" % LAUNCHD_LABEL)
+SYSTEMD_UNIT = os.path.expanduser("~/.config/systemd/user/mobius-connect.service")
+
+
+def _load_config():
+    try:
+        with open(CONFIG_PATH, "r", encoding="utf-8") as fh:
+            return json.load(fh)
+    except (OSError, ValueError):
+        return {}
+
+
+def _save_config(cfg):
+    os.makedirs(CONFIG_DIR, exist_ok=True)
+    with open(CONFIG_PATH, "w", encoding="utf-8") as fh:
+        json.dump(cfg, fh)
+    os.chmod(CONFIG_PATH, 0o600)
+
+
+def _post(url, payload, token=None):
+    data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(url, data=data, method="POST")
+    req.add_header("Content-Type", "application/json")
+    if token:
+        req.add_header("Authorization", "Bearer " + token)
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def _pair(base, code):
+    out = _post(base + "/api/connect/pair", {"code": code})
+    cfg = {"url": base, "host_id": out["host_id"], "token": out["token"]}
+    _save_config(cfg)
+    print("Paired as '%s'." % out.get("name", "machine"))
+    return cfg
+
+
+def _run(cmd):
+    return subprocess.run(cmd, capture_output=True, text=True)
+
+
+def _self_download(base):
+    os.makedirs(CONFIG_DIR, exist_ok=True)
+    with urllib.request.urlopen(base + "/api/connect/runner", timeout=30) as resp:
+        src = resp.read()
+    with open(RUNNER_PATH, "wb") as fh:
+        fh.write(src)
+    os.chmod(RUNNER_PATH, 0o755)
+
+
+def _install_launchd(py):
+    os.makedirs(os.path.dirname(LAUNCHD_PLIST), exist_ok=True)
+    plist = (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" '
+        '"http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n'
+        '<plist version="1.0"><dict>\n'
+        "  <key>Label</key><string>%s</string>\n"
+        "  <key>ProgramArguments</key><array>"
+        "<string>%s</string><string>%s</string></array>\n"
+        "  <key>RunAtLoad</key><true/>\n"
+        "  <key>KeepAlive</key><true/>\n"
+        "  <key>StandardOutPath</key><string>%s</string>\n"
+        "  <key>StandardErrorPath</key><string>%s</string>\n"
+        "</dict></plist>\n"
+    ) % (LAUNCHD_LABEL, py, RUNNER_PATH, LOG_PATH, LOG_PATH)
+    with open(LAUNCHD_PLIST, "w", encoding="utf-8") as fh:
+        fh.write(plist)
+    _run(["launchctl", "unload", LAUNCHD_PLIST])
+    r = _run(["launchctl", "load", "-w", LAUNCHD_PLIST])
+    if r.returncode != 0:
+        print("launchctl load failed: %s" % r.stderr.strip())
+        return False
+    print("Installed as a launchd service (starts at login, restarts if it crashes).")
+    print("  Logs:      tail -f %s" % LOG_PATH)
+    print("  Uninstall: python3 %s --uninstall" % RUNNER_PATH)
+    return True
+
+
+def _install_systemd(py):
+    os.makedirs(os.path.dirname(SYSTEMD_UNIT), exist_ok=True)
+    unit = (
+        "[Unit]\n"
+        "Description=Mobius Connect runner\n"
+        "After=network-online.target\n\n"
+        "[Service]\n"
+        "ExecStart=%s %s\n"
+        "Restart=always\n"
+        "RestartSec=5\n\n"
+        "[Install]\n"
+        "WantedBy=default.target\n"
+    ) % (py, RUNNER_PATH)
+    with open(SYSTEMD_UNIT, "w", encoding="utf-8") as fh:
+        fh.write(unit)
+    _run(["systemctl", "--user", "daemon-reload"])
+    r = _run(["systemctl", "--user", "enable", "--now", "mobius-connect.service"])
+    if r.returncode != 0:
+        print("systemctl --user failed: %s" % r.stderr.strip())
+        return _install_background(py)
+    linger = _run(["loginctl", "enable-linger", os.environ.get("USER", "")])
+    if linger.returncode != 0:
+        print("note: could not enable linger; the service may pause when you log "
+              "out (%s)" % linger.stderr.strip())
+    print("Installed as a systemd --user service (starts at boot, restarts if it crashes).")
+    print("  Status:    systemctl --user status mobius-connect")
+    print("  Logs:      journalctl --user -u mobius-connect -f")
+    print("  Uninstall: python3 %s --uninstall" % RUNNER_PATH)
+    return True
+
+
+def _install_background(py):
+    # Last resort (no launchd/systemd): detached background process. Survives
+    # closing the terminal, but NOT a reboot.
+    with open(LOG_PATH, "ab") as log:
+        subprocess.Popen(
+            [py, RUNNER_PATH], stdout=log, stderr=log,
+            stdin=subprocess.DEVNULL, start_new_session=True,
+        )
+    print("Started in the background (survives closing this terminal, NOT a reboot).")
+    print("  Logs: tail -f %s" % LOG_PATH)
+    print("  Stop: pkill -f %s" % RUNNER_PATH)
+    return True
+
+
+def _install_service(cfg):
+    _self_download(cfg["url"])
+    py = sys.executable or "python3"
+    system = platform.system()
+    if system == "Darwin":
+        return _install_launchd(py)
+    if system == "Linux":
+        return _install_systemd(py)
+    return _install_background(py)
+
+
+def _uninstall_service():
+    system = platform.system()
+    if system == "Darwin" and os.path.exists(LAUNCHD_PLIST):
+        _run(["launchctl", "unload", LAUNCHD_PLIST])
+        os.remove(LAUNCHD_PLIST)
+        print("Removed launchd service.")
+    elif system == "Linux" and os.path.exists(SYSTEMD_UNIT):
+        _run(["systemctl", "--user", "disable", "--now", "mobius-connect.service"])
+        os.remove(SYSTEMD_UNIT)
+        _run(["systemctl", "--user", "daemon-reload"])
+        print("Removed systemd service.")
+    else:
+        print("No service unit found. If it is running in the background, "
+              "stop it with: pkill -f %s" % RUNNER_PATH)
+    print("(Your token in %s is kept; remove the machine in Connect to revoke it.)"
+          % CONFIG_PATH)
+
+
+def _run_command(cmd, cwd, timeout):
+    try:
+        proc = subprocess.run(
+            cmd, shell=True, capture_output=True, text=True,
+            cwd=(cwd or None), timeout=timeout,
+        )
+        return proc.stdout, proc.stderr, proc.returncode
+    except subprocess.TimeoutExpired:
+        return "", "command timed out after %ss" % timeout, 124
+    except Exception as exc:  # noqa: BLE001 - report any spawn failure back
+        return "", "runner error: %s" % exc, 1
+
+
+def _serve(cfg):
+    base = cfg["url"].rstrip("/")
+    token = cfg["token"]
+    ctx = ssl.create_default_context()
+    plat = "%s %s" % (platform.system(), platform.release())
+    stream_url = base + "/api/connect/stream?platform=" + urllib.parse.quote(plat)
+    backoff = 1
+    print("Connecting to %s ..." % base)
+    while True:
+        try:
+            req = urllib.request.Request(stream_url)
+            req.add_header("Authorization", "Bearer " + token)
+            req.add_header("Accept", "text/event-stream")
+            with urllib.request.urlopen(req, timeout=None, context=ctx) as stream:
+                print("Connected. This machine is now reachable from Mobius.")
+                backoff = 1
+                for raw in stream:
+                    line = raw.decode("utf-8", "replace").rstrip("\n")
+                    if not line.startswith("data:"):
+                        continue
+                    try:
+                        evt = json.loads(line[5:].strip())
+                    except ValueError:
+                        continue
+                    if evt.get("type") != "exec":
+                        continue
+                    print("$ " + evt.get("cmd", ""))
+                    out, err, rc = _run_command(
+                        evt.get("cmd", ""), evt.get("cwd"),
+                        int(evt.get("timeout", 60)),
+                    )
+                    try:
+                        _post(base + "/api/connect/result", {
+                            "request_id": evt.get("request_id"),
+                            "stdout": out, "stderr": err, "exit_code": rc,
+                        }, token=token)
+                    except urllib.error.URLError as exc:
+                        print("failed to report result: %s" % exc)
+        except KeyboardInterrupt:
+            print("\nStopped.")
+            return
+        except urllib.error.HTTPError as exc:
+            if exc.code in (401, 403):
+                print("Token rejected (removed from Mobius?). Re-pair to reconnect.")
+                return
+            print("HTTP %s; retrying in %ss" % (exc.code, backoff))
+        except urllib.error.URLError as exc:
+            print("connection lost (%s); retrying in %ss" % (exc.reason, backoff))
+        time.sleep(backoff)
+        backoff = min(backoff * 2, 30)
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Mobius Connect runner")
+    ap.add_argument("--pair", help="one-time pairing code from the Connect app")
+    ap.add_argument("--url", help="your Mobius instance URL")
+    ap.add_argument("--install", action="store_true",
+                    help="install as a service that starts on boot")
+    ap.add_argument("--uninstall", action="store_true",
+                    help="remove the installed service")
+    ap.add_argument("--foreground", action="store_true",
+                    help="run in this terminal (Ctrl-C stops it)")
+    args = ap.parse_args()
+
+    if args.uninstall:
+        _uninstall_service()
+        return
+
+    cfg = _load_config()
+    if args.pair:
+        base = (args.url or cfg.get("url") or "").rstrip("/")
+        if not base:
+            print("Missing --url")
+            sys.exit(2)
+        cfg = _pair(base, args.pair.strip())
+    if not cfg.get("token"):
+        print("Not paired. Run with --pair CODE --url URL first.")
+        sys.exit(2)
+
+    if args.install:
+        _install_service(cfg)
+        return
+
+    _serve(cfg)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/app/connect_runner.py
+++ b/backend/app/connect_runner.py
@@ -21,6 +21,7 @@ import argparse
 import json
 import os
 import platform
+import signal
 import ssl
 import subprocess
 import sys
@@ -187,16 +188,54 @@ def _uninstall_service():
           % CONFIG_PATH)
 
 
+def _terminate_process_tree(proc):
+    """Stop the shell and every process the remote command started."""
+    if os.name == "nt":
+        if proc.poll() is None:
+            # CREATE_NEW_PROCESS_GROUP gives taskkill a tree root to terminate.
+            _run(["taskkill", "/PID", str(proc.pid), "/T", "/F"])
+    else:
+        # The shell may already have exited while one of its descendants keeps
+        # the captured pipes open. Its process group still identifies that tree.
+        try:
+            os.killpg(proc.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+    if proc.poll() is None:
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
+
+
 def _run_command(cmd, cwd, timeout):
+    popen_args = {
+        "shell": True,
+        "stdout": subprocess.PIPE,
+        "stderr": subprocess.PIPE,
+        "text": True,
+        "cwd": (cwd or None),
+    }
+    if os.name == "nt":
+        popen_args["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
+    else:
+        popen_args["start_new_session"] = True
+    proc = None
     try:
-        proc = subprocess.run(
-            cmd, shell=True, capture_output=True, text=True,
-            cwd=(cwd or None), timeout=timeout,
-        )
-        return proc.stdout, proc.stderr, proc.returncode
+        proc = subprocess.Popen(cmd, **popen_args)
+        stdout, stderr = proc.communicate(timeout=timeout)
+        return stdout, stderr, proc.returncode
     except subprocess.TimeoutExpired:
+        _terminate_process_tree(proc)
         return "", "command timed out after %ss" % timeout, 124
+    except KeyboardInterrupt:
+        if proc is not None:
+            _terminate_process_tree(proc)
+        raise
     except Exception as exc:  # noqa: BLE001 - report any spawn failure back
+        if proc is not None:
+            _terminate_process_tree(proc)
         return "", "runner error: %s" % exc, 1
 
 

--- a/backend/app/deps.py
+++ b/backend/app/deps.py
@@ -927,6 +927,28 @@ def get_owner_or_app_with_connections_manage(
   )
 
 
+def get_owner_or_app_with_connect_manage(
+  principal: Principal = Depends(get_principal),
+  db: Session = Depends(get_db),
+) -> models.Owner:
+  """Owner JWT, or an app token granted external-machine management."""
+  owner = principal.owner
+  if principal.app_id is None:
+    return owner
+  app = db.query(models.App).filter(models.App.id == principal.app_id).first()
+  if not app:
+    raise HTTPException(status_code=401, detail="App not found.")
+  if bool(app.connect_manage):
+    return owner
+  raise HTTPException(
+    status_code=403,
+    detail=(
+      "This app needs permissions.connect_manage=true in its manifest "
+      "to manage paired machines on your behalf."
+    ),
+  )
+
+
 def get_owner_or_app_with_identity_manage(
   principal: Principal = Depends(get_principal),
   db: Session = Depends(get_db),

--- a/backend/app/install.py
+++ b/backend/app/install.py
@@ -2412,6 +2412,7 @@ async def _prepare_app_row(
     github_connect=bool(permissions.get("github_connect", False)),
     filesystem_access=bool(permissions.get("filesystem_access", False)),
     connections_manage=bool(permissions.get("connections_manage", False)),
+    connect_manage=bool(permissions.get("connect_manage", False)),
     offline_capable=bool(manifest.get("offline_capable", False)),
     embeds_agent=bool(manifest.get("embeds_agent", False)),
     offline_contract=manifest.get("offline") or None,
@@ -2486,6 +2487,7 @@ async def _activate_install_source(
     app.github_connect = bool(permissions.get("github_connect", False))
     app.filesystem_access = bool(permissions.get("filesystem_access", False))
     app.connections_manage = bool(permissions.get("connections_manage", False))
+    app.connect_manage = bool(permissions.get("connect_manage", False))
     if "offline_capable" in manifest:
       app.offline_capable = bool(manifest["offline_capable"])
     if "embeds_agent" in manifest:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -77,6 +77,7 @@ from app.routes import (
   client_error_router, client_signal_router, standalone_router, storage_router,
   theme_router, uploads_router, platform_router,
   published_router,
+  connect_router,
 )
 
 _BOOT_ID = os.environ.get("MOBIUS_BOOT_ID") or f"{os.getpid()}-{time.time_ns()}"
@@ -744,6 +745,7 @@ app.include_router(notify_router)
 app.include_router(proxy_router)
 app.include_router(public_apps_router)
 app.include_router(local_services_router)
+app.include_router(connect_router)
 app.include_router(client_error_router)
 app.include_router(client_signal_router)
 app.include_router(settings_router)

--- a/backend/app/manifest_contract.py
+++ b/backend/app/manifest_contract.py
@@ -16,6 +16,7 @@ RECOGNIZED_CAPABILITIES = (
   "github_connect",
   "filesystem_access",
   "connections_manage",
+  "connect_manage",
   "identity_manage",
   "railway_manage",
 )

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -766,6 +766,10 @@ class App(Base):
   # canonical holder. Stored keys and broker capabilities never cross this
   # surface, so the grant manages rows without holding what they protect.
   connections_manage = Column(Boolean, nullable=False, default=False)
+  # External-machine management: pair/revoke runners and dispatch commands.
+  # Connect is the canonical holder. This is separate from filesystem_access:
+  # the command runs on another machine rather than this Möbius host.
+  connect_manage = Column(Boolean, nullable=False, default=False)
   # Offline capability. The agent opts an app in (default False) only
   # when it's built to run without the network — it uses
   # window.mobius.storage (which queues writes and syncs on reconnect)

--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -89,6 +89,7 @@ client_error_router = _load("client_error")
 client_signal_router = _load("client_signal")
 platform_router = _load("platform")
 published_router = _load("published")
+connect_router = _load("connect")
 
 __all__ = [
   "admin_router",
@@ -127,4 +128,5 @@ __all__ = [
   "client_signal_router",
   "platform_router",
   "published_router",
+  "connect_router",
 ]

--- a/backend/app/routes/connect.py
+++ b/backend/app/routes/connect.py
@@ -1,0 +1,442 @@
+"""Pair external machines and dispatch owner-approved commands to them.
+
+A small runner on the target machine dials out to this owner-trusted Möbius
+instance and holds an SSE command channel open. Each machine authenticates with
+a per-host bearer token minted through a short-lived, one-time pairing code.
+
+Transport is plain HTTP so the runner needs only the Python stdlib:
+
+  POST /api/connect/pair    {code}          -> {host_id, token}   (one-time)
+  GET  /api/connect/stream  (host bearer)   -> SSE stream of {exec} commands
+  POST /api/connect/result  (host bearer)   -> {request_id, stdout, ...}
+
+Owner/app surface:
+
+  POST   /api/connect/hosts               create a host + pairing code
+  GET    /api/connect/hosts               list hosts + live status
+  GET    /api/connect/hosts/{id}/pairing  re-show/refresh the install command
+  DELETE /api/connect/hosts/{id}          remove a host
+  POST   /api/connect/hosts/{id}/exec     run a command on that host
+  GET    /api/connect/runner              download the runner script
+
+State is in-process — safe because the backend runs a single uvicorn worker,
+the same assumption broadcast.py already relies on. A live SSE channel per
+connected host holds an outbound command queue plus the pending result futures
+that /exec awaits.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import secrets
+import time
+from hashlib import sha256
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import PlainTextResponse, StreamingResponse
+from pydantic import BaseModel, Field, field_validator
+
+from app import models
+from app.config import get_settings
+from app.deps import get_owner_or_app_with_connect_manage, reject_cross_site
+
+log = logging.getLogger("moebius.connect")
+
+router = APIRouter(
+  prefix="/api/connect",
+  tags=["connect"],
+  dependencies=[Depends(reject_cross_site)],
+)
+
+# How long a freshly minted pairing code stays redeemable.
+_PAIRING_TTL_SECONDS = 15 * 60
+# SSE heartbeat cadence; also the granularity at which we notice a dropped
+# runner connection.
+_HEARTBEAT_SECONDS = 15
+# Default ceiling for a single remote command.
+_DEFAULT_EXEC_TIMEOUT = 60
+
+
+# --------------------------------------------------------------------------- #
+# Registry persistence (file-backed JSON under shared storage)
+# --------------------------------------------------------------------------- #
+def _hosts_dir() -> Path:
+  d = Path(get_settings().data_dir) / "shared" / "connect" / "hosts"
+  d.mkdir(parents=True, exist_ok=True)
+  return d
+
+
+def _host_path(host_id: str) -> Path:
+  # host ids are minted by _new_id() (alnum + underscore) so they are safe as
+  # a filename, but guard against traversal from any other caller.
+  if not host_id or "/" in host_id or "\\" in host_id or host_id.startswith("."):
+    raise HTTPException(status_code=400, detail="Invalid host id.")
+  return _hosts_dir() / f"{host_id}.json"
+
+
+def _load_host(host_id: str) -> dict | None:
+  p = _host_path(host_id)
+  if not p.exists():
+    return None
+  try:
+    return json.loads(p.read_text("utf-8"))
+  except (OSError, ValueError):
+    return None
+
+
+def _save_host(host: dict) -> None:
+  p = _host_path(host["id"])
+  tmp = p.with_suffix(".json.tmp")
+  tmp.write_text(json.dumps(host, indent=2), "utf-8")
+  tmp.replace(p)
+
+
+def _list_hosts() -> list[dict]:
+  out: list[dict] = []
+  for p in sorted(_hosts_dir().glob("*.json")):
+    try:
+      out.append(json.loads(p.read_text("utf-8")))
+    except (OSError, ValueError):
+      continue
+  return out
+
+
+def _new_id() -> str:
+  return "h_" + secrets.token_hex(8)
+
+
+def _new_code() -> str:
+  # Human-friendly, unambiguous alphabet (no 0/O/1/I), grouped for readability.
+  alphabet = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
+  raw = "".join(secrets.choice(alphabet) for _ in range(8))
+  return f"{raw[:4]}-{raw[4:]}"
+
+
+def _hash(token: str) -> str:
+  return sha256(token.encode("utf-8")).hexdigest()
+
+
+def _now() -> float:
+  return time.time()
+
+
+# --------------------------------------------------------------------------- #
+# In-memory live channels (one per connected runner)
+# --------------------------------------------------------------------------- #
+class _Channel:
+  """A live runner connection: an outbound command queue plus the futures the
+  exec endpoint is waiting on."""
+
+  def __init__(self) -> None:
+    self.queue: asyncio.Queue[dict] = asyncio.Queue()
+    self.pending: dict[str, asyncio.Future] = {}
+    self.connected_at = _now()
+
+
+_channels: dict[str, _Channel] = {}
+
+
+def _touch(host_id: str) -> None:
+  host = _load_host(host_id)
+  if host is not None:
+    host["last_seen"] = _now()
+    _save_host(host)
+
+
+# --------------------------------------------------------------------------- #
+# Host-token auth (runner side) — separate from owner/app JWT auth
+# --------------------------------------------------------------------------- #
+def _auth_host(request: Request) -> dict:
+  header = request.headers.get("authorization", "")
+  if not header.lower().startswith("bearer "):
+    raise HTTPException(status_code=401, detail="Missing host token.")
+  token = header[7:].strip()
+  wanted = _hash(token)
+  for host in _list_hosts():
+    stored = host.get("token_sha256")
+    if stored and secrets.compare_digest(stored, wanted):
+      return host
+  raise HTTPException(status_code=401, detail="Unknown or revoked host token.")
+
+
+# --------------------------------------------------------------------------- #
+# Request bodies
+# --------------------------------------------------------------------------- #
+class CreateHostBody(BaseModel):
+  name: str = Field(default="My machine", max_length=80)
+
+  @field_validator("name")
+  @classmethod
+  def normalize_name(cls, value: str) -> str:
+    return value.strip() or "My machine"
+
+
+class PairBody(BaseModel):
+  code: str = Field(min_length=1, max_length=16)
+
+
+class ResultBody(BaseModel):
+  request_id: str = Field(min_length=1, max_length=64)
+  stdout: str = Field(default="", max_length=8 * 1024 * 1024)
+  stderr: str = Field(default="", max_length=8 * 1024 * 1024)
+  exit_code: int = 0
+
+
+class ExecBody(BaseModel):
+  cmd: str = Field(min_length=1, max_length=64 * 1024)
+  cwd: str | None = Field(default=None, max_length=4096)
+  timeout: int = Field(default=_DEFAULT_EXEC_TIMEOUT, ge=1, le=3600)
+
+
+# --------------------------------------------------------------------------- #
+# Owner/app surface
+# --------------------------------------------------------------------------- #
+def _base_url() -> str:
+  return get_settings().frontend_origin.rstrip("/")
+
+
+def _install_command(base: str, code: str) -> str:
+  # --install sets up a service that survives reboot; drop it to run in the
+  # foreground for a quick try.
+  return (
+    f'curl -fsSL "{base}/api/connect/runner" | python3 - '
+    f'--pair {code} --url "{base}" --install'
+  )
+
+
+def _public_host(host: dict) -> dict:
+  """Registry view safe to hand to the owner/app (no token hash)."""
+  return {
+    "id": host["id"],
+    "name": host.get("name") or "Machine",
+    "paired": bool(host.get("token_sha256")),
+    "online": host["id"] in _channels,
+    "last_seen": host.get("last_seen"),
+    "created_at": host.get("created_at"),
+    "platform": host.get("platform"),
+  }
+
+
+@router.post("/hosts")
+async def create_host(
+  body: CreateHostBody,
+  _owner: models.Owner = Depends(get_owner_or_app_with_connect_manage),
+) -> dict:
+  host_id = _new_id()
+  code = _new_code()
+  host = {
+    "id": host_id,
+    "name": body.name,
+    "created_at": _now(),
+    "pairing_code": code,
+    "pairing_expires_at": _now() + _PAIRING_TTL_SECONDS,
+    "token_sha256": None,
+    "paired_at": None,
+    "last_seen": None,
+    "platform": None,
+  }
+  _save_host(host)
+  base = _base_url()
+  return {
+    "id": host_id,
+    "name": host["name"],
+    "pairing_code": code,
+    "install_command": _install_command(base, code),
+    "expires_at": host["pairing_expires_at"],
+  }
+
+
+@router.get("/hosts")
+async def list_hosts(
+  _owner: models.Owner = Depends(get_owner_or_app_with_connect_manage),
+) -> dict:
+  return {"hosts": [_public_host(h) for h in _list_hosts()]}
+
+
+@router.get("/hosts/{host_id}/pairing")
+async def host_pairing(
+  host_id: str,
+  _owner: models.Owner = Depends(get_owner_or_app_with_connect_manage),
+) -> dict:
+  """Re-show the install command for an unpaired host (refreshes the code so it
+  is always valid), so the owner never has to remove + re-add just to copy it."""
+  host = _load_host(host_id)
+  if host is None:
+    raise HTTPException(status_code=404, detail="No such host.")
+  if host.get("token_sha256"):
+    raise HTTPException(status_code=409, detail="This machine is already paired.")
+  code = _new_code()
+  host["pairing_code"] = code
+  host["pairing_expires_at"] = _now() + _PAIRING_TTL_SECONDS
+  _save_host(host)
+  base = _base_url()
+  return {
+    "id": host_id,
+    "name": host["name"],
+    "pairing_code": code,
+    "install_command": _install_command(base, code),
+    "expires_at": host["pairing_expires_at"],
+  }
+
+
+@router.delete("/hosts/{host_id}")
+async def delete_host(
+  host_id: str,
+  _owner: models.Owner = Depends(get_owner_or_app_with_connect_manage),
+) -> dict:
+  host = _load_host(host_id)
+  if host is None:
+    raise HTTPException(status_code=404, detail="No such host.")
+  ch = _channels.pop(host_id, None)
+  if ch is not None:
+    for fut in ch.pending.values():
+      if not fut.done():
+        fut.cancel()
+  _host_path(host_id).unlink(missing_ok=True)
+  return {"ok": True}
+
+
+@router.post("/hosts/{host_id}/exec")
+async def exec_on_host(
+  host_id: str,
+  body: ExecBody,
+  _owner: models.Owner = Depends(get_owner_or_app_with_connect_manage),
+) -> dict:
+  host = _load_host(host_id)
+  if host is None:
+    raise HTTPException(status_code=404, detail="No such host.")
+  ch = _channels.get(host_id)
+  if ch is None:
+    raise HTTPException(
+      status_code=409,
+      detail=f"{host.get('name') or 'That machine'} is offline right now.",
+    )
+  request_id = secrets.token_hex(8)
+  loop = asyncio.get_running_loop()
+  fut: asyncio.Future = loop.create_future()
+  ch.pending[request_id] = fut
+  timeout = max(1, min(int(body.timeout or _DEFAULT_EXEC_TIMEOUT), 3600))
+  await ch.queue.put(
+    {
+      "type": "exec",
+      "request_id": request_id,
+      "cmd": body.cmd,
+      "cwd": body.cwd,
+      "timeout": timeout,
+    }
+  )
+  try:
+    # Give the runner its own command timeout plus a network grace margin.
+    result = await asyncio.wait_for(fut, timeout=timeout + 15)
+  except asyncio.TimeoutError:
+    raise HTTPException(status_code=504, detail="The command timed out.")
+  except asyncio.CancelledError:
+    raise HTTPException(status_code=409, detail="The machine disconnected.")
+  finally:
+    ch.pending.pop(request_id, None)
+  return result
+
+
+# --------------------------------------------------------------------------- #
+# Runner surface (host-token authenticated)
+# --------------------------------------------------------------------------- #
+@router.post("/pair")
+async def pair(body: PairBody) -> dict:
+  code = (body.code or "").strip().upper()
+  if not code:
+    raise HTTPException(status_code=400, detail="Missing pairing code.")
+  for host in _list_hosts():
+    stored = host.get("pairing_code")
+    if not stored:
+      continue
+    if not secrets.compare_digest(stored.upper(), code):
+      continue
+    if _now() > float(host.get("pairing_expires_at") or 0):
+      raise HTTPException(status_code=400, detail="That pairing code has expired.")
+    token = secrets.token_urlsafe(32)
+    host["token_sha256"] = _hash(token)
+    host["pairing_code"] = None
+    host["pairing_expires_at"] = None
+    host["paired_at"] = _now()
+    _save_host(host)
+    return {"host_id": host["id"], "token": token, "name": host["name"]}
+  raise HTTPException(status_code=400, detail="Invalid pairing code.")
+
+
+@router.get("/stream")
+async def stream(request: Request) -> StreamingResponse:
+  host = _auth_host(request)
+  host_id = host["id"]
+  # The runner reports its OS on connect so the app can label the machine.
+  plat = request.query_params.get("platform")
+  if plat:
+    host["platform"] = plat[:80]
+    _save_host(host)
+  ch = _Channel()
+  # A reconnecting runner replaces any stale channel.
+  old = _channels.get(host_id)
+  if old is not None:
+    for fut in old.pending.values():
+      if not fut.done():
+        fut.cancel()
+  _channels[host_id] = ch
+  _touch(host_id)
+
+  async def gen():
+    try:
+      yield ": connected\n\n"
+      while True:
+        if await request.is_disconnected():
+          break
+        try:
+          evt = await asyncio.wait_for(ch.queue.get(), timeout=_HEARTBEAT_SECONDS)
+          yield f"data: {json.dumps(evt)}\n\n"
+        except asyncio.TimeoutError:
+          yield ": ping\n\n"
+    finally:
+      if _channels.get(host_id) is ch:
+        del _channels[host_id]
+      for fut in ch.pending.values():
+        if not fut.done():
+          fut.cancel()
+      _touch(host_id)
+
+  return StreamingResponse(
+    gen(),
+    media_type="text/event-stream",
+    headers={"Cache-Control": "no-cache, no-transform", "X-Accel-Buffering": "no"},
+  )
+
+
+@router.post("/result")
+async def result(body: ResultBody, request: Request) -> dict:
+  host = _auth_host(request)
+  ch = _channels.get(host["id"])
+  if ch is not None:
+    fut = ch.pending.get(body.request_id)
+    if fut is not None and not fut.done():
+      fut.set_result(
+        {
+          "stdout": body.stdout,
+          "stderr": body.stderr,
+          "exit_code": body.exit_code,
+        }
+      )
+  _touch(host["id"])
+  return {"ok": True}
+
+
+# --------------------------------------------------------------------------- #
+# The runner script (served for download; pure Python stdlib)
+# --------------------------------------------------------------------------- #
+_RUNNER_PATH = Path(__file__).resolve().parents[1] / "connect_runner.py"
+
+
+@router.get("/runner")
+async def runner_script() -> PlainTextResponse:
+  return PlainTextResponse(
+    _RUNNER_PATH.read_text("utf-8"), media_type="text/x-python",
+  )

--- a/backend/app/schema_migrations.py
+++ b/backend/app/schema_migrations.py
@@ -1430,6 +1430,22 @@ def _add_app_connections_manage(eng) -> None:
     ))
 
 
+def _add_app_connect_manage(eng) -> None:
+  """Grant column for the Connect mini-app's external-machine access."""
+  from sqlalchemy import inspect as sa_inspect, text
+
+  columns = {
+    column["name"] for column in sa_inspect(eng).get_columns("apps")
+  }
+  if "connect_manage" in columns:
+    return
+  with eng.begin() as conn:
+    conn.execute(text(
+      "ALTER TABLE apps ADD COLUMN connect_manage BOOLEAN "
+      "NOT NULL DEFAULT FALSE"
+    ))
+
+
 def _add_chat_pending_question_id(eng) -> None:
   """Add the durable open-AskUserQuestion marker (models.Chat).
 
@@ -1643,6 +1659,7 @@ _SCHEMA_MIGRATIONS = (
   ("0013_app_hosted_publication", _add_app_hosted_publication),
   ("0014_chat_run_goal_plan", _add_chat_run_goal_plan),
   ("0015_chat_run_goal_identity", _add_chat_run_goal_identity),
+  ("0016_app_connect_manage", _add_app_connect_manage),
 )
 
 

--- a/backend/tests/test_apps_install.py
+++ b/backend/tests/test_apps_install.py
@@ -20,7 +20,7 @@ from urllib.parse import urlparse
 
 import pytest
 
-from app import app_git
+from app import app_git, models
 from app.config import get_settings
 from test_app_fixtures import create_local_app
 
@@ -4040,7 +4040,7 @@ def _install_simple(client, auth, base, manifest, jsx=JSX):
 
 
 def test_install_response_includes_capability_flags(
-  client, auth, bypass_url_validation,
+  client, auth, db, bypass_url_validation,
 ):
   """The immediate install response must match the persisted app capabilities."""
   base = "https://caps.test/repo/"
@@ -4051,6 +4051,7 @@ def test_install_response_includes_capability_flags(
   manifest["permissions"]["manage_skills"] = True
   manifest["permissions"]["github_connect"] = True
   manifest["permissions"]["filesystem_access"] = True
+  manifest["permissions"]["connect_manage"] = True
 
   r = _install_simple(client, auth, base, manifest)
 
@@ -4071,6 +4072,8 @@ def test_install_response_includes_capability_flags(
   assert row["manage_skills"] is True
   assert row["github_connect"] is True
   assert row["filesystem_access"] is True
+  persisted = db.query(models.App).filter(models.App.id == payload["id"]).one()
+  assert persisted.connect_manage is True
 
 
 def test_install_rejects_non_boolean_filesystem_capability(

--- a/backend/tests/test_connect.py
+++ b/backend/tests/test_connect.py
@@ -1,11 +1,15 @@
 """Pairing, revocation, and app-capability boundaries for Möbius Connect."""
 
+import shlex
+import sys
+import time
 from pathlib import Path
 
 import pytest
 from sqlalchemy import create_engine, inspect, text
 
 from app import models
+from app.connect_runner import _run_command
 from app.database import SessionLocal
 from app.manifest_contract import ManifestContractError, validate_manifest_contract
 from app.routes import connect as connect_routes
@@ -98,6 +102,32 @@ def test_pairing_is_one_time_and_delete_revokes_runner(client, auth):
     "/api/connect/result", headers=runner_auth,
     json={"request_id": "not-pending"},
   ).status_code == 401
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX process-group contract")
+def test_runner_timeout_terminates_the_entire_command_tree(tmp_path: Path):
+  """A timed-out command must not leave descendants running on the machine."""
+  marker = tmp_path / "descendant-finished"
+  descendant = (
+    "import pathlib,time; time.sleep(0.5); "
+    f"pathlib.Path({str(marker)!r}).touch()"
+  )
+  launcher = (
+    "import subprocess,sys; "
+    f"subprocess.Popen([sys.executable, '-c', {descendant!r}])"
+  )
+  # The launcher and its shell both exit immediately. The descendant retains
+  # their captured pipes, reproducing the case where checking only the shell's
+  # status would mistake a still-running command tree for completed work.
+  cmd = f"{shlex.quote(sys.executable)} -c {shlex.quote(launcher)}"
+
+  stdout, stderr, exit_code = _run_command(cmd, None, 0.05)
+
+  assert stdout == ""
+  assert "timed out" in stderr
+  assert exit_code == 124
+  time.sleep(0.6)
+  assert not marker.exists()
 
 
 def test_manifest_requires_boolean_connect_permission():

--- a/backend/tests/test_connect.py
+++ b/backend/tests/test_connect.py
@@ -1,0 +1,155 @@
+"""Pairing, revocation, and app-capability boundaries for Möbius Connect."""
+
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine, inspect, text
+
+from app import models
+from app.database import SessionLocal
+from app.manifest_contract import ManifestContractError, validate_manifest_contract
+from app.routes import connect as connect_routes
+from app.schema_migrations import run_migrations, schema_migration_history
+
+
+@pytest.fixture(autouse=True)
+def _clear_connect_channels():
+  connect_routes._channels.clear()
+  yield
+  connect_routes._channels.clear()
+
+
+def _app_auth(client, auth, *, granted: bool) -> dict[str, str]:
+  from test_app_fixtures import create_local_app
+
+  app_id = create_local_app(
+    client, auth, name="connect-test", description="test app",
+  )["id"]
+  session = SessionLocal()
+  try:
+    app = session.query(models.App).filter(models.App.id == app_id).first()
+    app.connect_manage = granted
+    session.commit()
+  finally:
+    session.close()
+  minted = client.post(
+    "/api/auth/app-token", json={"app_id": app_id}, headers=auth,
+  )
+  assert minted.status_code == 200, minted.text
+  return {"Authorization": f"Bearer {minted.json()['token']}"}
+
+
+def test_app_token_requires_connect_manage(client, auth):
+  denied = _app_auth(client, auth, granted=False)
+  response = client.get("/api/connect/hosts", headers=denied)
+  assert response.status_code == 403
+  assert "permissions.connect_manage=true" in response.json()["detail"]
+
+  granted = _app_auth(client, auth, granted=True)
+  assert client.get("/api/connect/hosts", headers=granted).json() == {"hosts": []}
+  created = client.post(
+    "/api/connect/hosts", headers=granted, json={"name": "Workstation"},
+  )
+  assert created.status_code == 200
+  assert created.json()["name"] == "Workstation"
+
+
+def test_pairing_is_one_time_and_delete_revokes_runner(client, auth):
+  runner = client.get("/api/connect/runner")
+  assert runner.status_code == 200
+  assert runner.text.startswith("#!/usr/bin/env python3")
+
+  created = client.post(
+    "/api/connect/hosts", headers=auth, json={"name": "   "},
+  )
+  assert created.status_code == 200, created.text
+  pairing = created.json()
+  assert pairing["name"] == "My machine"
+  assert pairing["pairing_code"] in pairing["install_command"]
+
+  before = client.get("/api/connect/hosts", headers=auth).json()["hosts"]
+  assert len(before) == 1
+  public_host = before[0]
+  assert public_host["id"] == pairing["id"]
+  assert public_host["name"] == "My machine"
+  assert public_host["paired"] is False
+  assert public_host["online"] is False
+  assert "pairing_code" not in public_host
+  assert "token_sha256" not in public_host
+
+  paired = client.post(
+    "/api/connect/pair", json={"code": pairing["pairing_code"]},
+  )
+  assert paired.status_code == 200, paired.text
+  runner_token = paired.json()["token"]
+  assert client.post(
+    "/api/connect/pair", json={"code": pairing["pairing_code"]},
+  ).status_code == 400
+
+  runner_auth = {"Authorization": f"Bearer {runner_token}"}
+  assert client.post(
+    "/api/connect/result", headers=runner_auth,
+    json={"request_id": "not-pending"},
+  ).status_code == 200
+
+  removed = client.delete(f"/api/connect/hosts/{pairing['id']}", headers=auth)
+  assert removed.status_code == 200
+  assert client.post(
+    "/api/connect/result", headers=runner_auth,
+    json={"request_id": "not-pending"},
+  ).status_code == 401
+
+
+def test_manifest_requires_boolean_connect_permission():
+  manifest = {
+    "id": "connect",
+    "name": "Connect",
+    "version": "0.1.0",
+    "description": "Pair an external machine.",
+    "entry": "index.jsx",
+    "permissions": {"connect_manage": "yes"},
+  }
+  with pytest.raises(ManifestContractError, match="connect_manage"):
+    validate_manifest_contract(manifest)
+
+
+def test_connect_manage_reaches_a_ledgered_database(tmp_path: Path):
+  eng = create_engine(f"sqlite:///{tmp_path / 'ledgered-apps.db'}")
+  with eng.begin() as conn:
+    conn.execute(text(
+      "CREATE TABLE apps ("
+      "id INTEGER PRIMARY KEY, name VARCHAR(255), slug VARCHAR(128), "
+      "token_nonce VARCHAR(32), capability_contract JSON)"
+    ))
+    conn.execute(text(
+      "CREATE TABLE schema_migrations ("
+      "version VARCHAR(128) PRIMARY KEY, applied_at TIMESTAMP NOT NULL)"
+    ))
+    for version in (
+      "0001_legacy_schema_convergence",
+      "0002_chat_run_goal_objective",
+      "0003_chat_run_root_identity",
+      "0004_app_identity_required",
+      "0005_connectors",
+      "0006_connector_capability_identity",
+      "0007_chat_has_messages",
+      "0008_chat_search_documents",
+      "0009_app_connections_manage",
+      "0010_chat_pending_question_id",
+      "0011_delegation_parent_wake",
+      "0012_connector_oauth_gcloud",
+      "0013_app_hosted_publication",
+      "0014_chat_run_goal_plan",
+      "0015_chat_run_goal_identity",
+    ):
+      conn.execute(text(
+        "INSERT INTO schema_migrations (version, applied_at) "
+        "VALUES (:version, '2026-08-22 00:00:00')"
+      ), {"version": version})
+
+  run_migrations(eng)
+  columns = {column["name"] for column in inspect(eng).get_columns("apps")}
+  assert "connect_manage" in columns
+  assert "0016_app_connect_manage" in {
+    entry["version"] for entry in schema_migration_history(eng)
+  }

--- a/backend/tests/test_db_migrations.py
+++ b/backend/tests/test_db_migrations.py
@@ -24,6 +24,15 @@ from app.schema_migrations import (
 )
 
 
+def _migration_versions_before(target: str) -> list[str]:
+  versions: list[str] = []
+  for version, _migration in migrations._SCHEMA_MIGRATIONS:
+    if version == target:
+      return versions
+    versions.append(version)
+  raise AssertionError(f"Unknown migration: {target}")
+
+
 PREVIOUS_RELEASE_SCHEMA = (
   Path(__file__).parent / "fixtures" / "schema_0013.sql"
 )
@@ -1060,6 +1069,7 @@ def test_run_migrations_records_an_inspectable_append_only_history(tmp_path):
     "0013_app_hosted_publication",
     "0014_chat_run_goal_plan",
     "0015_chat_run_goal_identity",
+    "0016_app_connect_manage",
   ]
   assert second == first
 
@@ -1180,7 +1190,7 @@ def test_hosted_publication_reaches_a_fully_ledgered_private_app(tmp_path):
       "CREATE TABLE schema_migrations ("
       "version VARCHAR(128) PRIMARY KEY, applied_at TIMESTAMP NOT NULL)"
     ))
-    for version, _migration in migrations._SCHEMA_MIGRATIONS[:-3]:
+    for version in _migration_versions_before("0013_app_hosted_publication"):
       conn.execute(text(
         "INSERT INTO schema_migrations (version, applied_at) "
         "VALUES (:version, '2026-08-15 00:00:00')"
@@ -1238,7 +1248,7 @@ def test_hosted_publication_migrates_the_unmerged_live_flag_to_a_snapshot(
       "CREATE TABLE schema_migrations ("
       "version VARCHAR(128) PRIMARY KEY, applied_at TIMESTAMP NOT NULL)"
     ))
-    for version, _migration in migrations._SCHEMA_MIGRATIONS[:-3]:
+    for version in _migration_versions_before("0013_app_hosted_publication"):
       conn.execute(text(
         "INSERT INTO schema_migrations (version, applied_at) "
         "VALUES (:version, '2026-08-15 00:00:00')"
@@ -1677,7 +1687,7 @@ def test_goal_plan_migration_adds_snapshot_and_revision_to_existing_runs(
       "CREATE TABLE IF NOT EXISTS schema_migrations ("
       "version VARCHAR(128) PRIMARY KEY, applied_at TIMESTAMP NOT NULL)"
     ))
-    for version, _migration in migrations._SCHEMA_MIGRATIONS[:-2]:
+    for version in _migration_versions_before("0014_chat_run_goal_plan"):
       conn.execute(text(
         "INSERT INTO schema_migrations (version, applied_at) "
         "VALUES (:version, :at)"
@@ -1724,7 +1734,7 @@ def test_goal_identity_migration_preserves_distinct_historical_roots_and_index(
       "CREATE TABLE IF NOT EXISTS schema_migrations ("
       "version VARCHAR(128) PRIMARY KEY, applied_at TIMESTAMP NOT NULL)"
     ))
-    for version, _migration in migrations._SCHEMA_MIGRATIONS[:-1]:
+    for version in _migration_versions_before("0015_chat_run_goal_identity"):
       conn.execute(text(
         "INSERT INTO schema_migrations (version, applied_at) "
         "VALUES (:version, :at)"


### PR DESCRIPTION
## Summary

- add the Connect service for pairing, listing, revoking, and dispatching commands to external machines
- serve a dependency-free Python runner that connects outbound and can install itself with launchd or systemd
- use short-lived one-time pairing codes, hashed per-machine tokens, bounded request bodies, and immediate revocation
- add a dedicated `connect_manage` app permission so unrelated app tokens cannot manage machines
- persist the machine registry under shared data while keeping live command channels in the single backend process

The runner executes commands as the local user, matching the trust model of a coding CLI installed on that machine. Removing a machine invalidates its bearer token immediately.

## Testing

- 53 focused backend tests passed across Connect routes, migrations, and app install permissions
- Python compilation checks passed for the route, runner, migration, and capability changes