### PR TITLE
Improve standalone app installation on Android and Chromium

### DIFF
--- a/backend/app/routes/standalone.py
+++ b/backend/app/routes/standalone.py
@@ -276,6 +276,20 @@ def standalone_manifest(
           "purpose": "any maskable",
         },
       ],
+      # Screenshots upgrade Chromium's install prompt from the mini-infobar
+      # to the richer install sheet (narrow serves phones, wide serves
+      # desktop). Generated covers, not live captures — see
+      # `_render_screenshot_png` for why this stays privacy-safe.
+      "screenshots": [
+        {
+          "src": f"{base}{shot_name}?v={v}",
+          "sizes": f"{w}x{h}",
+          "type": "image/png",
+          "form_factor": form,
+          "label": app.name or slug,
+        }
+        for shot_name, (w, h, form) in _SCREENSHOT_SPECS.items()
+      ],
     },
     media_type="application/manifest+json",
     # Revalidate on every fetch so a freshly-renamed app never serves a
@@ -294,6 +308,84 @@ def standalone_manifest(
 # else 404s — we don't want the route accidentally serving arbitrary
 # sizes that aren't declared in the manifest.
 _ICON_NAME = re.compile(r"^icon-(\d+)\.png$")
+
+# Manifest `screenshots` assets. With at least one narrow and one wide entry,
+# Chromium replaces the minimal install mini-infobar with the richer
+# app-store-style install sheet — which also makes "Install" visually
+# unmistakable next to "Create shortcut". Fixed names only; the cache can't
+# be flooded with arbitrary dimensions.
+_SCREENSHOT_SPECS = {
+  "screenshot-narrow.png": (1080, 1920, "narrow"),
+  "screenshot-wide.png": (1920, 1080, "wide"),
+}
+
+
+def _render_screenshot_png(
+  icon_png: bytes | None, name: str, slug: str, bg_hex: str,
+  width: int, height: int,
+) -> bytes:
+  """Generated install-sheet cover: the app's icon and name on the app's own
+  background color, arranged like a launcher tile.
+
+  Deliberately NOT a live capture of the running app. This route is public —
+  the OS fetches manifest assets before any login — so a real screenshot
+  could leak app content to an unauthenticated visitor. A generated cover
+  carries the same information class as the icon route and is a pure
+  function of the same inputs, so it shares the icon cache's keying.
+  """
+  from PIL import Image, ImageDraw, ImageFont
+  r = int(bg_hex[1:3], 16)
+  g = int(bg_hex[3:5], 16)
+  b = int(bg_hex[5:7], 16)
+  img = Image.new("RGB", (width, height), (r, g, b))
+
+  # The icon reuses the standalone render (uploaded art composited onto the
+  # background, or the generated letter mark), rounded like a launcher icon.
+  icon_size = int(min(width, height) * 0.34)
+  icon = Image.open(io.BytesIO(
+    _render_standalone_icon(icon_png, name, slug, bg_hex, icon_size)
+  )).convert("RGB")
+  radius = int(icon_size * 0.22)
+  mask = Image.new("L", (icon_size, icon_size), 0)
+  ImageDraw.Draw(mask).rounded_rectangle(
+    (0, 0, icon_size - 1, icon_size - 1), radius=radius, fill=255,
+  )
+  icon_x = (width - icon_size) // 2
+  icon_y = (height // 2) - int(icon_size * 0.75)
+  img.paste(icon, (icon_x, icon_y), mask)
+
+  # Name below, in whichever of light/dark ink reads on this background.
+  luminance = 0.299 * r + 0.587 * g + 0.114 * b
+  fg = (28, 28, 30) if luminance > 150 else (255, 255, 255)
+  draw = ImageDraw.Draw(img)
+  font = None
+  for path in (
+    "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf",
+    "/usr/share/fonts/truetype/liberation/LiberationSans-Bold.ttf",
+  ):
+    try:
+      font = ImageFont.truetype(path, int(min(width, height) * 0.052))
+      break
+    except OSError:
+      continue
+  if font is None:
+    font = ImageFont.load_default()
+  label = (name or slug).strip() or slug
+  max_w = int(width * 0.86)
+  bbox = draw.textbbox((0, 0), label, font=font)
+  while len(label) > 1 and bbox[2] - bbox[0] > max_w:
+    label = label[:-2].rstrip() + "…"
+    bbox = draw.textbbox((0, 0), label, font=font)
+  draw.text(
+    (
+      (width - (bbox[2] - bbox[0])) / 2 - bbox[0],
+      icon_y + icon_size + int(icon_size * 0.18) - bbox[1],
+    ),
+    label, fill=fg, font=font,
+  )
+  buf = io.BytesIO()
+  img.save(buf, format="PNG", optimize=True)
+  return buf.getvalue()
 
 
 def _render_standalone_icon(
@@ -359,15 +451,18 @@ async def standalone_icon(
   `max-age` + `stale-while-revalidate` keep warm opens free; an icon change
   advances the validator so a stale icon is never pinned.
   """
-  m = _ICON_NAME.match(icon_name)
-  if not m:
+  shot_spec = _SCREENSHOT_SPECS.get(icon_name)
+  m = None if shot_spec else _ICON_NAME.match(icon_name)
+  if not shot_spec and not m:
     raise HTTPException(status_code=404, detail="Not found.")
-  size = int(m.group(1))
-  if size < 16 or size > 1024:
-    raise HTTPException(status_code=400, detail="Invalid icon size.")
+  size = 0
+  if m:
+    size = int(m.group(1))
+    if size < 16 or size > 1024:
+      raise HTTPException(status_code=400, detail="Invalid icon size.")
   app = _get_app_by_slug(db, slug)
   ts_us = int(app.updated_at.timestamp() * 1e6) if app.updated_at else 0
-  etag = f'W/"{ts_us}-{size}"'
+  etag = f'W/"{ts_us}-{icon_name if shot_spec else size}"'
   headers = {
     "ETag": etag,
     "Cache-Control": "public, max-age=3600, stale-while-revalidate=86400",
@@ -385,6 +480,24 @@ async def standalone_icon(
   name = app.name
   app_slug = app.slug
   bg_inputs = (app.background_color, app.theme_color)
+
+  if shot_spec:
+    shot_w, shot_h, _form = shot_spec
+
+    def _compute_shot() -> bytes:
+      bg_hex = _resolve_bg_hex(bg_inputs[0], bg_inputs[1], icon_png)
+      return _render_screenshot_png(
+        icon_png, name, app_slug, bg_hex, shot_w, shot_h,
+      )
+
+    body = await icon_cache.get_or_compute(
+      app_id=app_id,
+      updated_us=ts_us,
+      kind="standalone-shot",
+      size=shot_w,
+      compute=_compute_shot,
+    )
+    return Response(content=body, media_type="image/png", headers=headers)
 
   def _compute() -> bytes:
     bg_hex = _resolve_bg_hex(bg_inputs[0], bg_inputs[1], icon_png)

--- a/backend/tests/test_standalone_manifest.py
+++ b/backend/tests/test_standalone_manifest.py
@@ -390,3 +390,51 @@ def test_standalone_boot_slot_cannot_break_out_of_json_script(client, owner_toke
   assert "</" not in match.group(1)
   boot = json.loads(match.group(1))
   assert boot["name"].startswith("</script>")
+
+
+def test_manifest_declares_generated_screenshots(client, owner_token):
+  """Narrow + wide screenshots unlock Chromium's richer install sheet; both
+  must be versioned like the icons so a rename/icon change refreshes them."""
+  app = _create_app(client, owner_token, "Cover App")
+  r = client.get(f"/apps/{app['slug']}/manifest.json")
+  assert r.status_code == 200
+  shots = r.json()["screenshots"]
+  by_form = {s["form_factor"]: s for s in shots}
+  assert set(by_form) == {"narrow", "wide"}
+  assert by_form["narrow"]["sizes"] == "1080x1920"
+  assert by_form["wide"]["sizes"] == "1920x1080"
+  for s in shots:
+    assert s["type"] == "image/png"
+    assert s["label"] == "Cover App"
+    assert re.search(r"\?v=\d+$", s["src"])
+    assert s["src"].startswith(f"/apps/{app['slug']}/screenshot-")
+
+
+def test_screenshot_route_serves_generated_cover(client, owner_token):
+  """The screenshot route renders a real PNG at the declared dimensions and
+  gives the browser the same 304 path as the icons."""
+  import io
+  from PIL import Image
+  app = _create_app(client, owner_token, "Cover App Two")
+  r = client.get(f"/apps/{app['slug']}/screenshot-narrow.png")
+  assert r.status_code == 200
+  assert r.headers["content-type"] == "image/png"
+  img = Image.open(io.BytesIO(r.content))
+  assert img.size == (1080, 1920)
+  etag = r.headers["etag"]
+  r304 = client.get(
+    f"/apps/{app['slug']}/screenshot-narrow.png",
+    headers={"If-None-Match": etag},
+  )
+  assert r304.status_code == 304
+  wide = client.get(f"/apps/{app['slug']}/screenshot-wide.png")
+  assert wide.status_code == 200
+  assert Image.open(io.BytesIO(wide.content)).size == (1920, 1080)
+
+
+def test_screenshot_route_rejects_unknown_asset_names(client, owner_token):
+  app = _create_app(client, owner_token, "Cover App Three")
+  assert client.get(
+    f"/apps/{app['slug']}/screenshot-huge.png"
+  ).status_code == 404
+  assert client.get(f"/apps/{app['slug']}/anything.png").status_code == 404

--- a/frontend/src/components/Drawer/InstallSheet.jsx
+++ b/frontend/src/components/Drawer/InstallSheet.jsx
@@ -6,6 +6,7 @@ import { appQueries } from '../../hooks/queries.js'
 import useDialogFocus from '../../hooks/useDialogFocus.js'
 import { loginBoundaryPath } from '../../lib/safeReturnPath.js'
 import {
+  androidBrowserIntentHref,
   detectInstallPlatform,
   isStandaloneDisplay,
 } from '../../utils/installPlatform.js'
@@ -62,11 +63,14 @@ export default function InstallSheet({ app, onClose }) {
   // the app. So every platform, iOS Safari included, navigates to the app's
   // own page, which serves the app's manifest, name, and icon.
   //
-  // The one case that cannot navigate is the installed Möbius app: it has no
-  // Share button, and iOS gives a PWA no supported way to hand off to Safari
-  // (`x-safari-https:` is undocumented and errors on some versions). There
-  // `handoff` flips the card to a tappable link plus a copyable address, so
-  // the user carries the destination across instead of retyping it.
+  // The one case that cannot navigate usefully is the installed Möbius app.
+  // iOS: it has no Share button, and iOS gives a PWA no supported way to hand
+  // off to Safari (`x-safari-https:` is undocumented and errors on some
+  // versions). Android: navigating out of the installed app's scope opens an
+  // in-app Custom Tab, where Chromium never fires `beforeinstallprompt`, so
+  // the install card would sit there looking broken. Both flip `handoff`: the
+  // card becomes a tappable link (an intent: URI on Android, which escapes to
+  // the real browser) plus a copyable address as the fallback.
   const [platform] = useState(() => detectInstallPlatform())
   const [standalone] = useState(() => isStandaloneDisplay())
   const [handoff, setHandoff] = useState(false)
@@ -194,10 +198,11 @@ export default function InstallSheet({ app, onClose }) {
       const url = platform.ios
         ? await buildInstallUrl()
         : new URL(installPath, window.location.origin).href
-      if (platform.ios && standalone) {
-        // No Share button here and nowhere to navigate that would produce
-        // one. Hand the destination over instead.
-        setHandoffUrl(url)
+      if (standalone && (platform.ios || platform.android)) {
+        // Installed-app context: navigating in place can't complete an
+        // install (no Share button on iOS; an install-less Custom Tab on
+        // Android). Hand the destination over instead.
+        setHandoffUrl(platform.ios ? url : androidBrowserIntentHref(url))
         setSubmitting(false)
         setHandoff(true)
         return
@@ -241,22 +246,31 @@ export default function InstallSheet({ app, onClose }) {
               ×
             </button>
             <h2 className="is__title">Add {label} to your home screen</h2>
-            <p className="is__hint is__hint--steps">
-              Only Safari can put an app on your home screen, and you’re in
-              the installed Möbius app right now. Open {label}’s own page,
-              then tap <strong>Share</strong> and choose{' '}
-              <strong>Add to Home Screen</strong>.
-            </p>
+            {platform.ios ? (
+              <p className="is__hint is__hint--steps">
+                Only Safari can put an app on your home screen, and you’re in
+                the installed Möbius app right now. Open {label}’s own page,
+                then tap <strong>Share</strong> and choose{' '}
+                <strong>Add to Home Screen</strong>.
+              </p>
+            ) : (
+              <p className="is__hint is__hint--steps">
+                You’re in the installed Möbius app, and Android only offers
+                installs from a real browser tab. Open {label}’s page in your
+                browser, then tap <strong>Install</strong>.
+              </p>
+            )}
 
             <div className="is__handoff">
               <a
                 ref={primaryFocusRef}
                 className="is__btn is__btn--primary is__btn--link"
                 href={handoffUrl}
-                target="_blank"
-                rel="noopener noreferrer"
+                {...(platform.ios
+                  ? { target: '_blank', rel: 'noopener noreferrer' }
+                  : {})}
               >
-                Open {label}’s page
+                {platform.ios ? `Open ${label}’s page` : 'Open in your browser'}
               </a>
               <button
                 type="button"
@@ -269,11 +283,18 @@ export default function InstallSheet({ app, onClose }) {
 
             {error && <div className="is__error" role="alert">{error}</div>}
 
-            <p className="is__hint">
-              If it opens inside Möbius rather than Safari, tap the compass
-              icon to switch over. Or open Safari yourself and go to{' '}
-              <span className="is__url">{plainHandoffUrl}</span>
-            </p>
+            {platform.ios ? (
+              <p className="is__hint">
+                If it opens inside Möbius rather than Safari, tap the compass
+                icon to switch over. Or open Safari yourself and go to{' '}
+                <span className="is__url">{plainHandoffUrl}</span>
+              </p>
+            ) : (
+              <p className="is__hint">
+                If nothing opens, copy the link and paste it into your
+                browser: <span className="is__url">{plainHandoffUrl}</span>
+              </p>
+            )}
           </>
         ) : (
         <>

--- a/frontend/src/components/StandaloneApp/StandaloneApp.css
+++ b/frontend/src/components/StandaloneApp/StandaloneApp.css
@@ -213,8 +213,8 @@
 }
 
 .standalone-install__warming-skip {
-  min-height: 0;
-  padding: 4px 8px;
+  min-height: 44px;
+  padding: 8px 12px;
   border: none;
   background: transparent;
   color: var(--accent, #a78bfa);

--- a/frontend/src/components/StandaloneApp/StandaloneApp.css
+++ b/frontend/src/components/StandaloneApp/StandaloneApp.css
@@ -185,6 +185,50 @@
   font-weight: 600;
 }
 
+/* The bounded wait for Chromium's install eligibility: a quiet status line,
+   not a panel — the card is waiting, not instructing. */
+.standalone-install__warming {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  margin-top: 16px;
+  text-align: center;
+  color: var(--muted, #aaa);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.standalone-install__spinner {
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  border: 2px solid color-mix(in srgb, var(--accent, #a78bfa) 30%, transparent);
+  border-top-color: var(--accent, #a78bfa);
+  animation: standalone-install-spin 0.9s linear infinite;
+}
+
+@keyframes standalone-install-spin {
+  to { transform: rotate(360deg); }
+}
+
+.standalone-install__warming-skip {
+  min-height: 0;
+  padding: 4px 8px;
+  border: none;
+  background: transparent;
+  color: var(--accent, #a78bfa);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .standalone-install__spinner { animation: none; opacity: 0.6; }
+}
+
 .standalone-install__arrow {
   display: flex;
   align-items: center;

--- a/frontend/src/components/StandaloneApp/StandaloneInstallCard.jsx
+++ b/frontend/src/components/StandaloneApp/StandaloneInstallCard.jsx
@@ -51,8 +51,22 @@ export default function StandaloneInstallCard({ app, forceOpen, onClose }) {
   // not the app is already on the home screen (adding twice is harmless),
   // which is exactly why they are safe to show without knowing. Other
   // platforms keep the native prompt primary and reveal steps only if it fails.
+  //
+  // Chromium is the special case: it CAN offer one-tap install but gates the
+  // prompt behind engagement heuristics (a tap plus ~30 seconds on the site),
+  // so a fresh arrival often lands in `manual` with the prompt seconds away.
+  // Showing menu instructions immediately reads as "install is broken" and
+  // sends people into the browser menu, where Create shortcut waits to be
+  // mistaken for Install. Hold a visible warming state instead, and reveal
+  // the manual steps only when the browser has had a fair chance and stayed
+  // silent (or on request).
+  const warmupCapable = platform.bipCapable && !platform.ios
   const [showInstructions, setShowInstructions] = useState(
-    () => platform.ios || (installState === 'manual' && forceOpen),
+    () => platform.ios ||
+      (installState === 'manual' && forceOpen && !warmupCapable),
+  )
+  const [warmingUp, setWarmingUp] = useState(
+    () => warmupCapable && installState === 'manual',
   )
   const dialogRef = useRef(null)
   const primaryRef = useRef(null)
@@ -62,6 +76,23 @@ export default function StandaloneInstallCard({ app, forceOpen, onClose }) {
   useEffect(() => {
     if (forceOpen) setOpen(true)
   }, [forceOpen])
+
+  // The browser sends no "not eligible yet" signal — silence is the only
+  // negative answer. Give it a bounded window; if the prompt arrives the
+  // store flips this card to `ready` on its own, and if the window closes
+  // quietly the manual steps take over.
+  useEffect(() => {
+    if (!warmingUp) return undefined
+    if (installState !== 'manual') {
+      setWarmingUp(false)
+      return undefined
+    }
+    const timer = setTimeout(() => {
+      setWarmingUp(false)
+      setShowInstructions(true)
+    }, 25000)
+    return () => clearTimeout(timer)
+  }, [warmingUp, installState])
 
   useEffect(() => {
     const previous = previousInstallStateRef.current
@@ -111,8 +142,11 @@ export default function StandaloneInstallCard({ app, forceOpen, onClose }) {
   // native install prompt, or reveal guidance not yet on screen. On iPhone
   // neither is ever true — there is no install API and the steps show on
   // arrival — so the card ends at the sentence rather than at a button whose
-  // only effect is to close a dialog that already has a close.
-  const showAction = installState === 'ready' || !showInstructions
+  // only effect is to close a dialog that already has a close. While the
+  // warming state is on screen its own skip button covers the reveal, so a
+  // second "Show me" would be a duplicate.
+  const warming = warmingUp && installState === 'manual' && !showInstructions
+  const showAction = installState === 'ready' || (!showInstructions && !warming)
 
   if (!open) return null
 
@@ -160,6 +194,25 @@ export default function StandaloneInstallCard({ app, forceOpen, onClose }) {
               />
               <h1 id="standalone-install-title">Install {app.name}</h1>
             </div>
+            {warming && (
+              <div className="standalone-install__warming" role="status">
+                <span className="standalone-install__spinner" aria-hidden="true" />
+                <span>
+                  Getting one-tap install ready — this can take a moment on a
+                  first visit.
+                </span>
+                <button
+                  type="button"
+                  className="standalone-install__warming-skip"
+                  onClick={() => {
+                    setWarmingUp(false)
+                    revealInstructions()
+                  }}
+                >
+                  Show the manual steps
+                </button>
+              </div>
+            )}
             {showInstructions && (platform.iosSafari && !platform.ipad ? (
               // On iPhone the sentence IS the card, so it gets no box of its
               // own — a bordered panel inside a bordered card is nesting that

--- a/frontend/src/components/StandaloneApp/StandaloneInstallCard.jsx
+++ b/frontend/src/components/StandaloneApp/StandaloneInstallCard.jsx
@@ -82,7 +82,7 @@ export default function StandaloneInstallCard({ app, forceOpen, onClose }) {
   // store flips this card to `ready` on its own, and if the window closes
   // quietly the manual steps take over.
   useEffect(() => {
-    if (!warmingUp) return undefined
+    if (!open || !warmingUp) return undefined
     if (installState !== 'manual') {
       setWarmingUp(false)
       return undefined
@@ -90,9 +90,9 @@ export default function StandaloneInstallCard({ app, forceOpen, onClose }) {
     const timer = setTimeout(() => {
       setWarmingUp(false)
       setShowInstructions(true)
-    }, 25000)
+    }, 30000)
     return () => clearTimeout(timer)
-  }, [warmingUp, installState])
+  }, [open, warmingUp, installState])
 
   useEffect(() => {
     const previous = previousInstallStateRef.current

--- a/frontend/src/lib/__tests__/standaloneInstallCardWarming.test.js
+++ b/frontend/src/lib/__tests__/standaloneInstallCardWarming.test.js
@@ -1,0 +1,53 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+import StandaloneInstallCard from '../../components/StandaloneApp/StandaloneInstallCard.jsx'
+
+// Fresh module state on purpose (separate file = separate process):
+// `installPrompt` never saw a capture start, so the snapshot is `manual` —
+// exactly the state a fresh Chromium arrival lands in while the browser's
+// engagement heuristics still gate `beforeinstallprompt`.
+
+function withNavigator(userAgent, run) {
+  const descriptor = Object.getOwnPropertyDescriptor(globalThis, 'navigator')
+  Object.defineProperty(globalThis, 'navigator', {
+    configurable: true,
+    value: { userAgent, maxTouchPoints: 0 },
+  })
+  try {
+    return run()
+  } finally {
+    if (descriptor) Object.defineProperty(globalThis, 'navigator', descriptor)
+    else delete globalThis.navigator
+  }
+}
+
+const app = { slug: 'notes', name: 'Notes', updated_at: '1' }
+
+test('Chromium arrival in manual state warms up instead of instructing', () => {
+  const html = withNavigator(
+    'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.6099.144 Mobile Safari/537.36',
+    () => renderToStaticMarkup(
+      createElement(StandaloneInstallCard, { app, forceOpen: true }),
+    ),
+  )
+  assert.match(html, /standalone-install__warming/)
+  assert.match(html, /Show the manual steps/)
+  // No menu instructions yet, and no duplicate "Show me" action while the
+  // warming skip button is on screen.
+  assert.doesNotMatch(html, /standalone-install__instructions/)
+  assert.doesNotMatch(html, /standalone-install__actions/)
+})
+
+test('a browser with no install prompt gets instructions immediately', () => {
+  const html = withNavigator(
+    'Mozilla/5.0 (Android 14; Mobile; rv:121.0) Gecko/121.0 Firefox/121.0',
+    () => renderToStaticMarkup(
+      createElement(StandaloneInstallCard, { app, forceOpen: true }),
+    ),
+  )
+  assert.doesNotMatch(html, /standalone-install__warming/)
+  assert.match(html, /standalone-install__instructions/)
+})

--- a/frontend/src/utils/__tests__/installPlatform.test.js
+++ b/frontend/src/utils/__tests__/installPlatform.test.js
@@ -5,6 +5,7 @@ import { test } from 'node:test'
 import assert from 'node:assert/strict'
 
 import {
+  androidBrowserIntentHref,
   detectInstallPlatform,
   installCopyForPlatform,
   isStandaloneDisplay,
@@ -206,4 +207,22 @@ test('standalone detection never throws on hostile or absent globals', () => {
   assert.equal(isStandaloneDisplay(null), false)
   assert.equal(isStandaloneDisplay({}), false)
   assert.equal(isStandaloneDisplay({ matchMedia() { throw new Error('denied') } }), false)
+})
+
+test('Android Chromium copy warns against Create shortcut', () => {
+  const copy = installCopyForPlatform(detectInstallPlatform(UA.androidChrome))
+  assert.match(copy.body, /Install/)
+  assert.match(copy.body, /not Create shortcut/)
+})
+
+test('androidBrowserIntentHref escapes the in-app tab with a fallback', () => {
+  const href = androidBrowserIntentHref('https://mobius.example/apps/notes/?install=1')
+  assert.equal(
+    href,
+    'intent://mobius.example/apps/notes/?install=1' +
+      '#Intent;scheme=https;S.browser_fallback_url=' +
+      'https%3A%2F%2Fmobius.example%2Fapps%2Fnotes%2F%3Finstall%3D1;end',
+  )
+  // Non-https input is left alone rather than turned into a broken intent.
+  assert.equal(androidBrowserIntentHref('http://x.test/a'), 'http://x.test/a')
 })

--- a/frontend/src/utils/installPlatform.js
+++ b/frontend/src/utils/installPlatform.js
@@ -76,6 +76,27 @@ export function detectInstallPlatform(ua, maxTouchPoints) {
   }
 }
 
+/**
+ * Android intent: URI that asks the OS to open `httpsUrl` in the user's full
+ * browser rather than the in-app tab the current context would use.
+ *
+ * From inside an installed PWA (WebAPK), an ordinary link to a page outside
+ * the app's scope opens in a Custom Tab, where Chromium never offers installs
+ * (`beforeinstallprompt` does not fire there). Intent resolution leaves the
+ * app entirely: the target is outside this app's scope, so Android hands the
+ * URL to the default browser as a real tab. `browser_fallback_url` keeps the
+ * link working if nothing claims the intent.
+ */
+export function androidBrowserIntentHref(httpsUrl) {
+  const url = new URL(httpsUrl)
+  if (url.protocol !== 'https:') return httpsUrl
+  const pathAndQuery = `${url.pathname}${url.search}`
+  return (
+    `intent://${url.host}${pathAndQuery}` +
+    `#Intent;scheme=https;S.browser_fallback_url=${encodeURIComponent(httpsUrl)};end`
+  )
+}
+
 // Manual fallback for browsers that do not expose `beforeinstallprompt`.
 // Native prompt availability always wins in the UI; these instructions keep
 // iOS, Android, and desktop useful without it.
@@ -124,7 +145,9 @@ export function installCopyForPlatform(
     return {
       title: `Install ${productName}`,
       summary: 'Use your browser menu to add it.',
-      body: 'Open the browser menu, then choose Install app or Add to Home screen.',
+      body: 'Open the browser menu, then choose Install app. If you only see ' +
+        'Add to Home screen, tap it and pick Install — not Create shortcut, ' +
+        'which only makes a browser bookmark.',
       ctaLabel: 'Show me',
     }
   }


### PR DESCRIPTION
## Summary

- hand installed Android shells off to a real browser tab with an `intent:` URL instead of an install-ineligible Custom Tab
- keep a bounded Chromium warm-up state while `beforeinstallprompt` eligibility catches up, with an immediate manual-steps escape
- add privacy-safe narrow and wide manifest covers so Chromium can show its richer install sheet
- make Android guidance distinguish a real install from `Create shortcut`

## Privacy and failure handling

The manifest covers are generated from the app name, icon, and theme color; they never capture authenticated app content. Screenshot names and sizes are fixed, cached with the existing icon inputs, and unknown asset names still return 404.

## Testing

- `scripts/wt-pytest.sh backend/tests/test_standalone_manifest.py -q`
- `node --loader=./src/lib/__tests__/vite-env-loader.mjs --test src/lib/__tests__/standaloneInstallCardWarming.test.js src/utils/__tests__/installPlatform.test.js`
- rendered the install card at a mobile viewport

The Android installed-PWA → full-browser handoff remains device-only and should be confirmed on physical Android hardware.