### PR TITLE
Fix Claude child-sidechain ownership

### DIFF
--- a/backend/app/claude_events.py
+++ b/backend/app/claude_events.py
@@ -69,6 +69,21 @@ _TASK_TEXT_CAP = 2000
 _TASK_LABEL_CAP = 200
 
 
+def is_root_conversation_message(message: Any) -> bool:
+  """Whether one Claude conversation frame belongs to the owner turn.
+
+  Claude streams native Agent/Task work on the same SDK connection as its
+  parent, but marks each child-sidechain StreamEvent, AssistantMessage, and
+  UserMessage with ``parent_tool_use_id``. Only frames without that parent own
+  the root chat row. Child activity is already represented by the separate
+  Task lifecycle and by the parent's later synthesis.
+
+  Result/System messages do not expose this field and are root lifecycle
+  frames, so the runner can use this predicate for its broader session-id gate.
+  """
+  return getattr(message, "parent_tool_use_id", None) is None
+
+
 def _clip_task_text(value: object, cap: int) -> str | None:
   """Coerce a task_* text field to a bounded string (or None).
 
@@ -252,6 +267,15 @@ def dispatch_sdk_message(
   + stop_reason side channels) without spinning up a live SDK
   subprocess.
   """
+  if (
+    isinstance(sdk_msg, (StreamEvent, AssistantMessage, UserMessage))
+    and not is_root_conversation_message(sdk_msg)
+  ):
+    # A native child turn is a sidechain, not another piece of the owner's
+    # assistant row. Its Task lifecycle remains visible and the root agent
+    # later emits its own synthesis.
+    return current_session_id, None
+
   if isinstance(sdk_msg, SystemMessage):
     if isinstance(sdk_msg, TaskStartedMessage):
       # tool_use_id ties this sub-task back to the parent turn's tool call that

--- a/backend/app/claude_sdk_runner.py
+++ b/backend/app/claude_sdk_runner.py
@@ -86,7 +86,11 @@ from claude_agent_sdk.types import (
 )
 
 from app import activity
