### PR TITLE
Fit tall images in the lightbox and make them readable

### DIFF
--- a/frontend/src/components/ChatView/__tests__/imageGallery.test.js
+++ b/frontend/src/components/ChatView/__tests__/imageGallery.test.js
@@ -135,7 +135,7 @@ test('lightbox navigation keeps the painted image until its replacement decodes'
   assert.match(lightboxSource, /const imageIsPending = paintedSrc !== activeSrc/)
   assert.match(lightboxSource, /await image\.decode\?\.\(\)/)
   assert.match(lightboxSource, /imgRef\.current !== image/)
-  assert.match(lightboxSource, /lightbox-image lightbox-image--previous/)
+  assert.match(lightboxSource, /lightbox-image\$\{hasGallery [^}]+\} lightbox-image--previous/)
   assert.match(lightboxSource, /key=\{paintedSrc\}/)
   assert.match(lightboxSource, /imageIsPending \? ' is-pending' : ''/)
   assert.match(lightboxSource, /if \(nextIndex !== null\) goToIndex\(nextIndex\)/)

--- a/frontend/src/components/ChatView/__tests__/imageTransform.test.js
+++ b/frontend/src/components/ChatView/__tests__/imageTransform.test.js
@@ -3,6 +3,10 @@ import assert from 'node:assert/strict'
 import {
   clampImageScale,
   clampImageTransform,
+  hasPanRoom,
+  imageScaleCeiling,
+  readingZoomScale,
+  wheelScrollPans,
   zoomImageAround,
 } from '../markdown/imageTransform.js'
 
@@ -13,10 +17,45 @@ const metrics = {
   viewportHeight: 800,
 }
 
