### PR TITLE
Build gate: measure unreclaimable footprint, name refusal causes, surface watcher deferrals

### DIFF
--- a/backend/app/build_admission.py
+++ b/backend/app/build_admission.py
@@ -73,13 +73,23 @@ def require_vite_build_admission(memory: dict | None = None) -> None:
   )
   if state not in {"constrained", "critical"} and not too_little_headroom:
     return
-  detail = f"memory pressure is {state}"
-  if isinstance(headroom, int):
-    detail += f" with {headroom // MIB} MiB cgroup headroom"
+  # Say exactly which condition refused the build. A single headroom-shaped
+  # template once produced "5260 MiB headroom; 512 MiB is required" while the
+  # real trigger was a PSI spike — a self-contradiction that misdirects
+  # whoever is debugging a stalled rebuild.
+  causes: list[str] = []
+  if state in {"constrained", "critical"}:
+    signals = (assessment.get("reason") or {}).get("signals") or []
+    named = "; ".join(signals) if signals else f"memory pressure is {state}"
+    causes.append(f"memory pressure is {state} ({named})")
+  if too_little_headroom:
+    causes.append(
+      f"only {headroom // MIB} MiB cgroup headroom;"
+      f" {VITE_BUILD_MIN_HEADROOM_BYTES // MIB} MiB is required to start"
+    )
   raise ViteBuildDeferred(
-    "Vite build deferred: "
-    f"{detail}; {VITE_BUILD_MIN_HEADROOM_BYTES // MIB} MiB is required "
-    "before starting. Retry after memory pressure falls."
+    "Vite build deferred: " + " and ".join(causes) +
+    ". Retry after memory pressure falls."
   )
 
 

--- a/backend/app/frontend_watcher.py
+++ b/backend/app/frontend_watcher.py
@@ -806,6 +806,13 @@ class _FrontendHandler(FileSystemEventHandler):
     self._last_source_change = 0.0
     self._last_build_reason = "startup"
     self._blocked_conflict_signature: str | None = None
+    # Memory-admission deferrals were once invisible: the watcher requeued
+    # silently while health read "running, no error", and a stale reading
+    # could hold builds for hours on an idle box. Track them so health and
+    # the log say that builds are waiting, on what, and since when.
+    self._deferred_since: float | None = None
+    self._deferral_count = 0
+    self._deferred_reason: str | None = None
     self._staging_dirty = False
     self._incomplete_since: float | None = None
     self._incomplete_notified = False
@@ -891,12 +898,26 @@ class _FrontendHandler(FileSystemEventHandler):
         pass
     with self._state_lock:
       staging_dirty = self._staging_dirty
+      deferred_since = self._deferred_since
+      deferral_count = self._deferral_count
+      deferred_reason = self._deferred_reason
     return {
       "running": not self._closed.is_set(),
       "building": pid is not None,
       "pid": pid,
       "rss_bytes": rss_bytes,
       "staging_dirty": staging_dirty,
+      # Present only while a source change is waiting on memory admission,
+      # so "running, no error" can never again hide a stalled rebuild.
+      "build_deferred": (
+        {
+          "since": deferred_since,
+          "attempts": deferral_count,
+          "reason": deferred_reason,
+        }
+        if deferred_since is not None
+        else None
+      ),
       "lease_path": str(_FRONTEND_DIR / ".watch.lock"),
     }
 
@@ -1015,6 +1036,7 @@ class _FrontendHandler(FileSystemEventHandler):
     try:
       with build_lease(blocking=False):
         if _memory_is_tight():
+          self._note_build_deferred(reason)
           self._queue_build(reason)
           return
         with self._state_lock:
@@ -1080,6 +1102,7 @@ class _FrontendHandler(FileSystemEventHandler):
           with self._proc_lock:
             self._watch_proc = proc
           log.info("frontend demand build started after %s", reason)
+          self._clear_build_deferral()
           try:
             output, _ = proc.communicate(timeout=180)
           except subprocess.TimeoutExpired as exc:
@@ -1128,6 +1151,39 @@ class _FrontendHandler(FileSystemEventHandler):
     except BuildLeaseUnavailable:
       # Only the acquisition above can raise this; the body takes no lease.
       self._queue_build(reason)
