### PR TITLE
Make Goals discoverable and durable across providers

### DIFF
--- a/backend/app/claude_sdk_runner.py
+++ b/backend/app/claude_sdk_runner.py
@@ -107,6 +107,64 @@ from app.runtime_types import RunnerResult
 
 log = logging.getLogger(__name__)
 
+_CONTROL_MCP_READY_TIMEOUT_SECONDS = 10.0
+
+
+async def _await_control_mcp_ready(client, *, enabled: bool) -> str | None:
+  """Wait for Claude's local control tool to be discoverable before query.
+
+  ``ClaudeSDKClient.connect()`` establishes the SDK control channel, but stdio
+  MCP servers may still be pending. Querying before the tool appears creates a
+  cold-start race where ToolSearch reports no match and the same session sees
+  it only later. The SDK's MCP status is the owning readiness signal.
+
+  Return ``None`` when ready, otherwise a bounded diagnostic. Agent turns keep
+  the documented shell fallback rather than failing wholesale when this
+  optional control cannot start.
+  """
+  if not enabled:
+    return None
+  get_status = getattr(client, "get_mcp_status", None)
+  if not callable(get_status):
+    # Lightweight test doubles and older compatible SDK clients do not expose
+    # the status call. Production's pinned SDK does.
+    return None
+
+  from app.platform_tools import CONTROL_SERVER_NAME, CONTROL_TOOL_NAME
+
+  loop = asyncio.get_running_loop()
+  deadline = loop.time() + _CONTROL_MCP_READY_TIMEOUT_SECONDS
+  last_state = "not listed"
+  while True:
+    remaining = deadline - loop.time()
+    if remaining <= 0:
+      return f"timed out ({last_state})"
+    try:
+      payload = await asyncio.wait_for(get_status(), timeout=remaining)
+    except asyncio.TimeoutError:
+      return f"timed out ({last_state})"
+    except Exception as exc:
+      return f"status unavailable: {exc}"
+
+    servers = payload.get("mcpServers", []) if isinstance(payload, dict) else []
+    server = next((
+      item for item in servers
+      if isinstance(item, dict) and item.get("name") == CONTROL_SERVER_NAME
+    ), None)
+    if server is not None:
+      status = str(server.get("status") or "unknown")
+      tools = server.get("tools") if isinstance(server.get("tools"), list) else []
+      if status == "connected" and any(
+        isinstance(tool, dict) and tool.get("name") == CONTROL_TOOL_NAME
+        for tool in tools
+      ):
+        return None
+      if status in {"failed", "needs-auth", "disabled"}:
+        detail = server.get("error")
+        return f"{status}: {detail}" if detail else status
+      last_state = status
+    await asyncio.sleep(min(0.05, max(0, deadline - loop.time())))
+
 # --- Provider register (documented amendment to system_prompts.py's contract) ---
 # The per-chat snapshot in `system_prompts.py` is the identical behavioral
 # constitution handed to every provider. A runner MAY append its own small,
