### PR TITLE
Migrate established chats after explicit model selection

### DIFF
--- a/backend/app/schema_migrations.py
+++ b/backend/app/schema_migrations.py
@@ -1685,6 +1685,168 @@ def _retire_restart_resume_toggle(eng) -> None:
     ))
 
 
+def _pin_established_legacy_chat_models(eng) -> None:
+  """Replace the retired interactive SDK default with explicit chat choices.
+
+  Chats that already completed an assistant turn before model selection became
+  mandatory were allowed to persist no model at all. Pin only those established
+  conversations to an explicit model the owner has already chosen for the same
+  provider. Empty chats keep the intentional first-send selection prompt, while
+  deleted and already-explicit chats remain byte-for-byte unchanged.
+
+  The current shared picker file is the strongest source for its provider. For
+  the other provider, the most recently used explicit owner chat is the best
+  durable evidence available: historical SDK defaults were never recorded.
+  """
+  from sqlalchemy import JSON as SAJSON, bindparam, inspect as sa_inspect, text
+
+  inspector = sa_inspect(eng)
+  tables = set(inspector.get_table_names())
+  if "chats" not in tables:
+    return
+  columns = {column["name"] for column in inspector.get_columns("chats")}
+  required = {"id", "provider", "messages", "agent_settings_json"}
+  if not required.issubset(columns):
+    return
+
+  invalid_json = object()
+
+  def decoded_json(value):
+    if isinstance(value, str):
+      try:
+        return json.loads(value)
+      except (TypeError, ValueError):
+        return invalid_json
+    return value
+
+  def model_provider(model):
+    if not isinstance(model, str) or not model.strip():
+      return None
+    normalized = model.strip()
+    if normalized.startswith("claude-"):
+      return "claude"
+    if normalized.startswith("gpt-"):
+      return "codex"
+    return None
+
+  provider_ids = {"claude", "codex"}
+  selected_models = {}
+
+  # The shared file contains the latest picker choice. Associate a future or
+  # custom model id with owner.provider unless its known prefix contradicts it.
+  owner_provider = None
+  if "owner" in tables:
+    owner_columns = {
+      column["name"] for column in inspector.get_columns("owner")
+    }
+    if "provider" in owner_columns:
+      with eng.connect() as conn:
+        owner_provider = conn.execute(text(
+          "SELECT provider FROM owner ORDER BY id LIMIT 1"
+        )).scalar_one_or_none()
+  try:
+    global_settings = json.loads(
+      (Path(os.environ.get("DATA_DIR", "/data"))
+       / "shared" / "agent-settings.json").read_text(encoding="utf-8")
+    )
+  except (OSError, TypeError, ValueError):
+    global_settings = {}
+  global_model = (
+    global_settings.get("model") if isinstance(global_settings, dict) else None
+  )
+  global_model_provider = model_provider(global_model)
+  if (
+    owner_provider in provider_ids
+    and isinstance(global_model, str)
+    and global_model.strip()
+    and global_model_provider in {None, owner_provider}
+  ):
+    selected_models[owner_provider] = global_model.strip()
+
+  optional_columns = [
+    name for name in (
+      "deleted_at", "created_by_app_id", "activity_at", "updated_at",
+      "created_at",
+    ) if name in columns
+  ]
+  select_columns = [
+    "id", "provider", "messages", "agent_settings_json", *optional_columns,
+  ]
+  source_where = " WHERE deleted_at IS NULL" if "deleted_at" in columns else ""
+  order_columns = [
+    name for name in ("activity_at", "updated_at", "created_at")
+    if name in columns
+  ]
+  if len(order_columns) > 1:
+    source_order = " ORDER BY COALESCE(" + ", ".join(order_columns) + ") DESC"
+  elif order_columns:
+    source_order = f" ORDER BY {order_columns[0]} DESC"
+  else:
+    source_order = " ORDER BY id DESC"
+
+  with eng.begin() as conn:
+    rows = conn.execute(text(
+      "SELECT " + ", ".join(select_columns) + " FROM chats"
+      + source_where + source_order
+    )).mappings().all()
+
+    # Fill any provider the shared file did not cover from the latest explicit
+    # owner chat. Unknown ids remain valid evidence unless they are visibly a
+    # model from the other supported provider.
+    for row in rows:
+      provider = row["provider"]
+      if provider not in provider_ids or provider in selected_models:
+        continue
+      if (
+        "created_by_app_id" in columns
+        and row.get("created_by_app_id") is not None
+      ):
+        continue
+      settings = decoded_json(row["agent_settings_json"])
+      if settings is invalid_json or not isinstance(settings, dict):
+        continue
+      model = settings.get("model")
+      classified = model_provider(model)
+      if (
+        isinstance(model, str)
+        and model.strip()
+        and classified in {None, provider}
+      ):
+        selected_models[provider] = model.strip()
+
+    update_settings = text(
+      "UPDATE chats SET agent_settings_json = :settings WHERE id = :chat_id"
+    ).bindparams(bindparam("settings", type_=SAJSON))
+    for row in rows:
+      provider = row["provider"]
+      selected_model = selected_models.get(provider)
+      if selected_model is None:
+        continue
+      settings = decoded_json(row["agent_settings_json"])
+      if settings is invalid_json:
+        # A malformed JSON value is partner data, not an empty settings object.
+        continue
+      if settings is None:
+        settings = {}
+      if not isinstance(settings, dict):
+        continue
+      model = settings.get("model")
+      if isinstance(model, str) and model.strip():
+        continue
+      messages = decoded_json(row["messages"])
+      if messages is invalid_json or not isinstance(messages, list) or not any(
+        isinstance(message, dict) and message.get("role") == "assistant"
+        for message in messages
+      ):
+        continue
+      migrated_settings = dict(settings)
+      migrated_settings["model"] = selected_model
+      conn.execute(update_settings, {
+        "settings": migrated_settings,
+        "chat_id": row["id"],
+      })
+
+
 _SCHEMA_MIGRATIONS = (
   ("0001_legacy_schema_convergence", _converge_legacy_schema),
   ("0002_chat_run_goal_objective", _add_chat_run_goal_objective),
@@ -1703,6 +1865,7 @@ _SCHEMA_MIGRATIONS = (
   ("0015_chat_run_goal_identity", _add_chat_run_goal_identity),
   ("0016_app_connect_manage", _add_app_connect_manage),
   ("0017_retire_restart_resume_toggle", _retire_restart_resume_toggle),
+  ("0018_explicit_legacy_chat_models", _pin_established_legacy_chat_models),
 )
 
 

--- a/backend/tests/test_db_migrations.py
+++ b/backend/tests/test_db_migrations.py
@@ -1163,8 +1163,220 @@ def test_run_migrations_records_an_inspectable_append_only_history(tmp_path):
     "0015_chat_run_goal_identity",
     "0016_app_connect_manage",
     "0017_retire_restart_resume_toggle",
+    "0018_explicit_legacy_chat_models",
   ]
   assert second == first