+
+  def _note_build_deferred(self, reason: str) -> None:
+    """Record one memory-admission deferral where health and logs can see it."""
+    with self._state_lock:
+      self._deferral_count += 1
+      self._deferred_reason = reason
+      first = self._deferred_since is None
+      if first:
+        self._deferred_since = time.time()
+      count = self._deferral_count
+    # Warn on the first deferral, then periodically — a persisted deferral is
+    # exactly the state that must not stay quiet, but every debounce tick
+    # would be noise.
+    if first or count % 20 == 0:
+      log.warning(
+        "frontend build deferred by memory admission"
+        " (%d attempt%s, change: %s); the last good dist remains served",
+        count, "" if count == 1 else "s", reason,
+      )
+
+  def _clear_build_deferral(self) -> None:
+    with self._state_lock:
+      if self._deferred_since is None:
+        return
+      since = self._deferred_since
+      count = self._deferral_count
+      self._deferred_since = None
+      self._deferral_count = 0
+      self._deferred_reason = None
+    log.info(
+      "frontend build admitted after %d deferred attempt%s (%.0f s waiting)",
+      count, "" if count == 1 else "s", time.time() - since,
+    )
 
   def _refresh_staging_signature(self) -> bool:
     sig = _tree_signature(_STAGING_DIST_DIR)

--- a/backend/app/memory_observability.py
+++ b/backend/app/memory_observability.py
@@ -222,7 +222,18 @@ def cgroup_memory_snapshot(
   proc_root: Path = Path("/proc"),
   cgroup_root: Path = Path("/sys/fs/cgroup"),
 ) -> dict[str, Any]:
-  """Return cgroup-v2 memory split so file cache is not mistaken for heap."""
+  """Return cgroup-v2 memory split so file cache is not mistaken for heap.
+
+  ``working_set_bytes`` is the unreclaimable footprint: everything the kernel
+  cannot simply drop before OOMing this cgroup. Both file-LRU halves are
+  subtracted, not just ``inactive_file``: the active/inactive split records
+  access recency, not evictability, and the kernel evicts either before an
+  OOM kill. Counting active file cache as footprint once held the frontend
+  build gate "constrained" for hours on an idle box, because a test/grep-heavy
+  agent session had promoted gigabytes of page cache to the active list and
+  nothing ever reclaims it on an idle machine. PSI — reported alongside —
+  remains the signal for whether reclaim is actually hurting.
+  """
   root = _cgroup_dir(proc_root=proc_root, cgroup_root=cgroup_root)
   current = _read_int(root / "memory.current")
   if current is None:
