### PR TITLE
Keep owner questions authoritative across recovery

### DIFF
--- a/backend/app/chat.py
+++ b/backend/app/chat.py
@@ -76,6 +76,7 @@ from app.chat_logging import (
 from app.chat_writer import (
   AppendPending,
   Barrier,
+  CancelPending,
   ClearPending,
   FinishRun,
   Finalize,
@@ -1027,7 +1028,11 @@ async def sweep_idle_pending_chats(db: Session) -> list[str]:
     # the rows were released. The queue is the candidate index; load one full
     # Chat only after its projected pending head proves old enough to recover.
     candidates = (
-      db.query(models.Chat.id, models.Chat.pending_messages)
+      db.query(
+        models.Chat.id,
+        models.Chat.pending_messages,
+        models.Chat.pending_question_id,
+      )
       .filter(models.Chat.deleted_at.is_(None))
       .all()
     )
@@ -1040,6 +1045,8 @@ async def sweep_idle_pending_chats(db: Session) -> list[str]:
     chat_id = candidate.id
     pending = list(candidate.pending_messages or [])
     if not _pending_head_is_stale(pending, now_ms):
+      continue
+    if candidate.pending_question_id is not None:
       continue
     # A limit-parked queue is NOT abandoned work: LIMIT_PARKED preserves
     # pending precisely so it is not fired back into the exhausted limit
@@ -1069,6 +1076,7 @@ async def sweep_idle_pending_chats(db: Session) -> list[str]:
             if (
               has_running_run(db, chat_id)
               or not _pending_head_is_stale(pending, now_ms)
+              or chat.pending_question_id is not None
               or _parked_until_for_chat(db, chat_id) is not None
               or _restart_manual_hold_for_chat(db, chat_id)
               or not mark_starting(chat_id)
@@ -1103,6 +1111,12 @@ async def sweep_idle_pending_chats(db: Session) -> list[str]:
       if claimed:
         discard_starting(chat_id)
       raise
+    except chat_queue.PendingQuestionBlocksPromotion:
+      if claimed:
+        discard_starting(chat_id)
+      # The actor closed a check-to-commit race by observing a question that
+      # opened after the locked preflight. Leaving the queue untouched is the
+      # intended outcome, not a failed recovery attempt.
     except Exception:
       if claimed:
         discard_starting(chat_id)
@@ -1627,6 +1641,11 @@ async def _auto_resume_chat(
           if not mark_starting(chat_id):
             return False
           claimed = True
+          continuation_cid = (
+            f"restart-resume-{park_token or chat_id}"
+            if resume_reason == "restart"
+            else f"limit-resume-{park_token or chat_id}"
+          )
           ack = get_writer().submit(
             AppendPending(
               chat_id=chat_id,
@@ -1639,22 +1658,31 @@ async def _auto_resume_chat(
                 "continuation_reason": resume_reason,
                 # A retry after AppendPending succeeded but a later step failed
                 # must not enqueue a second synthetic continuation.
-                "cid": (
-                  f"restart-resume-{park_token or chat_id}"
-                  if resume_reason == "restart"
-                  else f"limit-resume-{park_token or chat_id}"
-                ),
+                "cid": continuation_cid,
               },
               initiated_by_app_id=resume_app_id,
             )
           )
           await _await_ack(ack)
           drain_token = alloc_run_token()
-          next_messages, next_user, next_session_id = (
-            await chat_queue.promote_pending_messages_locked(
-              None, chat_id, drain_token,
+          try:
+            next_messages, next_user, next_session_id = (
+              await chat_queue.promote_pending_messages_locked(
+                None, chat_id, drain_token,
+              )
             )
-          )
+          except chat_queue.PendingQuestionBlocksPromotion:
+            # A question committed between the locked preflight and the actor
+            # transition. Remove only this synthetic retry marker; real queued
+            # owner/product rows stay behind the question.
+            await _await_ack(get_writer().submit(CancelPending(
+              chat_id=chat_id,
+              run_token="",
+              cid=continuation_cid,
+            )))
+            discard_starting(chat_id)
+            claimed = False
+            return False
           if not next_user:
             discard_starting(chat_id)
             claimed = False
@@ -3001,7 +3029,8 @@ async def _complete_turn(
        disposition: `CONTINUATION_PROMOTED` (a head was promoted — marker
        stays set, schedule the continuation), `EMPTY_TERMINAL_CLEARED` (the
        drain already cleared the marker + forgot the chat under the lock),
-       or `STALE_NO_ACTION` (a newer gen owns the chat).
+       `QUESTION_PARKED` (queued work stayed behind the owner barrier), or
+       `STALE_NO_ACTION` (a newer gen owns the chat).
 
   A drain that RAISES — the `PromotePending` / `FinishRun` ack failed
   or timed out, OR the terminal lock acquisition exceeded
@@ -3409,7 +3438,8 @@ async def run_chat(
     # still owns. Every other disposition handled its own marker INSIDE the
     # locked terminal transition: EMPTY_TERMINAL_CLEARED + the setup-error
     # cleanups already cleared it; CONTINUATION_PROMOTED leaves it set for
-    # the next turn; STALE_NO_ACTION leaves a newer run's marker untouched;
+    # the next turn; QUESTION_PARKED preserves it for the owner;
+    # STALE_NO_ACTION leaves a newer run's marker untouched;
     # FAILED_LEAVE_MARKER leaves it set for reconciliation. Here we clear ONLY
     # when this run was Stop-bumped AND Stop still owns the immediate
     # successor generation (current == run_gen + 1) — never a newer run's
@@ -3559,14 +3589,16 @@ def _chat_note_mtime(data_dir: str, chat_id: str) -> float:
 # its title-sync sibling) fires. STOP_HANDOFF_CLEARED only results when NO
 # fresh claim raced in — a stopped chat genuinely settled — and a Stop is often
 # the day's last touch on a chat; skipping it left the chat note-less for the
-# night's reflection. LIMIT_PARKED is settled too. Its publisher is forced onto
-# the deterministic path so it never retries the provider that just hit a
-# limit, while still preserving the final parked state for compaction/recovery.
+# night's reflection. LIMIT_PARKED and QUESTION_PARKED are settled too. The
+# former is forced onto the deterministic path so it never retries the provider
+# that just hit a limit; the latter preserves the owner handoff in the ordinary
+# summary without advancing the chat.
 _NOTE_SETTLED_DISPOSITIONS = frozenset({
   chat_queue.TerminalDisposition.EMPTY_TERMINAL_CLEARED,
   chat_queue.TerminalDisposition.PROVIDER_FREE_COMPLETED,
   chat_queue.TerminalDisposition.STOP_HANDOFF_CLEARED,
   chat_queue.TerminalDisposition.LIMIT_PARKED,
+  chat_queue.TerminalDisposition.QUESTION_PARKED,
 })
 
 

--- a/backend/app/chat_queue.py
+++ b/backend/app/chat_queue.py
@@ -113,6 +113,10 @@ class TerminalDisposition(enum.Enum):
   # (the "limit storm"). The queue is preserved and self-heals on the user's
   # next send via the stale-pending drain. No auto-resume: the user resends
   # (or waits for the limit to reset) themselves.
+  QUESTION_PARKED = "question_parked"
+  # Pending work was deliberately left queued because an unanswered owner
+  # question is the transcript's protocol barrier. The exact run is closed as
+  # interrupted without clearing that question; no continuation is scheduled.
   DRAINED_FOR_RESTART = "drained_for_restart"
   # The turn was interrupted by a drain-gated restart (design §2.2), NOT by
   # Stop. Its partial blocks + a "paused for a platform update" note were
@@ -122,6 +126,14 @@ class TerminalDisposition(enum.Enum):
   # preserved marker and marks the note resumable so the owner's one-tap Resume
   # works; the queue self-heals on the next send. Never promoted at drain time —
   # promoting would start a turn while the worker is shutting down.
+
+
+class PendingQuestionBlocksPromotion(RuntimeError):
+  """Expected refusal to start queued work past an owner question."""
+
+  def __init__(self, question_id: str):
+    super().__init__("an owner question must be answered before promotion")
+    self.question_id = question_id
 
 
 _locks: "weakref.WeakValueDictionary[str, asyncio.Lock]" = (
@@ -220,17 +232,23 @@ async def promote_pending_messages_locked(
 
   Returns (next_messages, promoted_message, session_id) on success.
   Returns ([], None, session_id) when the pending queue is empty. Raises
-  if the actor ack fails — missing row / dropped commit / a MALFORMED
-  pending entry (the actor leaves the queue intact and fails the ack rather
-  than returning promoted=None, which would be indistinguishable from an
-  empty queue and let the caller clear the marker on stranded work) — so
-  the turn-end caller surfaces a transport error / leaves the marker
-  rather than promoting a write that never landed.
+  ``PendingQuestionBlocksPromotion`` when the owner must answer first. Other
+  actor-ack failures — missing row / dropped commit / a MALFORMED pending
+  entry (the actor leaves the queue intact and fails the ack rather than
+  returning promoted=None, which would be indistinguishable from an empty
+  queue and let the caller clear the marker on stranded work) — propagate so
+  the turn-end caller surfaces a transport error / leaves the marker rather
+  than promoting a write that never landed.
   """
   del db  # the actor owns the JSON-blob write on its own session
   if not chat_id:
     return [], None, None
-  from app.chat_writer import PromotePending, await_ack, get_writer
+  from app.chat_writer import (
+    PromotePending,
+    PromotePendingBlockedByPendingQuestion,
+    await_ack,
+    get_writer,
+  )
 
   ack = get_writer().submit(
     PromotePending(
@@ -240,6 +258,8 @@ async def promote_pending_messages_locked(
     )
   )
   result = await await_ack(ack)
+  if isinstance(result, PromotePendingBlockedByPendingQuestion):
+    raise PendingQuestionBlocksPromotion(result.question_id)
   promoted = result["promoted"]
   if promoted is None:
     # Empty queue — nothing to promote (the actor returned promoted=None
@@ -307,6 +327,10 @@ async def drain_and_release(
       Promoted follow-ups → `CONTINUATION_PROMOTED`: the marker stays
       continuously set (PromotePending re-set it for the next turn) and
       ownership passes to the scheduled continuation; do NOT clear/forget.
+    - An open owner question makes PromotePending refuse without mutating the
+      queue. Close the exact finishing run as interrupted while preserving the
+      question marker, release the in-process claim, and return
+      `QUESTION_PARKED`; no continuation is scheduled.
     - If nothing to promote AND we_own_gen, clears the durable run marker
       (strict `FinishRun`, identity-keyed on `ending_run_token`), then
       releases _starting, then forgets the chat — the clear-before-forget
@@ -334,10 +358,11 @@ async def drain_and_release(
   Bounding: the lock acquisition is wrapped in
   `asyncio.timeout(TERMINAL_LOCK_TIMEOUT_SECS)`. A lock-acquisition timeout
   (another task holds the lock past the bound) OR a failed strict ack
-  (PromotePending / FinishRun didn't land, timed out, or hit a
-  malformed pending entry) raises out of this function; the caller maps that
-  to `FAILED_LEAVE_MARKER`, leaving the marker set for reconciliation
-  rather than scheduling a continuation / clearing on a lost write.
+  (PromotePending / FinishRun didn't land, timed out, or hit a malformed
+  pending entry) raises out of this function; the caller maps that to
+  `FAILED_LEAVE_MARKER`, leaving the marker set for reconciliation rather than
+  scheduling a continuation / clearing on a lost write. The typed open-question
+  refusal is handled as the expected `QUESTION_PARKED` outcome instead.
 
   `discard_starting`, `forget_chat`, and `finish_run_strict` are
   injected so this module stays free of an import cycle back into chat.py /
@@ -358,11 +383,24 @@ async def drain_and_release(
       we_own_gen = run_gen is None or current_generation(chat_id) == run_gen
       if not we_own_gen:
         return None, [], None, TerminalDisposition.STALE_NO_ACTION
-      next_messages, first_pending, next_session_id = (
-        await promote_pending_messages_locked(
-          db, chat_id, run_token, ending_status=ending_status,
+      try:
+        next_messages, first_pending, next_session_id = (
+          await promote_pending_messages_locked(
+            db, chat_id, run_token, ending_status=ending_status,
+          )
         )
-      )
+      except PendingQuestionBlocksPromotion:
+        # A late durable QuestionCommit can win after Finalize's ordinary
+        # marker clear. That is a valid parked state, not a persistence error:
+        # close only this physical run as interrupted (FinishRun deliberately
+        # preserves the question marker for that status), leave every queued
+        # row untouched, and release the in-process claim without scheduling.
+        await finish_run_strict(
+          chat_id, ending_run_token, "interrupted",
+        )
+        discard_starting(chat_id)
+        forget_chat(chat_id)
+        return None, [], None, TerminalDisposition.QUESTION_PARKED
       if first_pending is None:
         # Clear-before-forget, all under this one lock: clear the durable
         # marker (strict — a failed ack raises and the caller leaves the

--- a/backend/app/chat_writer.py
+++ b/backend/app/chat_writer.py
@@ -399,6 +399,13 @@ class StartTurnBlockedByPendingQuestion:
   question_id: str
 
 
+@dataclass(frozen=True)
+class PromotePendingBlockedByPendingQuestion:
+  """Expected non-promotion while an owner question is open."""
+
+  question_id: str
+
+
 @dataclass
 class StartTurn(_Command):
   """Initial send: append the user message, set title/provider, mark run.
@@ -502,12 +509,13 @@ class PromotePending(_Command):
   committing (so a malformed entry can't silently consume a turn — building
   the validated schema surfaces it), moves pending rows into `messages`,
   sets the durable run marker, stamps `updated_at`, and commits. Returns
-  `{"history", "promoted", "session_id"}`; `promoted` is None (queue
-  unchanged) only when there was nothing to promote. Newer code persists
-  each promoted pending row as its own visible user message, while
-  `promoted.content` remains the combined provider-facing text for the
-  continuation turn. A malformed pending entry that can't build a valid
-  history instead RAISES `_PersistFailed` — the turn-end drain maps that to
+  `{"history", "promoted", "session_id"}` with `promoted=None` only when
+  there was nothing to promote. Returns
+  ``PromotePendingBlockedByPendingQuestion`` when an owner question is open.
+  Newer code persists each promoted pending row as its own visible user message,
+  while `promoted.content` remains the combined provider-facing text for the
+  continuation turn. A malformed pending entry that can't build a valid history
+  instead RAISES `_PersistFailed` — the turn-end drain maps that to
   FAILED_LEAVE_MARKER (leave the marker for reconciliation) rather than
   confusing it with an empty queue and clearing the marker on stranded work.
   """
@@ -1886,6 +1894,11 @@ class ChatWriterActor:
         messages=cmd.messages,
         has_messages=bool(cmd.messages),
         live_assistant=None,
+        # Startup repair owns the durable transcript after a process loss.
+        # Rebuild the protocol barrier from that repaired source instead of
+        # preserving a marker that Finalize may have cleared just before the
+        # process died (or that an older write may have left stale).
+        pending_question_id=_tail_open_question_id(cmd.messages),
       )
     )
     if chat_update.rowcount != 1:
@@ -2570,7 +2583,9 @@ class ChatWriterActor:
       raise _PersistFailed("PersistCompaction did not persist")
     return {"status": "committed", "stored": new_msg}
 
-  def _promote_pending(self, db, cmd: PromotePending) -> dict:
+  def _promote_pending(
+    self, db, cmd: PromotePending,
+  ) -> dict | PromotePendingBlockedByPendingQuestion:
     """Move pending follow-ups into the transcript and mark the run.
 
     Replicates `promote_pending_messages_locked`: builds the next-turn
@@ -2586,6 +2601,14 @@ class ChatWriterActor:
     chat = _active_chat(db, cmd.chat_id)
     if chat is None:
       raise _PersistFailed("PromotePending: chat not found or deleted")
+    # Moving queued rows into the transcript is a turn-admission operation,
+    # just like StartTurn. Keep the owner-question barrier
+    # at the actor-owned commit boundary so every caller — including recovery
+    # sweepers and future programmatic wakes — gets the same TOCTOU-safe rule.
+    if chat.pending_question_id is not None:
+      question_id = chat.pending_question_id
+      db.rollback()
+      return PromotePendingBlockedByPendingQuestion(question_id)
     pending = list(chat.pending_messages or [])
     if not pending:
       return {"history": [], "promoted": None, "session_id": chat.session_id}

--- a/backend/app/routes/chats_stream.py
+++ b/backend/app/routes/chats_stream.py
@@ -784,6 +784,9 @@ async def send_message(
             "question_id": body.question_id,
             "answers": body.answers,
           })
+      except chat_queue.PendingQuestionBlocksPromotion:
+        discard_starting(chat_id)
+        raise _pending_question_open_conflict()
       except HTTPException:
         discard_starting(chat_id)
         raise
@@ -1067,6 +1070,9 @@ async def _send_message_locked(
             # MALFORMED head no longer lands here: it raises in the actor and
             # is handled by the `except` below (→ FAILED_LEAVE_MARKER).
             discard_starting(chat_id)
+        except chat_queue.PendingQuestionBlocksPromotion:
+          discard_starting(chat_id)
+          raise _pending_question_open_conflict()
         except Exception:
           discard_starting(chat_id)
           raise

--- a/backend/tests/test_chat_note.py
+++ b/backend/tests/test_chat_note.py
@@ -112,6 +112,14 @@ def test_fires_on_limit_parked(tmp_path):
   )
 
 
+def test_fires_when_owner_question_is_parked(tmp_path):
+  assert chat._should_ensure_chat_note(
+    _settings(on=True), "c1",
+    chat_queue.TerminalDisposition.QUESTION_PARKED,
+    str(tmp_path), 0.0,
+  )
+
+
 def test_fires_on_provider_free_completion(tmp_path):
   assert chat._should_ensure_chat_note(
     _settings(on=True), "c1",

--- a/backend/tests/test_chat_queue_module.py
+++ b/backend/tests/test_chat_queue_module.py
@@ -127,6 +127,71 @@ def test_promote_pending_messages_locked_returns_none_on_empty_queue(db):
   assert sid == "sess-empty"
 
 
+def test_drain_parks_queued_work_behind_owner_question(db):
+  """A terminal handoff cannot turn an owner barrier into a continuation."""
+  question = {
+    "role": "assistant",
+    "ts": 2,
+    "blocks": [{
+      "type": "question",
+      "question_id": "owner-decision",
+      "questions": [{"id": "choice", "question": "Which direction?"}],
+    }],
+  }
+  queued = [{
+    "role": "user",
+    "content": "<wait_result>checks completed</wait_result>",
+    "hidden": True,
+    "ts": 3,
+    "cid": "wait-result",
+  }]
+  chat = models.Chat(
+    id="cq-question-barrier",
+    title="t",
+    messages=[question],
+    pending_messages=queued,
+    pending_question_id="owner-decision",
+    session_id="sess-question",
+  )
+  db.add(chat)
+  db.commit()
+  discarded = []
+  forgotten = []
+  finished = []
+
+  async def finish(chat_id, run_token, status):
+    finished.append((chat_id, run_token, status))
+
+  async def go():
+    return await chat_queue.drain_and_release(
+      db,
+      chat.id,
+      run_gen=7,
+      run_token="rt-next",
+      ending_run_token="rt-question",
+      discard_starting=discarded.append,
+      forget_chat=forgotten.append,
+      finish_run_strict=finish,
+      current_generation=lambda _chat_id: 7,
+    )
+
+  head, history, sid, disposition = asyncio.run(go())
+
+  assert head is None
+  assert history == []
+  assert sid is None
+  assert disposition is chat_queue.TerminalDisposition.QUESTION_PARKED
+  assert finished == [(
+    "cq-question-barrier", "rt-question", "interrupted",
+  )]
+  assert discarded == ["cq-question-barrier"]
+  assert forgotten == ["cq-question-barrier"]
+  db.refresh(chat)
+  assert chat.messages == [question]
+  assert chat.pending_messages == queued
+  assert chat.pending_question_id == "owner-decision"
+
+
 def test_drain_and_release_promotes_then_holds_starting(db):
   """When the queue has a head, drain_and_release returns it and
   does NOT call discard_starting / forget_chat (the next turn owns

--- a/backend/tests/test_chat_writer_contention.py
+++ b/backend/tests/test_chat_writer_contention.py
@@ -36,6 +36,7 @@ from app.chat_writer import (
   PersistSessionId,
   PersistTranscript,
   PromotePending,
+  PromotePendingBlockedByPendingQuestion,
   QuestionCommit,
   RecoverWedgedRun,
   ReplaceTranscript,
@@ -781,6 +782,74 @@ def test_start_turn_does_not_bypass_pending_owner_question(actor):
   assert chat["live_assistant"] is None
   assert chat["running_status"] is None
   assert _load_run("blocked-run") is None
+
+
+def test_promote_pending_does_not_bypass_pending_owner_question(actor):
+  question = _question_msg("owner-decision", content="Choose a direction.")
+  queued = [{
+    "role": "user",
+    "content": "<wait_result>checks completed</wait_result>",
+    "hidden": True,
+    "ts": 5,
+    "cid": "wait-result",
+  }]
+  _seed_chat(
+    messages=[question],
+    pending=queued,
+    pending_question_id="owner-decision",
+  )
+
+  result = _await(actor.submit(PromotePending(
+    chat_id="c1",
+    run_token="blocked-promotion",
+  )))
+
+  assert result == PromotePendingBlockedByPendingQuestion("owner-decision")
+  chat = _load_chat()
+  assert chat["messages"] == [question]
+  assert chat["pending_messages"] == queued
+  assert chat["pending_question_id"] == "owner-decision"
+  assert chat["live_assistant"] is None
+  assert chat["running_status"] is None
+  assert _load_run("blocked-promotion") is None
+
+
+def test_answering_owner_question_releases_pending_promotion(actor):
+  """The owner barrier is monotonic but not sticky after a saved answer."""
+  question = _question_msg("owner-decision", content="Choose a direction.")
+  queued = [{
+    "role": "user",
+    "content": "<wait_result>checks completed</wait_result>",
+    "hidden": True,
+    "ts": 5,
+    "cid": "wait-result",
+  }]
+  _seed_chat(
+    messages=[question],
+    pending=queued,
+    pending_question_id="owner-decision",
+  )
+
+  assert _await(actor.submit(AnswerQuestion(
+    chat_id="c1",
+    run_token="",
+    question_id="owner-decision",
+    answers={"Choose a direction.": "Continue"},
+  ))) is True
+  promoted = _await(actor.submit(PromotePending(
+    chat_id="c1",
+    run_token="released-promotion",
+  )))
+
+  assert promoted["promoted"]["cid"] == "wait-result"
+  chat = _load_chat()
+  assert chat["messages"][0]["blocks"][0]["answers"] == {
+    "Choose a direction.": "Continue",
+  }
+  assert chat["pending_question_id"] is None
+  assert chat["pending_messages"] == []
+  assert chat["running_status"] == "running"
+  assert _load_run("released-promotion")["status"] == "running"
 
 
 def test_persist_session_id_updates_chat_without_touching_transcript(actor):

--- a/backend/tests/test_crash_recovery.py
+++ b/backend/tests/test_crash_recovery.py
@@ -142,6 +142,54 @@ def test_reconcile_merges_bounded_live_snapshot_before_restart_note(db):
   assert row.messages[-1]["blocks"][-1]["type"] == "error"
 
 
+def test_reconcile_rebuilds_open_question_barrier_from_repaired_tail(db):
+  """A pre-crash Finalize clear cannot orphan an unanswered card.
+
+  The transcript is the recovery source: the restart note belongs before the
+  trailing question and the durable admission marker must name that question,
+  even if the pre-restart marker was already null.
+  """
+  _make_chat(
+    db,
+    "question-recovery",
+    running=True,
+    messages=[
+      {"role": "user", "content": "Review PR #787", "ts": 1},
+      {
+        "role": "assistant",
+        "ts": 2,
+        "blocks": [{
+          "type": "question",
+          "question_id": "owner-decision",
+          "questions": [{
+            "id": "push_requeue_787",
+            "question": "Push and requeue PR #787?",
+          }],
+        }],
+      },
+    ],
+    pending_messages=[{
+      "role": "user",
+      "content": "<wait_result>PR checks completed</wait_result>",
+      "hidden": True,
+      "ts": 3,
+      "cid": "wait-result-787",
+    }],
+    pending_question_id=None,
+  )
+
+  assert chat_mod.reconcile_interrupted_chats(db) == ["question-recovery"]
+
+  db.expire_all()
+  row = db.get(models.Chat, "question-recovery")
+  blocks = row.messages[-1]["blocks"]
+  assert [block["type"] for block in blocks[-2:]] == ["error", "question"]
+  assert blocks[-1]["question_id"] == "owner-decision"
+  assert blocks[-1].get("answers") is None
+  assert row.pending_question_id == "owner-decision"
+  assert [item["cid"] for item in row.pending_messages] == ["wait-result-787"]
+
+
 def test_reconcile_appends_turn_when_no_assistant_message(db):
   """If the process died before any assistant content persisted, the
   interruption becomes a standalone assistant turn rather than mutating

--- a/backend/tests/test_idle_pending_sweep.py
+++ b/backend/tests/test_idle_pending_sweep.py
@@ -17,6 +17,8 @@ def _seed_pending(
   *,
   age_secs: float,
   running: bool = False,
+  pending_question_id: str | None = None,
+  messages: list[dict] | None = None,
 ) -> None:
   now_ms = int(time.time() * 1000)
   db = SessionLocal()
@@ -25,13 +27,18 @@ def _seed_pending(
       id=chat_id,
       title="pending",
       provider="claude",
-      messages=[{"role": "user", "content": "first", "ts": 1}],
+      messages=(
+        messages
+        if messages is not None
+        else [{"role": "user", "content": "first", "ts": 1}]
+      ),
       pending_messages=[{
         "role": "user",
         "content": "recover me",
         "ts": now_ms - int(age_secs * 1000),
         "cid": f"cid-{chat_id}",
       }],
+      pending_question_id=pending_question_id,
     )
     db.add(chat)
     db.flush()
@@ -132,6 +139,53 @@ def test_idle_pending_sweep_respects_age_gate(monkeypatch):
   status, _messages, pending = _read(chat_id)
   assert status is None
   assert [cid_of(row) for row in pending] == [f"cid-{chat_id}"]
+  assert not registry.is_alive(chat_id)
+
+
+def test_idle_pending_sweep_never_crosses_owner_question(monkeypatch):
+  """An aged product wake stays queued until the owner answers.
+
+  This is the restart failure shape from the reported chat: boot has closed
+  the interrupted run, the open question is durable, and a queued wake is old
+  enough for generic idle recovery. Age is not owner authorization.
+  """
+  chat_id = "question-blocked-old-pending"
+  question = {
+    "role": "assistant",
+    "content": "Choose how to proceed.",
+    "ts": 2,
+    "blocks": [{
+      "type": "question",
+      "question_id": "owner-decision",
+      "questions": [{
+        "id": "push_requeue_787",
+        "question": "Push and requeue PR #787?",
+      }],
+    }],
+  }
+  _seed_pending(
+    chat_id,
+    age_secs=180,
+    pending_question_id="owner-decision",
+    messages=[
+      {"role": "user", "content": "Review PR #787", "ts": 1},
+      question,
+    ],
+  )
+
+  swept, scheduled = _sweep(monkeypatch)
+
+  assert swept == []
+  assert scheduled == []
+  status, messages, pending = _read(chat_id)
+  assert status is None
+  assert messages[-1] == question
+  assert [cid_of(row) for row in pending] == [f"cid-{chat_id}"]
+  db = SessionLocal()
+  try:
+    assert db.get(models.Chat, chat_id).pending_question_id == "owner-decision"
+  finally:
+    db.close()
   assert not registry.is_alive(chat_id)
 
 

--- a/frontend/src/components/ChatView/ActiveAssistantSurface.jsx
+++ b/frontend/src/components/ChatView/ActiveAssistantSurface.jsx
@@ -2,7 +2,10 @@
 
 import { memo, useMemo } from 'react'
 import StreamingMessage from './StreamingMessage.jsx'
-import { streamItemsToAssistantPayload } from './streamPromotion.js'
+import {
+  carryQuestionAnswers,
+  streamItemsToAssistantPayload,
+} from './streamPromotion.js'
 
 
 /**
@@ -39,12 +42,20 @@ function ActiveAssistantSurface({
   const msg = useMemo(() => {
     if (useDbActivePayload) return activeMirrorMsg
     if (!hasLivePayload) return null
+    const livePayload = streamItemsToAssistantPayload(streamItems, { finalize: false })
     return {
       ...(activeMirrorMsg || {}),
       role: 'assistant',
       // Live rendering keeps running tool state and thinking clock anchors;
-      // final promotion converts the same items with finalize=true.
-      ...streamItemsToAssistantPayload(streamItems, { finalize: false }),
+      // final promotion converts the same items with finalize=true. The
+      // mirrored DB blocks supply only durable interaction state: a catch-up
+      // replay can be richer overall while still carrying the original blank
+      // form of a question whose answer has already committed.
+      ...livePayload,
+      blocks: carryQuestionAnswers(
+        livePayload.blocks,
+        activeMirrorMsg?.blocks || [],
+      ),
     }
   }, [activeMirrorMsg, hasLivePayload, streamItems, useDbActivePayload])
 

--- a/frontend/src/components/ChatView/__tests__/streamPromotion.test.js
+++ b/frontend/src/components/ChatView/__tests__/streamPromotion.test.js
@@ -7,6 +7,7 @@ import { assistantAnchorKey, messageKey } from '../../../lib/chatDetailCache.js'
 
 import {
   streamItemsToAssistantPayload,
+  carryQuestionAnswers,
   promoteAssistantStream,
   promoteAssistantStreamWithFollowingMessages,
   assistantStreamCoversMessage,
@@ -53,6 +54,71 @@ test('streamItemsToAssistantPayload preserves text boundaries in legacy content'
   assert.equal(payload.content, 'first\n\nsecond')
   assert.deepEqual(payload.blocks.map(b => b.type), ['text', 'tool', 'text'])
   assert.equal(payload.blocks[1].status, 'done')
+})
+
+test('active live payload keeps a durable answer while retaining newer replay output', () => {
+  const question = {
+    type: 'question',
+    question_id: 'b2991163-0d7b-4b85-9bf3-82fcc8ae0e04',
+    questions: [{
+      id: 'push_requeue_787',
+      question: 'Should I push exact commit fd0e64eed to #787 and requeue that head?',
+    }],
+  }
+  const answers = {
+    'Should I push exact commit fd0e64eed to #787 and requeue that head?':
+      'Push & requeue (Recommended)',
+  }
+  const payload = streamItemsToAssistantPayload([
+    { type: 'text', content: 'The remote is unchanged.' },
+    question,
+    { type: 'tool', tool: 'Bash', status: 'running', input: 'verify head' },
+    { type: 'text', content: 'The protected queue is still running.' },
+  ], { finalize: false })
+  payload.blocks = carryQuestionAnswers(payload.blocks, [
+    { type: 'text', content: 'The remote is unchanged.' },
+    { ...question, answers },
+  ])
+
+  assert.deepEqual(payload.blocks[1].answers, answers,
+    'the authoritative saved answer must survive a blank question replay')
+  assert.equal(payload.blocks.at(-1).content, 'The protected queue is still running.',
+    'newer live progress must remain visible while the answer is carried')
+  assert.equal(payload.blocks[2].status, 'running',
+    'the active payload must retain live tool state')
+})
+
+test('a durable answer overrides conflicting optimistic replay state', () => {
+  const question = {
+    type: 'question',
+    question_id: 'question-authority',
+    questions: [{ id: 'choice', question: 'Which direction?' }],
+  }
+  const savedAnswers = { 'Which direction?': 'Keep the durable choice' }
+  const liveAnswers = { 'Which direction?': 'Stale optimistic choice' }
+
+  const [carried] = carryQuestionAnswers(
+    [{ ...question, answers: liveAnswers }],
+    [{ ...question, answers: savedAnswers }],
+  )
+
+  assert.deepEqual(carried.answers, savedAnswers)
+})
+
+test('an empty saved answer map cannot erase newer live answer state', () => {
+  const question = {
+    type: 'question',
+    question_id: 'question-empty-snapshot',
+    questions: [{ id: 'choice', question: 'Which direction?' }],
+  }
+  const liveAnswers = { 'Which direction?': 'Accepted live choice' }
+
+  const [carried] = carryQuestionAnswers(
+    [{ ...question, answers: liveAnswers }],
+    [{ ...question, answers: {} }],
+  )
+
+  assert.deepEqual(carried.answers, liveAnswers)
 })
 
 test('context compaction survives live promotion as its own block', () => {

--- a/frontend/src/components/ChatView/streamPromotion.js
+++ b/frontend/src/components/ChatView/streamPromotion.js
@@ -448,15 +448,25 @@ export function streamItemsHaveRenderableContent(items) {
 export function carryQuestionAnswers(blocks, existingBlocks = []) {
   const existingAnswersByKey = new Map()
   for (const block of existingBlocks) {
-    if (block?.type === 'question' && block.answers) {
+    const answers = block?.answers
+    if (
+      block?.type === 'question'
+      && answers
+      && typeof answers === 'object'
+      && Object.keys(answers).length > 0
+    ) {
       existingAnswersByKey.set(questionKey(block), block.answers)
     }
   }
   if (existingAnswersByKey.size === 0) return blocks
 
   return blocks.map(block => {
-    if (block.type !== 'question' || block.answers) return block
+    if (block.type !== 'question') return block
     const carried = existingAnswersByKey.get(questionKey(block))
+    // The mirrored DB answer is authoritative. A reconnect can replay an
+    // older optimistic/non-empty answer as well as the original blank card;
+    // neither may replace the answer that actually committed. Conversely an
+    // empty saved map is still unanswered and must not erase newer live state.
     return carried ? { ...block, answers: carried } : block
   })
 }


### PR DESCRIPTION
## Summary
- treat an unanswered owner question as an atomic barrier for every pending-queue promotion, including idle recovery and turn-end or auto-resume races
- rebuild that barrier from the repaired transcript during startup recovery
- keep the committed answer authoritative when catch-up replay supplies an older blank or optimistic question, while retaining newer live tools and prose
- preserve queued work behind the question and release it normally once the owner answers

## Why
A queued wake can become old enough for idle recovery after a restart and start a new turn past an unanswered card. At the same time, live catch-up replay can temporarily replace a saved answer with an older question state until refresh. The writer actor now owns the promotion gate, startup derives the marker from repaired history, and durable answers remain authoritative in the active renderer.

## Related work
This builds on #688, #716, #741, #750, and #831. Those changes covered chat-start admission, resumable parks, stale replay visibility, recovered answers, and question-follow scrolling; this closes the remaining case where idle promotion after restart and active catch-up replay can cross or visually regress the same question.

## Tests
- 166 affected backend tests
- 83 fast backend contract tests
- 2,693 frontend unit and hook tests
- production frontend build
- Python compilation and canonical diff checks