@@ -1181,22 +1239,28 @@ async def run_claude_sdk_turn(
     # would let the argv-visible path alias an unrelated descriptor later.
     connector_config_stack = ExitStack()
     connector_config_handle = None
-    if connector_plan is not None:
-      try:
-        from app.connectors import claude_mcp_config_handle
-        connector_config_handle = connector_config_stack.enter_context(
-          claude_mcp_config_handle(connector_plan)
+    control_tools_enabled = run_policy is None
+    try:
+      from app.connectors import claude_mcp_config_handle
+      from app.platform_tools import claude_control_servers
+      connector_config_handle = connector_config_stack.enter_context(
+        claude_mcp_config_handle(
+          connector_plan,
+          extra_servers=claude_control_servers(
+            enabled=control_tools_enabled,
+          ),
         )
-        if connector_config_handle:
-          options_kwargs["mcp_servers"] = connector_config_handle.path
-      except Exception:
-        connector_config_stack.close()
-        connector_config_stack = ExitStack()
-        log.warning(
-          "Claude MCP connection injection skipped chat_id=%s",
-          chat_id,
-          exc_info=True,
-        )
+      )
+      if connector_config_handle:
+        options_kwargs["mcp_servers"] = connector_config_handle.path
+    except Exception:
+      connector_config_stack.close()
+      connector_config_stack = ExitStack()
+      log.warning(
+        "Claude MCP connection injection skipped chat_id=%s",
+        chat_id,
+        exc_info=True,
+      )
     try:
       options = ClaudeAgentOptions(**options_kwargs)
       client = ClaudeSDKClient(options)
@@ -1211,11 +1275,24 @@ async def run_claude_sdk_turn(
       try:
         try:
           await asyncio.wait_for(client.connect(), timeout=30.0)
+          control_ready_error = await _await_control_mcp_ready(
+            client,
+            enabled=(
+              control_tools_enabled and connector_config_handle is not None
+            ),
+          )
+          if control_ready_error:
+            log.warning(
+              "Claude control MCP unavailable before query chat_id=%s: %s",
+              chat_id,
+              control_ready_error,
+            )
         finally:
-          # Claude has consumed the config by the time the control channel is
-          # connected. Destroy its contents before query() gives the model a
-          # shell or process-inspection tool, while reserving the argv-visible
-          # fd number so it cannot alias another live descriptor.
+          # Keep the anonymous config readable until the local control MCP has
+          # completed its initialize + tools/list handshake. Then destroy its
+          # contents before query() gives the model a shell or process-
+          # inspection tool, while reserving the argv-visible fd number so it
+          # cannot alias another live descriptor.
           if connector_config_handle is not None:
             connector_config_handle.retire()
       except asyncio.TimeoutError:

--- a/backend/app/codex_sdk_runner.py
+++ b/backend/app/codex_sdk_runner.py
@@ -1578,7 +1578,6 @@ async def run_codex_sdk_turn(
   # detached plan rather than silently masking internal contract violations.
   connector_thread_config = None
   if connector_plan is not None:
-    connector_thread_config = connector_plan.codex_config
     env.update(connector_plan.codex_env)
 
   # config_overrides always isolates the prompt stack, then carries the
@@ -1586,6 +1585,11 @@ async def run_codex_sdk_turn(
   # Delegated children disable those optional tools at this provider-owned seam.
   codex_bin = shutil.which("codex")
   delegated = run_policy is not None
+  from app.platform_tools import codex_turn_mcp_config
+  connector_thread_config = codex_turn_mcp_config(
+    connector_plan,
+    control_enabled=not delegated,
+  )
   needs_goal_control = _needs_native_goal_control(
     goal_mode=goal_mode,
     goal_objective=goal_objective,

--- a/backend/app/connectors.py
+++ b/backend/app/connectors.py
@@ -819,6 +819,8 @@ def build_turn_plan(
 @contextmanager
 def claude_mcp_config_handle(
   plan: ConnectorTurnPlan | None,
+  *,
+  extra_servers: dict[str, dict] | None = None,
 ) -> Iterator[ClaudeMcpConfigHandle | None]:
   """Yield an anonymous 0600 MCP config handle for Claude startup only.
 
@@ -830,8 +832,13 @@ def claude_mcp_config_handle(
   with ``/dev/null``. Keeping the harmless descriptor reserved until teardown
   prevents the argv-visible fd number from being reused for unrelated data.
   There is no named capability file left behind after a crash or restart.
+  ``extra_servers`` carries non-secret platform controls through the same one
+  config surface so they coexist with optional remote connectors.
   """
-  servers = plan.claude_servers if plan else {}
+  servers = dict(plan.claude_servers if plan else {})
+  # Platform-owned local controls win the deliberately disjoint reserved key
+  # if a malformed connector snapshot ever tries to claim it.
+  servers.update(extra_servers or {})
   if not servers:
     yield None
     return

--- a/backend/app/goal_plans.py
+++ b/backend/app/goal_plans.py
@@ -482,6 +482,85 @@ def serialize_plan(
   }
 
 
+def terminal_goal_summaries_by_message_index(
+  db: Session,
+  chat_id: str,
+  messages: list[dict[str, Any]],
+) -> dict[int, list[dict[str, Any]]]:
+  """Project terminal Goals beside the assistant row that concluded them."""
+  goal_rows = (
+    db.query(models.ChatRun)
+    .filter(
+      models.ChatRun.chat_id == chat_id,
+      models.ChatRun.goal_objective.isnot(None),
+    )
+    .order_by(models.ChatRun.started_at.asc(), models.ChatRun.id.asc())
+    .all()
+  )
+  grouped: dict[str, list[models.ChatRun]] = {}
+  for row in goal_rows:
+    identity = row.goal_id or row.root_run_id or row.id
+    grouped.setdefault(identity, []).append(row)
+
+  assistant_rows: list[tuple[int, int]] = []
+  for index, message in enumerate(messages):
+    if not isinstance(message, dict) or message.get("role") != "assistant":
+      continue
+    ts = message.get("ts")
+    if isinstance(ts, (int, float)) and not isinstance(ts, bool):
+      assistant_rows.append((index, int(ts)))
+
+  def epoch_ms(value: datetime | None) -> int | None:
+    if value is None:
+      return None
+    if value.tzinfo is None:
+      value = value.replace(tzinfo=UTC)
+    return round(value.timestamp() * 1000)
+
+  projected: dict[int, list[dict[str, Any]]] = {}
+  for identity, rows in grouped.items():
+    latest = rows[-1]
+    if latest.ended_at is None or latest.status not in {"completed", "failed"}:
+      continue
+    root = next(
+      (row for row in rows if isinstance(row.goal_plan_json, dict)),
+      rows[0],
+    )
+    plan = serialize_plan(db, latest, root)
+    if (
+      latest.status == "completed"
+      and plan is not None
+      and not plan["summary"]["can_complete"]
+    ):
+      continue
+    started_at = min(
+      (row.started_at for row in rows if row.started_at is not None),
+      default=None,
+    )
+    started_ms = epoch_ms(started_at)
+    ended_ms = epoch_ms(latest.ended_at)
+    if started_ms is None or ended_ms is None:
+      continue
+    candidate_index = next((
+      index for index, ts in reversed(assistant_rows)
+      if started_ms - 1000 <= ts <= ended_ms + 1000
+    ), None)
+    if candidate_index is None:
+      continue
+    status = "failed" if latest.status == "failed" else "completed"
+    projected.setdefault(candidate_index, []).append({
+      "id": identity,
+      "objective": latest.goal_objective,
+      "status": status,
+      "resumable": False,
+      "started_at": started_at.isoformat(),
+      "completed_at": latest.ended_at.isoformat(),
+      "duration_seconds": max(0, round((ended_ms - started_ms) / 1000)),
+      "plan": plan,
+    })
+  return projected
+
+
 def replace_plan(
   db: Session,
   *,

--- a/backend/app/platform_tools.py
+++ b/backend/app/platform_tools.py
@@ -1,0 +1,66 @@
+"""Provider-neutral tool configuration owned by the Möbius platform.
+
+Remote connectors are optional owner capabilities.  These local tools are a
+different class: small control-plane primitives that every ordinary top-level
+agent should see with the same name and contract, regardless of provider.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+
+CONTROL_SERVER_NAME = "mobius_control"
+CONTROL_TOOL_NAME = "promote_goal"
+CONTROL_ENV_VARS = (
+  "API_BASE_URL",
+  "AGENT_TOKEN",
+  "CHAT_ID",
+  "MOBIUS_RUN_TOKEN",
+)
+
+
+def _control_script() -> str:
+  return str(
+    Path(__file__).resolve().parents[1] / "scripts" / "mobius_control_mcp.py"
+  )
+
+
+def claude_control_servers(*, enabled: bool) -> dict[str, dict[str, Any]]:
+  """Return Claude's stdio configuration for ordinary owner turns."""
+  if not enabled:
+    return {}
+  return {
+    CONTROL_SERVER_NAME: {
+      "type": "stdio",
+      "command": sys.executable,
+      "args": [_control_script()],
+    },
+  }
+
+
+def codex_turn_mcp_config(
+  connector_plan: Any | None,
+  *,
+  control_enabled: bool,
+) -> dict[str, Any] | None:
+  """Merge local control tools with one detached Codex connector snapshot."""
+  servers: dict[str, Any] = {}
+  if connector_plan is not None and connector_plan.codex_config:
+    configured = connector_plan.codex_config.get("mcp_servers")
+    if isinstance(configured, dict):
+      servers.update(configured)
+  if control_enabled:
+    servers[CONTROL_SERVER_NAME] = {
+      "command": sys.executable,
+      "args": [_control_script()],
+      # Codex intentionally starts stdio MCP children with a minimal
+      # environment. Forward only the run-bound names this trusted local
+      # control needs; unlike an `env` mapping, `env_vars` keeps their values
+      # out of thread configuration and process arguments.
+      "env_vars": list(CONTROL_ENV_VARS),
+      "startup_timeout_sec": 30,
+    }
+  return {"mcp_servers": servers} if servers else None

--- a/backend/app/routes/chats.py
+++ b/backend/app/routes/chats.py
@@ -508,6 +508,20 @@ def _chat_detail_response(
     chat_id=chat.id,
     data_dir=get_settings().data_dir,
   )
+  from app.goal_plans import terminal_goal_summaries_by_message_index
+  summaries_by_index = terminal_goal_summaries_by_message_index(
+    db, chat.id, all_msgs,
+  )
+  if summaries_by_index:
+    next_page = list(page)
+    for relative_index, message in enumerate(page):
+      summaries = summaries_by_index.get(start + relative_index)
+      if not summaries:
+        continue
+      projected_message = dict(message)
+      projected_message["goal_summaries"] = summaries
+      next_page[relative_index] = projected_message
+    page = next_page
 
   provider = chat.provider or "claude"
   settings_obj = _coerce_agent_settings(chat.agent_settings_json) or None

--- a/backend/scripts/init_skills.py
+++ b/backend/scripts/init_skills.py
@@ -68,6 +68,13 @@ _UNMODIFIED_MIGRATIONS = {
     "2adb39457e0ec2ee9d9a3596cb96e5a6240bae23d725e6459ba0f6e77d5474c4",
     # Dependency-aware plan seed before provider-neutral automatic promotion.
     "a3edc5fcc453a5305102e144c2d58ae16b828612ac93a6a7442be7e267779f59",
+    # Hierarchical Goal seed before provider-neutral automatic promotion.
+    "bca228c745881bfffdad5d7adaab3c62871e6f62801252784fb0522787cfb850",
+    # Provider-neutral promotion seed before phase-transition rechecks and the
+    # first-class platform promote_goal affordance.
+    "0c2b88ff8a79ff05f75ebaa60af2899f0b9ed27d0a23bfff83b54f4e2a1de97a",
+    # Phase-transition seed before the mandatory turn-local routing decision.
+    "7a80e90870f75be7c8802f421e76ac21790f1ef812d4a4d0d923d474e5dadd2d",
   },
   "reflection.md": {
     "c0f57c227f61cd8539a56b70eadfbbe2212125c23b7137472dd173a578baacd8",

--- a/backend/scripts/mobius_control_mcp.py
+++ b/backend/scripts/mobius_control_mcp.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Stdio MCP server for run-bound Möbius control-plane operations."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+from mcp.server.fastmcp import FastMCP
+
+
+def _goal_promote_module() -> ModuleType:
+  path = Path(__file__).with_name("goal_promote.py")
+  spec = importlib.util.spec_from_file_location("mobius_goal_promote", path)
+  if spec is None or spec.loader is None:  # pragma: no cover - import invariant
+    raise RuntimeError("goal promotion helper is unavailable")
+  module = importlib.util.module_from_spec(spec)
+  spec.loader.exec_module(module)
+  return module
+
+
+_GOALS = _goal_promote_module()
+server = FastMCP(
+  "Möbius control",
+  instructions=(
+    "Run-bound platform controls for the current top-level owner turn. "
+    "Never use these tools from a delegated child."
+  ),
+  log_level="ERROR",
+)
+
+
+def _promote_goal(objective: str) -> dict:
+  try:
+    payload = _GOALS.promote_goal(objective)
+  except SystemExit as exc:
+    raise RuntimeError(str(exc)) from exc
+  return {
+    "state": payload["state"],
+    "objective": payload["objective"],
+    "goal_id": payload["root_run_id"],
+    "run_id": payload["run_id"],
+  }
+
+
+@server.tool(
+  name="promote_goal",
+  description=(
+    "Promote the current ordinary top-level owner turn into a durable, "
+    "platform-owned Goal after the goal-planning criteria are satisfied. "
+    "Use at task start or when an owner choice, investigation, or discovery "
+    "turns bounded work into a multi-stage outcome. Do not use for questions, "
+    "honest one-turn work, or delegated children."
+  ),
+)
+def promote_goal(objective: str) -> dict:
+  """Promote and verify the current physical run with one concise objective."""
+  return _promote_goal(objective)
+
+
+if __name__ == "__main__":
+  server.run(transport="stdio")

--- a/backend/scripts/seed-skills/goal-planning.md
+++ b/backend/scripts/seed-skills/goal-planning.md
@@ -9,40 +9,81 @@ subagent keeps its assigned task bounded rather than starting another Goal.
 
 ## Decide whether the request should become a Goal
 
-Automatically promote the current turn only when all of these are true:
+The working agent already has the request, context, and constraints; do not add
+a second classifier call. Automatically create a Goal only when all of these
+are true:
 
-- The partner delegated an outcome to complete, not merely an explanation,
-  recommendation, critique, or investigation to report back.
+- The partner delegated an outcome to complete, not merely a question,
+  explanation, recommendation, critique, or investigation to report back.
 - Completion has an observable condition the agent can eventually verify.
 - Durability materially helps because the route likely spans multiple
   independently verifiable stages or turns, repeated work, dynamic discovery,
-  safe parallel branches, a long operation, or a plausible restart.
-- Work can begin without first waiting for a material owner choice, destructive
-  approval, or external event.
+  safe parallel branches, a long-running operation, or a plausible restart.
+- The task can make meaningful progress without first waiting for a material
+  owner choice, destructive approval, or an external event.
 
-Do not infer a Goal from message length, words such as “thoroughly,” a
-multi-file edit, or the mere fact that a useful task list could be written.
-Keep bounded work that can honestly finish in one turn as a standard prompt.
-Honor “just answer,” “one pass,” and “don't make this a Goal” as opt-outs.
+Make this decision before the first material tool call for **every** ordinary
+top-level delegated outcome. Do not silently skip it because the work looks
+easy enough to finish in one turn or is described as synthetic, a fixture, or
+a test; those labels say nothing about durability. Several independently
+verifiable stages followed by an explicit final verification are strong
+evidence that durability materially helps, even when each individual action is
+simple. This remains a structural judgment using all criteria above, not a
+keyword trigger.
 
-When the criteria hold, promote the current physical turn before material work:
+### Recheck when the work changes phase
+
+Goal routing is a transition check, not a one-time classification of the first
+message. Reapply every criterion **before the first material action** when any
+of these boundaries is crossed, even inside the same agent turn:
+
+- the partner answers a required scope, direction, or approval question;
+- investigation or critique turns into an implementation request;
+- a bounded task reveals a durable multi-stage branch, merge surprise, or
+  substantially broader scope; or
+- a later instruction adds independently verifiable outcomes to work already
+  underway.
+
+An unanswered question may correctly prevent promotion because meaningful work
+cannot begin yet. Its answer removes that blocker; it is not a reason to keep
+the newly approved implementation ordinary. Likewise, discovery can make a
+request Goal-shaped after several standard steps. Promote at that boundary
+before editing or launching the expanded branch—do not wait for another user
+message and do not rewrite completed work as if the Goal existed earlier.
+
+Do not infer a Goal from message length, words such as “thoroughly” or
+“production-ready,” a multi-file edit, or the mere fact that a useful task list
+could be written. Keep bounded work that can honestly finish in one turn as a
+standard prompt. Use schedules for recurring background work. Honor “just
+answer,” “one pass,” and “don't make this a Goal” as explicit opt-outs.
+
+Examples:
+
+- **Goal:** “Migrate every caller to the new API, update the documentation, and
+  keep working until the complete test suite passes.”
+- **Goal:** “Address all issues you discover in this checkout flow, including
+  substantial nested work, then run a production-readiness audit.”
+- **Standard prompt:** “Explain why this failed and recommend what to do.”
+- **Standard prompt:** “Add a loading state to this button and test it.”
+
+When the criteria hold, promote the current physical turn before material work.
+Call the platform's first-class `promote_goal` tool when it is available; its
+single `objective` argument is the concise outcome and observable completion
+condition. The helper is resilience, not an equivalent convenience path: use
+it only when the tool is absent from the callable inventory or an attempted
+tool call returns a failure:
 
 ```bash
 python3 /data/platform/backend/scripts/goal_promote.py \
   'Concise outcome and observable completion condition'
 ```
 
-Run that helper as its own command. It attaches the already-running turn to
-Möbius's provider-neutral Goal state and verifies the committed identity; it
-does not add a hidden message or start a second turn. Do not call a
+Run the helper as its own command. The tool and helper attach the already-running
+turn to Möbius's provider-neutral Goal state and verify the committed identity;
+neither adds a hidden message nor starts a second turn. Do not call a
 provider-private `create_goal` from an ordinary turn, queue a synthetic `/goal`,
-or claim activation before the helper succeeds. Explicit `/goal` remains
+or claim activation before the operation succeeds. Explicit `/goal` remains
 authoritative.
-
-If an ordinary turn begins bounded but discovery later reveals substantial
-durable work that now meets every criterion, promote at that point before
-starting the newly discovered branch. Do not rewrite completed work as if the
-Goal existed earlier.
 
 ## Decide whether the Goal earns a plan
 

--- a/backend/tests/test_chat_skills_context.py
+++ b/backend/tests/test_chat_skills_context.py
@@ -170,6 +170,30 @@ def test_core_prompt_requires_approval_before_changing_guarded_invariants():
   assert "preserves the same contract does not require escalation" in normalized
 
 
+def test_goal_routing_rechecks_phase_transitions_and_prefers_platform_tool():
+  repo = Path(__file__).resolve().parents[2]
+  core = (repo / "skill" / "core.md").read_text(encoding="utf-8")
+  planning = (
+    repo / "backend" / "scripts" / "seed-skills" / "goal-planning.md"
+  ).read_text(encoding="utf-8")
+  core_normalized = " ".join(core.split())
+  planning_normalized = " ".join(planning.split())
+
+  assert "Before the first material tool call" in core_normalized
+  assert "labels such as “synthetic,” “fixture,” or “test”" in core_normalized
+  assert "after an owner choice resolves" in core_normalized
+  assert "not merely at the next user message" in core_normalized
+  assert "`promote_goal` tool when available" in core_normalized
+  assert "### Recheck when the work changes phase" in planning
+  assert "before the first material action" in planning_normalized
+  assert "for **every** ordinary top-level delegated outcome" in planning_normalized
+  assert "not a keyword trigger" in planning_normalized
+  assert "Its answer removes that blocker" in planning_normalized
+  assert "first-class `promote_goal` tool" in planning_normalized
+  assert "resilience, not an equivalent convenience path" in planning_normalized
+  assert "an attempted tool call returns a failure" in planning_normalized
+
+
 def test_core_prompt_distinguishes_durable_delegation_and_owner_led_contribution():
   repo = Path(__file__).resolve().parents[2]
   core = (repo / "skill" / "core.md").read_text(encoding="utf-8")

--- a/backend/tests/test_claude_sdk_runner.py
+++ b/backend/tests/test_claude_sdk_runner.py
@@ -1159,6 +1159,61 @@ def test_dispatch_thinking_delta_emits_thinking(monkeypatch):
   }]
 
 
+def test_control_mcp_readiness_waits_for_promote_goal_tool():
+  from app import claude_sdk_runner
+
+  class _Client:
+    def __init__(self):
+      self.calls = 0
+
+    async def get_mcp_status(self):
+      self.calls += 1
+      if self.calls == 1:
+        return {"mcpServers": [{
+          "name": "mobius_control",
+          "status": "pending",
+        }]}
+      return {"mcpServers": [{
+        "name": "mobius_control",
+        "status": "connected",
+        "tools": [{"name": "promote_goal"}],
+      }]}
+
+  client = _Client()
+  assert asyncio.run(
+    claude_sdk_runner._await_control_mcp_ready(client, enabled=True)
+  ) is None
+  assert client.calls == 2
+
+
+def test_control_mcp_readiness_reports_terminal_failure_without_retrying():
+  from app import claude_sdk_runner
+
+  class _Client:
+    async def get_mcp_status(self):
+      return {"mcpServers": [{
+        "name": "mobius_control",
+        "status": "failed",
+        "error": "stdio child exited",
+      }]}
+
+  assert asyncio.run(
+    claude_sdk_runner._await_control_mcp_ready(_Client(), enabled=True)
+  ) == "failed: stdio child exited"
+
+
+def test_control_mcp_readiness_is_absent_for_restricted_turns():
+  from app import claude_sdk_runner
+
+  class _Client:
+    async def get_mcp_status(self):
+      raise AssertionError("restricted turns must not inspect owner controls")
+
+  assert asyncio.run(
+    claude_sdk_runner._await_control_mcp_ready(_Client(), enabled=False)
+  ) is None
+
+
 def test_claude_thinking_config_requests_summarized_adaptive_thinking():
   assert claude_sdk_runner._claude_thinking_config("claude-opus-4-8") == {
     "type": "adaptive",

--- a/backend/tests/test_codex_sdk_runner.py
+++ b/backend/tests/test_codex_sdk_runner.py
@@ -3967,7 +3967,13 @@ def test_run_codex_sdk_turn_controls_prompt_layers(monkeypatch, session_id):
   )
   assert captured["thread_options"]["developer_instructions"] == ""
   assert captured["thread_options"]["personality"] == "none"
-  assert captured["thread_options"]["config"] == connector_plan.codex_config
+  thread_mcp = captured["thread_options"]["config"]["mcp_servers"]
+  assert thread_mcp["search"] == (
+    connector_plan.codex_config["mcp_servers"]["search"]
+  )
+  assert thread_mcp["mobius_control"]["args"][0].endswith(
+    "/scripts/mobius_control_mcp.py"
+  )
   process_env = captured["process_config"].kwargs["env"]
   assert process_env["MOBIUS_CONNECTOR_3_SEARCH"] == "private-key"
   assert "private-key" not in repr(captured["thread_options"]["config"])

--- a/backend/tests/test_goal_plans.py
+++ b/backend/tests/test_goal_plans.py
@@ -50,6 +50,104 @@ def _agent_run_auth(db, chat_id, run_id):
   return {"Authorization": f"Bearer {token}"}
 
 
+def test_terminal_goal_history_projects_onto_final_assistant_message(
+  client, owner_token, db,
+):
+  auth = {"Authorization": f"Bearer {owner_token}"}
+  base = datetime(2026, 8, 23, 12, 0, tzinfo=UTC)
+  created = client.post(
+    "/api/chats",
+    json={
+      "title": "Goal history",
+      "messages": [
+        {"role": "user", "content": "start", "ts": 1_787_486_400_000},
+        {"role": "assistant", "content": "first leg", "ts": 1_787_486_401_000},
+        {"role": "user", "content": "continue", "ts": 1_787_486_410_000},
+        {"role": "assistant", "content": "finished", "ts": 1_787_486_411_000},
+      ],
+    },
+    headers=auth,
+  )
+  chat_id = created.json()["id"]
+  db.add_all([
+    models.ChatRun(
+      id="history-root", root_run_id="history-root", chat_id=chat_id,
+      status="completed", provider="codex", goal_objective="Ship safely",
+      goal_id="history-goal", started_at=base,
+      ended_at=base + timedelta(seconds=5),
+      goal_plan_json={
+        "version": 1,
+        "updated_at": base.isoformat(),
+        "tasks": [{
+          "id": "ship", "title": "Ship safely", "status": "completed",
+          "depends_on": [],
+        }],
+      },
+      goal_plan_revision=1,
+    ),
+    models.ChatRun(
+      id="history-resume", root_run_id="history-root", chat_id=chat_id,
+      status="completed", provider="codex", goal_objective="Ship safely",
+      goal_id="history-goal", started_at=base + timedelta(seconds=10),
+      ended_at=base + timedelta(seconds=15),
+    ),
+  ])
+  db.commit()
+
+  response = client.get(f"/api/chats/{chat_id}?limit=20", headers=auth)
+  assert response.status_code == 200, response.text
+  messages = response.json()["messages"]
+  assert "goal_summaries" not in messages[1]
+  summary = messages[3]["goal_summaries"][0]
+  assert summary["id"] == "history-goal"
+  assert summary["objective"] == "Ship safely"
+  assert summary["status"] == "completed"
+  assert summary["duration_seconds"] == 15
+  assert summary["plan"]["summary"] == {
+    "completed": 1,
+    "total": 1,
+    "running": [],
+    "ready": [],
+    "can_complete": True,
+    "completion_blockers": [],
+  }
+
+
+def test_terminal_goal_history_respects_message_pagination(
+  client, owner_token, db,
+):
+  auth = {"Authorization": f"Bearer {owner_token}"}
+  base = datetime(2026, 8, 23, 13, 0, tzinfo=UTC)
+  created = client.post(
+    "/api/chats",
+    json={
+      "title": "Paginated goal history",
+      "messages": [
+        {"role": "user", "content": "older", "ts": 1_787_490_000_000},
+        {"role": "assistant", "content": "done", "ts": 1_787_490_001_000},
+        {"role": "user", "content": "newer", "ts": 1_787_490_010_000},
+      ],
+    },
+    headers=auth,
+  )
+  chat_id = created.json()["id"]
+  db.add(models.ChatRun(
+    id="old-goal-run", root_run_id="old-goal-run", chat_id=chat_id,
+    status="completed", provider="claude", goal_objective="Old Goal",
+    goal_id="old-goal", started_at=base,
+    ended_at=base + timedelta(seconds=3),
+  ))
+  db.commit()
+
+  latest = client.get(f"/api/chats/{chat_id}?limit=1", headers=auth).json()
+  assert latest["offset"] == 2
+  assert "goal_summaries" not in latest["messages"][0]
+  older = client.get(
+    f"/api/chats/{chat_id}?limit=2&before=2", headers=auth,
+  ).json()
+  assert older["messages"][1]["goal_summaries"][0]["id"] == "old-goal"
+
+
 def test_current_turn_promotes_atomically_without_a_goal_message(
   client, owner_token, db,
 ):

--- a/backend/tests/test_goal_promote.py
+++ b/backend/tests/test_goal_promote.py
@@ -95,6 +95,7 @@ def test_promotion_requires_the_current_physical_run(monkeypatch):
   monkeypatch.setenv("API_BASE_URL", "http://mobius.test")
   monkeypatch.setenv("AGENT_TOKEN", "owner-token")
   monkeypatch.setenv("CHAT_ID", "chat-1")
+  monkeypatch.delenv("MOBIUS_RUN_TOKEN", raising=False)
 
   with pytest.raises(SystemExit, match="MOBIUS_RUN_TOKEN"):
     helper.promote_goal("Ship and verify")

--- a/backend/tests/test_memory_boot.py
+++ b/backend/tests/test_memory_boot.py
@@ -134,6 +134,9 @@ def test_controlled_skills_have_fix_forward_migrations():
   assert module._UNMODIFIED_MIGRATIONS["goal-planning.md"] == {
     "2adb39457e0ec2ee9d9a3596cb96e5a6240bae23d725e6459ba0f6e77d5474c4",
     "a3edc5fcc453a5305102e144c2d58ae16b828612ac93a6a7442be7e267779f59",
+    "bca228c745881bfffdad5d7adaab3c62871e6f62801252784fb0522787cfb850",
+    "0c2b88ff8a79ff05f75ebaa60af2899f0b9ed27d0a23bfff83b54f4e2a1de97a",
+    "7a80e90870f75be7c8802f421e76ac21790f1ef812d4a4d0d923d474e5dadd2d",
   }
   assert "1086688efd4dede48ebc95b12b92fb958280e67896a53e52e02cd5def3aa265f" in (
     module._UNMODIFIED_MIGRATIONS["reflection.md"]

--- a/backend/tests/test_platform_tools.py
+++ b/backend/tests/test_platform_tools.py
@@ -1,0 +1,82 @@
+"""Provider-neutral Möbius controls are exposed consistently and safely."""
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from app import platform_tools
+
+
+def test_control_server_configs_share_one_script_and_no_secret_arguments():
+  claude = platform_tools.claude_control_servers(enabled=True)
+  codex = platform_tools.codex_turn_mcp_config(None, control_enabled=True)
+
+  claude_server = claude[platform_tools.CONTROL_SERVER_NAME]
+  codex_server = codex["mcp_servers"][platform_tools.CONTROL_SERVER_NAME]
+  assert claude_server["command"] == sys.executable
+  assert codex_server["command"] == sys.executable
+  assert claude_server["args"] == codex_server["args"]
+  assert claude_server["args"][0].endswith("/scripts/mobius_control_mcp.py")
+  assert "env" not in claude_server
+  assert "env" not in codex_server
+  assert "env_vars" not in claude_server
+  assert codex_server["env_vars"] == list(platform_tools.CONTROL_ENV_VARS)
+  assert set(codex_server["env_vars"]) == {
+    "API_BASE_URL", "AGENT_TOKEN", "CHAT_ID", "MOBIUS_RUN_TOKEN",
+  }
+
+
+def test_codex_control_merges_without_mutating_remote_connector_snapshot():
+  remote = {"mcp_servers": {"search": {"url": "https://mcp.example/mcp"}}}
+  plan = SimpleNamespace(codex_config=remote)
+
+  merged = platform_tools.codex_turn_mcp_config(plan, control_enabled=True)
+
+  assert set(merged["mcp_servers"]) == {"search", "mobius_control"}
+  assert remote == {
+    "mcp_servers": {"search": {"url": "https://mcp.example/mcp"}},
+  }
+  assert platform_tools.codex_turn_mcp_config(
+    None, control_enabled=False,
+  ) is None
+
+
+def _control_module():
+  path = (
+    Path(__file__).resolve().parents[1] / "scripts" / "mobius_control_mcp.py"
+  )
+  spec = importlib.util.spec_from_file_location("mobius_control_mcp_test", path)
+  module = importlib.util.module_from_spec(spec)
+  spec.loader.exec_module(module)
+  return module
+
+
+def test_promote_goal_tool_returns_verified_platform_identity(monkeypatch):
+  control = _control_module()
+  monkeypatch.setattr(control._GOALS, "promote_goal", lambda objective: {
+    "state": "promoted",
+    "objective": objective,
+    "root_run_id": "goal-1",
+    "run_id": "run-1",
+  })
+
+  assert control._promote_goal("Ship and verify") == {
+    "state": "promoted",
+    "objective": "Ship and verify",
+    "goal_id": "goal-1",
+    "run_id": "run-1",
+  }
+
+
+def test_promote_goal_tool_preserves_helper_rejection(monkeypatch):
+  control = _control_module()
+
+  def reject(_objective):
+    raise SystemExit("goal promotion failed: wrong physical run")
+
+  monkeypatch.setattr(control._GOALS, "promote_goal", reject)
+  with pytest.raises(RuntimeError, match="wrong physical run"):
+    control._promote_goal("Ship and verify")

--- a/frontend/src/components/ChatView/ChatView.css
+++ b/frontend/src/components/ChatView/ChatView.css
@@ -3336,6 +3336,102 @@
   scrollbar-width: thin;
 }
 
+.chat__goal-history {
+  display: grid;
+  grid-template-columns: 22px minmax(0, 1fr);
+  gap: 10px;
+  margin-top: 14px;
+  padding: 12px 14px;
+  border: 1px solid color-mix(in srgb, var(--green) 30%, var(--border-light));
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--green) 6%, var(--surface));
+}
+
+.chat__goal-history--failed {
+  border-color: color-mix(in srgb, var(--danger) 28%, var(--border-light));
+  background: color-mix(in srgb, var(--danger) 5%, var(--surface));
+}
+
+.chat__goal-history-marker {
+  position: relative;
+  width: 18px;
+  height: 18px;
+  margin-top: 1px;
+  border-radius: 50%;
+  background: var(--green);
+}
+
+.chat__goal-history-marker::after {
+  content: '';
+  position: absolute;
+  left: 6px;
+  top: 3px;
+  width: 4px;
+  height: 8px;
+  border-right: 2px solid var(--bg);
+  border-bottom: 2px solid var(--bg);
+  transform: rotate(45deg);
+}
+
+.chat__goal-history--failed .chat__goal-history-marker {
+  background: var(--danger);
+}
+
+.chat__goal-history--failed .chat__goal-history-marker::after {
+  content: '!';
+  inset: 0;
+  width: auto;
+  height: auto;
+  border: 0;
+  color: white;
+  font-size: 12px;
+  font-weight: 800;
+  line-height: 18px;
+  text-align: center;
+  transform: none;
+}
+
+.chat__goal-history-copy {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.chat__goal-history-kicker {
+  color: var(--green);
+  font-size: 11px;
+  font-weight: 750;
+  letter-spacing: 0.055em;
+  text-transform: uppercase;
+}
+
+.chat__goal-history--failed .chat__goal-history-kicker { color: var(--danger); }
+
+.chat__goal-history-objective {
+  color: var(--text);
+  font-size: 13px;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
+}
+
+.chat__goal-history-meta {
+  color: var(--muted);
+  font-size: 11px;
+}
+
+.chat__goal-history-details { margin-top: 5px; }
+
+.chat__goal-history-details > summary {
+  width: fit-content;
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.chat__goal-history-details[open] > summary { color: var(--text); }
+
 .chat__goal-task {
   display: grid;
   grid-template-columns: 14px minmax(0, 1fr);

--- a/frontend/src/components/ChatView/GoalHistoryCard.jsx
+++ b/frontend/src/components/ChatView/GoalHistoryCard.jsx
@@ -1,0 +1,31 @@
+/* GoalHistoryCard keeps a terminal Goal's outcome beside its final answer. */
+
+import GoalPlanDetails from './GoalPlanDetails.jsx'
+import { goalHistoryViewModel } from './goalHistory.js'
+
+export default function GoalHistoryCard({ summary }) {
+  const view = goalHistoryViewModel(summary)
+  if (!view) return null
+
+  return (
+    <aside
+      className={`chat__goal-history chat__goal-history--${view.completed ? 'completed' : 'failed'}`}
+      aria-label={view.ariaLabel}
+    >
+      <span className="chat__goal-history-marker" aria-hidden="true" />
+      <div className="chat__goal-history-copy">
+        <span className="chat__goal-history-kicker">
+          {view.kicker}
+        </span>
+        <strong className="chat__goal-history-objective">{view.objective}</strong>
+        {view.metadata && <span className="chat__goal-history-meta">{view.metadata}</span>}
+        {view.hasPlan && (
+          <details className="chat__goal-history-details">
+            <summary>View plan</summary>
+            <GoalPlanDetails plan={summary.plan} />
+          </details>
+        )}
+      </div>
+    </aside>
+  )
+}

--- a/frontend/src/components/ChatView/MsgContent.jsx
+++ b/frontend/src/components/ChatView/MsgContent.jsx
@@ -21,6 +21,7 @@ import ContextCompactionMarker from './ContextCompactionMarker.jsx'
 import { assistantBlockKey } from './streamPromotion.js'
 import { copyAssistantSelection } from './markdownClipboard.js'
 import { goalMessageObjectiveFromText } from './goalProgress.js'
+import GoalHistoryCard from './GoalHistoryCard.jsx'
 
 
 // Answerability is purely a function of the block + its position + live hint.
@@ -78,6 +79,13 @@ function UserMessageText({ text }) {
       <span className="chat__goal-message-objective">{goalObjective}</span>
     </span>
   )
+}
+
+function GoalHistory({ msg }) {
+  if (msg.role !== 'assistant' || !Array.isArray(msg.goal_summaries)) return null
+  return msg.goal_summaries.map(summary => (
+    <GoalHistoryCard key={summary.id} summary={summary} />
+  ))
 }
 
 function MsgContentInner({
@@ -441,6 +449,7 @@ function MsgContentInner({
             disclosureKey={`${messageKey}:references`}
           />
         )}
+        {!isStreaming && <GoalHistory msg={msg} />}
       </AssistantCopySurface>
     )
   }
@@ -473,6 +482,7 @@ function MsgContentInner({
             : msg.role === 'user' ? <UserMessageText text={text} /> : text}
         </div>
       ) : null}
+      {!isStreaming && <GoalHistory msg={msg} />}
     </AssistantCopySurface>
   )
 }

--- a/frontend/src/components/ChatView/__tests__/goalHistoryCard.test.js
+++ b/frontend/src/components/ChatView/__tests__/goalHistoryCard.test.js
@@ -1,0 +1,42 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { formatGoalDuration, goalHistoryViewModel } from '../goalHistory.js'
+
+test('Goal history formats useful elapsed time compactly', () => {
+  assert.equal(formatGoalDuration(14.6), '15s')
+  assert.equal(formatGoalDuration(125), '2m 5s')
+  assert.equal(formatGoalDuration(7260), '2h 1m')
+})
+
+test('Goal history summarizes a terminal outcome and its plan', () => {
+  assert.deepEqual(goalHistoryViewModel({
+    objective: ' Ship the Goal experience ',
+    status: 'completed',
+    duration_seconds: 125,
+    plan: {
+      summary: { completed: 3, total: 3 },
+      tasks: [{ id: 'verify', title: 'Verify', status: 'completed' }],
+    },
+  }), {
+    objective: 'Ship the Goal experience',
+    completed: true,
+    kicker: 'Goal completed',
+    ariaLabel: 'Completed goal: Ship the Goal experience',
+    metadata: '3 of 3 steps complete · 2m 5s',
+    hasPlan: true,
+  })
+})
+
+test('Goal history rejects active snapshots and labels failed outcomes', () => {
+  assert.equal(goalHistoryViewModel({ objective: 'Still working', status: 'active' }), null)
+  assert.deepEqual(goalHistoryViewModel({
+    objective: 'Needs repair', status: 'failed', duration_seconds: null,
+  }), {
+    objective: 'Needs repair',
+    completed: false,
+    kicker: 'Goal needs attention',
+    ariaLabel: 'Goal needing attention: Needs repair',
+    metadata: '',
+    hasPlan: false,
+  })
+})

--- a/frontend/src/components/ChatView/goalHistory.js
+++ b/frontend/src/components/ChatView/goalHistory.js
@@ -1,0 +1,35 @@
+/* Pure presentation helpers for terminal Goal transcript summaries. */
+
+export function formatGoalDuration(seconds) {
+  const total = Math.max(0, Math.round(Number(seconds) || 0))
+  if (total < 60) return `${total}s`
+  const minutes = Math.floor(total / 60)
+  const remainder = total % 60
+  if (minutes < 60) return remainder ? `${minutes}m ${remainder}s` : `${minutes}m`
+  const hours = Math.floor(minutes / 60)
+  const minuteRemainder = minutes % 60
+  return minuteRemainder ? `${hours}h ${minuteRemainder}m` : `${hours}h`
+}
+
+export function goalHistoryViewModel(summary) {
+  const objective = String(summary?.objective || '').trim()
+  if (!objective || !['completed', 'failed'].includes(summary?.status)) return null
+  const completed = summary.status === 'completed'
+  const done = summary?.plan?.summary?.completed
+  const total = summary?.plan?.summary?.total
+  const progress = Number.isInteger(done) && Number.isInteger(total)
+    ? `${done} of ${total} steps complete`
+    : null
+  const duration = summary.duration_seconds != null
+    && Number.isFinite(Number(summary.duration_seconds))
+    ? formatGoalDuration(summary.duration_seconds)
+    : null
+  return {
+    objective,
+    completed,
+    kicker: completed ? 'Goal completed' : 'Goal needs attention',
+    ariaLabel: `${completed ? 'Completed goal' : 'Goal needing attention'}: ${objective}`,
+    metadata: [progress, duration].filter(Boolean).join(' · '),
+    hasPlan: Array.isArray(summary?.plan?.tasks) && summary.plan.tasks.length > 0,
+  }
+}

--- a/skill/core.md
+++ b/skill/core.md
@@ -104,16 +104,22 @@ Then triage the prompt into one of three tiers:
   clarifying-question tool, and wait for a pick. Recommendations in prose alone
   do not count as waiting.
 
-**Automatic Goal routing.** Before material work on an ordinary top-level
-partner request that delegates an outcome, create a Goal only when completion
-is observable and durability materially helps (multiple stages/turns,
-repetition, discovery, parallel work,
-or restart risk), and work can begin without an owner choice or external event.
-When those criteria hold, before material work read `goal-planning`, then run
-`python3 /data/platform/backend/scripts/goal_promote.py '<objective>'`. Never use a
-provider-private Goal or synthetic `/goal` message.
-If discovery makes the criteria true only later, promote promptly before
-starting the newly discovered durable branch.
+**Automatic Goal routing.** Before the first material tool call for every
+ordinary top-level delegated outcome, make a turn-local Goal-routing decision;
+do not let apparent ease, likely one-turn completion, or labels such as
+“synthetic,” “fixture,” or “test” skip that checkpoint. Recheck again before
+the first material action after an owner choice resolves, an investigation
+becomes implementation, or bounded work expands. Create a Goal
+only when completion is observable and durability materially helps (multiple
+stages/turns, repetition, discovery, parallel work, or restart risk), and work
+can begin without an owner choice or external event. When those criteria hold,
+before material work read `goal-planning`, then call the platform
+`promote_goal` tool when available; otherwise run
+`python3 /data/platform/backend/scripts/goal_promote.py '<objective>'`. Never use
+a provider-private Goal or synthetic `/goal` message. A question or approval
+gate defers the decision; once resolved, re-evaluate before implementing. If
+discovery makes the criteria true later, promote before the newly durable
+branch—not merely at the next user message.
 Keep questions, explanations, and honestly bounded one-turn work standard.
 Delegated subagents remain bounded tasks rather than starting their own Goals.
 Explicit `/goal` and explicit opt-outs remain authoritative.


### PR DESCRIPTION
## Summary

- expose Goal promotion as the same run-bound platform tool to ordinary Claude and Codex turns while keeping it unavailable to delegated agents
- make Goal routing an explicit start-of-work and phase-transition decision, with the script retained only as a fallback
- wait for Claude tool readiness and pass only the required run-bound environment names to Codex
- attach a compact completed or failed Goal summary, duration, and optional plan to the assistant message that concluded it

## Testing

- `scripts/wt-pytest.sh backend/tests/test_platform_tools.py backend/tests/test_claude_sdk_runner.py backend/tests/test_codex_sdk_runner.py backend/tests/test_goal_plans.py backend/tests/test_chat_skills_context.py backend/tests/test_memory_boot.py -q` — 251 passed
- `scripts/test.sh --fast` — 83 passed
- `npm test` — frontend library and hook suites passed
- `npm run lint` — passed within the existing warning budget
- `npm run build` — production and service-worker builds passed
- live Claude and Codex positive, negative, and post-clarification scenarios exercised the first-class promotion tool; restart continuation and completed-Goal rendering were also verified