### PR TITLE
Stabilize sent image attachment geometry

### DIFF
--- a/frontend/src/components/ChatView/Attachments.jsx
+++ b/frontend/src/components/ChatView/Attachments.jsx
@@ -30,7 +30,9 @@ export default function Attachments({ attachments, chatId }) {
           {images.map((img, i) => (
             <AttachImage
               key={i}
-              src={`${BASE}/api/chats/${chatId}/uploads/${encodeURIComponent(img.name)}${tokenParam}`}
+              src={tokenParam
+                ? `${BASE}/api/chats/${chatId}/uploads/${encodeURIComponent(img.name)}${tokenParam}`
+                : ''}
               alt={img.name}
             />
           ))}
@@ -54,14 +56,19 @@ export default function Attachments({ attachments, chatId }) {
 }
 
 function AttachImage({ src, alt }) {
-  // Don't render the image until we have a token (src would 403 without one).
-  if (!src.includes('?token=')) return null
   return (
-    <ImagePreviewButton
-      src={src}
-      alt={alt || 'attached image'}
-      buttonClassName="chat__attach-thumb-button"
-      imageClassName="chat__attach-thumb"
-    />
+    // Authorization controls when the image bytes can render, not when the
+    // message gets its layout. Keeping this frame mounted transfers the fixed
+    // attachment-card geometry from composer to transcript in one send paint.
+    <span className="chat__attach-thumb-frame" aria-hidden={!src || undefined}>
+      {src && (
+        <ImagePreviewButton
+          src={src}
+          alt={alt || 'attached image'}
+          buttonClassName="chat__attach-thumb-button"
+          imageClassName="chat__attach-thumb"
+        />
+      )}
+    </span>
   )
 }

--- a/frontend/src/components/ChatView/ChatView.css
+++ b/frontend/src/components/ChatView/ChatView.css
@@ -3067,9 +3067,22 @@
   gap: 6px;
 }
 