+// A 750×8000 screenshot fitted to a 1000×800 viewport is an 80px-wide strip;
+// reading it needs scales well past the default 5× ceiling.
+const tallStrip = {
+  baseWidth: 80,
+  baseHeight: 800,
+  viewportWidth: 1000,
+  viewportHeight: 800,
+  naturalWidth: 750,
+  dpr: 1,
+}
+
 test('image scale stays within the natural viewer range', () => {
   assert.equal(clampImageScale(0.2), 1)
   assert.equal(clampImageScale(2.5), 2.5)
   assert.equal(clampImageScale(9), 5)
+})
+
+test('the ceiling parameter is a true ceiling in both directions', () => {
+  assert.equal(clampImageScale(9, 9.4), 9)
+  assert.equal(clampImageScale(20, 9.4), 9.4)
+  assert.equal(clampImageScale(4, 3), 3)
+})
+
+test('the zoom ceiling reaches 1:1 device pixels for downscaled images', () => {
+  assert.equal(imageScaleCeiling(tallStrip), 750 / 80)
+  // On a 2× display half the CSS scale already reaches device pixels.
+  assert.equal(imageScaleCeiling({ ...tallStrip, dpr: 2 }), 5)
+  // Without natural measurements the default ceiling holds (legacy metrics).
+  assert.equal(imageScaleCeiling(metrics), 5)
+})
+
+test('metrics flow through transform clamping and zooming', () => {
+  const clamped = clampImageTransform({ scale: 9, x: 0, y: -99999 }, tallStrip)
+  assert.equal(clamped.scale, 9)
+  assert.equal(clamped.y, -(800 * 9 - 800) / 2)
+  const zoomed = zoomImageAround(
+    { scale: 1, x: 0, y: 0 }, 12, { x: 500, y: 400 }, { x: 500, y: 400 }, tallStrip,
+  )
+  assert.equal(zoomed.scale, 750 / 80)
 })
 
 test('returning to fitted size recentres the image', () => {
@@ -42,4 +81,50 @@ test('pointer-centred zoom keeps the inspected point under the pointer', () => {
     metrics,
   )
   assert.deepEqual(result, { scale: 2, x: -150, y: 50 })
+})
+
+test('pan engages on room, not zoom level, so a toolbar-hidden strip stays reachable', () => {
+  // Fully visible at fit: no room, no pan.
+  assert.equal(hasPanRoom(1, tallStrip), false)
+  // A small image zoomed but still inside the screen has nothing to pan.
+  assert.equal(hasPanRoom(1.2, { ...metrics, baseWidth: 400, baseHeight: 300 }), false)
+  // Fitted to the layout viewport but taller than the visible (visual)
+  // viewport — a mobile toolbar case: pan must engage at 1× and the clamp
+  // must allow reaching the hidden ends instead of pinning to centre.
+  const toolbarHidden = { ...tallStrip, baseHeight: 800, viewportHeight: 640 }
+  assert.equal(hasPanRoom(1, toolbarHidden), true)
+  assert.equal(wheelScrollPans({ scale: 1, x: 0, y: 0 }, 0, 100, toolbarHidden), true)
+  assert.deepEqual(
+    clampImageTransform({ scale: 1, x: 0, y: -999 }, toolbarHidden),
+    { scale: 1, x: 0, y: -80 },
+  )
+})
+
+test('plain scroll pans only an image with room on the dominant axis', () => {
+  // Fitted image: nothing to pan.
+  assert.equal(wheelScrollPans({ scale: 1, x: 0, y: 0 }, 0, 100, tallStrip), false)
+  // Zoomed tall strip has vertical room.
+  assert.equal(wheelScrollPans({ scale: 9, x: 0, y: 0 }, 0, 100, tallStrip), true)
+  // A wide image zoomed slightly has no vertical room — vertical wheel must
+  // stay a zoom so the wheel is never dead...
+  const wide = { ...metrics, baseWidth: 968, baseHeight: 242 }
+  assert.equal(wheelScrollPans({ scale: 2, x: 0, y: 0 }, 0, 100, wide), false)
+  // ...while a dominant horizontal scroll with horizontal room pans.
+  assert.equal(wheelScrollPans({ scale: 2, x: 0, y: 0 }, 100, 10, wide), true)
+})
+
+test('reading zoom targets legible width without upscaling past native pixels', () => {
+  // Tall strip: native sharpness (9.375×) runs out before reading width.
+  assert.equal(readingZoomScale(tallStrip), 750 / 80)
+  // On a 2× display native sharpness runs out sooner still.
+  assert.equal(readingZoomScale({ ...tallStrip, dpr: 2 }), 750 / (80 * 2))
+  // A narrower viewport makes reading width the binding limit.
+  assert.equal(readingZoomScale({ ...tallStrip, viewportWidth: 500 }), (500 - 32) / 80)
+  // A small image keeps the classic 2× instead of blowing up into blur.
+  const thumb = {
+    baseWidth: 400, baseHeight: 300,
+    viewportWidth: 1400, viewportHeight: 800,
+    naturalWidth: 400, dpr: 2,
+  }
+  assert.equal(readingZoomScale(thumb), 2)
 })

--- a/frontend/src/components/ChatView/lightbox.css
+++ b/frontend/src/components/ChatView/lightbox.css
@@ -16,6 +16,11 @@
   position: absolute;
   inset: 0;
   display: grid;
+  /* One definite full-viewport cell. Without explicit tracks the implicit row
+   * is sized by its content, so the image's percentage max-height resolves
+   * cyclically against the image's own height and never clamps — a tall
+   * screenshot then overflows the hidden overlay and appears cropped. */
+  grid-template: 100% / 100%;
   place-items: center;
   overflow: hidden;
 }
@@ -129,6 +134,11 @@
 @media (max-width: 34rem) {
   .lightbox-image {
     max-width: calc(100% - 16px);
+    max-height: calc(100% - 16px);
+  }
+
+  /* Only a gallery renders the bottom nav chevrons this clearance is for. */
+  .lightbox-image--gallery {
     max-height: calc(100% - 96px);
   }
 

--- a/frontend/src/components/ChatView/markdown/ImageLightbox.jsx
+++ b/frontend/src/components/ChatView/markdown/ImageLightbox.jsx
@@ -4,6 +4,10 @@ import useDialogFocus from '../../../hooks/useDialogFocus.js'
 import {
   clampImageScale,
   clampImageTransform,
+  hasPanRoom,
+  imageScaleCeiling,
+  readingZoomScale,
+  wheelScrollPans,
   zoomImageAround,
 } from './imageTransform.js'
 import { gallerySwipeTarget } from './imageGallery.js'
@@ -87,6 +91,10 @@ export default function ImageLightbox({
         viewport?.height || window.innerHeight,
         space,
       ),
+      // Measurements, not policy: imageTransform.js derives the zoom ceiling
+      // and reading zoom from these.
+      naturalWidth: img?.naturalWidth || 0,
+      dpr: window.devicePixelRatio || 1,
     }
   }, [])
 