-from app.claude_events import _clip_task_text, dispatch_sdk_message
+from app.claude_events import (
+  _clip_task_text,
+  dispatch_sdk_message,
+  is_root_conversation_message,
+)
 from app.claude_sdk_contract import transport_exit_error, transport_process_pid
 from app.process_groups import (
   isolated_process_group_id,
@@ -211,33 +215,28 @@ def _claude_cli_path() -> str:
 
 
 async def _drain_background_tasks(client, bc, inflight, session_id, chat_id):
-  """Let still-running background subagents/tasks finish before the turn reaps.
+  """Carry Claude's native background wake through its parent follow-up.
 
   The main agent's terminal ResultMessage ends the TURN, not the background
-  tasks it spawned — the SDK keeps the channel open past the result frame
-  ("result frame ends one turn, not necessarily the run"). The turn-end
-  process-group reap would kill any task still running and lose its work. So at a
-  genuine terminal we keep the connected client and keep reading its stream,
-  dispatching each event and clearing tasks as they settle, until every tracked
-  task finishes; then the caller returns into the normal reap.
-
-  Wait for the real work, not an arbitrary clock. Only drainable delegated-agent
-  tasks are tracked (``dispatch_sdk_message`` maintains ``inflight``), and those
-  reliably reach a terminal status, so this returns as soon as the subagents
-  actually settle — there is deliberately no time cap. Fail-safe: on ANY stream
-  error it returns so the reap proceeds; a real Stop raises CancelledError
-  (BaseException), which propagates untouched and aborts the wait at once.
+  work it spawned. Claude completes a native child, wakes its parent, and emits
+  another ResultMessage after the parent synthesizes the result. A task_done
+  notification is therefore not the drain boundary; keep the client connected
+  until that parent result arrives. Stop still cancels the surrounding task,
+  and a stream error fails safe into the ordinary reap.
   """
   try:
     async for sdk_msg in client.receive_messages():
-      dispatch_sdk_message(sdk_msg, bc, session_id, inflight)
-      if not inflight:
-        return
+      session_id, terminal = dispatch_sdk_message(
+        sdk_msg, bc, session_id, inflight,
+      )
+      if terminal is not None and not inflight:
+        return session_id, terminal
   except Exception as exc:
     log.warning(
       "background-task drain ended early chat_id=%s inflight=%d: %s",
       chat_id, len(inflight), exc,
     )
+  return session_id, None
 
 
 def _claude_process_group_id(client: ClaudeSDKClient) -> int | None:
@@ -1247,7 +1246,7 @@ async def run_claude_sdk_turn(
       inflight_tasks: set = set()
       while True:
         async for sdk_msg in client.receive_response():
-          # Persist the session id ONLY from real conversation messages.
+          # Persist the session id ONLY from ROOT conversation messages.
           # SystemMessage and its subclasses — notably HookEventMessage,
           # which the codex plugin's SessionStart hook emits on every
           # resumed turn — carry a PHANTOM session id that gets a
@@ -1256,10 +1255,13 @@ async def run_claude_sdk_turn(
           # the CLI cannot resume, so the next turn dies "No conversation
           # found". Only StreamEvent/Assistant/User/Result carry the
           # resumable id (the same types dispatch advances the session from).
+          # Native child-agent sidechains use those same classes but carry
+          # parent_tool_use_id; they must not repoint the chat at a child
+          # session or contribute content to the root row.
           if isinstance(
             sdk_msg,
             (StreamEvent, AssistantMessage, UserMessage, ResultMessage),
-          ):
+          ) and is_root_conversation_message(sdk_msg):
             incoming_session_id = getattr(sdk_msg, "session_id", None)
             if incoming_session_id and incoming_session_id != current_session_id:
               await _persist_session_id(db, chat_id, incoming_session_id)
@@ -1337,14 +1339,15 @@ async def run_claude_sdk_turn(
             terminal.setdefault("rate_limit_resets_at", rate_limit_resets_at)
           # Background subagents/tasks the agent launched but did not block on
           # are still live at this terminal result. The turn-end reap would kill
-          # them mid-work; keep the connected client and drain until they finish,
-          # THEN return into the reap. Skipped on a Stop — the owner asked to
-          # stop, so honor it immediately. Fail-safe: on any stream error the
-          # drain returns and the reap proceeds exactly as before.
+          # them mid-work. Keep the connected client through Claude's parent
+          # follow-up ResultMessage so the synthesized result is not discarded.
           if inflight_tasks and not active_client.interrupt_requested:
-            await _drain_background_tasks(
+            current_session_id, followup = await _drain_background_tasks(
               client, bc, inflight_tasks, current_session_id, chat_id,
             )
+            if followup is not None:
+              terminal = followup
+              cost_usd = terminal.get("cost_usd")
           return terminal
         else:
           # The stream ended without a terminal ResultMessage. Any buffered

--- a/backend/tests/test_claude_sdk_runner.py
+++ b/backend/tests/test_claude_sdk_runner.py
@@ -435,6 +435,97 @@ def _success_result(
   )
 
 
+@pytest.mark.asyncio
+async def test_native_child_drain_waits_for_clean_parent_synthesis(monkeypatch):
+  async def _ignore_session_persistence(*_args):
+    return None
+
+  class _FakeClient:
+    def __init__(self, _options):
+      pass
+
+    async def connect(self):
+      return None
+
+    async def query(self, _message):
+      return None
+
+    async def disconnect(self):
+      return None
+
+    async def receive_response(self):
+      yield TaskStartedMessage(
+        subtype="task_started",
+        data={},
+        task_id="agent-1",
+        description="inspect the implementation",
+        uuid="task-start-1",
+        session_id="root-session",
+        tool_use_id="spawn-1",
+        task_type="local_agent",
+      )
+      yield _success_result("root-session", cost=0.01)
+
+    async def receive_messages(self):
+      yield StreamEvent(
+        uuid="child-delta",
+        session_id="child-session",
+        parent_tool_use_id="spawn-1",
+        event={
+          "type": "content_block_delta",
+          "index": 0,
+          "delta": {"type": "text_delta", "text": "Child raw report."},
+        },
+      )
+      yield AssistantMessage(
+        content=[TextBlock(text="Child raw report.")],
+        model="claude-sonnet",
+        parent_tool_use_id="spawn-1",
+        session_id="child-session",
+      )
+      yield TaskNotificationMessage(
+        subtype="task_notification",
+        data={},
+        task_id="agent-1",
+        status="completed",
+        output_file="/tmp/agent-1",
+        summary="inspection complete",
+        uuid="task-done-1",
+        session_id="root-session",
+        tool_use_id="spawn-1",
+      )
+      yield AssistantMessage(
+        content=[TextBlock(text="Parent synthesized the result.")],
+        model="claude-sonnet",
+        session_id="root-session",
+      )
+      yield _success_result("root-session", cost=0.03)
+
+  monkeypatch.setattr(claude_sdk_runner, "ClaudeSDKClient", _FakeClient)
+  monkeypatch.setattr(
+    claude_sdk_runner, "_persist_session_id", _ignore_session_persistence,
+  )
+  bus = _Bus()
+
+  result = await run_claude_sdk_turn(
+    "delegate this inspection",
+    session_id=None,
+    base_env={},
+    cwd="/data",
+    chat_id="native-followup",
+    skill_text="system",
+    bc=bus,
+    pending_questions={},
+    db=None,
+  )
+
+  assert result["cost_usd"] == 0.03
+  assert next(
+    event for event in bus.events if event["type"] == "text_final"
+  )["content"] == "Parent synthesized the result."
+  assert "Child raw report" not in str(bus.events)
+
+
 def _interrupt_result(session_id: str = "sess-1") -> ResultMessage:
   """The terminal an SDK interrupt produces — error_during_execution."""
   return ResultMessage(
@@ -1245,6 +1336,56 @@ def test_dispatch_assistant_tool_use_emits_tool_start():
   dispatch_sdk_message(msg, bus, None)
   types = [e["type"] for e in bus.events]
   assert "tool_start" in types
+
+
+def test_child_sidechain_messages_never_enter_the_owner_assistant_row():
+  bus = _Bus()
+  bus.current_message_id = "root-message"
+  current_session_id = "root-session"
+  child_messages = [
+    StreamEvent(
+      uuid="child-start",
+      session_id="child-session",
+      parent_tool_use_id="spawn-1",
+      event={"type": "message_start", "message": {"id": "child-message"}},
+    ),
+    StreamEvent(
+      uuid="child-delta",
+      session_id="child-session",
+      parent_tool_use_id="spawn-1",
+      event={
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {"type": "text_delta", "text": "child prose"},
+      },
+    ),
+    AssistantMessage(
+      content=[
+        TextBlock(text="child prose"),
+        ToolUseBlock(id="child-bash", name="Bash", input={"command": "pwd"}),
+      ],
+      model="claude-sonnet",
+      parent_tool_use_id="spawn-1",
+      message_id="child-message",
+      session_id="child-session",
+      usage={"input_tokens": 10, "output_tokens": 5},
+      stop_reason="tool_use",
+    ),
+    UserMessage(
+      content=[ToolResultBlock(tool_use_id="child-bash", content="/tmp")],
+      parent_tool_use_id="spawn-1",
+    ),
+  ]
+
+  for message in child_messages:
+    current_session_id, terminal = dispatch_sdk_message(
+      message, bus, current_session_id,
+    )
+    assert terminal is None
+
+  assert current_session_id == "root-session"
+  assert bus.current_message_id == "root-message"
+  assert bus.events == []
 
 
 def test_dispatch_claude_edit_carries_shared_diff_preview(tmp_path):

--- a/backend/tests/test_claude_sdk_session_id.py
+++ b/backend/tests/test_claude_sdk_session_id.py
@@ -3,12 +3,13 @@
 Two failure modes break `claude --resume <Chat.session_id>`, and these
 tests lock in the fixes:
 
-1. PHANTOM session ids. The codex plugin's SessionStart hook emits a
+1. NON-ROOT session ids. The codex plugin's SessionStart hook emits a
    `HookEventMessage` (a `SystemMessage` subclass) carrying a session
    id that gets a `session-env/<id>` dir but never a transcript
-   `.jsonl`. The runner's early-persist is type-gated so only real
-   conversation messages (StreamEvent/Assistant/User/Result) advance
-   `Chat.session_id` — the phantom is never persisted.
+   `.jsonl`. Native child-agent sidechains use real conversation message
+   classes but carry `parent_tool_use_id`. The runner's early-persist gate
+   admits only root conversation messages, so neither kind can repoint
+   `Chat.session_id`.
 
 2. MISSING transcript. A correctly-stored id can still have no
    transcript (CLI ~30-day cleanup, or a pre-fix phantom already on an
@@ -74,6 +75,19 @@ def _real_result() -> ResultMessage:
   )
 
 
+def _child_stream() -> StreamEvent:
+  return StreamEvent(
+    uuid="evt-child",
+    session_id="CHILD",
+    parent_tool_use_id="spawn-1",
+    event={
+      "type": "content_block_delta",
+      "index": 0,
+      "delta": {"type": "text_delta", "text": "child detail"},
+    },
+  )
+
+
 def _phantom_hook() -> HookEventMessage:
   """A SessionStart HookEventMessage carrying a phantom session id.
 
@@ -93,9 +107,9 @@ def test_phantom_session_id_never_persisted(monkeypatch):
   """The phantom hook id is never persisted; REAL is the final id.
 
   Drives the runner with [HookEventMessage(PHANTOM), StreamEvent(REAL),
-  ResultMessage(REAL)] and records every PersistSessionId the runner
-  submits. The early-persist type-gate must skip the SystemMessage so
-  PHANTOM is never written, and REAL is the persisted + returned id.
+  child StreamEvent(CHILD), ResultMessage(REAL)] and records every
+  PersistSessionId the runner submits. The ownership gate skips both non-root
+  frames, leaving REAL as the only persisted + returned id.
   """
   persisted: list[str] = []
 
@@ -123,6 +137,7 @@ def test_phantom_session_id_never_persisted(monkeypatch):
     async def receive_response(self):
       yield _phantom_hook()
       yield _real_stream()
+      yield _child_stream()
       yield _real_result()
 
   monkeypatch.setattr(claude_sdk_runner, "ClaudeSDKClient", _FakeClient)
@@ -143,8 +158,9 @@ def test_phantom_session_id_never_persisted(monkeypatch):
       )
     )
 