+.chat__attach-thumb-frame {
+  /* The token fetch may finish after the optimistic message commits. Layout
+     readiness cannot depend on that authorization hop: reserve the exact
+     composer-card footprint immediately, then paint the image inside it. */
+  display: inline-flex;
+  flex: 0 0 auto;
+  width: var(--attach-card, 96px);
+  height: var(--attach-card, 96px);
+  border-radius: 14px;
+  background: var(--surface2);
+}
+
 .chat__attach-thumb-button {
   display: inline-flex;
-  width: fit-content;
+  width: 100%;
+  height: 100%;
   padding: 0;
   border: 0;
   border-radius: 14px;
@@ -3087,8 +3100,8 @@
   /* Match the composer's attachment card after send — same `--attach-card`
      token, so the two can't drift. The thumbnail is a consistent square
      crop; tapping it still opens the full source image. */
-  width: var(--attach-card, 96px);
-  height: var(--attach-card, 96px);
+  width: 100%;
+  height: 100%;
   object-fit: cover;
   border-radius: 14px;
   border: 1px solid var(--border-light); /* CONTRACT: subtle 1px hairline on opaque fill */

--- a/frontend/src/components/ChatView/__tests__/attachmentSizing.test.js
+++ b/frontend/src/components/ChatView/__tests__/attachmentSizing.test.js
@@ -14,18 +14,25 @@ function ruleBody(selector) {
 
 test('roomy composer images match sent attachment size and corners', () => {
   const composer = ruleBody('.chat__attach-card--image')
+  const sentFrame = ruleBody('.chat__attach-thumb-frame')
   const sentButton = ruleBody('.chat__attach-thumb-button')
   const sent = ruleBody('.chat__attach-thumb')
 
   // Pending and sent squares share one roomy-size token instead of repeating a
   // literal. A pending card may compact below that ceiling when the keyboard
   // leaves very little room; its fallback must still be the sent-card token so
-  // the normal layout and a token change remain in step.
+  // the normal layout and a token change remain in step. The permanent frame,
+  // not the authorization-gated image, owns the sent footprint.
   assert.match(ruleBody('.chat'), /--attach-card:\s*96px/)
   assert.match(composer, /height:\s*var\(--composer-attach-card,\s*var\(--attach-card/)
-  assert.match(sent, /width:\s*var\(--attach-card/)
-  assert.match(sent, /height:\s*var\(--attach-card/)
+  assert.match(sentFrame, /width:\s*var\(--attach-card/)
+  assert.match(sentFrame, /height:\s*var\(--attach-card/)
+  assert.match(sentButton, /width:\s*100%/)
+  assert.match(sentButton, /height:\s*100%/)
+  assert.match(sent, /width:\s*100%/)
+  assert.match(sent, /height:\s*100%/)
   assert.match(composer, /border-radius:\s*14px/)
+  assert.match(sentFrame, /border-radius:\s*14px/)
   assert.match(sentButton, /border-radius:\s*14px/)
   assert.match(sent, /border-radius:\s*14px/)
 })

--- a/tests/composer-draft-attachments.spec.mjs
+++ b/tests/composer-draft-attachments.spec.mjs
@@ -125,7 +125,9 @@ test('a sent image keeps one geometry while its media token resolves', async ({ 
     })
 
   await composer.fill('Image attachment geometry check')
-  await paintedChat.getByRole('button', { name: 'Send' }).click()
+  const send = paintedChat.getByRole('button', { name: 'Send', exact: true })
+  await expect(send).toBeEnabled()
+  await send.click()
   await requested
 
   const userRow = paintedChat.locator('.chat__msg--user').last()

--- a/tests/composer-draft-attachments.spec.mjs
+++ b/tests/composer-draft-attachments.spec.mjs
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test'
 import { attachCleanup, createTaggedChat } from './_chatTracker.mjs'
+import { mockAcceptedMessages } from './_mockAcceptedMessages.mjs'
 
 const BASE = process.env.MOBIUS_URL || 'http://localhost:8001'
 
@@ -65,4 +66,115 @@ test('an uploaded attachment survives a chat switch and remains sendable', async
   await composer.press('Enter')
   await expect.poll(() => sentBody?.attachments?.map(file => file.name) || [])
     .toEqual(['draft-note.txt'])
+})
+
+test('a sent image keeps one geometry while its media token resolves', async ({ page }) => {
+  await page.setViewportSize({ width: 1512, height: 861 })
+  await page.route(/\/api\/chats\/[0-9a-f-]+\/stream$/, route =>
+    route.fulfill({ status: 204, body: '' }))
+  await mockAcceptedMessages(page)
+
+  await page.goto(BASE, { waitUntil: 'domcontentloaded' })
+  const chat = await createTaggedChat(page, 'attachment-send-geometry')
+  expect(chat?.id).toBeTruthy()
+
+  let releaseMediaToken
+  let mediaTokenRequested
+  const requested = new Promise(resolve => { mediaTokenRequested = resolve })
+  const released = new Promise(resolve => { releaseMediaToken = resolve })
+  const imageSvg = [
+    '<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480">',
+    '<rect width="640" height="480" fill="#5f7f78"/>',
+    '</svg>',
+  ].join('')
+  await page.route(new RegExp(`/api/chats/${chat.id}/media-token$`), async route => {
+    mediaTokenRequested()
+    await released
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ token: 'attachment-geometry-test' }),
+    })
+  })
+  await page.route(
+    new RegExp(`/api/chats/${chat.id}/uploads/send-geometry\\.svg(?:\\?.*)?$`),
+    route => route.fulfill({
+      status: 200,
+      contentType: 'image/svg+xml',
+      body: imageSvg,
+    }),
+  )
+
+  await page.goto(`${BASE}/shell/?chat=${encodeURIComponent(chat.id)}`, {
+    waitUntil: 'domcontentloaded',
+  })
+  const paintedChat = page.locator('[data-chat-surface="painted"]')
+  const composer = paintedChat.getByRole('textbox', { name: 'Message Möbius…' })
+  await expect(composer).toBeVisible({ timeout: 8000 })
+  await paintedChat.locator('input[type="file"]').setInputFiles({
+    name: 'send-geometry.svg',
+    mimeType: 'image/svg+xml',
+    buffer: Buffer.from(imageSvg),
+  })
+  await expect(paintedChat.getByRole('button', { name: 'Remove send-geometry.svg' }))
+    .toBeVisible({ timeout: 8000 })
+  const composerCard = await paintedChat.locator('.chat__attach-card--image')
+    .evaluate(element => {
+      const rect = element.getBoundingClientRect()
+      return { width: rect.width, height: rect.height }
+    })
+
+  await composer.fill('Image attachment geometry check')
+  await paintedChat.getByRole('button', { name: 'Send' }).click()
+  await requested
+
+  const userRow = paintedChat.locator('.chat__msg--user').last()
+  const frame = userRow.locator('.chat__attach-thumb-frame')
+  await expect(frame).toBeVisible()
+  await expect(frame.locator('img')).toHaveCount(0)
+
+  const before = await userRow.evaluate(row => {
+    const scroll = row.closest('.chat__scroll')
+    const frameEl = row.querySelector('.chat__attach-thumb-frame')
+    const rowRect = row.getBoundingClientRect()
+    const scrollRect = scroll.getBoundingClientRect()
+    const frameRect = frameEl.getBoundingClientRect()
+    return {
+      rowTop: rowRect.top - scrollRect.top,
+      rowHeight: rowRect.height,
+      scrollTop: scroll.scrollTop,
+      frameWidth: frameRect.width,
+      frameHeight: frameRect.height,
+    }
+  })
+  // Compare painted geometry rather than literal CSS pixels: desktop shell
+  // density intentionally scales the whole chat while mobile stays at 100%.
+  expect(Math.abs(before.frameWidth - composerCard.width)).toBeLessThanOrEqual(1)
+  expect(Math.abs(before.frameHeight - composerCard.height)).toBeLessThanOrEqual(1)
+
+  releaseMediaToken()
+  await expect(frame.locator('img')).toBeVisible()
+  await page.evaluate(() => new Promise(resolve => (
+    requestAnimationFrame(() => requestAnimationFrame(resolve))
+  )))
+
+  const after = await userRow.evaluate(row => {
+    const scroll = row.closest('.chat__scroll')
+    const frameEl = row.querySelector('.chat__attach-thumb-frame')
+    const rowRect = row.getBoundingClientRect()
+    const scrollRect = scroll.getBoundingClientRect()
+    const frameRect = frameEl.getBoundingClientRect()
+    return {
+      rowTop: rowRect.top - scrollRect.top,
+      rowHeight: rowRect.height,
+      scrollTop: scroll.scrollTop,
+      frameWidth: frameRect.width,
+      frameHeight: frameRect.height,
+    }
+  })
+  expect(after.frameWidth).toBe(before.frameWidth)
+  expect(after.frameHeight).toBe(before.frameHeight)
+  expect(Math.abs(after.rowHeight - before.rowHeight)).toBeLessThanOrEqual(1)
+  expect(Math.abs(after.rowTop - before.rowTop)).toBeLessThanOrEqual(1)
+  expect(Math.abs(after.scrollTop - before.scrollTop)).toBeLessThanOrEqual(1)
 })


### PR DESCRIPTION
## Summary

- reserve each sent image attachment’s final thumbnail frame before the media token resolves
- keep the composer-to-transcript handoff at one stable geometry without adding scroll compensation
- preserve the shared composer/sent attachment sizing contract and cover the delayed-token transition in the browser

## Testing

- `cd frontend && npm test`
- `cd frontend && npm run build`
- live rendered delayed-token verification at 1512×861 (0 px row, height, or scroll movement)