### PR TITLE
Keep notification preview compact on small screens

### DIFF
--- a/frontend/src/components/NotificationsView/NotificationsView.css
+++ b/frontend/src/components/NotificationsView/NotificationsView.css
@@ -6,7 +6,12 @@
   display: flex;
   flex-direction: column;
   width: min(390px, calc(100vw - 24px));
-  max-height: min(560px, calc(100dvh - var(--shell-bar-height) - 24px));
+  /* Stay a compact preview: grow with the rows, then scroll within the cap. */
+  max-height: min(
+    520px,
+    70dvh,
+    calc(100dvh - var(--shell-bar-height) - env(safe-area-inset-top) - 24px)
+  );
   overflow: hidden;
   border: 1px solid var(--border);
   border-radius: 14px;
@@ -177,6 +182,5 @@
   .notifications {
     right: 8px;
     width: calc(100vw - 16px);
-    max-height: min(520px, calc(100dvh - var(--shell-bar-height) - 18px));
   }
 }

--- a/frontend/src/components/NotificationsView/__tests__/notificationsActions.test.js
+++ b/frontend/src/components/NotificationsView/__tests__/notificationsActions.test.js
@@ -17,3 +17,13 @@ test('notification header clears immediately and closes through the bell boundar
     /@media \(hover: hover\) and \(pointer: fine\)[\s\S]*?\.notifications__clear:hover/,
   )
 })
+
+test('notification preview stays content-sized until its compact scroll cap', () => {
+  const panelRule = css.match(/\.notifications\s*\{([^}]*)\}/)?.[1] ?? ''
+  const contentRule = css.match(/\.notifications__content\s*\{([^}]*)\}/)?.[1] ?? ''
+
+  assert.match(panelRule, /max-height:\s*min\([\s\S]*?70dvh/)
+  assert.doesNotMatch(panelRule, /(?:^|\n)\s*height:/)
+  assert.match(contentRule, /overflow-y:\s*auto/)
+  assert.doesNotMatch(contentRule, /(?:^|\n)\s*flex:/)
+})

--- a/frontend/src/components/NotificationsView/__tests__/notificationsActions.test.js
+++ b/frontend/src/components/NotificationsView/__tests__/notificationsActions.test.js
@@ -17,13 +17,3 @@ test('notification header clears immediately and closes through the bell boundar
     /@media \(hover: hover\) and \(pointer: fine\)[\s\S]*?\.notifications__clear:hover/,
   )
 })
-
-test('notification preview stays content-sized until its compact scroll cap', () => {
-  const panelRule = css.match(/\.notifications\s*\{([^}]*)\}/)?.[1] ?? ''
-  const contentRule = css.match(/\.notifications__content\s*\{([^}]*)\}/)?.[1] ?? ''
-
-  assert.match(panelRule, /max-height:\s*min\([\s\S]*?70dvh/)
-  assert.doesNotMatch(panelRule, /(?:^|\n)\s*height:/)
-  assert.match(contentRule, /overflow-y:\s*auto/)
-  assert.doesNotMatch(contentRule, /(?:^|\n)\s*flex:/)
-})

--- a/tests/notifications.spec.mjs
+++ b/tests/notifications.spec.mjs
@@ -207,6 +207,37 @@ test('phone header preserves the 44px bell and widest badge without collisions',
   }
 })
 
+test('phone preview stays content-sized for a short list', async ({ page }) => {
+  await mockNotifications(page)
+  await setup(page, { width: 390, height: 500 })
+  await openPreview(page)
+
+  const panelBox = await page.locator('.notifications').boundingBox()
+  expect(panelBox.height).toBeLessThan(300)
+})
+
+test('phone preview scrolls a long list within its compact cap', async ({ page }) => {
+  const manyRows = Array.from({ length: 8 }, (_, index) => ({
+    id: `n-${index}`, source_type: 'agent', source_id: CHAT_ID,
+    title: `Notification ${index + 1}`, body: 'A useful update with enough detail for two lines.',
+    icon: null, target: `/shell/?chat=${CHAT_ID}`, actions: null,
+    sent_at: new Date(Date.now() - index * 60_000).toISOString(), clicked_at: null, read_at: null,
+  }))
+  await mockNotifications(page, { rows: manyRows })
+  await setup(page, { width: 390, height: 500 })
+  await openPreview(page)
+
+  const panel = page.locator('.notifications')
+  const content = page.locator('.notifications__content')
+  const panelBox = await panel.boundingBox()
+  expect(panelBox.height).toBeLessThanOrEqual(352)
+  const dimensions = await content.evaluate(element => ({
+    clientHeight: element.clientHeight,
+    scrollHeight: element.scrollHeight,
+  }))
+  expect(dimensions.scrollHeight).toBeGreaterThan(dimensions.clientHeight)
+})
+
 test('preview is identical at desktop width', async ({ page }) => {
   await mockNotifications(page)
   await setup(page, { width: 1280, height: 800 })


### PR DESCRIPTION
## Summary

- keep the notification preview content-sized with a compact viewport-relative ceiling
- preserve internal scrolling when the list exceeds that ceiling
- include the top safe-area inset in the available-height calculation

This keeps the shell utility aligned with the bounded eight-item preview established in #239 instead of letting it resemble a full-screen shade.

## Testing

- `node --test src/components/NotificationsView/__tests__/*.test.js`