### PR TITLE
Clarify the container testing boundary

### DIFF
--- a/backend/scripts/init_skills.py
+++ b/backend/scripts/init_skills.py
@@ -61,6 +61,12 @@ RETIRED_SKILLS = DATA_DIR / "shared" / "retired-skills"
 # touched. A set preserves every known unmodified predecessor when one skill
 # needs more than one fix-forward migration over its lifetime.
 _UNMODIFIED_MIGRATIONS = {
+  "platform-maintenance.md": {
+    # Baked copies before the container-boundary guidance. Both hashes are
+    # released, untouched generations; owner-edited copies remain protected.
+    "bcc617354747c49ddad7fa1f419cf921fd7280909358096323cdbc427ad063c3",
+    "b591d15e335c72c0acf394ca7ce4b0daa633e124a487df7a713847cafc13ab6d",
+  },
   "goal-planning.md": {
     # First dependency-aware Goal-plan seed. Replace only the untouched copy
     # so existing instances learn the completion preflight without clobbering

--- a/backend/scripts/seed-skills/platform-maintenance.md
+++ b/backend/scripts/seed-skills/platform-maintenance.md
@@ -21,6 +21,31 @@ not part of the agent's authority. Package changes made only in a running
 container are ephemeral; declare them in the Dockerfile or lockfile and ship a
 new image when they must survive recreation.
 
+### Container root stops at the container boundary
+
+The normal Möbius app container intentionally has no Docker daemon or CLI and
+does not mount the host's Docker socket. `sudo` grants root inside that
+container only. Treat Docker's absence there as an expected trust boundary,
+not a broken dependency. Do not install a Docker CLI, start Docker-in-Docker,
+or request a host-socket mount for agent tests: the CLI alone has no daemon,
+while a socket or privileged daemon would cross into operator-owned host
+authority and would not work consistently on managed deployments.
+
+This boundary is not a reason to hide or skip validation. Inside Möbius:
+
+- run `scripts/test.sh --fast` for the cheap hermetic contracts and
+  `scripts/wt-pytest.sh <focused tests>` for the changed behavior;
+- if the worktree runner says the checkout lock differs from the image
+  runtime, treat those results as useful but not dependency-authoritative and
+  use a lock-matched environment or hosted checks for that contract; and
+- for concurrency or ordering, persistence, auth or security, migrations,
+  provider protocols, dependency/runtime changes, or broad cross-cutting work,
+  explicitly recommend Contribute's **Run GitHub checks** before **Send PR**.
+
+`scripts/test.sh --backend` remains for a Docker-capable contributor host. The
+hosted pre-PR workflow gives early full-suite evidence for the exact reviewed
+commit, and the merge queue remains the unconditional authoritative gate.
+
 Recovery is not a daemon, listener, alternate boot mode, or second process
 inside Möbius. If the interface is unavailable, ask the partner to open
 **Recovery** from the deployment card in Möbius Launch. The launcher creates a

--- a/backend/tests/test_memory_boot.py
+++ b/backend/tests/test_memory_boot.py
@@ -131,6 +131,10 @@ def test_later_boot_migrates_only_unmodified_graph_aware_base_skill(
 def test_controlled_skills_have_fix_forward_migrations():
   module = _load("init_skills")
 
+  assert module._UNMODIFIED_MIGRATIONS["platform-maintenance.md"] == {
+    "bcc617354747c49ddad7fa1f419cf921fd7280909358096323cdbc427ad063c3",
+    "b591d15e335c72c0acf394ca7ce4b0daa633e124a487df7a713847cafc13ab6d",
+  }
   assert module._UNMODIFIED_MIGRATIONS["goal-planning.md"] == {
     "2adb39457e0ec2ee9d9a3596cb96e5a6240bae23d725e6459ba0f6e77d5474c4",
     "a3edc5fcc453a5305102e144c2d58ae16b828612ac93a6a7442be7e267779f59",

--- a/backend/tests/test_test_entrypoint.py
+++ b/backend/tests/test_test_entrypoint.py
@@ -27,7 +27,9 @@ def test_fast_mode_uses_host_runtime_before_any_docker_preflight():
 
 def test_full_backend_keeps_the_isolated_container_contract():
   source = SCRIPT.read_text()
-  assert "Docker is not available in this runtime" in source
+  assert "normal Möbius app container" in source
+  assert "intentional trust boundary" in source
+  assert "Run GitHub checks" in source
   assert "docker compose -p \"${TEST_PROJECT}\"" in source
   assert "docker-compose.test.yml run --rm --no-deps" in source
 
@@ -36,3 +38,10 @@ def test_host_runner_checks_backend_node_surface_not_full_frontend_tree():
   source = HOST_RUNNER.read_text()
   assert "backend_test_node_deps \"$ROOT/frontend\"" in source
   assert "npm ls --depth=0" not in source
+
+
+def test_image_runtime_reports_when_its_python_lock_differs():
+  source = HOST_RUNNER.read_text()
+  assert 'cmp -s "$ROOT/backend/requirements.lock" /app/requirements.lock' in source
+  assert "checkout requirements.lock differs from the image runtime" in source
+  assert "not dependency-authoritative" in source

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -75,8 +75,11 @@ EOF
 # run` chew through a 3-minute build with no explanation.
 check_backend_prereqs() {
   if ! command -v docker >/dev/null 2>&1; then
-    die "Docker is not available in this runtime. Use --fast for local iteration;
-    run --backend on a Docker-capable host or rely on the complete CI gate."
+    die "Docker is unavailable. In the normal Möbius app container this is an
+    intentional trust boundary: no daemon or host socket is exposed. Use
+    --fast plus focused scripts/wt-pytest.sh tests for local evidence; run
+    --backend on a Docker-capable host, use Contribute's Run GitHub checks for
+    early full coverage, or rely on the merge queue's complete gate."
   fi
   if ! docker compose version >/dev/null 2>&1; then
     die "Docker Compose is not available. Install the compose plugin before --backend."

--- a/scripts/wt-pytest.sh
+++ b/scripts/wt-pytest.sh
@@ -106,6 +106,11 @@ elif python3 -c 'import pytest' >/dev/null 2>&1; then
   # interpreter through the wrapper is not the guarded direct-pytest path.
   PYTHON="$(command -v python3)"
   echo "wt-pytest: shared venv absent; using the image's Python test runtime" >&2
+  if [ -r /app/requirements.lock ] \
+      && ! cmp -s "$ROOT/backend/requirements.lock" /app/requirements.lock; then
+    echo "wt-pytest: WARNING — checkout requirements.lock differs from the image runtime" >&2
+    echo "wt-pytest: results are useful but not dependency-authoritative; use a lock-matched venv or hosted checks" >&2
+  fi
 else
   echo "wt-pytest: neither shared venv nor image pytest is available" >&2
   echo "  create the shared venv once with:" >&2


### PR DESCRIPTION
## Problem

The normal Möbius app container intentionally has root inside its own boundary but no Docker CLI, daemon, or host socket. The full backend test entrypoint currently reports Docker as simply unavailable, which repeatedly makes the expected boundary look like a broken dependency. Focused host tests can also use the image's Python packages even when the reviewed checkout carries a different dependency lock, without saying that the result is not authoritative for dependency behavior.

## Change

- document why container root does not imply Docker or host authority, and explicitly avoid Docker-in-Docker or a host-socket mount
- define one risk-based evidence ladder: focused and fast local checks, a lock-matched hosted run when early full-suite evidence is warranted, and the merge queue as the unconditional final gate
- make the full-suite error point to the existing supported paths instead of implying the container is misconfigured
- warn when the worktree dependency lock differs from the image runtime
- migrate only byte-for-byte untouched copies of the seeded maintenance guidance

This builds on #335, which established the small hermetic host suite and explicit Docker gate, and #702, which made manual dispatch and the merge queue the complete-suite paths. It clarifies how agents should choose among those existing mechanisms rather than adding another test system.

## Verification

- bash -n scripts/test.sh scripts/wt-pytest.sh
- focused entrypoint and skill-migration tests: 19 passed
- scripts/test.sh --fast: 84 passed
- git diff --check