### PR TITLE
Register explicit SQLite date/datetime adapters for Python 3.12+

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -23,6 +23,7 @@ from app.config import get_settings
 
 
 _log = logging.getLogger(__name__)
+sqlite_policy.install_adapters()
 _request_label: ContextVar[str] = ContextVar(
   "mobius_database_request_label", default="background",
 )

--- a/backend/app/sqlite_policy.py
+++ b/backend/app/sqlite_policy.py
@@ -7,6 +7,9 @@ builds an engine at module load, so a script needing this policy must be able
 to reach it without paying for that.
 """
 
+import sqlite3
+from datetime import date, datetime
+
 # Waits for a lock instead of raising "database is locked" the moment two
 # writers overlap. Must be installed before any pragma that can itself take a
 # lock — see connection_pragmas.
@@ -28,6 +31,20 @@ BUSY_TIMEOUT_MS = 5000
 # data volume. No formula: raise it if checkpoint churn shows up in write
 # latency, lower it if retained journal space becomes material.
 RETAINED_JOURNAL_LIMIT_BYTES = 64 * 1024 * 1024
+
+
+def install_adapters() -> None:
+  """Keep raw SQL datetime parameters stable after Python removes defaults.
+
+  SQLAlchemy converts values for typed columns itself, but migration and
+  maintenance statements intentionally use ``text()`` and therefore reach the
+  DBAPI without column-type processors. Python 3.12 deprecated sqlite3's
+  implicit date/datetime adapters. Register the same ISO encodings explicitly
+  so those durable statements do not depend on a disappearing interpreter
+  default.
+  """
+  sqlite3.register_adapter(date, lambda value: value.isoformat())
+  sqlite3.register_adapter(datetime, lambda value: value.isoformat(" "))
 
 
 def connection_pragmas() -> tuple[str, ...]:

--- a/backend/tests/test_database_pragmas.py
+++ b/backend/tests/test_database_pragmas.py
@@ -2,10 +2,27 @@
 
 import importlib.util
 import sqlite3
+from datetime import datetime
 from pathlib import Path
 from types import SimpleNamespace
 
 from app import database, sqlite_policy
+
+
+def test_explicit_datetime_adapter_replaces_deprecated_python_default(
+  tmp_path,
+):
+  sqlite_policy.install_adapters()
+  value = datetime(2026, 8, 19, 12, 34, 56, 123456)
+
+  with sqlite3.connect(tmp_path / "adapter.db") as connection:
+    connection.execute("CREATE TABLE events (occurred_at TEXT NOT NULL)")
+    connection.execute("INSERT INTO events VALUES (?)", (value,))
+    stored = connection.execute(
+      "SELECT occurred_at FROM events"
+    ).fetchone()[0]
+
+  assert stored == "2026-08-19 12:34:56.123456"
 
 
 def _capture_connect_pragmas(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- explicitly register SQLite date and datetime adapters
- preserve the ISO encoding used by raw maintenance and migration statements
- remove reliance on Python's deprecated implicit adapters

## Tests
- `scripts/wt-pytest.sh tests/test_database_pragmas.py --tb=short -q` (4 passed)