### PR TITLE
Make the mapi helper callable by bare name on PATH

### DIFF
--- a/backend/scripts/entrypoint.sh
+++ b/backend/scripts/entrypoint.sh
@@ -1134,6 +1134,15 @@ _health_url="http://127.0.0.1:${_public_port}/api/health"
   exit 1
 ) &
 
+# Make the mapi helper callable by bare name in agent shells. The Bash tool's
+# shell snapshot hard-sets PATH (clobbering any exported prefix), but
+# /usr/local/bin is on it — so expose the helper there via a stable symlink.
+_mapi=/data/platform/backend/scripts/mapi
+[ -x "$_mapi" ] || _mapi=/app/scripts/mapi
+if [ -x "$_mapi" ]; then
+  ln -sfn "$_mapi" /usr/local/bin/mapi 2>/dev/null || true
+fi
+
 # --timeout-graceful-shutdown bounds uvicorn's SIGTERM drain. Without it,
 # uvicorn waits FOREVER for open connections to close on SIGTERM — and the chat
 # SSE stream never closes on its own — so an in-app restart (the Settings


### PR DESCRIPTION
## What

Symlink the `mapi` helper into `/usr/local/bin` during container boot so it can be invoked as bare `mapi …` in agent shells, instead of requiring a full script path.

## Why

`mapi` already ships in `backend/scripts/`, but it isn't on the agent shell's PATH. The Bash tool's shell snapshot hard-sets `PATH` (so a prefix exported from the entrypoint doesn't survive), yet `/usr/local/bin` is always on it. A stable symlink there is the reliable way to expose the helper by short name, which keeps helper usage in skills and docs simpler and less error-prone.

## How

A small block in `entrypoint.sh`, right after the health-probe launch, resolves the live (`/data/platform/backend/scripts/mapi`) or baked (`/app/scripts/mapi`) helper and symlinks it if present. It is idempotent (`ln -sfn`), acts only when the executable exists, and never fails boot.

## Scope

Deliberately limited to `mapi` rather than blanket-symlinking every script in `backend/scripts/`, so internal maintenance tooling is not exposed as global commands.