### PR TITLE
Improve Connect machine and command ergonomics

### DIFF
--- a/backend/app/connect_runner.py
+++ b/backend/app/connect_runner.py
@@ -285,10 +285,10 @@ def _run_command(cmd, cwd, timeout):
     try:
         proc = subprocess.Popen(cmd, **popen_args)
         stdout, stderr = proc.communicate(timeout=timeout)
-        return stdout, stderr, proc.returncode
+        return stdout, stderr, proc.returncode, False
     except subprocess.TimeoutExpired:
         _terminate_process_tree(proc)
-        return "", "command timed out after %ss" % timeout, 124
+        return "", "command timed out after %ss" % timeout, 124, True
     except KeyboardInterrupt:
         if proc is not None:
             _terminate_process_tree(proc)
@@ -296,7 +296,7 @@ def _run_command(cmd, cwd, timeout):
     except Exception as exc:  # noqa: BLE001 - report any spawn failure back
         if proc is not None:
             _terminate_process_tree(proc)
-        return "", "runner error: %s" % exc, 1
+        return "", "runner error: %s" % exc, 1, False
 
 
 def _serve(cfg):
@@ -344,7 +344,7 @@ def _serve(cfg):
                     if evt.get("type") != "exec":
                         continue
                     print("$ " + evt.get("cmd", ""))
-                    out, err, rc = _run_command(
+                    out, err, rc, timed_out = _run_command(
                         evt.get("cmd", ""), evt.get("cwd"),
                         int(evt.get("timeout", 60)),
                     )
@@ -352,6 +352,7 @@ def _serve(cfg):
                         _post(base + "/api/connect/result", {
                             "request_id": evt.get("request_id"),
                             "stdout": out, "stderr": err, "exit_code": rc,
+                            "timed_out": timed_out,
                         }, token=token)
                     except urllib.error.URLError as exc:
                         print("failed to report result: %s" % exc)

--- a/backend/app/routes/connect.py
+++ b/backend/app/routes/connect.py
@@ -59,6 +59,10 @@ _PAIRING_TTL_SECONDS = 15 * 60
 _HEARTBEAT_SECONDS = 15
 # Default ceiling for a single remote command.
 _DEFAULT_EXEC_TIMEOUT = 60
+# Keep each returned stream bounded so one remote command cannot flood the
+# caller's context. Preserve both ends because diagnostics commonly put the
+# error at the tail after a large body.
+_MAX_EXEC_STREAM = 60_000
 _DISCONNECT_COMMAND = "python3 ~/.mobius-connect/runner.py --uninstall"
 # Older runners only understand exec events. The uninstall command can return
 # without stopping a fallback runner, so terminate its parent runner too.
@@ -199,6 +203,10 @@ class ExecBody(BaseModel):
   timeout: int = Field(default=_DEFAULT_EXEC_TIMEOUT, ge=1, le=3600)
 
 
+class RenameHostBody(BaseModel):
+  name: str = Field(min_length=1, max_length=80)
+
+
 # --------------------------------------------------------------------------- #
 # Owner/app surface
 # --------------------------------------------------------------------------- #
@@ -321,6 +329,24 @@ async def list_hosts(
   return {"hosts": [_public_host(h) for h in _list_hosts()]}
 
 
+@router.patch("/hosts/{host_id}")
+async def rename_host(
+  host_id: str,
+  body: RenameHostBody,
+  _owner: models.Owner = Depends(get_owner_or_app_with_connect_manage),
+) -> dict:
+  """Rename a paired machine without requiring it to be online."""
+  host = _load_host(host_id)
+  if host is None:
+    raise HTTPException(status_code=404, detail="No such host.")
+  name = body.name.strip()
+  if not name:
+    raise HTTPException(status_code=400, detail="A machine name can’t be empty.")
+  host["name"] = name
+  _save_host(host)
+  return _public_host(host)
+
+
 @router.get("/hosts/{host_id}/pairing")
 async def host_pairing(
   host_id: str,
@@ -413,7 +439,26 @@ async def exec_on_host(
     raise HTTPException(status_code=409, detail="The machine disconnected.")
   finally:
     ch.pending.pop(request_id, None)
-  return result
+  stdout, stdout_truncated = _cap_stream(result.get("stdout", ""))
+  stderr, stderr_truncated = _cap_stream(result.get("stderr", ""))
+  exit_code = int(result.get("exit_code", 0))
+  return {
+    "stdout": stdout,
+    "stderr": stderr,
+    "exit_code": exit_code,
+    "truncated": stdout_truncated or stderr_truncated,
+    "timed_out": exit_code == 124,
+  }
+
+
+def _cap_stream(text: str) -> tuple[str, bool]:
+  if len(text) <= _MAX_EXEC_STREAM:
+    return text, False
+  marker = "\n…[output truncated]…\n"
+  kept = _MAX_EXEC_STREAM - len(marker)
+  head = (kept + 1) // 2
+  tail = kept // 2
+  return f"{text[:head]}{marker}{text[-tail:]}", True
 
 
 # --------------------------------------------------------------------------- #

--- a/backend/app/routes/connect.py
+++ b/backend/app/routes/connect.py
@@ -195,6 +195,7 @@ class ResultBody(BaseModel):
   stdout: str = Field(default="", max_length=8 * 1024 * 1024)
   stderr: str = Field(default="", max_length=8 * 1024 * 1024)
   exit_code: int = 0
+  timed_out: bool = False
 
 
 class ExecBody(BaseModel):
@@ -447,7 +448,7 @@ async def exec_on_host(
     "stderr": stderr,
     "exit_code": exit_code,
     "truncated": stdout_truncated or stderr_truncated,
-    "timed_out": exit_code == 124,
+    "timed_out": bool(result.get("timed_out", False)),
   }
 
 
@@ -545,6 +546,7 @@ async def result(body: ResultBody, request: Request) -> dict:
           "stdout": body.stdout,
           "stderr": body.stderr,
           "exit_code": body.exit_code,
+          "timed_out": body.timed_out,
         }
       )
   _touch(host["id"])

--- a/backend/tests/test_connect.py
+++ b/backend/tests/test_connect.py
@@ -357,6 +357,7 @@ async def test_exec_caps_large_output_and_reports_runner_timeout(client, auth):
     "stdout": oversized,
     "stderr": "runner timed out",
     "exit_code": 124,
+    "timed_out": True,
   })
 
   result = await request