+
+
+def test_legacy_chat_models_pin_only_established_unselected_chats(
+  tmp_path, monkeypatch,
+):
+  """0018 repairs invisible defaults without creating a new default path."""
+  data_dir = tmp_path / "data"
+  shared = data_dir / "shared"
+  shared.mkdir(parents=True)
+  (shared / "agent-settings.json").write_text(json.dumps({
+    "model": "gpt-5.6-sol",
+    "effort": "xhigh",
+  }))
+  monkeypatch.setenv("DATA_DIR", str(data_dir))
+  eng = create_engine(f"sqlite:///{tmp_path / 'legacy-chat-models.db'}")
+  models.Base.metadata.create_all(eng)
+  established = [
+    {"role": "user", "content": "hello"},
+    {"role": "assistant", "content": "hi"},
+  ]
+  with Session(eng) as session:
+    session.add(models.Owner(
+      username="owner",
+      hashed_password="hash",
+      provider="codex",
+    ))
+    rows = [
+      models.Chat(
+        id="claude-source-old", title="Old Claude choice", provider="claude",
+        messages=[], agent_settings_json={"model": "claude-sonnet-4-6"},
+        activity_at=datetime(2026, 8, 20),
+      ),
+      models.Chat(
+        id="claude-source-current", title="Current Claude choice",
+        provider="claude", messages=[],
+        agent_settings_json={"model": "claude-opus-4-8"},
+        activity_at=datetime(2026, 8, 22),
+      ),
+      # A newer app-owned model is not evidence of the owner's picker choice.
+      models.Chat(
+        id="claude-app-source", title="App model", provider="claude",
+        messages=[], agent_settings_json={"model": "claude-fable-5"},
+        created_by_app_id=99, activity_at=datetime(2026, 8, 23),
+      ),
+      models.Chat(
+        id="legacy-claude", title="Legacy Claude", provider="claude",
+        messages=established, agent_settings_json=None,
+      ),
+      models.Chat(
+        id="legacy-codex", title="Legacy Codex", provider="codex",
+        messages=established,
+        agent_settings_json={"effort": "high", "project_id": "alpha"},
+      ),
+      models.Chat(
+        id="legacy-app", title="Legacy app", provider="claude",
+        messages=established, created_by_app_id=99,
+        agent_settings_json={"report_kind": "reflection"},
+      ),
+      models.Chat(
+        id="empty-chat", title="First run", provider="codex",
+        messages=[{"role": "user", "content": "not completed"}],
+        agent_settings_json={"effort": "medium"},
+      ),
+      models.Chat(
+        id="deleted-chat", title="Deleted", provider="codex",
+        messages=established, agent_settings_json=None,
+        deleted_at=datetime(2026, 8, 22),
+      ),
+      models.Chat(
+        id="explicit-chat", title="Explicit", provider="codex",
+        messages=established,
+        agent_settings_json={"model": "gpt-5.5", "effort": "low"},
+      ),
+    ]
+    session.add_all(rows)
+    session.commit()
+
+  with eng.begin() as conn:
+    conn.execute(text(
+      "CREATE TABLE schema_migrations ("
+      "version VARCHAR(128) PRIMARY KEY, applied_at TIMESTAMP NOT NULL)"
+    ))
+    for version in _migration_versions_before(
+      "0018_explicit_legacy_chat_models",
+    ):
+      conn.execute(text(
+        "INSERT INTO schema_migrations (version, applied_at) "
+        "VALUES (:version, '2026-08-23 00:00:00')"
+      ), {"version": version})
+
+  run_migrations(eng)
+  with Session(eng) as session:
+    settings = {
+      row.id: row.agent_settings_json
+      for row in session.query(models.Chat).all()
+    }
+  assert settings["legacy-claude"] == {"model": "claude-opus-4-8"}
+  assert settings["legacy-codex"] == {
+    "effort": "high",
+    "project_id": "alpha",
+    "model": "gpt-5.6-sol",
+  }
+  assert settings["legacy-app"] == {
+    "report_kind": "reflection",
+    "model": "claude-opus-4-8",
+  }
+  assert settings["empty-chat"] == {"effort": "medium"}
+  assert settings["deleted-chat"] is None
+  assert settings["explicit-chat"] == {"model": "gpt-5.5", "effort": "low"}
+
+  # Simulate a crash after the data commit but before the ledger insert. The
+  # retry must no-op rather than revising any newly explicit conversation.
+  with eng.begin() as conn:
+    conn.execute(text(
+      "DELETE FROM schema_migrations "
+      "WHERE version = '0018_explicit_legacy_chat_models'"
+    ))
+  run_migrations(eng)
+  with Session(eng) as session:
+    assert session.get(models.Chat, "legacy-codex").agent_settings_json == {
+      "effort": "high",
+      "project_id": "alpha",
+      "model": "gpt-5.6-sol",
+    }
+
+
+def test_legacy_chat_models_never_invent_a_provider_default(
+  tmp_path, monkeypatch,
+):
+  data_dir = tmp_path / "data"
+  shared = data_dir / "shared"
+  shared.mkdir(parents=True)
+  (shared / "agent-settings.json").write_text(json.dumps({
+    "model": "gpt-5.6-sol",
+  }))
+  monkeypatch.setenv("DATA_DIR", str(data_dir))
+  eng = create_engine(f"sqlite:///{tmp_path / 'no-invented-model.db'}")
+  models.Base.metadata.create_all(eng)
+  transcript = [
+    {"role": "user", "content": "hello"},
+    {"role": "assistant", "content": "hi"},
+  ]
+  with Session(eng) as session:
+    session.add(models.Owner(
+      username="owner",
+      hashed_password="hash",
+      provider="codex",
+    ))
+    session.add_all([
+      models.Chat(
+        id="known-provider-choice", title="Codex", provider="codex",
+        messages=transcript, agent_settings_json=None,
+      ),
+      models.Chat(
+        id="no-provider-choice", title="Claude", provider="claude",
+        messages=transcript, agent_settings_json=None,
+      ),
+    ])
+    session.commit()
+
+  migrations._pin_established_legacy_chat_models(eng)
+  migrations._pin_established_legacy_chat_models(eng)
+
+  with Session(eng) as session:
+    assert session.get(
+      models.Chat, "known-provider-choice",
+    ).agent_settings_json == {"model": "gpt-5.6-sol"}
+    assert session.get(
+      models.Chat, "no-provider-choice",
+    ).agent_settings_json is None
+
+
+def test_legacy_chat_models_preserve_malformed_settings(tmp_path, monkeypatch):
+  data_dir = tmp_path / "data"
+  shared = data_dir / "shared"
+  shared.mkdir(parents=True)
+  (shared / "agent-settings.json").write_text(json.dumps({
+    "model": "gpt-5.6-sol",
+  }))
+  monkeypatch.setenv("DATA_DIR", str(data_dir))
+  eng = create_engine(f"sqlite:///{tmp_path / 'malformed-settings.db'}")
+  models.Base.metadata.create_all(eng)
+  with Session(eng) as session:
+    session.add(models.Owner(
+      username="owner",
+      hashed_password="hash",
+      provider="codex",
+    ))
+    session.add(models.Chat(
+      id="malformed-settings",
+      title="Malformed settings",
+      provider="codex",
+      messages=[
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "hi"},
+      ],
+      agent_settings_json=None,
+    ))
+    session.commit()
+  with eng.begin() as conn:
+    conn.execute(text(
+      "UPDATE chats SET agent_settings_json = '{malformed' "
+      "WHERE id = 'malformed-settings'"
+    ))
+
+  migrations._pin_established_legacy_chat_models(eng)
+
+  with eng.connect() as conn:
+    assert conn.execute(text(
+      "SELECT agent_settings_json FROM chats WHERE id = 'malformed-settings'"
+    )).scalar_one() == "{malformed"
 
 
 def test_pending_question_migration_backfills_only_active_latest_question(

--- a/tests/_chatTracker.mjs
+++ b/tests/_chatTracker.mjs
@@ -126,6 +126,7 @@ export async function createTaggedChat(
   })
   const result = response.ok() ? await response.json() : null
   if (result?.id) {
+    if (info) registerCreatedChats(info.workerIndex, result.id)
     // Most browser tests exercise chat behavior after the first-send choice,
     // not the picker itself. Keep that prerequisite explicit in the shared
     // fixture now that production no longer inherits an SDK default.
@@ -139,7 +140,6 @@ export async function createTaggedChat(
         `Could not select the test chat model (${selected.status()})`,
       )
     }
