### PR TITLE
Present running chats before stream catch-up

### DIFF
--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -401,8 +401,7 @@ export default function ChatView({
   // Cached rows are safe restoration geometry, but their persisted liveness can
   // be stale. Do not publish a chat-to-chat handoff until this activation's
   // runtime/detail verdict has arrived: otherwise an apparently idle cache can
-  // be promoted, then disappear when the server reports a running turn and the
-  // stream catch-up gate closes one frame later.
+  // be promoted before the server reports that its turn is still running.
   const [activationSettled, setActivationSettled] = useState(false)
   const acceptCachedReadingCoordinate = useCallback(() => {
     // The scroll owner has proved the exact nested part against committed DOM.
@@ -1936,8 +1935,10 @@ export default function ChatView({
           ? visibleMessages[visibleMessages.length - 1]
           : null,
       })
-      // Persisted rows are not the complete surface of a running turn. Keep
-      // the outgoing chat visible until the subscribe-time replay commits.
+      // Runtime truth is enough to present the canonical transcript and its
+      // stable in-progress assistant surface. Subscribe-time replay reconciles
+      // into that same row after presentation instead of holding the outgoing
+      // chat—and its stale reading cues—through the transport catch-up.
       setInitialEntryPhase(attachesToStream ? 'stream-catchup' : 'ready')
       setLoading(false)
       setActivationSettled(true)
@@ -3915,9 +3916,13 @@ export default function ChatView({
 
   // A safe cached window can prepare while its freshness check runs. History
   // and progressive preparation remain hidden; `cached` is granted only after
-  // the saved-coordinate coverage check above.
+  // the saved-coordinate coverage check above. The display-ready gate below
+  // publishes a running frame only after the activation verdict settles, while
+  // catch-up continues to reconcile into the same active assistant row.
   const transcriptPaintable = (
-    initialEntryPhase === 'cached' || initialEntryPhase === 'ready'
+    initialEntryPhase === 'cached'
+    || initialEntryPhase === 'stream-catchup'
+    || initialEntryPhase === 'ready'
   ) && revealed
   const displayReady = activationSettled
     && !loading

--- a/frontend/src/components/ChatView/__tests__/chatDetailCache.test.js
+++ b/frontend/src/components/ChatView/__tests__/chatDetailCache.test.js
@@ -45,7 +45,7 @@ test('cache first paint requires the saved reading coordinate when one exists', 
 })
 
 
-test('a running cache waits for subscribe-time replay', () => {
+test('a running cache enters the in-place stream reconciliation phase', () => {
   const running = {
     restorationWindowComplete: true,
     running: true,

--- a/frontend/src/components/ChatView/__tests__/entryRestoreGate.test.js
+++ b/frontend/src/components/ChatView/__tests__/entryRestoreGate.test.js
@@ -65,7 +65,7 @@ function paintedScrollEl(row, { scrollTop = 0, clientHeight = 900, spacer = 0 } 
   return scrollEl
 }
 
-for (const phase of ['cached', 'ready', 'cache-validating']) {
+for (const phase of ['cached', 'stream-catchup', 'ready', 'cache-validating']) {
   test(`entryRestoreDecision waits (never commits INITIAL) with no painted rows: ${phase}`, () => {
     const decision = entryRestoreDecision({
       mode: { kind: 'INITIAL' },
@@ -104,6 +104,20 @@ test('entryRestoreDecision commits an explicit saved anchor once it resolves (re
     messages: [{ id: 'm-1' }],
     scrollEl,
     phase: 'ready',
+  })
+  assert.equal(decision.action, 'commit')
+  assert.equal(decision.mode.key, 'm-1')
+  assert.equal(decision.resolved, true)
+})
+
+test('entryRestoreDecision commits an explicit saved anchor while running catch-up continues', () => {
+  const scrollEl = paintedScrollEl(partedRow('m-1', 0, [700]))
+  const decision = entryRestoreDecision({
+    mode: { kind: 'INITIAL' },
+    saved: { kind: 'ANCHOR_AT', key: 'm-1', offset: 40, at: 1 },
+    messages: [{ id: 'm-1' }],
+    scrollEl,
+    phase: 'stream-catchup',
   })
   assert.equal(decision.action, 'commit')
   assert.equal(decision.mode.key, 'm-1')

--- a/frontend/src/components/ChatView/useScrollMode.js
+++ b/frontend/src/components/ChatView/useScrollMode.js
@@ -750,6 +750,7 @@ export function entryRestoreDecision({ mode, saved, messages, scrollEl, phase })
   const savedPresent = !!saved
   const restorePhase = phase === 'cache-validating'
     || phase === 'cached'
+    || phase === 'stream-catchup'
     || phase === 'ready'
   if (mode?.kind !== 'INITIAL' || !restorePhase) {
     return { action: 'idle', resolved: false, savedPresent }
@@ -1390,9 +1391,10 @@ export function modeForQueuedSubmission(scrollEl, currentMode) {
  * @param {'history'|'cache-validating'|'cached'|'stream-catchup'|'preparing'|'ready'} args.initialEntryPhase
  *   History blocks reveal, cached is a caller-validated restoration window,
  *   cache-validating mounts a complete cached window behind the gate so its
- *   exact nested coordinate can be checked, stream-catchup holds a running
- *   transcript until replay commits, preparing is a hidden progressive
- *   cold render, and ready means authoritative history has settled.
+ *   exact nested coordinate can be checked, stream-catchup is an authoritative
+ *   running frame whose transport replay may still reconcile in place,
+ *   preparing is a hidden progressive cold render, and ready means settled
+ *   authoritative history.
  * @param {() => void} [args.onCachedCoordinateReady]
  *   Promotes a hidden validation cache after its exact saved part resolves.
  * @param {boolean} args.ownsReadingPosition
@@ -1536,6 +1538,7 @@ export default function useScrollMode({
       // is assigned only after the caller proves saved-coordinate coverage.
       if (
         initialEntryPhaseRef.current !== 'cached'
+        && initialEntryPhaseRef.current !== 'stream-catchup'
         && initialEntryPhaseRef.current !== 'ready'
       ) return
       if (forceRevealRef.current) forceRevealRef.current()
@@ -2269,6 +2272,7 @@ export default function useScrollMode({
     let revealTimer = 0
     let mountMutationObserver = null
     const entryReady = () => initialEntryPhaseRef.current === 'cached'
+      || initialEntryPhaseRef.current === 'stream-catchup'
       || initialEntryPhaseRef.current === 'ready'
     const requestRevealOnQuiet = () => {
       clearTimeout(revealTimer)

--- a/frontend/src/components/Shell/__tests__/chatHandoff.test.js
+++ b/frontend/src/components/Shell/__tests__/chatHandoff.test.js
@@ -35,12 +35,12 @@ test('chat display readiness admits only coordinate-complete cached transcripts'
     /const activationCacheEntryState = chatCacheEntryState\([\s\S]*setLoading\(activationCacheEntryState === 'missing'\)[\s\S]*activationCacheEntryState === 'validating'[\s\S]*'cache-validating'/,
     'a retained chat revalidates cache coverage on every visible activation')
   assert.match(scrollMode,
-    /initialEntryPhaseRef\.current !== 'cached'[\s\S]*initialEntryPhaseRef\.current !== 'ready'[\s\S]*forceRevealRef/,
-    'the reveal deadline admits only caller-validated cache or authoritative history')
+    /initialEntryPhaseRef\.current !== 'cached'[\s\S]*initialEntryPhaseRef\.current !== 'stream-catchup'[\s\S]*initialEntryPhaseRef\.current !== 'ready'[\s\S]*forceRevealRef/,
+    'the reveal deadline admits only caller-validated or authoritative transcript frames')
   assert.match(
     chatView,
-    /const transcriptPaintable = \([\s\S]*initialEntryPhase === 'cached' \|\| initialEntryPhase === 'ready'[\s\S]*\) && revealed[\s\S]*const displayReady = activationSettled[\s\S]*&& !loading[\s\S]*&& \(transcriptPaintable \|\| showEmpty \|\| showLoadError\)/,
-    'a coordinate-complete cache can paint only after this activation confirms its runtime state',
+    /const transcriptPaintable = \([\s\S]*initialEntryPhase === 'cached'[\s\S]*initialEntryPhase === 'stream-catchup'[\s\S]*initialEntryPhase === 'ready'[\s\S]*\) && revealed[\s\S]*const displayReady = activationSettled[\s\S]*&& !loading[\s\S]*&& \(transcriptPaintable \|\| showEmpty \|\| showLoadError\)/,
+    'a coordinate-complete frame, including a running one, publishes only after runtime confirmation',
   )
   assert.match(chatView, /useLayoutEffect\(\(\) => \{[\s\S]*onDisplayReady\?\.\(chatId\)/,
     'ChatView must report layout readiness before its transcript can be promoted')
@@ -71,7 +71,7 @@ test('chat display readiness admits only coordinate-complete cached transcripts'
   )
 })
 
-test('activation holds an unchanged running transcript until stream catch-up', () => {
+test('activation presents a confirmed running transcript while stream catch-up reconciles', () => {
   const initialLoad = chatView.match(
     /const loadActivation = async \(\) => \{[\s\S]*?\n    loadActivation\(\)/,
   )?.[0] || ''
@@ -125,7 +125,7 @@ test('activation holds an unchanged running transcript until stream catch-up', (
   assert.match(
     chatView,
     /setInitialEntryPhase\(attachesToStream \? 'stream-catchup' : 'ready'\)[\s\S]*if \(running\) \{[\s\S]*connectToStream\(false\)/,
-    'a running persisted frame remains gated until stream catch-up commits',
+    'a running persisted frame keeps an explicit reconciliation phase while its stream attaches',
   )
   assert.match(
     chatView,

--- a/tests/frontend.spec.mjs
+++ b/tests/frontend.spec.mjs
@@ -989,7 +989,7 @@ test.describe('Scroll position', () => {
     expect(restored.scrollTop).toBeGreaterThan(0)
   })
 
-  test('10d. Previous-chat entry stays held until catch-up, then settles without movement', async ({ page }) => {
+  test('10d. Running chat presents before catch-up, then settles without movement', async ({ page }) => {
     await setup(page, { width: 900, height: 760 })
     await newChat(page)
 
@@ -1163,7 +1163,15 @@ test.describe('Scroll position', () => {
       chatId,
       { timeout: 3000 },
     )
-    await expect(page.locator('.shell__chat-view--held')).toHaveCount(1)
+    await page.waitForFunction(id => {
+      const painted = document.querySelector(
+        `[data-chat-surface="painted"][data-chat-id="${id}"]`,
+      )
+      const el = painted?.querySelector('.chat__scroll')
+      const target = painted?.querySelector('[data-key="entry-anchor"]')
+      return !!el && getComputedStyle(el).visibility !== 'hidden' && !!target
+    }, chatId, { timeout: 5000 })
+    await expect(page.locator('.shell__chat-view--held')).toHaveCount(0)
     expect(catchUpServed).toBe(false)
     releaseCatchUp()
     await expect.poll(() => catchUpServed, { timeout: 3000 }).toBe(true)


### PR DESCRIPTION
## What

- allow a runtime-confirmed running transcript to publish while its stream replay catches up
- preserve the existing runtime-confirmation and exact saved-position gates
- update focused and browser contracts for immediate running-chat presentation

## Why

Returning to a chat while its agent is still running currently keeps the outgoing chat onscreen until stream replay catches up. That can briefly expose stale reading controls and extend the visual handoff. Once runtime state and the saved reading coordinate are confirmed, the persisted transcript already has a stable in-progress assistant row, so replay can reconcile into it in place.

## Testing

- 29 focused ChatView and Shell contracts
- structural-test ratchet (88/88 files, 779/779 cases)
- frontend lint (0 errors, within the existing warning budget)