-    # The phantom id is never persisted; only REAL is.
+    # Neither non-root id is persisted; only REAL is.
     assert "PHANTOM" not in persisted
+    assert "CHILD" not in persisted
     assert persisted == ["REAL"]
     # The returned session id is the resumable one.
     assert result["session_id"] == "REAL"


### PR DESCRIPTION
## Summary

- treat Claude's `parent_tool_use_id` as the root-versus-child ownership boundary
- keep native child text, tools, and results out of the owner's assistant row
- drain through Claude's parent follow-up result so the synthesized answer remains visible
- prevent child sessions from replacing the root resumable session

## Problem

Claude's native child agents share an SDK connection with their parent. Child frames carry `parent_tool_use_id`, but Möbius translated them as root conversation events. That could append helper output after an unanswered owner question and replace the root session identity with a child session.

## Fix

Use the provider's ownership field at the Claude event-normalization boundary. Only root frames may contribute owner-visible content or advance the resumable session. Child work remains visible through task lifecycle events, and the existing drain now waits for Claude's later parent result rather than stopping at `task_done`, preserving the parent's synthesis.

## Related work

This complements #670 and #688. Those changes make unanswered questions durable and gate new turns; this change prevents child frames from entering owner chat state in the first place while keeping the parent synthesis.

## Validation

- 87 focused Claude ownership, drain, and session tests passed
- 85 related event, question, and live-assistant tests passed
- Python compilation and canonical diff checks passed