-    if (info) registerCreatedChats(info.workerIndex, result.id)
   }
   return result
 }

--- a/tests/chat-fixture-registry.test.mjs
+++ b/tests/chat-fixture-registry.test.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
 import test from 'node:test'
 
 import {
@@ -18,6 +19,24 @@ test('registry drains only exact IDs registered by one worker', () => {
   assert.deepEqual(drainCreatedChats(3), ['chat-a', 'chat-b'])
   assert.deepEqual(drainCreatedChats(3), [])
   assert.deepEqual(drainCreatedChats(4), ['other-worker-chat'])
+})
+
+test('created chats are registered before model setup can fail', async () => {
+  const source = await readFile(
+    new URL('./_chatTracker.mjs', import.meta.url),
+    'utf8',
+  )
+  const createStart = source.indexOf('export async function createTaggedChat')
+  const cleanupStart = source.indexOf('export async function cleanupWorkerChats')
+  const createSource = source.slice(createStart, cleanupStart)
+  const registerIndex = createSource.indexOf(
+    'registerCreatedChats(info.workerIndex, result.id)',
+  )
+  const modelSetupIndex = createSource.indexOf('persistTestChatModel(page')
+
+  assert.ok(registerIndex >= 0)
+  assert.ok(modelSetupIndex >= 0)
+  assert.ok(registerIndex < modelSetupIndex)
 })
 
 test('chat fixtures persist a model and simulate its provider boundary', async () => {


### PR DESCRIPTION
## Summary
- pin established chats that relied on the retired SDK default to an explicit model already chosen for the same provider
- preserve empty, deleted, malformed, and already-configured chats so genuine first-run selection remains explicit
- register browser-test chats for cleanup before model setup can fail

## Context
#869 removed invisible interactive model defaults and now requires an explicit choice before a turn starts. Chats created before that contract could already contain assistant history without a persisted model, causing an unexpected selection prompt when their owners returned.

This follow-up migrates only those established legacy chats. It does not restore a runtime fallback or assign a model to untouched first-run chats. It also resolves the final review note on #869 by ensuring a fixture chat remains eligible for teardown when its model-selection request fails.

## Verification
- 58 migration and migration-history tests
- 28 chat-settings and send-admission tests
- 10 focused frontend model-selection tests
- 5 end-to-end harness tests
- append-only migration history verified against current `main`