@@ -416,13 +417,23 @@ def test_runner_timeout_terminates_the_entire_command_tree(tmp_path: Path):
   # status would mistake a still-running command tree for completed work.
   cmd = f"{shlex.quote(sys.executable)} -c {shlex.quote(launcher)}"
 
-  stdout, stderr, exit_code = _run_command(cmd, None, 0.05)
+  stdout, stderr, exit_code, timed_out = _run_command(cmd, None, 0.05)
 
   assert stdout == ""
   assert "timed out" in stderr
   assert exit_code == 124
+  assert timed_out is True
   time.sleep(0.6)
   assert not marker.exists()
+
+
+def test_runner_does_not_mislabel_command_exit_124_as_timeout():
+  stdout, stderr, exit_code, timed_out = _run_command("exit 124", None, 1)
+
+  assert stdout == ""
+  assert stderr == ""
+  assert exit_code == 124
+  assert timed_out is False
 
 
 def test_manifest_requires_boolean_connect_permission():

--- a/backend/tests/test_connect.py
+++ b/backend/tests/test_connect.py
@@ -73,6 +73,40 @@ def test_app_token_requires_connect_manage(client, auth):
   assert created.json()["name"] == "Workstation"
 
 
+def test_host_rename_updates_and_trims_the_name(client, auth):
+  pairing, _ = _paired_host(client, auth, name="Old name")
+
+  renamed = client.patch(
+    f"/api/connect/hosts/{pairing['id']}",
+    headers=auth,
+    json={"name": "  New name  "},
+  )
+
+  assert renamed.status_code == 200, renamed.text
+  assert renamed.json()["name"] == "New name"
+  assert client.get(
+    "/api/connect/hosts", headers=auth,
+  ).json()["hosts"][0]["name"] == "New name"
+
+
+def test_host_rename_rejects_empty_or_unknown_hosts(client, auth):
+  pairing, _ = _paired_host(client, auth)
+
+  empty = client.patch(
+    f"/api/connect/hosts/{pairing['id']}",
+    headers=auth,
+    json={"name": "   "},
+  )
+  missing = client.patch(
+    "/api/connect/hosts/h_does_not_exist",
+    headers=auth,
+    json={"name": "New name"},
+  )
+
+  assert empty.status_code == 400, empty.text
+  assert missing.status_code == 404, missing.text
+
+
 def test_pairing_is_one_time_and_delete_revokes_runner(client, auth):
   runner = client.get("/api/connect/runner")
   assert runner.status_code == 200
@@ -297,8 +331,44 @@ async def test_exec_correlates_the_runner_result(client, auth):
     "stdout": "ready", "stderr": "", "exit_code": 0,
   })
 
-  assert await request == {"stdout": "ready", "stderr": "", "exit_code": 0}
+  assert await request == {
+    "stdout": "ready",
+    "stderr": "",
+    "exit_code": 0,
+    "truncated": False,
+    "timed_out": False,
+  }
   assert channel.pending == {}
+
+
+@pytest.mark.asyncio
+async def test_exec_caps_large_output_and_reports_runner_timeout(client, auth):
+  pairing, _ = _paired_host(client, auth)
+  channel = connect_routes._Channel()
+  connect_routes._channels[pairing["id"]] = channel
+  request = asyncio.create_task(connect_routes.exec_on_host(
+    pairing["id"],
+    connect_routes.ExecBody(cmd="large command"),
+    _owner=object(),
+  ))
+  event = await asyncio.wait_for(channel.queue.get(), timeout=1)
+  oversized = "head-" + ("x" * connect_routes._MAX_EXEC_STREAM) + "-tail"
+  channel.pending[event["request_id"]].set_result({
+    "stdout": oversized,
+    "stderr": "runner timed out",
+    "exit_code": 124,
+  })
+
+  result = await request
+
+  assert result["stdout"].startswith("head-")
+  assert result["stdout"].endswith("-tail")
+  assert "output truncated" in result["stdout"]
+  assert len(result["stdout"]) == connect_routes._MAX_EXEC_STREAM
+  assert result["stderr"] == "runner timed out"
+  assert result["exit_code"] == 124
+  assert result["truncated"] is True
+  assert result["timed_out"] is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- let owners rename paired machines while they are online or offline
- bound each command output stream while preserving its beginning and end
- report truncation and runner-side timeouts explicitly to callers

## Tests
- `scripts/wt-pytest.sh tests/test_connect.py --tb=short -q` (17 passed)