@@ -244,10 +255,11 @@ def cgroup_memory_snapshot(
     except ValueError:
       pass
   inactive_file = stat.get("inactive_file", 0)
+  file_lru = inactive_file + stat.get("active_file", 0)
   return {
     "available": True,
     "current_bytes": current,
-    "working_set_bytes": max(0, current - inactive_file),
+    "working_set_bytes": max(0, current - file_lru),
     "limit_bytes": limit,
     "swap_current_bytes": _read_int(root / "memory.swap.current"),
     "anon_bytes": stat.get("anon"),

--- a/backend/app/resource_pressure.py
+++ b/backend/app/resource_pressure.py
@@ -236,30 +236,56 @@ def _memory_pressure(memory: dict[str, Any]) -> dict[str, Any]:
   some_avg60 = _float(some.get("avg60"))
   full_avg60 = _float(full.get("avg60"))
 
+  # Name each tripped signal so downstream refusals can say WHY instead of
+  # reciting all three values. A gate message that printed generous headroom
+  # while refusing on a PSI spike sent a debugging session in the wrong
+  # direction; the owner of the thresholds is the right place to know which
+  # comparison actually fired.
+  def _signals(ratio_at: float, some_at: float, full_at: float) -> list[str]:
+    tripped = []
+    if ratio >= ratio_at:
+      tripped.append(
+        f"unreclaimable footprint is {ratio:.0%} of the limit"
+        f" (threshold {ratio_at:.0%})"
+      )
+    if some_avg60 >= some_at:
+      tripped.append(
+        f"PSI some avg60 {some_avg60:.1f} >= {some_at:.1f}"
+      )
+    if full_avg60 >= full_at:
+      tripped.append(
+        f"PSI full avg60 {full_avg60:.1f} >= {full_at:.1f}"
+      )
+    return tripped
+
   state = "normal"
   reason = None
-  if (
-    ratio >= _MEMORY_CRITICAL_RATIO
-    or some_avg60 >= _MEMORY_CRITICAL_SOME_AVG60
-    or full_avg60 >= _MEMORY_CRITICAL_FULL_AVG60
-  ):
+  critical_signals = _signals(
+    _MEMORY_CRITICAL_RATIO,
+    _MEMORY_CRITICAL_SOME_AVG60,
+    _MEMORY_CRITICAL_FULL_AVG60,
+  )
+  constrained_signals = _signals(
+    _MEMORY_CONSTRAINED_RATIO,
+    _MEMORY_CONSTRAINED_SOME_AVG60,
+    _MEMORY_CONSTRAINED_FULL_AVG60,
+  )
+  if critical_signals:
     state = "critical"
     reason = {
       "resource": "memory",
       "code": "memory_pressure_critical",
+      "signals": critical_signals,
       "working_set_ratio": ratio,
       "some_avg60": some_avg60,
       "full_avg60": full_avg60,
     }
-  elif (
-    ratio >= _MEMORY_CONSTRAINED_RATIO
-    or some_avg60 >= _MEMORY_CONSTRAINED_SOME_AVG60
-    or full_avg60 >= _MEMORY_CONSTRAINED_FULL_AVG60
-  ):
+  elif constrained_signals:
     state = "constrained"
     reason = {
       "resource": "memory",
       "code": "memory_pressure_constrained",
+      "signals": constrained_signals,
       "working_set_ratio": ratio,
       "some_avg60": some_avg60,
       "full_avg60": full_avg60,

--- a/backend/tests/test_build_admission.py
+++ b/backend/tests/test_build_admission.py
@@ -195,3 +195,27 @@ def test_all_frontend_native_build_entrypoints_enter_admission():
     source = (scripts / name).read_text(encoding="utf-8")
     assert "from './build-admission.mjs'" in source
     assert "enterBuildAdmission(" in source
+
+
+def test_refusal_names_psi_not_headroom_when_psi_trips():
+  """The message must name the tripped condition. A fixed headroom template
+  once produced "5260 MiB headroom; 512 MiB is required" during a PSI spike."""
+  one_gib = 1024 * 1024 * 1024
+  psi_spike = _memory(working_set=128 * 1024 * 1024, limit=one_gib)
+  psi_spike["pressure"] = {"some": {"avg60": 2.0}, "full": {"avg60": 0.0}}
+
+  assert vite_build_admitted(psi_spike) is False
+  with pytest.raises(ViteBuildDeferred) as exc:
+    require_vite_build_admission(psi_spike)
+  message = str(exc.value)
+  assert "PSI some avg60 2.0" in message
+  assert "headroom" not in message
+
+
+def test_refusal_names_footprint_ratio_when_ratio_trips():
+  one_gib = 1024 * 1024 * 1024
+  hot = _memory(working_set=int(one_gib * 0.8), limit=one_gib)
+
+  with pytest.raises(ViteBuildDeferred) as exc:
+    require_vite_build_admission(hot)
+  assert "unreclaimable footprint is 80% of the limit" in str(exc.value)

--- a/backend/tests/test_frontend_watcher_publish.py
+++ b/backend/tests/test_frontend_watcher_publish.py
@@ -875,3 +875,28 @@ def test_vite_env_preserves_operator_resource_overrides(fw_dirs, monkeypatch):
 
   assert env["CHOKIDAR_INTERVAL"] == "900"
   assert env["NODE_OPTIONS"] == "--trace-warnings --max_old_space_size=768"
+
+
+@pytest.mark.asyncio
+async def test_memory_deferral_is_visible_in_health_and_clears():
+  """A build waiting on memory admission must be visible: health once read
+  "running, no error" while a stale pressure reading held builds for hours."""
+  handler = fw._FrontendHandler(asyncio.get_running_loop(),
+                                start_threads=False)
+  try:
+    assert handler.health()["build_deferred"] is None
+
+    handler._note_build_deferred("edit: App.jsx")
+    handler._note_build_deferred("edit: App.jsx")
+    deferred = handler.health()["build_deferred"]
+    assert deferred is not None
+    assert deferred["attempts"] == 2
+    assert deferred["reason"] == "edit: App.jsx"
+    assert deferred["since"] <= time.time()
+
+    handler._clear_build_deferral()
+    assert handler.health()["build_deferred"] is None
+    # Clearing when nothing is deferred stays a no-op.
+    handler._clear_build_deferral()
+  finally:
+    handler.close()

--- a/backend/tests/test_memory_observability.py
+++ b/backend/tests/test_memory_observability.py
@@ -126,10 +126,14 @@ def test_cgroup_snapshot_separates_reclaimable_file_cache(tmp_path: Path):
     cgroup_root=cgroup_root,
   )
 
+  # Working set excludes BOTH file-LRU halves (1000 - 400 inactive - 200
+  # active): the active/inactive split is access recency, not evictability,
+  # and counting active cache as footprint once stalled frontend builds for
+  # hours behind a cache-warmed "constrained" reading.
   assert snapshot == {
     "available": True,
     "current_bytes": 1000,
-    "working_set_bytes": 600,
+    "working_set_bytes": 400,
     "limit_bytes": 2000,
     "swap_current_bytes": 30,
     "anon_bytes": 300,

--- a/backend/tests/test_resource_pressure.py
+++ b/backend/tests/test_resource_pressure.py
@@ -192,3 +192,17 @@ def test_resource_status_keeps_facts_and_pressure_separate():
 
   assert set(status) == {"facts", "pressure"}
   assert status["pressure"]["state"] == "normal"
+
+
+def test_memory_reason_names_each_tripped_signal():
+  constrained = assess_memory_pressure({
+    "available": True,
+    "working_set_bytes": 800 * MIB,
+    "limit_bytes": 1000 * MIB,
+    "pressure": {"some": {"avg60": 1.5}, "full": {"avg60": 0.0}},
+  })
+  assert constrained["state"] == "constrained"
+  signals = constrained["reason"]["signals"]
+  assert any("unreclaimable footprint is 80%" in s for s in signals)
+  assert any("PSI some avg60 1.5" in s for s in signals)
+  assert not any("PSI full" in s for s in signals)


### PR DESCRIPTION
## Problem

The cgroup memory snapshot computes `working_set_bytes` as `memory.current - inactive_file`, counting **active** file cache as unreclaimable footprint. Any page-cache-heavy workload (test runs, greps over the repo) promotes gigabytes of cache to the active LRU, so an otherwise idle instance can read a footprint ratio of 0.90+ — past the constrained/critical thresholds — while kernel PSI is 0.0. Nothing reclaims that cache on an idle box, so the state persists indefinitely.

Three symptoms compound:

1. **Silent rebuild stalls.** The frontend watcher defers builds on admission failure and requeues quietly; `health()` keeps reporting `running`, no error, so the served shell silently stops updating (observed: hours behind, dist stale, no signal anywhere).
2. **Self-contradictory refusals.** `require_vite_build_admission` uses one headroom-shaped message template regardless of the actual trigger, producing refusals like *"5260 MiB cgroup headroom; 512 MiB is required before starting"* when the trigger was a PSI spike or the (misread) footprint ratio.
3. **Misleading debug telemetry.** `/api/debug` surfaces the inflated working set.

## Fix

- `memory_observability.cgroup_memory_snapshot`: working set now excludes **both** file-LRU halves (`inactive_file + active_file`). The active/inactive split records access recency, not evictability — the kernel evicts either before OOMing a cgroup. PSI, reported alongside, remains the signal for whether reclaim actually hurts.
- `resource_pressure._memory_pressure`: the reason dict now carries `signals` — the exact comparisons that tripped (footprint ratio, PSI some/full), built where the thresholds live.
- `build_admission.require_vite_build_admission`: refusals name the tripped condition(s) instead of the fixed headroom template.
- `frontend_watcher`: memory-admission deferrals are tracked and exposed as `health()["build_deferred"]` (`since`/`attempts`/`reason`), warned on first occurrence and periodically after, and cleared with an info line when a build is finally admitted.

No guard is weakened: the ratio thresholds, PSI thresholds, and the absolute 512 MiB starting reserve are unchanged — they now just operate on truthful numbers.

## Tests

- snapshot arithmetic excludes both LRU halves (updated fixture expectation)
- assessment names each tripped signal, and only tripped signals
- refusal message names PSI (not headroom) on a PSI trip, and the footprint ratio on a ratio trip
- watcher `health()` exposes a deferral after `_note_build_deferred` and clears it; clearing while idle is a no-op

All four owning suites pass (60 tests) against this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)