@@ -107,13 +115,13 @@ export default function ImageLightbox({
     }
   }, [metrics])
 
-  const zoomAt = useCallback((nextScale, x, y, space = captureRootLayoutSpace()) => {
+  const zoomAt = useCallback((nextScale, x, y, space = captureRootLayoutSpace(), m = metrics(space)) => {
     setTransform((current) => zoomImageAround(
       current,
       nextScale,
       { x, y },
       baseCenter(current, space),
-      metrics(space),
+      m,
     ))
   }, [baseCenter, metrics])
 
@@ -159,20 +167,63 @@ export default function ImageLightbox({
     return () => document.removeEventListener('keydown', onKeyDown, true)
   }, [canNext, canPrevious, goToIndex, hasGallery, index])
 
-  // Trackpad/mouse-wheel zoom follows the pointer rather than the image centre.
+  // Plain scrolling pans an enlarged image (a long screenshot reads
+  // top-to-bottom); pinch — delivered as ctrl/cmd+wheel — always zooms; a
+  // wheel with nothing to pan (fitted image, or a wide one scrolled
+  // vertically) zooms so wheel input is never dead. A zoom begun that way
+  // stays a zoom while the wheel keeps moving, so crossing 1× mid-gesture
+  // cannot flip it into a pan; pinch never latches, so the scroll right
+  // after a pinch pans immediately.
+  const WHEEL_ZOOM_CONTINUES_MS = 400
+  const wheelZoomUntilRef = useRef(0)
   const handleWheel = useCallback((event) => {
     event.preventDefault()
-    const delta = event.deltaY * (event.deltaMode === 1 ? 16 : event.deltaMode === 2 ? window.innerHeight : 1)
-    const nextScale = transformRef.current.scale * Math.exp(-delta * 0.0015)
+    const unitX = event.deltaMode === 1 ? 16 : event.deltaMode === 2 ? window.innerWidth : 1
+    const unitY = event.deltaMode === 1 ? 16 : event.deltaMode === 2 ? window.innerHeight : 1
+    const deltaX = event.deltaX * unitX
+    const deltaY = event.deltaY * unitY
     const space = captureRootLayoutSpace()
+    const m = metrics(space)
+    const pinching = event.ctrlKey || event.metaKey
+    const zooms = pinching
+      || event.timeStamp < wheelZoomUntilRef.current
+      || !wheelScrollPans(transformRef.current, deltaX, deltaY, m)
+
+    if (!zooms) {
+      const dx = clientLengthToLayout(deltaX, space)
+      const dy = clientLengthToLayout(deltaY, space)
+      setTransform((current) => clampImageTransform({
+        ...current,
+        x: current.x - dx,
+        y: current.y - dy,
+      }, m))
+      return
+    }
+    if (!pinching) wheelZoomUntilRef.current = event.timeStamp + WHEEL_ZOOM_CONTINUES_MS
+    const nextScale = transformRef.current.scale * Math.exp(-deltaY * 0.0015)
     const point = rootLayoutPoint(event.clientX, event.clientY, space)
-    zoomAt(nextScale, point.x, point.y, space)
-  }, [zoomAt])
+    zoomAt(nextScale, point.x, point.y, space, m)
+  }, [metrics, zoomAt])
+
+  // React binds onWheel through a passive root listener, so preventDefault
+  // there is a no-op and the page behind the overlay would scroll, page-zoom
+  // on ctrl+wheel, or back-swipe with the gesture. Bind natively with
+  // passive: false, like the touch handlers below.
+  useEffect(() => {
+    const el = imgRef.current
+    if (!el) return undefined
+    el.addEventListener('wheel', handleWheel, { passive: false })
+    return () => el.removeEventListener('wheel', handleWheel)
+  }, [handleWheel, activeSrc])
 
   const toggleZoomAt = useCallback((x, y, space = captureRootLayoutSpace()) => {
-    if (transformRef.current.scale > 1) reset()
-    else zoomAt(2, x, y, space)
-  }, [reset, zoomAt])
+    if (transformRef.current.scale > 1) {
+      reset()
+      return
+    }
+    const m = metrics(space)
+    zoomAt(readingZoomScale(m), x, y, space, m)
+  }, [metrics, reset, zoomAt])
 
   const handleDoubleClick = useCallback((event) => {
     event.preventDefault()
@@ -184,9 +235,10 @@ export default function ImageLightbox({
 
   // Mouse/stylus drag-to-pan. Touch uses the pinch-aware handlers below.
   const handlePointerDown = useCallback((event) => {
-    if (event.pointerType === 'touch' || event.button !== 0 || transformRef.current.scale <= 1) return
-    event.currentTarget.setPointerCapture(event.pointerId)
+    if (event.pointerType === 'touch' || event.button !== 0) return
     const space = captureRootLayoutSpace()
+    if (!hasPanRoom(transformRef.current.scale, metrics(space))) return
+    event.currentTarget.setPointerCapture(event.pointerId)
     const point = rootLayoutPoint(event.clientX, event.clientY, space)
     pointerPanRef.current = {
       id: event.pointerId,
@@ -198,7 +250,7 @@ export default function ImageLightbox({
     }
     setDragging(true)
     event.preventDefault()
-  }, [])
+  }, [metrics])
 
   const handlePointerMove = useCallback((event) => {
     const pan = pointerPanRef.current
@@ -250,7 +302,7 @@ export default function ImageLightbox({
         const touch = event.touches[0]
         const point = rootLayoutPoint(touch.clientX, touch.clientY, space)
         tapStartRef.current = { x: touch.clientX, y: touch.clientY, moved: false }
-        if (current.scale > 1) {
+        if (hasPanRoom(current.scale, metrics(space))) {
           panRef.current = {
             space,
             x: point.x - current.x,
@@ -285,13 +337,17 @@ export default function ImageLightbox({
         event.preventDefault()
         const pinch = pinchRef.current
         const mid = midpoint(event.touches[0], event.touches[1], pinch.space)
-        const scale = clampImageScale(pinch.scale * (distance(event.touches[0], event.touches[1]) / pinch.distance))
+        const pinchMetrics = metrics(pinch.space)
+        const scale = clampImageScale(
+          pinch.scale * (distance(event.touches[0], event.touches[1]) / pinch.distance),
+          imageScaleCeiling(pinchMetrics),
+        )
         setTransform(clampImageTransform({
           scale,
           x: mid.x - pinch.center.x - pinch.imageX * scale,
           y: mid.y - pinch.center.y - pinch.imageY * scale,
-        }, metrics(pinch.space)))
-      } else if (event.touches.length === 1 && panRef.current && transformRef.current.scale > 1) {
+        }, pinchMetrics))
+      } else if (event.touches.length === 1 && panRef.current) {
         event.preventDefault()
         const touch = event.touches[0]
         const pan = panRef.current
@@ -412,7 +468,7 @@ export default function ImageLightbox({
             key={paintedSrc}
             src={paintedSrc}
             alt=""
-            className="lightbox-image lightbox-image--previous"
+            className={`lightbox-image${hasGallery ? ' lightbox-image--gallery' : ''} lightbox-image--previous`}
             aria-hidden="true"
             draggable={false}
           />
@@ -422,12 +478,11 @@ export default function ImageLightbox({
           ref={imgRef}
           src={activeSrc}
           alt={activeAlt}
-          className={`lightbox-image${imageIsPending ? ' is-pending' : ''}${dragging ? ' is-dragging' : ''}`}
+          className={`lightbox-image${hasGallery ? ' lightbox-image--gallery' : ''}${imageIsPending ? ' is-pending' : ''}${dragging ? ' is-dragging' : ''}`}
           onLoad={revealActiveImage}
           onError={revealImageError}
           onClick={(event) => event.stopPropagation()}
           onDoubleClick={handleDoubleClick}
-          onWheel={handleWheel}
           onPointerDown={handlePointerDown}
           onPointerMove={handlePointerMove}
           onPointerUp={endPointerPan}

--- a/frontend/src/components/ChatView/markdown/imageTransform.js
+++ b/frontend/src/components/ChatView/markdown/imageTransform.js
@@ -3,25 +3,57 @@
 export const MIN_IMAGE_SCALE = 1
 export const MAX_IMAGE_SCALE = 5
 
-export function clampImageScale(scale) {
-  return Math.min(MAX_IMAGE_SCALE, Math.max(MIN_IMAGE_SCALE, scale))
+// Mirrors the desktop .lightbox-image gutter in lightbox.css so the reading
+// zoom lands on the same fitted width the stylesheet gives the image.
+const LIGHTBOX_GUTTER = 32
+
+/** `maxScale` is a true ceiling: callers may raise it above the 5× default or
+ * lower it for a constrained mode. */
+export function clampImageScale(scale, maxScale = MAX_IMAGE_SCALE) {
+  return Math.min(maxScale, Math.max(MIN_IMAGE_SCALE, scale))
+}
+
+/** The zoom ceiling for a fitted image. 5× of the fitted size covers ordinary
+ * images; a very long screenshot fits the screen as a thin strip, so its
+ * ceiling extends to true 1:1 device pixels (`naturalWidth` painted across
+ * `baseWidth × dpr` device pixels) or small text could never become readable.
+ * Metrics without the natural measurements keep the default ceiling. */
+export function imageScaleCeiling(metrics) {
+  const dpr = metrics.dpr || 1
+  if (!(metrics.baseWidth > 0) || !(metrics.naturalWidth > 0)) return MAX_IMAGE_SCALE
+  return Math.max(MAX_IMAGE_SCALE, metrics.naturalWidth / (metrics.baseWidth * dpr))
+}
+
+function panLimits(scale, metrics) {
+  return {
+    maxX: Math.max(0, (metrics.baseWidth * scale - metrics.viewportWidth) / 2),
+    maxY: Math.max(0, (metrics.baseHeight * scale - metrics.viewportHeight) / 2),
+  }
+}
+
+/** Pan engages whenever there is room, not merely when zoomed: the viewport
+ * here is the visual viewport, so a tall image fitted to the layout viewport
+ * still has room at 1× while a mobile browser toolbar hides its ends, and a
+ * small image zoomed within the screen has none. */
+export function hasPanRoom(scale, metrics) {
+  const { maxX, maxY } = panLimits(scale, metrics)
+  return maxX > 0 || maxY > 0
 }
 
 export function clampImageTransform(transform, metrics) {
-  const scale = clampImageScale(transform.scale)
-  if (scale <= 1) return { scale: 1, x: 0, y: 0 }
-
-  const maxX = Math.max(0, (metrics.baseWidth * scale - metrics.viewportWidth) / 2)
-  const maxY = Math.max(0, (metrics.baseHeight * scale - metrics.viewportHeight) / 2)
+  const scale = clampImageScale(transform.scale, imageScaleCeiling(metrics))
+  const { maxX, maxY } = panLimits(scale, metrics)
+  // + 0 normalises the -0 a zero-room clamp produces, so a recentred
+  // transform compares equal to the reset state.
   return {
     scale,
-    x: Math.min(maxX, Math.max(-maxX, transform.x)),
-    y: Math.min(maxY, Math.max(-maxY, transform.y)),
+    x: Math.min(maxX, Math.max(-maxX, transform.x)) + 0,
+    y: Math.min(maxY, Math.max(-maxY, transform.y)) + 0,
   }
 }
 
 export function zoomImageAround(transform, nextScale, point, baseCenter, metrics) {
-  const scale = clampImageScale(nextScale)
+  const scale = clampImageScale(nextScale, imageScaleCeiling(metrics))
   if (scale <= 1) return { scale: 1, x: 0, y: 0 }
 
   // Preserve the image-space point beneath the cursor/fingers. This is what
@@ -34,4 +66,27 @@ export function zoomImageAround(transform, nextScale, point, baseCenter, metrics
     x: point.x - baseCenter.x - imageX * scale,
     y: point.y - baseCenter.y - imageY * scale,
   }, metrics)
+}
+
+/** True when a plain scroll should pan the image: it has pan room on the
+ * scroll's dominant axis. A fully visible image, or one with no room that way
+ * (a wide image scrolled vertically), falls through to zoom so wheel input is
+ * never dead. Only the deltas' relative magnitude matters, so client- or
+ * layout-space deltas both work. */
+export function wheelScrollPans(transform, deltaX, deltaY, metrics) {
+  const { maxX, maxY } = panLimits(transform.scale, metrics)
+  return Math.abs(deltaY) >= Math.abs(deltaX) ? maxY > 0 : maxX > 0
+}
+
+/** Double-click target for a fitted image: ordinary images keep the classic
+ * 2×; a tall strip jumps to reading width — the viewport less the stylesheet
+ * gutter — but never past its own legible 1:1 device pixels, so a small image
+ * is not blown up into blur. */
+export function readingZoomScale(metrics) {
+  if (!(metrics.baseWidth > 0)) return 2
+  const fitWidth = Math.max(0, metrics.viewportWidth - LIGHTBOX_GUTTER) / metrics.baseWidth
+  const native = metrics.naturalWidth > 0
+    ? metrics.naturalWidth / (metrics.baseWidth * (metrics.dpr || 1))
+    : 2
+  return Math.max(2, Math.min(fitWidth, native))
 }


### PR DESCRIPTION
A tall image opened in the chat lightbox was cropped to the middle of the screen with no way to reach the rest.

**Root cause.** `.lightbox-content` centres the image in a grid with no explicit tracks, so the implicit row is content-sized and the image's `max-height: calc(100% - 32px)` resolves cyclically against the image's own height — it never clamps. The overflow is hidden, and the pan clamp pins the transform at fitted scale, so the rest of the image is unreachable. (Measured: a 750×1708 screenshot laid out 1676px tall inside an 861px viewport.)

**Fit.** The stage now declares one definite full-viewport cell (`grid-template: 100% / 100%`), so the percentage max-sizes resolve against the screen on both axes. No viewport units — the overlay stays the single source of bounds, which matters because the shell scales root layout and `vh`/`dvh` would mis-fit there.

**Reading.**
- Plain scroll pans an enlarged image on the axis that has pan room, and zooms otherwise, so wheel input is never dead. A zoom begun at fitted size latches for 400ms so it cannot flip into a pan mid-gesture; pinch (ctrl/cmd+wheel) always zooms and never latches, so a scroll right after a pinch pans immediately.
- The wheel listener is bound natively with `passive: false`: React's `onWheel` root listener is passive, so the previous `preventDefault` was a no-op and browser page-zoom, back-swipe, and background scroll bled through the overlay.
- Double-click jumps a tall strip to reading width, capped at native sharpness; ordinary images keep the classic 2×.

**Geometry policy in one place.** `imageTransform.js` now owns the zoom ceiling — `max(5×, natural / (fitted × devicePixelRatio))`, so long screenshots reach legible 1:1 device pixels while small images cannot be blown into blur — and pan engagement (`hasPanRoom`), one rule for wheel, drag, and touch. Pan metrics use the visual viewport, so a strip fitted to the layout viewport but taller than the visible area (mobile toolbar expanded) is pannable at 1× instead of pinned. Page-mode wheel units are per-axis. The mobile 96px chevron clearance now applies only to gallery images, so a single tall screenshot on a phone gets the full height.

Unit tests cover the ceiling, pan-room, wheel-routing, and reading-zoom policies. Verified in the rendered shell: fit, double-click reading zoom, scroll-pan while zoomed, wheel-zoom continuity from fit, and `defaultPrevented` on the native listener.

Builds on the gallery lightbox work in #368 and full-screen attachment viewing in #251.