### PR TITLE
Add missing close-tabs-left action

### DIFF
--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -4323,6 +4323,9 @@ export default function Shell({ onInitialVisualReady }) {
           tab => tabModel.tabKey(tab) === tabMenu.tabKey,
         ) ?? -1
         const hasSiblingTabs = Boolean(menuPane && menuPane.tabs.length > 1)
+        const hasTabsToLeft = Boolean(
+          menuPane && menuTabIndex > 0,
+        )
         const hasTabsToRight = Boolean(
           menuPane && menuTabIndex >= 0 && menuTabIndex < menuPane.tabs.length - 1,
         )
@@ -4365,6 +4368,22 @@ export default function Shell({ onInitialVisualReady }) {
                     }}
                   >
                     Close all other tabs
+                  </button>
+                )}
+                {hasTabsToLeft && (
+                  <button
+                    type="button"
+                    role="menuitem"
+                    className="workspace__menu-item"
+                    onClick={() => {
+                      dispatchWorkspace({
+                        type: 'CLOSE_TABS_TO_LEFT',
+                        tabKey: tabMenu.tabKey,
+                      })
+                      closeTabMenu()
+                    }}
+                  >
+                    Close tabs to the left
                   </button>
                 )}
                 {hasTabsToRight && (

--- a/frontend/src/components/Shell/__tests__/paneModel.test.js
+++ b/frontend/src/components/Shell/__tests__/paneModel.test.js
@@ -1149,6 +1149,49 @@ test('CLOSE_TABS_TO_RIGHT removes only later siblings and is undoable', () => {
   assert.equal(paneModel.workspaceReducer(closed, { type: 'UNDO_LAST' }).ws, ws)
 })
 
+test('CLOSE_TABS_TO_LEFT removes only earlier siblings and is undoable', () => {
+  const ws = paneModel.seedFromFlatTabs([
+    makeTab('chat', 'a'),
+    makeTab('app', 42),
+    makeTab('chat', 'c'),
+    makeTab('chat', 'd'),
+  ])
+  const paneId = ws.focusedPaneId
+  const start = paneModel.initialWorkspaceState(ws)
+  const closed = paneModel.workspaceReducer(start, {
+    type: 'CLOSE_TABS_TO_LEFT',
+    tabKey: 'chat:c',
+  })
+  assert.deepEqual(closed.ws.panes[paneId].tabs.map(tabKey), ['chat:c', 'chat:d'])
+  assert.equal(closed.ws.panes[paneId].activeTabKey, 'chat:d',
+    'a surviving active tab stays active')
+  assert.equal(closed.undo.toast, 'Closed tabs to the left')
+  assert.equal(paneModel.workspaceReducer(closed, {
+    type: 'CLOSE_TABS_TO_LEFT',
+    tabKey: 'chat:c',
+  }), closed, 'the first tab has no left-side action')
+  assert.equal(paneModel.workspaceReducer(closed, { type: 'UNDO_LAST' }).ws, ws)
+})
+
+test('closeTabsToLeft selects the menu tab when it closes the active tab and preserves other panes', () => {
+  let ws = paneModel.seedFromFlatTabs([
+    makeTab('chat', 'a'),
+    makeTab('chat', 'b'),
+    makeTab('chat', 'c'),
+  ])
+  const leftPane = ws.focusedPaneId
+  ws = paneModel.setActiveTab(ws, leftPane, 'chat:a')
+  ws = paneModel.splitPaneWithTab(ws, makeTab('app', 42), {
+    paneId: leftPane,
+    edge: 'right',
+  })
+  const closed = paneModel.closeTabsToLeft(ws, 'chat:b')
+  assert.deepEqual(closed.panes[leftPane].tabs.map(tabKey), ['chat:b', 'chat:c'])
+  assert.equal(closed.panes[leftPane].activeTabKey, 'chat:b')
+  assert.ok(paneModel.flatten(closed).map(tabKey).includes('app:42'))
+  assert.equal(paneModel.closeTabsToLeft(ws, 'chat:nope'), ws)
+})
+
 test('closeTabsToRight preserves a surviving active tab and other panes', () => {
   let ws = paneModel.seedFromFlatTabs([
     makeTab('chat', 'a'),

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -61,6 +61,7 @@ test('the workspace tab menu stays close-only, edge-clamped, and keyboard naviga
   assert.match(shell, /aria-label="Tab actions"/)
   assert.match(menuMarkup, /Close tab/)
   assert.match(menuMarkup, /Close all other tabs/)
+  assert.match(menuMarkup, /Close tabs to the left/)
   assert.match(menuMarkup, /Close tabs to the right/)
   assert.doesNotMatch(
     menuMarkup,
@@ -256,6 +257,9 @@ test('the context menu offers pane-scoped bulk close actions only when useful', 
   assert.match(shell, /const hasSiblingTabs = Boolean\(menuPane && menuPane\.tabs\.length > 1\)/)
   assert.match(shell, /type: 'CLOSE_OTHER_TABS',[\s\S]*?tabKey: tabMenu\.tabKey/)
   assert.match(shell, /Close all other tabs/)
+  assert.match(shell, /const hasTabsToLeft = Boolean\(/)
+  assert.match(shell, /type: 'CLOSE_TABS_TO_LEFT',[\s\S]*?tabKey: tabMenu\.tabKey/)
+  assert.match(shell, /Close tabs to the left/)
   assert.match(shell, /const hasTabsToRight = Boolean\(/)
   assert.match(shell, /type: 'CLOSE_TABS_TO_RIGHT',[\s\S]*?tabKey: tabMenu\.tabKey/)
   assert.match(shell, /Close tabs to the right/)

--- a/frontend/src/components/Shell/paneModel.js
+++ b/frontend/src/components/Shell/paneModel.js
@@ -955,6 +955,29 @@ export function closeTabsToRight(ws, tabKey) {
   })
 }
 
+// Close only the tabs before the named tab in its pane. If the active tab is
+// among those removed, the named tab becomes active; otherwise focus stays
+// where it was. Other panes are untouched and the operation is reversible.
+export function closeTabsToLeft(ws, tabKey) {
+  const pane = paneOf(ws, tabKey)
+  if (!pane) return ws
+  const index = pane.tabs.findIndex(tab => tabModel.tabKey(tab) === tabKey)
+  if (index <= 0) return ws
+  const tabs = pane.tabs.slice(index)
+  const activeSurvives = tabs.some(tab => tabModel.tabKey(tab) === pane.activeTabKey)
+  return commit(ws, {
+    ...ws,
+    panes: {
+      ...ws.panes,
+      [pane.id]: {
+        ...pane,
+        tabs,
+        activeTabKey: activeSurvives ? pane.activeTabKey : tabKey,
+      },
+    },
+  })
+}
+
 // Move a tab within/between panes. target is one of:
 //   { paneId, index? }  insert into an existing pane at index (append if absent)
 //   { paneId, edge }    split that pane on the edge, the tab alone in the new one
@@ -1742,6 +1765,12 @@ export function workspaceReducer(state, action) {
       const next = closeTabsToRight(ws, action.tabKey)
       if (next === ws) return state
       const label = action.label || 'Closed tabs to the right'
+      return { ws: next, undo: { ws, label, toast: label } }
+    }
+    case 'CLOSE_TABS_TO_LEFT': {
+      const next = closeTabsToLeft(ws, action.tabKey)
+      if (next === ws) return state
+      const label = action.label || 'Closed tabs to the left'
       return { ws: next, undo: { ws, label, toast: label } }
     }
     case 'MOVE_TAB': {


### PR DESCRIPTION
## Summary
- add **Close tabs to the left** when the selected tab has earlier siblings
- keep the action pane-scoped, reversible, and consistent with the existing right-side action
- preserve the surviving active tab, or focus the selected tab when the active tab is closed

## Testing
- focused pane-model and workspace-menu tests
- structural test-budget check