### PR TITLE
Add an authenticated Möbius API helper

### DIFF
--- a/backend/scripts/mapi
+++ b/backend/scripts/mapi
@@ -11,9 +11,16 @@ previous=""
 for argument in "$@"; do
   case "$argument" in
     -d|--data|--data-raw|--data-binary|--data-urlencode) has_body=true ;;
+    -d?*|--data=*|--data-raw=*|--data-binary=*|--data-urlencode=*)
+      has_body=true
+      ;;
   esac
+  lower_argument="${argument,,}"
   if [[ "$previous" == "-H" || "$previous" == "--header" ]]; then
-    [[ "${argument,,}" == content-type:* ]] && has_content_type=true
+    [[ "$lower_argument" == content-type:* ]] && has_content_type=true
+  elif [[ "$lower_argument" == -hcontent-type:* \
+       || "$lower_argument" == --header=content-type:* ]]; then
+    has_content_type=true
   fi
   if [[ "$argument" == /api/* || "$argument" == /api ]]; then
     argument="${API_BASE_URL%/}$argument"

--- a/backend/scripts/mapi
+++ b/backend/scripts/mapi
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Call the Möbius backend with the current agent's base URL and owner auth.
+set -euo pipefail
+: "${AGENT_TOKEN:?mapi: AGENT_TOKEN is not set in this environment}"
+: "${API_BASE_URL:?mapi: API_BASE_URL is not set in this environment}"
+
+resolved=()
+has_body=false
+has_content_type=false
+previous=""
+for argument in "$@"; do
+  case "$argument" in
+    -d|--data|--data-raw|--data-binary|--data-urlencode) has_body=true ;;
+  esac
+  if [[ "$previous" == "-H" || "$previous" == "--header" ]]; then
+    [[ "${argument,,}" == content-type:* ]] && has_content_type=true
+  fi
+  if [[ "$argument" == /api/* || "$argument" == /api ]]; then
+    argument="${API_BASE_URL%/}$argument"
+  fi
+  resolved+=("$argument")
+  previous="$argument"
+done
+
+curl_args=(-sS -H "Authorization: Bearer $AGENT_TOKEN")
+if $has_body && ! $has_content_type; then
+  curl_args+=(-H "Content-Type: application/json")
+fi
+exec curl "${curl_args[@]}" "${resolved[@]}"

--- a/backend/tests/test_mapi_script.py
+++ b/backend/tests/test_mapi_script.py
@@ -64,3 +64,21 @@ def test_mapi_preserves_an_explicit_content_type(tmp_path: Path):
   assert result.returncode == 0, result.stderr
   assert result.curl_arguments.count(b"Content-Type: text/css") == 1
   assert b"Content-Type: application/json" not in result.curl_arguments
+
+
+def test_mapi_recognizes_joined_data_and_header_options(tmp_path: Path):
+  result = _run_mapi(
+    tmp_path,
+    "/api/chats",
+    '--data={"title":"Notes"}',
+    "--header=Content-Type: application/merge-patch+json",
+  )
+
+  assert result.returncode == 0, result.stderr
+  assert result.curl_arguments == [
+    b"-sS",
+    b"-H", b"Authorization: Bearer owner-token",
+    b"https://mobius.example/api/chats",
+    b'--data={"title":"Notes"}',
+    b"--header=Content-Type: application/merge-patch+json",
+  ]

--- a/backend/tests/test_mapi_script.py
+++ b/backend/tests/test_mapi_script.py
@@ -1,0 +1,66 @@
+"""Contract tests for the authenticated curl convenience wrapper."""
+
+import os
+import subprocess
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "mapi"
+
+
+def _run_mapi(tmp_path: Path, *arguments: str) -> subprocess.CompletedProcess:
+  bin_dir = tmp_path / "bin"
+  bin_dir.mkdir()
+  capture = tmp_path / "curl-arguments"
+  fake_curl = bin_dir / "curl"
+  fake_curl.write_text(
+    "#!/usr/bin/env bash\nprintf '%s\\0' \"$@\" > \"$MAPI_CAPTURE\"\n",
+    encoding="utf-8",
+  )
+  fake_curl.chmod(0o755)
+  env = {
+    **os.environ,
+    "AGENT_TOKEN": "owner-token",
+    "API_BASE_URL": "https://mobius.example/",
+    "MAPI_CAPTURE": str(capture),
+    "PATH": f"{bin_dir}:{os.environ['PATH']}",
+  }
+  result = subprocess.run(
+    [str(SCRIPT), *arguments],
+    env=env,
+    capture_output=True,
+    text=True,
+    check=False,
+  )
+  result.curl_arguments = capture.read_bytes().split(b"\0")[:-1]
+  return result
+
+
+def test_mapi_resolves_api_paths_and_adds_json_for_data(tmp_path: Path):
+  result = _run_mapi(
+    tmp_path,
+    "-X", "PATCH", "/api/connect/hosts/h_1", "-d", '{"name":"Desk"}',
+  )
+
+  assert result.returncode == 0, result.stderr
+  assert result.curl_arguments == [
+    b"-sS",
+    b"-H", b"Authorization: Bearer owner-token",
+    b"-H", b"Content-Type: application/json",
+    b"-X", b"PATCH",
+    b"https://mobius.example/api/connect/hosts/h_1",
+    b"-d", b'{"name":"Desk"}',
+  ]
+
+
+def test_mapi_preserves_an_explicit_content_type(tmp_path: Path):
+  result = _run_mapi(
+    tmp_path,
+    "/api/storage/shared/theme.css",
+    "--data-binary", "@theme.css",
+    "-H", "Content-Type: text/css",
+  )
+
+  assert result.returncode == 0, result.stderr
+  assert result.curl_arguments.count(b"Content-Type: text/css") == 1
+  assert b"Content-Type: application/json" not in result.curl_arguments


### PR DESCRIPTION
## Summary
- add a small curl wrapper that supplies the current Möbius URL and owner authorization
- resolve `/api/...` paths automatically while preserving ordinary curl arguments
- default request bodies to JSON unless the caller supplies another content type

## Tests
- `scripts/wt-pytest.sh tests/test_mapi_script.py --tb=short -q` (2 passed)