### PR TITLE
Fix secure input receipts, replay, and password autofill

### DIFF
--- a/backend/app/routes/chats_stream.py
+++ b/backend/app/routes/chats_stream.py
@@ -93,10 +93,6 @@ _SNAPSHOT_REPLAY_EVENT_TYPES = frozenset({
   "queued_turn_starting",
   "steer_delivery_failed",
   "steered_into_turn",
-  "secure_input_request",
-  "secure_input_filled",
-  "secure_input_consuming",
-  "secure_input_settled",
   "theme_updated",
 })
 

--- a/backend/tests/test_system_broadcast.py
+++ b/backend/tests/test_system_broadcast.py
@@ -925,6 +925,22 @@ async def test_snapshot_stream_sends_reduced_items_plus_control_tail(
   bc.publish({"type": "tool_start", "tool": "Bash", "tool_use_id": "u1"})
   bc.publish({"type": "build_phase", "phase": "rebuilding"})
   bc.publish({"type": "answers_applied", "question_id": "q1", "answers": {}})
+  bc.publish({
+    "type": "secure_input_request",
+    "request_id": "secure-1",
+    "title": "One-time secret",
+    "fields": [],
+  })
+  bc.publish({
+    "type": "secure_input_consuming",
+    "request_id": "secure-1",
+    "status": "consuming",
+  })
+  bc.publish({
+    "type": "secure_input_settled",
+    "request_id": "secure-1",
+    "status": "failed",
+  })
   bc.publish({"type": "steered_into_turn", "ts": 4, "content": "follow up"})
   bc.running = False
   bc_mod._broadcasts[bc.chat_id] = bc
@@ -961,6 +977,9 @@ async def test_snapshot_stream_sends_reduced_items_plus_control_tail(
     assert "steered_into_turn" in replay_types
     assert "text" not in replay_types
     assert "tool_start" not in replay_types
+    assert "secure_input_request" not in replay_types
+    assert "secure_input_consuming" not in replay_types
+    assert "secure_input_settled" not in replay_types
     assert replay_types[-2:] == ["catch_up_done", "done"]
   finally:
     bc_mod._broadcasts.pop(bc.chat_id, None)

--- a/frontend/src/components/ChatView/SecureInputCard.css
+++ b/frontend/src/components/ChatView/SecureInputCard.css
@@ -65,6 +65,7 @@
   font-size: 14px;
   font-weight: 400;
 }
+.secure-card__field input[data-secure-masked='true'] { -webkit-text-security: disc; }
 .secure-card__field input:focus-visible { border-color: var(--green); box-shadow: 0 0 0 3px color-mix(in srgb, var(--green) 16%, transparent); }
 .secure-card--reveal .secure-card__field input:focus-visible { border-color: var(--danger); box-shadow: 0 0 0 3px color-mix(in srgb, var(--danger) 14%, transparent); }
 .secure-card__consent { display: flex; align-items: flex-start; gap: 9px; padding: 10px; border: 1px solid color-mix(in srgb, var(--danger) 25%, var(--border)); border-radius: 8px; color: var(--muted); font-size: 11.5px; line-height: 1.4; }

--- a/frontend/src/components/ChatView/SecureInputCard.jsx
+++ b/frontend/src/components/ChatView/SecureInputCard.jsx
@@ -9,9 +9,38 @@ function settledLabel(status) {
   if (status === 'filled') return 'Provided'
   if (status === 'consuming') return 'Using securely…'
   if (status === 'completed') return 'Provided securely'
-  if (status === 'failed') return 'Not used'
+  // A failed consumer has already received the values. "Not used" would
+  // incorrectly describe the input lifecycle rather than the operation.
+  if (status === 'failed') return 'Used securely'
   if (status === 'cancelled' || status === 'expired') return 'Not provided'
   return ''
+}
+
+
+export function collectAndClearSecureFields(form, fields) {
+  const inputs = new Map(
+    Array.from(form.querySelectorAll('input[data-secure-field]'))
+      .map(input => [input.dataset.secureField, input]),
+  )
+  const values = {}
+  for (const field of fields || []) {
+    values[field.name] = String(inputs.get(field.name)?.value || '')
+  }
+
+  // Chrome can treat removal of a filled password form as a successful login.
+  // Clear and blur before the server can publish a state that replaces the form.
+  form.reset()
+  for (const input of inputs.values()) {
+    input.value = ''
+    input.blur()
+  }
+  return values
+}
+
+
+function declaredCredentialHint(field) {
+  const hint = field?.autocomplete
+  return typeof hint === 'string' && hint !== 'off' ? hint : null
 }
 
 
@@ -24,6 +53,7 @@ export default function SecureInputCard({ block, chatId, interactive = false }) 
   const blockStatus = block.status || 'pending'
   const status = blockStatus === 'pending' ? localStatus : blockStatus
   const open = status === 'pending' && interactive
+  const credentialForm = (block.fields || []).some(declaredCredentialHint)
 
   useEffect(() => {
     if (block.status && block.status !== 'pending') {
@@ -37,19 +67,16 @@ export default function SecureInputCard({ block, chatId, interactive = false }) 
     const form = formRef.current
     if (!form?.reportValidity()) return
 
-    const data = new FormData(form)
-    const fields = {}
-    for (const field of block.fields || []) {
-      fields[field.name] = String(data.get(field.name) || '')
-    }
-    if (reveal && data.get('reveal_confirmed') !== 'yes') {
+    const revealConfirmed = reveal
+      && form.elements.reveal_confirmed?.checked === true
+    if (reveal && !revealConfirmed) {
       setError('Confirm that these values may be sent to the AI provider.')
       return
     }
 
+    const fields = collectAndClearSecureFields(form, block.fields)
     setError('')
     setSubmitting(true)
-    const revealConfirmed = reveal && data.get('reveal_confirmed') === 'yes'
     try {
       await jsonOrThrow(
         await api.secureInputs.submit(chatId, block.request_id, {
@@ -58,15 +85,14 @@ export default function SecureInputCard({ block, chatId, interactive = false }) 
         }),
         'Secure input failed',
       )
-      // Remove values from the live DOM as soon as Möbius acknowledges its
-      // transient server copy. Nothing is mirrored into React state or browser
-      // storage; the visible card retains names + status only.
-      form.reset()
       setLocalStatus('filled')
     } catch (submitError) {
-      setError(submitError?.message || 'Secure input failed. Please try again.')
+      setError(
+        submitError?.message
+        || 'Secure input failed. Please enter the values again.',
+      )
     } finally {
-      // FormData/fields are ordinary JS memory and become unreachable here.
+      // Submitted fields are ordinary JS memory and become unreachable here.
       for (const key of Object.keys(fields)) fields[key] = ''
       setSubmitting(false)
     }
@@ -93,20 +119,35 @@ export default function SecureInputCard({ block, chatId, interactive = false }) 
       </p>
 
       {open ? (
-        <form ref={formRef} className="secure-card__form" onSubmit={submit}>
-          {(block.fields || []).map(field => (
-            <label className="secure-card__field" key={field.name}>
-              <span>{field.label}</span>
-              <input
-                name={field.name}
-                type={field.type === 'text' ? 'text' : 'password'}
-                autoComplete={field.autocomplete || 'off'}
-                required
-                disabled={submitting}
-                data-chat-inline-editor="secure-input"
-              />
-            </label>
-          ))}
+        <form
+          ref={formRef}
+          className="secure-card__form"
+          autoComplete={credentialForm ? 'on' : 'off'}
+          onSubmit={submit}
+        >
+          {(block.fields || []).map(field => {
+            const credentialHint = declaredCredentialHint(field)
+            const genericMaskedField = field.type !== 'text' && !credentialHint
+            return (
+              <label className="secure-card__field" key={field.name}>
+                <span>{field.label}</span>
+                <input
+                  name={credentialHint ? field.name : undefined}
+                  // Chromium deliberately ignores autocomplete="off" on
+                  // password fields. Generic secrets are ordinary text inputs
+                  // with visual masking; only explicitly declared owner
+                  // credentials enter the browser's password-manager flow.
+                  type={genericMaskedField ? 'text' : (field.type === 'text' ? 'text' : 'password')}
+                  autoComplete={credentialHint || 'off'}
+                  required
+                  disabled={submitting}
+                  data-secure-field={field.name}
+                  data-secure-masked={genericMaskedField ? 'true' : undefined}
+                  data-chat-inline-editor="secure-input"
+                />
+              </label>
+            )
+          })}
 
           {reveal && (
             <label className="secure-card__consent">
@@ -148,10 +189,14 @@ export default function SecureInputCard({ block, chatId, interactive = false }) 
         {reveal
           ? (open
               ? 'Explicit reveal sends values to AI; Möbius omits them from its transcript.'
-              : 'Receipt saved · revealed values omitted from the Möbius transcript')
+              : status === 'failed'
+                ? 'Operation failed · revealed values omitted from the Möbius transcript'
+                : 'Receipt saved · revealed values omitted from the Möbius transcript')
           : (open
               ? 'One-time entry · values bypass the chat and AI'
-              : 'Receipt saved · entered values omitted')}
+              : status === 'failed'
+                ? 'Operation failed · entered values omitted'
+                : 'Receipt saved · entered values omitted')}
       </p>
     </section>
   )

--- a/frontend/src/components/ChatView/__tests__/secureInputCard.test.js
+++ b/frontend/src/components/ChatView/__tests__/secureInputCard.test.js
@@ -3,21 +3,23 @@ import { test } from 'node:test'
 import { createElement } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 
-import SecureInputCard from '../SecureInputCard.jsx'
+import SecureInputCard, {
+  collectAndClearSecureFields,
+} from '../SecureInputCard.jsx'
 
 
 const fields = [
   {
-    name: 'username',
-    label: 'Username',
+    name: 'proxy_login',
+    label: 'Proxy login',
     type: 'text',
-    autocomplete: 'username',
+    autocomplete: 'off',
   },
   {
-    name: 'password',
-    label: 'Password',
+    name: 'proxy_password',
+    label: 'Proxy password',
     type: 'password',
-    autocomplete: 'current-password',
+    autocomplete: 'off',
   },
 ]
 
@@ -45,9 +47,15 @@ test('pending secure input renders one uncontrolled field per prompt', () => {
   const html = renderCard({}, true)
 
   assert.equal((html.match(/<input/g) || []).length, 2)
-  assert.match(html, /name="username"/)
-  assert.match(html, /name="password"/)
-  assert.match(html, /type="password"/)
+  assert.match(html, /data-secure-field="proxy_login"/)
+  assert.match(html, /data-secure-field="proxy_password"/)
+  assert.doesNotMatch(html, /type="password"/)
+  assert.equal((html.match(/type="text"/g) || []).length, 2)
+  assert.equal((html.match(/data-secure-masked="true"/g) || []).length, 1)
+  assert.equal((html.match(/<input[^>]*autoComplete="off"/g) || []).length, 2)
+  assert.doesNotMatch(html, /autoComplete="(?:username|current-password)"/)
+  assert.match(html, /<form[^>]*autoComplete="off"/)
+  assert.doesNotMatch(html, /<input[^>]* name=/)
   assert.match(html, /data-chat-inline-editor="secure-input"/)
   assert.match(html, />Enter securely</)
   assert.match(html, /values bypass the chat and AI/)
@@ -55,12 +63,71 @@ test('pending secure input renders one uncontrolled field per prompt', () => {
 })
 
 
+test('an explicit owner credential flow keeps its password-manager contract', () => {
+  const html = renderCard({
+    fields: [
+      {
+        name: 'current_password',
+        label: 'Current password',
+        type: 'password',
+        autocomplete: 'current-password',
+      },
+      {
+        name: 'new_password',
+        label: 'New password',
+        type: 'password',
+        autocomplete: 'new-password',
+      },
+    ],
+  }, true)
+
+  assert.match(html, /<form[^>]*autoComplete="on"/)
+  assert.match(html, /name="current_password"/)
+  assert.equal((html.match(/type="password"/g) || []).length, 2)
+  assert.match(html, /autoComplete="current-password"/)
+  assert.match(html, /name="new_password"/)
+  assert.match(html, /autoComplete="new-password"/)
+  assert.doesNotMatch(html, /data-secure-masked/)
+})
+
+
+test('secure values are collected and cleared before the form can disappear', () => {
+  const inputs = [
+    {
+      dataset: { secureField: 'proxy_login' },
+      value: 'owner',
+      blur() { assert.equal(this.value, '') },
+    },
+    {
+      dataset: { secureField: 'proxy_password' },
+      value: 'secret',
+      blur() { assert.equal(this.value, '') },
+    },
+  ]
+  const form = {
+    querySelectorAll() { return inputs },
+    reset() {
+      // Deliberately restore defaults to prove the explicit clearing wins.
+      for (const input of inputs) input.value = 'restored-default'
+    },
+  }
+
+  const values = collectAndClearSecureFields(form, fields)
+
+  assert.deepEqual(values, {
+    proxy_login: 'owner',
+    proxy_password: 'secret',
+  })
+  assert.deepEqual(inputs.map(input => input.value), ['', ''])
+})
+
+
 test('settled secure input renders locked prompt receipts without fields', () => {
   const html = renderCard({ status: 'completed' })
 
   assert.match(html, />Private connection</)
-  assert.match(html, />Username</)
-  assert.match(html, />Password</)
+  assert.match(html, />Proxy login</)
+  assert.match(html, />Proxy password</)
   assert.equal((html.match(/Provided securely/g) || []).length, 2)
   assert.equal((html.match(/secure-card__receipt-lock/g) || []).length, 2)
   assert.match(html, /Receipt saved · entered values omitted/)
@@ -68,11 +135,14 @@ test('settled secure input renders locked prompt receipts without fields', () =>
 })
 
 
-test('failed and expired receipts use non-success status copy', () => {
+test('failed receipt says values were used while expired input was not provided', () => {
+  const failed = renderCard({ status: 'failed' })
   assert.equal(
-    (renderCard({ status: 'failed' }).match(/Not used/g) || []).length,
+    (failed.match(/Used securely/g) || []).length,
     2,
   )
+  assert.match(failed, /Operation failed · entered values omitted/)
+  assert.doesNotMatch(failed, /Not used/)
   assert.equal(
     (renderCard({ status: 'expired' }).match(/Not provided/g) || []).length,
     2,


### PR DESCRIPTION
## Summary
- report failed secure operations as having consumed the submitted values while naming the operation failure separately
- stop snapshot catch-up from replaying secure-input lifecycle events already represented in the reduced chat
- keep generic secure values masked without presenting them as browser credentials
- clear submitted values before the live form can be replaced while preserving explicit owner credential flows

## Testing
- `node --loader=./src/lib/__tests__/vite-env-loader.mjs --test src/components/ChatView/__tests__/secureInputCard.test.js`
- `npx eslint src/components/ChatView/SecureInputCard.jsx src/components/ChatView/__tests__/secureInputCard.test.js`
- `scripts/wt-pytest.sh backend/tests/test_system_broadcast.py backend/tests/test_chats_stream_steer.py -q`
- manually verified in Chrome that a generic secure field shows neither a saved-password suggestion nor a save/update prompt