### PR TITLE
Expose the account link date so the identity app can show it

### DIFF
--- a/backend/app/routes/identity.py
+++ b/backend/app/routes/identity.py
@@ -324,7 +324,20 @@ async def _linked_remote(
   return _identity_contract(payload)
 
 
-def _merge_local_deployment(payload: dict) -> dict:
+def _linked_since(db: Session, owner_id: int) -> str | None:
+  """UTC link-creation instant, or None when no link row survives.
+
+  The remote profile deliberately carries no account-creation date, so the
+  local link row is the only truthful "since" the card can show. Relinking
+  creates a fresh row and honestly resets the date.
+  """
+  link = _linked_row(db, owner_id)
+  if link is None or link.linked_at is None:
+    return None
+  return link.linked_at.replace(microsecond=0).isoformat() + "Z"
+
+
+def _merge_local_deployment(payload: dict, linked_since: str | None = None) -> dict:
   local = _local_payload()
   remote_deployments = payload.get("deployments")
   deployments = list(remote_deployments) if isinstance(remote_deployments, list) else []
@@ -344,6 +357,7 @@ def _merge_local_deployment(payload: dict) -> dict:
       payload.get("profile") if isinstance(payload.get("profile"), dict) else None
     ),
     "deployments": deployments,
+    "linked_at": linked_since,
   }
 
 
@@ -375,11 +389,15 @@ async def read_identity(
       linked = await _linked_remote(db, owner.id, "GET")
     except HTTPException as exc:
       if exc.status_code == 502 and had_link:
-        return _local_payload(
+        degraded = _local_payload(
           account_mode="linked", account_unavailable=True,
         )
+        degraded["linked_at"] = _linked_since(db, owner.id)
+        return degraded
       raise
-    return _merge_local_deployment(linked) if linked is not None else local
+    if linked is None:
+      return local
+    return _merge_local_deployment(linked, _linked_since(db, owner.id))
   try:
     remote = await _managed_remote("GET")
   except HTTPException as exc:
@@ -416,7 +434,7 @@ async def update_profile(
   )
   if remote is None:
     raise HTTPException(409, "Sign in to edit your Möbius profile.")
-  return _merge_local_deployment(remote)
+  return _merge_local_deployment(remote, _linked_since(db, owner.id))
 
 
 @router.post("/avatar")
@@ -438,7 +456,7 @@ async def update_avatar(
   remote = await _linked_remote(db, owner.id, "POST", "/avatar", files=files)
   if remote is None:
     raise HTTPException(409, "Sign in to edit your Möbius profile.")
-  return _merge_local_deployment(remote)
+  return _merge_local_deployment(remote, _linked_since(db, owner.id))
 
 
 @router.get("/avatar")
@@ -1054,7 +1072,7 @@ async def complete_link(
       _open(winner.access_token_encrypted), token,
     ):
       raise HTTPException(409, "Another account link completed first.")
-  return _merge_local_deployment(identity)
+  return _merge_local_deployment(identity, _linked_since(db, owner.id))
 
 
 @router.delete("/link", status_code=204)

--- a/backend/tests/test_identity.py
+++ b/backend/tests/test_identity.py
@@ -388,6 +388,10 @@ def test_link_complete_consumes_attempt_and_stores_encrypted_grant(
   assert body["account_mode"] == "linked"
   assert body["profile"]["user_id"] == "usr_123"
   assert [item["id"] for item in body["deployments"]] == ["remote", "local"]
+  # The local link row is the only truthful "since" date the account card can
+  # show (the remote profile carries no creation date), so linked responses
+  # must expose the UTC link instant.
+  assert isinstance(body["linked_at"], str) and body["linked_at"].endswith("Z")
 
   with SessionLocal() as session:
     assert session.query(models.IdentityLinkAttempt).count() == 0

--- a/backend/tests/test_identity.py
+++ b/backend/tests/test_identity.py
@@ -545,6 +545,7 @@ def test_linked_host_outage_preserves_local_deployment(client, auth, monkeypatch
   assert body["account_mode"] == "linked"
   assert body["account_unavailable"] is True
   assert body["profile"] is None
+  assert isinstance(body["linked_at"], str) and body["linked_at"].endswith("Z")
   assert body["deployments"] == [{
     "id": "local",
     "name": "This Möbius",


### PR DESCRIPTION
## What this does

The mobius.you profile contract deliberately carries no account-creation date, so the Möbius · You app has no truthful "member since"-style fact to show. This adds the closest thing the platform genuinely knows: **when this Möbius was linked to the account**.

Linked identity responses now carry an optional top-level `linked_at` — the UTC instant the local `IdentityAccountLink` row was created:

- `GET /api/identity` (linked mode, including the degraded account-unavailable payload),
- `PATCH /api/identity/profile` and `POST /api/identity/avatar` responses,
- `POST /api/identity/link/complete`.

Managed and signed-out responses are unchanged. The field is nullable/optional by contract, so existing clients that ignore unknown fields keep working, and the companion app PR (mobius-os/app-mobius-you) renders "Linked since" only when the field is present — the two merge independently in either order.

Relinking creates a fresh link row, so the date honestly resets — it is a link date, not an account birthday. If mobius.you later exposes the real account-creation date in the profile, that can supersede this fact.

## Testing

- `backend/tests/test_identity.py`: the link-completion test now asserts the linked response carries a UTC `linked_at`; 14/16 tests pass locally — the two failures (`test_link_start_keeps_pkce_verifier…`, `test_linked_host_outage…`) are pre-existing on an untouched checkout in this environment (assertions on `FRONTEND_ORIGIN`-derived URLs that a configured deployment origin overrides) and are unrelated to this change.