### PR TITLE
Require explicit model selection before chat send

### DIFF
--- a/frontend/src/components/ChatView/ChatSettingsPanel.css
+++ b/frontend/src/components/ChatView/ChatSettingsPanel.css
@@ -97,17 +97,6 @@
   }
 }
 
-/* The selected provider-default row is state, not another choice. */
-.csp-row--static {
-  cursor: default;
-}
-@media (hover: hover) and (pointer: fine) {
-  .csp-row--static:hover,
-  .csp-row--selected.csp-row--static:hover {
-    background: color-mix(in srgb, var(--accent) 9%, var(--surface));
-  }
-}
-
 .csp-row--locked {
   opacity: 0.4;
   cursor: not-allowed;
@@ -210,6 +199,17 @@
   color: var(--muted);
   font-size: 13px;
   line-height: 1.35;
+}
+
+.csp__selection-required {
+  margin: 1px 10px 7px;
+  padding: 9px 10px;
+  border: 1px solid color-mix(in srgb, var(--accent) 20%, var(--border-light));
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--accent) 6%, var(--surface));
+  color: var(--text);
+  font-size: 12px;
+  line-height: 1.4;
 }
 
 .csp__availability-warning {

--- a/frontend/src/components/ChatView/ChatSettingsPanel.jsx
+++ b/frontend/src/components/ChatView/ChatSettingsPanel.jsx
@@ -623,12 +623,7 @@ export default function ChatSettingsPanel({
   }, [registry, hiddenIds, selectedModel, selectedProvider, draftModel, draftProvider])
 
   const currentProviderConfigured = availability.configuredProviders.has(draftProvider)
-  const currentProviderInfo = PROVIDER_INFO[draftProvider]
-  const currentProviderLabel = currentProviderInfo?.label || draftProvider
-  // A chat can deliberately have no model override: the provider then chooses
-  // its own default. Keep that real state selected in the picker instead of
-  // making every explicit model row look inactive.
-  const usesProviderDefault = !selectedModel
+  const currentProviderLabel = PROVIDER_INFO[draftProvider]?.label || draftProvider
 
   return (
     <div className="csp">
@@ -688,31 +683,9 @@ export default function ChatSettingsPanel({
             </span>
           </div>
       )}
-      {dataReady && usesProviderDefault && currentProviderInfo && (
-        <div className="csp__default-model">
-          <div
-            className="csp-row csp-row--selected csp-row--static"
-            aria-label={`Using ${currentProviderLabel}'s default model`}
-          >
-            <span className="csp-row__icon"><currentProviderInfo.Logo /></span>
-            <span className="csp-row__main">
-              <span className="csp-row__title">
-                <span>{currentProviderLabel} default model</span>
-              </span>
-              <span className="csp-row__sub">
-                No specific model is pinned for this chat
-              </span>
-            </span>
-            <span className="csp-row__dot" aria-hidden="true" />
-          </div>
-          <div className="csp-effort-indent">
-            <EffortStepper
-              efforts={currentProviderInfo.efforts}
-              value={draftEffort}
-              onChange={handleEffortChange}
-              disabled={switchBusy || !currentProviderConfigured}
-            />
-          </div>
+      {dataReady && !selectedModel && (
+        <div className="csp__selection-required" role="status" aria-live="polite">
+          Choose a model before sending your message.
         </div>
       )}
       {dataReady && PROVIDER_ORDER.map(pid => {

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -151,6 +151,7 @@ import {
   reconcileComposerTextarea,
   resetComposerTextarea,
 } from './composerTextareaSizing.js'
+import { needsModelSelection } from './modelSelectionPolicy.js'
 import {
   EMPTY_BUILD_PHASE_RAIL,
   accumulateBuildPhase,
@@ -624,6 +625,11 @@ export default function ChatView({
   // settles. Keep its serialized write tail at ChatView scope so both a closed
   // + popover and an immediate Send still observe the same ordering boundary.
   const settingsSaveTailRef = useRef(Promise.resolve())
+  // A send with no explicit model turns into an open-picker request rather
+  // than falling through to the provider SDK's invisible default. A monotonic
+  // request keeps the popover's open state local while making repeated submit
+  // attempts observable even when it was dismissed between them.
+  const [modelSelectionRequest, setModelSelectionRequest] = useState(0)
   // Refs for the absolutely-positioned foot. Its ResizeObserver notifies the
   // scroll controller, which owns publishing composer clearance together with
   // every other indirect scroll-geometry write.
@@ -3150,12 +3156,20 @@ export default function ChatView({
   function handleSubmit(e) {
     e.preventDefault()
     if (isProviderSwitchBlocking(chatId)) return
+    if (needsModelSelection({ showPicker, chatInfo })) {
+      setModelSelectionRequest(request => request + 1)
+      return
+    }
     doSend(input.trim())
   }
 
   function handleSubmitSteer(e) {
     e.preventDefault()
     if (isProviderSwitchBlocking(chatId)) return
+    if (needsModelSelection({ showPicker, chatInfo })) {
+      setModelSelectionRequest(request => request + 1)
+      return
+    }
     if (submitSteerInFlightRef.current) return
     submitSteerInFlightRef.current = true
     void doSend(input.trim(), { directSteer: true })
@@ -4725,6 +4739,7 @@ export default function ChatView({
                 providerSwitchState={providerSwitchState}
                 settingsSaveTailRef={settingsSaveTailRef}
                 composerInputRef={inputRef}
+                modelSelectionRequest={modelSelectionRequest}
                 onOpenInspector={() => setShowInspector(true)}
                 onOpenSummary={() => setShowSummary(true)}
                 embedded={embedded}

--- a/frontend/src/components/ChatView/ComposerPopover.jsx
+++ b/frontend/src/components/ChatView/ComposerPopover.jsx
@@ -66,6 +66,7 @@ export default function ComposerPopover({
   providerSwitchState,
   settingsSaveTailRef,
   composerInputRef,
+  modelSelectionRequest = 0,
   onOpenInspector,
   onOpenSummary,
   embedded = false,
@@ -87,11 +88,27 @@ export default function ComposerPopover({
   // between the click handler and the post-commit effect, leaving
   // the ref stale. Sync capture in onClick is reliable.
   const wasInputFocusedRef = useRef(false)
+  const handledModelSelectionRequestRef = useRef(modelSelectionRequest)
   // Measured cap on the panel's height: the space above the trigger inside both
   // the chat pane (which clips with `overflow: hidden`) and the keyboard-shrunk
   // visible viewport. See composerPopoverHeight.js for why CSS viewport units
   // can't express either boundary.
   const [maxHeight, setMaxHeight] = useState(null)
+
+  useEffect(() => {
+    if (
+      !modelSelectionRequest
+      || handledModelSelectionRequestRef.current === modelSelectionRequest
+    ) return
+    handledModelSelectionRequestRef.current = modelSelectionRequest
+
+    // A submit-time nudge opens the same picker the + button owns. Preserve
+    // the textarea focus state just as a direct + tap would, so mobile keeps
+    // its keyboard and desktop keeps the draft cursor where the user left it.
+    const el = composerInputRef?.current
+    wasInputFocusedRef.current = document.activeElement === el
+    setOpen(true)
+  }, [composerInputRef, modelSelectionRequest])
 
   function preservePickerInputFocus(event) {
     event.preventDefault()

--- a/frontend/src/components/ChatView/__tests__/modelSelectionPolicy.test.js
+++ b/frontend/src/components/ChatView/__tests__/modelSelectionPolicy.test.js
@@ -1,0 +1,45 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+import { needsModelSelection } from '../modelSelectionPolicy.js'
+
+
+test('interactive chats require a model before sending', () => {
+  assert.equal(needsModelSelection({
+    showPicker: true,
+    chatInfo: { effective: { model: null } },
+  }), true)
+  assert.equal(needsModelSelection({
+    showPicker: true,
+    chatInfo: null,
+  }), true)
+})
+
+test('an explicit effective model lets the composer send', () => {
+  assert.equal(needsModelSelection({
+    showPicker: true,
+    chatInfo: { effective: { model: 'gpt-5.6-sol' } },
+  }), false)
+})
+
+test('app embeds that intentionally hide the picker retain their configured send path', () => {
+  assert.equal(needsModelSelection({
+    showPicker: false,
+    chatInfo: { effective: { model: null } },
+  }), false)
+})
+
+test('the missing-model state opens the picker instead of sending', () => {
+  const chatView = readFileSync(new URL('../ChatView.jsx', import.meta.url), 'utf8')
+  const popover = readFileSync(new URL('../ComposerPopover.jsx', import.meta.url), 'utf8')
+  const picker = readFileSync(new URL('../ChatSettingsPanel.jsx', import.meta.url), 'utf8')
+
+  assert.match(
+    chatView,
+    /if \(needsModelSelection\(\{ showPicker, chatInfo \}\)\) \{\s*setModelSelectionRequest\(request => request \+ 1\)\s*return\s*\}\s*doSend/,
+  )
+  assert.match(popover, /modelSelectionRequest[\s\S]*setOpen\(true\)/)
+  assert.match(picker, /Choose a model before sending your message\./)
+  assert.doesNotMatch(picker, /default model/)
+})

--- a/frontend/src/components/ChatView/modelSelectionPolicy.js
+++ b/frontend/src/components/ChatView/modelSelectionPolicy.js
@@ -1,0 +1,6 @@
+/* Decides when the interactive composer must ask for an explicit model. */
+
+export function needsModelSelection({ showPicker, chatInfo }) {
+  if (!showPicker) return false
+  return !chatInfo?.effective?.model
+}


### PR DESCRIPTION
## Summary
- remove the invisible provider-default model path from interactive chats
- open the existing model picker when Send is pressed without a selected model
- preserve the draft and focus while asking for a choice

## Tests
- `node --test src/components/ChatView/__tests__/modelSelectionPolicy.test.js`

The full frontend build was also attempted against current `main`, but its memory-pressure guard deferred the run before compilation.