### PR TITLE
Preserve active chats across Host container cutovers

### DIFF
--- a/backend/app/chat.py
+++ b/backend/app/chat.py
@@ -505,10 +505,11 @@ async def _recover_wedged_run_strict(chat_id: str, run_token: str) -> None:
 
 @dataclass(frozen=True)
 class StartupReconcileResult:
-  """Distinct boot outcomes: manual crash recovery vs authenticated replay."""
+  """Distinct boot outcomes: manual, replayable, or question-waiting."""
 
   manual: list[str]
   restart_parks: list[str]
+  restart_waiting: list[str]
 
 
 def reconcile_startup_chats(
@@ -571,15 +572,18 @@ def reconcile_startup_chats(
   different from a generic crash. After the same transcript finalization, an
   opted-in owner turn with no unanswered question or app-attributed work is
   converted to a due ``restart`` park. The initial continuation sweep then
-  resumes it before lifespan yields. Every other stranded turn remains the
-  conservative manual-resume outcome.
+  resumes it before lifespan yields. An authenticated turn blocked on an
+  unanswered question instead preserves that durable question handoff without
+  automatic Continue or a false manual-Resume notification. Every other
+  stranded turn remains the conservative manual-resume outcome.
 
-  Returns both outcomes separately so startup can notify only genuinely manual
+  Returns the outcomes separately so startup can notify only genuinely manual
   recoveries and can report authenticated fallbacks without conflating them.
   """
   log = _get_logger()
   manual: list[str] = []
   restart_parks: list[str] = []
+  restart_waiting: list[str] = []
   try:
     from app.run_state import running_chat_ids
     stale_ids = running_chat_ids(db)
@@ -591,7 +595,11 @@ def reconcile_startup_chats(
     ) if stale_ids else []
   except Exception:
     log.exception("reconcile_startup_chats: query failed")
-    return StartupReconcileResult(manual=manual, restart_parks=restart_parks)
+    return StartupReconcileResult(
+      manual=manual,
+      restart_parks=restart_parks,
+      restart_waiting=restart_waiting,
+    )
 
   for chat in stale:
     # Belt-and-suspenders: if a live registry entry somehow exists for
@@ -631,6 +639,13 @@ def reconcile_startup_chats(
         isinstance(msg, dict)
         and msg.get("_initiated_by_app_id") is not None
         for msg in pending
+      )
+      restart_question_wait = bool(
+        restart_run is not None
+        and restart_run.initiated_by_app_id is None
+        and chat.auto_resume_on_restart
+        and not app_work_queued
+        and _has_unanswered_question(chat)
       )
       restart_eligible = bool(
         restart_run is not None
@@ -787,6 +802,13 @@ def reconcile_startup_chats(
       db.expire_all()
       if restart_eligible:
         restart_parks.append(chat.id)
+      elif restart_question_wait:
+        # The question card is already the durable continuation boundary.
+        # Starting a synthetic "continue" would compete with the owner's
+        # required answer (and could accidentally advance an approval gate).
+        # Keep it distinct from a generic crash/manual Resume so startup does
+        # not send the false "tap to resume" notification.
+        restart_waiting.append(chat.id)
       else:
         manual.append(chat.id)
     except Exception:
@@ -806,6 +828,11 @@ def reconcile_startup_chats(
       "recovered %d authenticated restart fallback(s) for immediate "
       "continuation: %s",
       len(restart_parks), ", ".join(restart_parks),
+    )
+  if restart_waiting:
+    log.info(
+      "preserved %d authenticated restart question handoff(s): %s",
+      len(restart_waiting), ", ".join(restart_waiting),
     )
 
   # A running row whose chat is gone or soft-deleted cannot receive transcript
@@ -859,6 +886,7 @@ def reconcile_startup_chats(
   return StartupReconcileResult(
     manual=manual,
     restart_parks=restart_parks,
+    restart_waiting=restart_waiting,
   )
 
 
@@ -1305,8 +1333,8 @@ async def drain_all_for_restart(
         stopped = False
       if not stopped:
         log.warning(
-          "drain-for-restart stop timed out; authenticated boot recovery "
-          "will continue chat_id=%s kind=%s",
+          "drain-for-restart stop timed out; authenticated boot "
+          "reconciliation will preserve chat_id=%s kind=%s",
           chat_id, getattr(handle, "kind", "?"),
         )
         all_interrupted = False

--- a/backend/app/deployment_control.py
+++ b/backend/app/deployment_control.py
@@ -56,6 +56,11 @@ _KNOWN_STATES = {
   "no_change", "failed", "rolled_back", "needs_recovery",
 }
 _ACTIVE_STATES = {"queued", "preparing", "replacing", "verifying"}
+_HANDOFF_VERSION = "external-cutover-v1"
+_UPGRADE_MESSAGE = (
+  "The Host replacement helper predates safe chat continuation. Re-run "
+  "scripts/install-rebuild-helper.sh from the current trusted checkout."
+)
 
 
 def _empty_status(
@@ -170,8 +175,13 @@ def _read_host_status() -> dict[str, Any]:
         "state": "queued",
         "expected_sha": expected,
         "message": "Container replacement queued.",
+        "handoff": value.get("handoff"),
       }
   return value
+
+
+def _current_handoff(raw: dict[str, Any]) -> bool:
+  return raw.get("handoff") == _HANDOFF_VERSION
 
 
 def _write_request(expected_sha: str) -> None:
@@ -245,7 +255,15 @@ async def read_rebuild_status() -> RebuildStatus:
       code="not_configured",
       message="Container replacement is not set up on this installation.",
     )
-  return _normalize_status(await asyncio.to_thread(_read_host_status))
+  raw = await asyncio.to_thread(_read_host_status)
+  if not _current_handoff(raw):
+    return _empty_status(
+      deployment,
+      supported=False,
+      code="controller_upgrade_required",
+      message=_UPGRADE_MESSAGE,
+    )
+  return _normalize_status(raw)
 
 
 async def request_rebuild() -> RebuildStatus:
@@ -260,6 +278,13 @@ async def request_rebuild() -> RebuildStatus:
     raise DeploymentControlError(
       "not_configured",
       "Container replacement is not set up on this installation.",
+      status_code=409,
+    )
+  host_status = await asyncio.to_thread(_read_host_status)
+  if not _current_handoff(host_status):
+    raise DeploymentControlError(
+      "controller_upgrade_required",
+      _UPGRADE_MESSAGE,
       status_code=409,
     )
   expected_sha = _expected_upstream_sha()
@@ -277,7 +302,7 @@ async def request_rebuild() -> RebuildStatus:
       "Commit them upstream or remove them before replacing this container.",
       status_code=409,
     )
-  current = _normalize_status(await asyncio.to_thread(_read_host_status))
+  current = _normalize_status(host_status)
   if current["state"] in _ACTIVE_STATES:
     raise DeploymentControlError(
       "already_running",

--- a/backend/app/restart_ledger.py
+++ b/backend/app/restart_ledger.py
@@ -15,6 +15,8 @@ from app.config import get_settings
 
 PROTOCOL_VERSION = 1
 MAX_ACK_BYTES = 64 * 1024
+MAX_CUTOVER_CHALLENGE_AGE_SECONDS = 120
+_CUTOVER_ID_MAX = 160
 
 
 def current_boot_id() -> str:
@@ -32,6 +34,36 @@ def _paths() -> tuple[Path, Path, Path]:
     root / ".platform-restart-requested",
     root / ".restart-ledger",
   )
+
+
+def _read_trusted_json(
+  path: Path,
+  *,
+  mode: int,
+  trusted_uid: int = 0,
+  trusted_gid: int = 0,
+) -> dict[str, Any] | None:
+  """Read one small immutable supervisor record, failing closed."""
+  try:
+    st = path.lstat()
+    if (
+      not stat.S_ISREG(st.st_mode)
+      or st.st_uid != trusted_uid
+      or st.st_gid != trusted_gid
+      or stat.S_IMODE(st.st_mode) != mode
+      or st.st_size > MAX_ACK_BYTES
+    ):
+      return None
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    fd = os.open(path, flags)
+    try:
+      raw = os.read(fd, MAX_ACK_BYTES + 1)
+    finally:
+      os.close(fd)
+    value = json.loads(raw.decode("utf-8"))
+    return value if isinstance(value, dict) else None
+  except (OSError, UnicodeError, json.JSONDecodeError):
+    return None
 
 
 def _atomic_json(path: Path, value: dict[str, Any]) -> None:
@@ -90,6 +122,74 @@ def request_restart(
   })
 
 
+def publish_cutover_intent(
+  *,
+  boot_id: str,
+  nonce: str,
+  cutover_id: str,
+  runs: list[dict[str, str]],
+  now: float | None = None,
+) -> None:
+  """Publish a Host-accepted cutover intent without self-terminating.
+
+  Unlike :func:`request_restart`, this deliberately does not create the
+  entrypoint sentinel.  The root Host helper must accept the exact cutover id;
+  Docker/Compose then owns the stop and the immediately following boot.
+  """
+  if not cutover_id or len(cutover_id) > _CUTOVER_ID_MAX:
+    raise ValueError("invalid cutover id")
+  intent_path, _request_path, _ledger_dir = _paths()
+  created_at = time.time() if now is None else now
+  normalized = [
+    {"chat_id": str(item["chat_id"]), "run_token": str(item["run_token"])}
+    for item in runs
+  ]
+  _atomic_json(intent_path, {
+    "version": PROTOCOL_VERSION,
+    "action": "external_cutover",
+    "cutover_id": cutover_id,
+    "nonce": nonce,
+    "source_boot_id": boot_id,
+    "created_at": created_at,
+    "runs": normalized,
+  })
+
+
+def authorized_cutover_challenge(
+  cutover_id: str,
+  *,
+  boot_id: str | None = None,
+  now: float | None = None,
+  trusted_uid: int = 0,
+  trusted_gid: int = 0,
+) -> bool:
+  """Whether the root supervisor opened this cutover on the current boot."""
+  expected_boot = boot_id if boot_id is not None else current_boot_id()
+  if not expected_boot or not cutover_id:
+    return False
+  _, _, ledger_dir = _paths()
+  value = _read_trusted_json(
+    ledger_dir / "cutover-challenge.json",
+    mode=0o444,
+    trusted_uid=trusted_uid,
+    trusted_gid=trusted_gid,
+  )
+  if not value:
+    return False
+  try:
+    created_at = float(value.get("created_at"))
+  except (TypeError, ValueError):
+    return False
+  current = time.time() if now is None else now
+  return bool(
+    value.get("version") == PROTOCOL_VERSION
+    and value.get("source_boot_id") == expected_boot
+    and value.get("cutover_id") == cutover_id
+    and created_at <= current + 5
+    and current - created_at <= MAX_CUTOVER_CHALLENGE_AGE_SECONDS
+  )
+
+
 def authorized_restart_nonce(
   boot_id: str | None = None,
   *,
@@ -104,28 +204,23 @@ def authorized_restart_nonce(
   ack_path = ledger_dir / "ack.json"
   try:
     dir_st = ledger_dir.lstat()
-    ack_st = ack_path.lstat()
     if (
       not stat.S_ISDIR(dir_st.st_mode)
       or stat.S_ISLNK(dir_st.st_mode)
       or dir_st.st_uid != trusted_uid
       or dir_st.st_gid != trusted_gid
       or dir_st.st_mode & (stat.S_IWGRP | stat.S_IWOTH)
-      or not stat.S_ISREG(ack_st.st_mode)
-      or ack_st.st_uid != trusted_uid
-      or ack_st.st_gid != trusted_gid
-      or ack_st.st_mode & (stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH)
-      or ack_st.st_size > MAX_ACK_BYTES
     ):
       return None
-    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
-    fd = os.open(ack_path, flags)
-    try:
-      raw = os.read(fd, MAX_ACK_BYTES + 1)
-    finally:
-      os.close(fd)
-    value = json.loads(raw.decode("utf-8"))
-  except (OSError, UnicodeError, json.JSONDecodeError):
+  except OSError:
+    return None
+  value = _read_trusted_json(
+    ack_path,
+    mode=0o444,
+    trusted_uid=trusted_uid,
+    trusted_gid=trusted_gid,
+  )
+  if value is None:
     return None
   if (
     not isinstance(value, dict)

--- a/backend/app/restart_util.py
+++ b/backend/app/restart_util.py
@@ -31,6 +31,51 @@ log = logging.getLogger("mobius.restart")
 # fallback a plain SIGTERM hangs the worker in shutdown limbo: it stops serving
 # but never exits, so tini (PID 1) never exits and the container never restarts.
 _FORCE_KILL_AFTER_SECONDS = 5.0
+_CUTOVER_FAILSAFE_SECONDS = 90.0
+
+
+async def _drain_exact_restart() -> tuple[str, str, list[dict[str, str]]]:
+  """Gate admission and bind every live run to one fresh restart nonce."""
+  from app import chat
+  from app.broadcast import get_system_broadcast
+
+  get_system_broadcast().publish({"type": "server_restarting"})
+  chat.begin_drain()
+
+  from app import restart_ledger
+
+  boot_id = restart_ledger.current_boot_id()
+  restart_nonce = restart_ledger.new_nonce()
+  restart_runs: list[dict[str, str]] = []
+  try:
+    restart_runs = await asyncio.wait_for(
+      chat.prepare_restart_intents(restart_nonce),
+      timeout=min(10.0, chat.DRAIN_TIMEOUT),
+    )
+  except Exception:
+    log.warning(
+      "restart-intent preparation failed; fallbacks will remain manual",
+      exc_info=True,
+    )
+  try:
+    drained_runs = await asyncio.wait_for(
+      chat.drain_all_for_restart(
+        timeout=chat.DRAIN_TIMEOUT,
+        restart_nonce=restart_nonce,
+        prepared_runs=restart_runs,
+      ),
+      timeout=chat.DRAIN_TIMEOUT,
+    )
+    known = {
+      (item["chat_id"], item["run_token"]) for item in restart_runs
+    }
+    restart_runs.extend(
+      item for item in drained_runs
+      if (item["chat_id"], item["run_token"]) not in known
+    )
+  except Exception:
+    log.warning("drain-for-restart failed; restarting anyway", exc_info=True)
+  return boot_id, restart_nonce, restart_runs
 
 
 async def restart_this_worker(ready_path: Path | None = None) -> None:
@@ -63,9 +108,6 @@ async def restart_this_worker(ready_path: Path | None = None) -> None:
   """
   from app import chat
 
-  # Gate new sends ASAP so the whole restart window queues rather than starts.
-  chat.begin_drain()
-
   pid = os.getpid()
 
   def _force_exit() -> None:
@@ -79,47 +121,7 @@ async def restart_this_worker(ready_path: Path | None = None) -> None:
 
   from app import restart_ledger
 
-  boot_id = restart_ledger.current_boot_id()
-  restart_nonce = restart_ledger.new_nonce()
-  restart_runs: list[dict[str, str]] = []
-  try:
-    # Bind the authenticated nonce to every exact live run BEFORE provider
-    # interruption. This small writer-only transaction is independent of
-    # transcript serialization and survives a later stop/finalize timeout.
-    restart_runs = await asyncio.wait_for(
-      chat.prepare_restart_intents(restart_nonce),
-      timeout=min(10.0, chat.DRAIN_TIMEOUT),
-    )
-  except Exception:
-    # Fail closed: without an exact DB binding the next boot treats stranded
-    # turns as generic crash recovery and leaves them for manual Resume.
-    log.warning(
-      "restart-intent preparation failed; fallbacks will remain manual",
-      exc_info=True,
-    )
-  try:
-    drained_runs = await asyncio.wait_for(
-      chat.drain_all_for_restart(
-        timeout=chat.DRAIN_TIMEOUT,
-        restart_nonce=restart_nonce,
-        prepared_runs=restart_runs,
-      ),
-      timeout=chat.DRAIN_TIMEOUT,
-    )
-    # The drain may discover a just-materialized handle after the initial
-    # snapshot. Keep every exact run it successfully authenticated.
-    known = {
-      (item["chat_id"], item["run_token"]) for item in restart_runs
-    }
-    restart_runs.extend(
-      item for item in drained_runs
-      if (item["chat_id"], item["run_token"]) not in known
-    )
-  except Exception:
-    # Never let a drain failure block the restart — the backstop timer and the
-    # fallback path still reboots the worker. Exact runs already transitioned
-    # remain due; nonce-stamped running markers use authenticated boot recovery.
-    log.warning("drain-for-restart failed; restarting anyway", exc_info=True)
+  boot_id, restart_nonce, restart_runs = await _drain_exact_restart()
 
   try:
     if not boot_id:
@@ -145,3 +147,71 @@ async def restart_this_worker(ready_path: Path | None = None) -> None:
       exc_info=True,
     )
     os.kill(pid, signal.SIGTERM)
+
+
+async def prepare_container_cutover(cutover_id: str) -> dict[str, object]:
+  """Drain once for a Host-owned replacement without self-terminating.
+
+  The root supervisor must first open the exact cutover challenge.  This
+  process then parks and nonce-binds active turns, but publishes no shutdown
+  sentinel: Docker/Compose owns the stop, so the accepted authorization binds
+  to the replacement boot rather than an accidental intermediate restart.
+  """
+  from app import restart_ledger
+
+  if not restart_ledger.authorized_cutover_challenge(cutover_id):
+    raise RuntimeError("the Host did not authorize this cutover")
+
+  boot_id, restart_nonce, restart_runs = await _drain_exact_restart()
+  try:
+    if not boot_id:
+      raise RuntimeError("entrypoint boot id is unavailable")
+    restart_ledger.publish_cutover_intent(
+      boot_id=boot_id,
+      nonce=restart_nonce,
+      cutover_id=cutover_id,
+      runs=restart_runs,
+    )
+  except Exception:
+    # A failed external handoff must not strand a live-but-drained worker.
+    # Convert it into the ordinary supervised restart using the same exact run
+    # bindings.  If even that cannot publish, fail closed to manual recovery.
+    log.warning(
+      "container-cutover handoff failed; falling back to a normal restart",
+      exc_info=True,
+    )
+    try:
+      restart_ledger.request_restart(
+        boot_id=boot_id,
+        nonce=restart_nonce,
+        runs=restart_runs,
+      )
+    except Exception:
+      os.kill(os.getpid(), signal.SIGTERM)
+    raise
+
+  pid = os.getpid()
+
+  def _recover_abandoned_cutover() -> None:
+    try:
+      restart_ledger.request_restart(
+        boot_id=boot_id,
+        nonce=restart_nonce,
+        runs=restart_runs,
+      )
+    except Exception:
+      log.warning(
+        "abandoned container cutover could not self-recover",
+        exc_info=True,
+      )
+      os.kill(pid, signal.SIGTERM)
+
+  watchdog = threading.Timer(_CUTOVER_FAILSAFE_SECONDS, _recover_abandoned_cutover)
+  watchdog.daemon = True
+  watchdog.start()
+  return {
+    "status": "prepared",
+    "cutover_id": cutover_id,
+    "boot_id": boot_id,
+    "run_count": len(restart_runs),
+  }

--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -22,13 +22,13 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import JSONResponse, StreamingResponse
 from starlette.background import BackgroundTask
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
 from app import activity, deployment_control, models
 from app.database import get_db
 from app.deps import get_current_owner, reject_cross_site
-from app.restart_util import restart_this_worker
+from app.restart_util import prepare_container_cutover, restart_this_worker
 
 # Event names the admin emit endpoint will accept. This is intentionally not
 # the complete activity vocabulary: ``app_signal`` has its own app-scoped,
@@ -143,6 +143,10 @@ class ContainerReplacementPrepare(BaseModel):
   operation_id: str
 
 
+class ContainerCutoverPrepare(BaseModel):
+  cutover_id: str = Field(pattern=r"^[A-Za-z0-9._:-]{8,160}$")
+
+
 @router.post("/activity/emit", status_code=204)
 def emit_activity_event(
   body: ActivityEmit,
@@ -231,6 +235,40 @@ def restart_server(
     {"status": "restarting"},
     background=BackgroundTask(restart_this_worker),
   )
+
+
+@router.post(
+  "/restart/prepare-cutover",
+  dependencies=[Depends(reject_cross_site)],
+)
+async def prepare_external_container_cutover(
+  body: ContainerCutoverPrepare,
+  _: models.Owner = Depends(get_current_owner),
+):
+  """Park exact live runs for a root-opened Host replacement.
+
+  An owner token alone is insufficient: the frozen root supervisor must first
+  publish the matching one-boot challenge.  The response means the app-side
+  intent is durable; the Host still has to accept it before replacing the
+  container.
+  """
+  from app.restart_ledger import authorized_cutover_challenge
+
+  if not authorized_cutover_challenge(body.cutover_id):
+    raise HTTPException(
+      status_code=409,
+      detail={
+        "code": "cutover_not_open",
+        "message": "The Host did not open this container cutover.",
+      },
+    )
+  try:
+    return await prepare_container_cutover(body.cutover_id)
+  except RuntimeError as exc:
+    raise HTTPException(
+      status_code=409,
+      detail={"code": "cutover_not_prepared", "message": str(exc)},
+    ) from exc
 
 
 @router.get("/rebuild")

--- a/backend/runtime/restart_ledger.py
+++ b/backend/runtime/restart_ledger.py
@@ -39,11 +39,14 @@ LEDGER_DIR = DATA_DIR / ".restart-ledger"
 ACCEPTED_PATH = LEDGER_DIR / "accepted.json"
 ACK_PATH = LEDGER_DIR / "ack.json"
 BOOT_PATH = LEDGER_DIR / "boot-id"
+CUTOVER_CHALLENGE_PATH = LEDGER_DIR / "cutover-challenge.json"
+CUTOVER_RECEIPT_PATH = LEDGER_DIR / "cutover-receipt.json"
 
 PROTOCOL_VERSION = 1
 MAX_REQUEST_BYTES = 64 * 1024
 MAX_REQUEST_AGE_SECONDS = 120
 MAX_ACCEPTED_AGE_SECONDS = 10 * 60
+MAX_CUTOVER_RECEIPT_AGE_SECONDS = 60 * 60
 _TOKEN_RE = re.compile(r"^[A-Za-z0-9._:-]{8,160}$")
 SUPERVISOR_UID = 0
 SUPERVISOR_GID = 0
@@ -192,6 +195,51 @@ def _valid_intent(
   }
 
 
+def _valid_cutover_intent(
+  intent: dict[str, Any] | None,
+  challenge: dict[str, Any] | None,
+  boot_id: str,
+  cutover_id: str,
+  now: float,
+) -> dict[str, Any] | None:
+  """Validate the platform half against a fresh root-opened challenge."""
+  if not intent or not challenge or not _valid_token(cutover_id):
+    return None
+  if (
+    intent.get("version") != PROTOCOL_VERSION
+    or intent.get("action") != "external_cutover"
+    or intent.get("cutover_id") != cutover_id
+    or challenge.get("version") != PROTOCOL_VERSION
+    or challenge.get("cutover_id") != cutover_id
+    or challenge.get("source_boot_id") != boot_id
+  ):
+    return None
+  nonce = intent.get("nonce")
+  if not _valid_token(nonce) or intent.get("source_boot_id") != boot_id:
+    return None
+  try:
+    created_at = float(intent.get("created_at"))
+    challenge_at = float(challenge.get("created_at"))
+  except (TypeError, ValueError):
+    return None
+  if (
+    created_at > now + 5
+    or challenge_at > now + 5
+    or now - created_at > MAX_REQUEST_AGE_SECONDS
+    or now - challenge_at > MAX_REQUEST_AGE_SECONDS
+  ):
+    return None
+  return {
+    "version": PROTOCOL_VERSION,
+    "action": "external_cutover",
+    "cutover_id": cutover_id,
+    "nonce": nonce,
+    "source_boot_id": boot_id,
+    "created_at": created_at,
+    "accepted_at": now,
+  }
+
+
 def begin_boot(boot_id: str, *, now: float | None = None) -> bool:
   """Bind a previously accepted restart to this one boot, or retire it."""
   if not _valid_token(boot_id):
@@ -201,6 +249,7 @@ def begin_boot(boot_id: str, *, now: float | None = None) -> bool:
   accepted = _read_bounded_json(ACCEPTED_PATH)
   if not _remove(ACK_PATH):
     raise OSError("could not retire the prior boot acknowledgement")
+  _remove(CUTOVER_CHALLENGE_PATH)
   authorized_payload: dict[str, Any] | None = None
   if accepted:
     try:
@@ -246,7 +295,13 @@ def harden(boot_id: str) -> bool:
     if BOOT_PATH.read_text(encoding="utf-8").strip() != boot_id:
       _remove(ACK_PATH)
       return False
-    for path in (BOOT_PATH, ACK_PATH, ACCEPTED_PATH):
+    for path in (
+      BOOT_PATH,
+      ACK_PATH,
+      ACCEPTED_PATH,
+      CUTOVER_CHALLENGE_PATH,
+      CUTOVER_RECEIPT_PATH,
+    ):
       if not path.exists():
         continue
       st = path.lstat()
@@ -254,7 +309,10 @@ def harden(boot_id: str) -> bool:
         _remove(path)
         continue
       os.chown(path, SUPERVISOR_UID, SUPERVISOR_GID)
-      os.chmod(path, 0o444 if path != ACCEPTED_PATH else 0o600)
+      os.chmod(
+        path,
+        0o600 if path in {ACCEPTED_PATH, CUTOVER_RECEIPT_PATH} else 0o444,
+      )
     os.chown(LEDGER_DIR, SUPERVISOR_UID, SUPERVISOR_GID)
     os.chmod(LEDGER_DIR, 0o755)
     return _trusted_ledger_dir()
@@ -285,18 +343,155 @@ def accept(boot_id: str, *, now: float | None = None) -> bool:
   return accepted is not None
 
 
+def open_cutover(cutover_id: str, *, now: float | None = None) -> bool:
+  """Open one short-lived root challenge before the app may drain chats."""
+  if not _valid_token(cutover_id):
+    return False
+  current = time.time() if now is None else now
+  _prepare_ledger_dir()
+  try:
+    boot_id = BOOT_PATH.read_text(encoding="utf-8").strip()
+  except OSError:
+    return False
+  if not _valid_token(boot_id):
+    return False
+  _remove(CUTOVER_CHALLENGE_PATH)
+  _write_json(CUTOVER_CHALLENGE_PATH, {
+    "version": PROTOCOL_VERSION,
+    "cutover_id": cutover_id,
+    "source_boot_id": boot_id,
+    "created_at": current,
+  }, 0o444)
+  return True
+
+
+def accept_cutover(cutover_id: str, *, now: float | None = None) -> bool:
+  """Accept an exact externally driven cutover without stopping the worker."""
+  current = time.time() if now is None else now
+  _prepare_ledger_dir()
+  try:
+    boot_id = BOOT_PATH.read_text(encoding="utf-8").strip()
+  except OSError:
+    boot_id = ""
+  accepted = _valid_cutover_intent(
+    _read_bounded_json(INTENT_PATH),
+    _read_bounded_json(CUTOVER_CHALLENGE_PATH),
+    boot_id,
+    cutover_id,
+    current,
+  )
+  _remove(ACCEPTED_PATH)
+  if accepted is not None:
+    _write_json(ACCEPTED_PATH, accepted, 0o600)
+    _write_json(CUTOVER_RECEIPT_PATH, accepted, 0o600)
+  _remove(CUTOVER_CHALLENGE_PATH)
+  _remove(INTENT_PATH)
+  _remove(REQUEST_PATH)
+  return accepted is not None
+
+
+def _matching_cutover_receipt(
+  cutover_id: str,
+  *,
+  now: float,
+) -> dict[str, Any] | None:
+  receipt = _read_bounded_json(CUTOVER_RECEIPT_PATH)
+  if not receipt or not _valid_token(cutover_id):
+    return None
+  try:
+    accepted_at = float(receipt.get("accepted_at"))
+  except (TypeError, ValueError):
+    return None
+  if (
+    receipt.get("version") != PROTOCOL_VERSION
+    or receipt.get("action") != "external_cutover"
+    or receipt.get("cutover_id") != cutover_id
+    or not _valid_token(receipt.get("nonce"))
+    or not _valid_token(receipt.get("source_boot_id"))
+    or accepted_at > now + 5
+    or now - accepted_at > MAX_CUTOVER_RECEIPT_AGE_SECONDS
+  ):
+    return None
+  return receipt
+
+
+def rearm_cutover(cutover_id: str, *, now: float | None = None) -> bool:
+  """Authorize one explicit rollback boot from the same root receipt."""
+  current = time.time() if now is None else now
+  _prepare_ledger_dir()
+  receipt = _matching_cutover_receipt(cutover_id, now=current)
+  if receipt is None:
+    return False
+
+  existing = _read_bounded_json(ACCEPTED_PATH)
+  if (
+    existing
+    and existing.get("nonce") == receipt.get("nonce")
+    and existing.get("cutover_id") == cutover_id
+  ):
+    return True
+
+  ack = _read_bounded_json(ACK_PATH)
+  if (
+    not ack
+    or ack.get("nonce") != receipt.get("nonce")
+    or ack.get("cutover_id") != cutover_id
+    or not _valid_token(ack.get("target_boot_id"))
+  ):
+    return False
+  _write_json(ACCEPTED_PATH, {
+    **receipt,
+    "source_boot_id": ack["target_boot_id"],
+    "accepted_at": current,
+  }, 0o600)
+  return True
+
+
+def finalize_cutover(cutover_id: str, *, now: float | None = None) -> bool:
+  """Retire the rollback receipt after the replacement is serviceable."""
+  current = time.time() if now is None else now
+  _prepare_ledger_dir()
+  receipt = _matching_cutover_receipt(cutover_id, now=current)
+  ack = _read_bounded_json(ACK_PATH)
+  if (
+    receipt is None
+    or not ack
+    or ack.get("nonce") != receipt.get("nonce")
+    or ack.get("cutover_id") != cutover_id
+    or not _valid_token(ack.get("target_boot_id"))
+  ):
+    return False
+  return _remove(CUTOVER_RECEIPT_PATH)
+
+
 def _main(argv: list[str]) -> int:
+  if len(argv) == 2 and argv[1] == "capabilities":
+    print("external-cutover-v1")
+    return 0
   if len(argv) != 3:
-    print("usage: restart_ledger.py begin-boot|harden|accept BOOT_ID", file=sys.stderr)
+    print(
+      "usage: restart_ledger.py begin-boot|harden|accept BOOT_ID | "
+      "open-cutover|accept-cutover|rearm-cutover|finalize-cutover CUTOVER_ID | "
+      "capabilities",
+      file=sys.stderr,
+    )
     return 2
-  command, boot_id = argv[1:]
+  command, value = argv[1:]
   try:
     if command == "begin-boot":
-      result = begin_boot(boot_id)
+      result = begin_boot(value)
     elif command == "harden":
-      result = harden(boot_id)
+      result = harden(value)
     elif command == "accept":
-      result = accept(boot_id)
+      result = accept(value)
+    elif command == "open-cutover":
+      result = open_cutover(value)
+    elif command == "accept-cutover":
+      result = accept_cutover(value)
+    elif command == "rearm-cutover":
+      result = rearm_cutover(value)
+    elif command == "finalize-cutover":
+      result = finalize_cutover(value)
     else:
       return 2
   except Exception as exc:
@@ -306,7 +501,10 @@ def _main(argv: list[str]) -> int:
   # A boot with no accepted prior intent is ordinary success. By contrast,
   # hardening and request acceptance are security gates: a false result must be
   # observable by the root entrypoint and must not trigger a restart.
-  if command in {"accept", "harden"} and not result:
+  if command in {
+    "accept", "harden", "open-cutover", "accept-cutover",
+    "rearm-cutover", "finalize-cutover",
+  } and not result:
     return 1
   return 0
 

--- a/backend/scripts/prepare-container-cutover.py
+++ b/backend/scripts/prepare-container-cutover.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Ask the live worker to prepare one root-opened Host cutover."""
+
+from __future__ import annotations
+
+import json
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+
+def main() -> int:
+  if len(sys.argv) != 2:
+    print("usage: prepare-container-cutover.py CUTOVER_ID", file=sys.stderr)
+    return 2
+  token = Path("/data/service-token.txt").read_text(encoding="utf-8").strip()
+  body = json.dumps({"cutover_id": sys.argv[1]}).encode("utf-8")
+  request = urllib.request.Request(
+    "http://127.0.0.1:8000/api/admin/restart/prepare-cutover",
+    data=body,
+    method="POST",
+    headers={
+      "Authorization": f"Bearer {token}",
+      "Content-Type": "application/json",
+      "Accept": "application/json",
+    },
+  )
+  try:
+    with urllib.request.urlopen(request, timeout=45) as response:
+      payload = response.read().decode("utf-8", errors="replace")
+      if payload:
+        print(payload)
+      return 0 if response.status == 200 else 1
+  except urllib.error.HTTPError as exc:
+    detail = exc.read().decode("utf-8", errors="replace")[:1000]
+    print(f"cutover preparation failed ({exc.code}): {detail}", file=sys.stderr)
+    return 1
+  except OSError as exc:
+    print(f"cutover preparation failed: {exc}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+  raise SystemExit(main())

--- a/backend/scripts/seed-skills/platform-maintenance.md
+++ b/backend/scripts/seed-skills/platform-maintenance.md
@@ -64,6 +64,29 @@ docker compose exec -u 0 app bash
 That also attaches to the normal live container; it does not select a Recovery
 boot profile.
 
+### Host-owned container replacement
+
+A container recreation is not an ordinary server restart. On a self-hosted
+Host, use one of the two owning paths:
+
+- `scripts/deploy-prod.sh` for a checkout/image deployment; or
+- the installed Settings replacement controller documented in
+  `scripts/CONTAINER-REBUILD.md` for an official-image refresh.
+
+Both paths open a root-owned cutover challenge, ask the still-running worker to
+park and nonce-bind exact active chat runs, then let Docker perform the only
+stop. A failed replacement explicitly re-arms the same receipt for one rollback
+boot. This is why a raw `docker compose up --force-recreate`, `docker restart`,
+or direct container replacement is not an equivalent shortcut: it bypasses the
+handoff and intentionally falls back to conservative manual Resume after boot.
+Unexpected crashes remain manual by design; never make arbitrary boots look
+planned merely to hide recovery prompts.
+
+The running image must already contain the frozen `external-cutover-v1` helper.
+The first upgrade from an older image cannot manufacture that root capability;
+`deploy-prod.sh` says when it is using the legacy owner-presence gate, and that
+one upgrade installs the helper for later replacements.
+
 ---
 
 ## Choose the smallest activation action

--- a/backend/tests/test_admin_rebuild.py
+++ b/backend/tests/test_admin_rebuild.py
@@ -25,6 +25,7 @@ def test_rebuild_routes_require_owner(client):
   assert client.get("/api/admin/rebuild").status_code == 401
   assert client.post("/api/admin/rebuild").status_code == 401
   assert client.post("/api/admin/rebuild/prepare").status_code == 401
+  assert client.post("/api/admin/restart/prepare-cutover").status_code == 401
 
 
 def test_rebuild_post_rejects_cross_site(client, auth):
@@ -109,3 +110,54 @@ def test_host_prepare_drains_only_the_matching_operation(
 
   assert response.status_code == 202
   assert calls == [ready]
+
+
+def test_external_cutover_requires_root_challenge_before_drain(
+  client, auth, monkeypatch,
+):
+  calls = []
+  monkeypatch.setattr(
+    "app.restart_ledger.authorized_cutover_challenge", lambda _value: False,
+  )
+
+  async def prepare(value):
+    calls.append(value)
+    return {"status": "prepared"}
+
+  monkeypatch.setattr(admin_routes, "prepare_container_cutover", prepare)
+
+  response = client.post(
+    "/api/admin/restart/prepare-cutover",
+    json={"cutover_id": "cutover-12345678"},
+    headers=auth,
+  )
+
+  assert response.status_code == 409
+  assert response.json()["detail"]["code"] == "cutover_not_open"
+  assert calls == []
+
+
+def test_external_cutover_prepares_only_the_root_opened_id(
+  client, auth, monkeypatch,
+):
+  calls = []
+  monkeypatch.setattr(
+    "app.restart_ledger.authorized_cutover_challenge",
+    lambda value: value == "cutover-12345678",
+  )
+
+  async def prepare(value):
+    calls.append(value)
+    return {"status": "prepared", "cutover_id": value, "run_count": 2}
+
+  monkeypatch.setattr(admin_routes, "prepare_container_cutover", prepare)
+
+  response = client.post(
+    "/api/admin/restart/prepare-cutover",
+    json={"cutover_id": "cutover-12345678"},
+    headers=auth,
+  )
+
+  assert response.status_code == 200
+  assert response.json()["run_count"] == 2
+  assert calls == ["cutover-12345678"]

--- a/backend/tests/test_deploy_cutover_contract.py
+++ b/backend/tests/test_deploy_cutover_contract.py
@@ -1,0 +1,33 @@
+"""Build-time contract for the shell-owned production cutover loop."""
+
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).parents[2] / "scripts" / "deploy-prod.sh"
+
+
+def test_prod_replacement_uses_exact_chat_handoff_and_rollback_receipt():
+  source = SCRIPT.read_text(encoding="utf-8")
+
+  assert "external-cutover-v1" in source
+  assert 'cutover_ledger open-cutover "$CUTOVER_ID"' in source
+  assert 'prepare-container-cutover.py "$CUTOVER_ID"' in source
+  assert 'cutover_ledger accept-cutover "$CUTOVER_ID"' in source
+  assert source.index("prepare_chat_cutover") < source.index(
+    'docker compose "${COMPOSE_ARGS[@]}" up -d "${recreate_args[@]}" app'
+  )
+  assert 'cutover_ledger rearm-cutover "$CUTOVER_ID"' in source
+  assert 'cutover_ledger finalize-cutover "$CUTOVER_ID"' in source
+  assert "attempt_rollback || true" in source
+
+
+def test_same_image_compose_recreation_is_inside_the_exact_handoff_gate():
+  source = SCRIPT.read_text(encoding="utf-8")
+
+  assert 'RUNNING_CONFIG_HASH=$(' in source
+  assert 'config --hash app' in source
+  assert 'compose_recreation_needed "$TARGET_IMAGE"' in source
+  assert source.index('compose_recreation_needed "$TARGET_IMAGE"') < source.index(
+    'docker compose "${COMPOSE_ARGS[@]}" up -d "${recreate_args[@]}" app'
+  )
+  assert 'recreate_args=(--force-recreate)' in source

--- a/backend/tests/test_deploy_image_identity.py
+++ b/backend/tests/test_deploy_image_identity.py
@@ -177,6 +177,87 @@ def test_scratch_preflight_runs_the_compose_image_not_the_old_reference():
   assert "RUNNING_IMAGE_REF" not in preflight
 
 
+def _recreation_harness(assertions: str, *, desired_hash: str | None) -> str:
+  function = _function_source(
+    "compose_recreation_needed", "prepare_chat_cutover()",
+  )
+  desired = (
+    "desired_compose_config_hash() { return 1; }\n"
+    if desired_hash is None
+    else f"desired_compose_config_hash() {{ printf '%s\\n' {desired_hash!r}; }}\n"
+  )
+  return textwrap.dedent("""\
+    info() { :; }
+    warn() { :; }
+    valid_compose_config_hash() {
+      [[ "${1:-}" =~ ^[0-9a-fA-F]{64}$ ]]
+    }
+  """) + desired + function + assertions
+
+
+def test_same_image_changed_compose_config_requires_handoff():
+  old_hash = "a" * 64
+  new_hash = "b" * 64
+  assertions = textwrap.dedent(f"""\
+    PREV_IMAGE=sha256:same
+    RUNNING_CONFIG_HASH={old_hash}
+    if compose_recreation_needed sha256:same; then
+      printf 'needed=%s force=%s target=%s\\n' 1 "$FORCE_APP_RECREATE" "$TARGET_CONFIG_HASH"
+    else
+      printf 'needed=0\\n'
+    fi
+  """)
+  result = subprocess.run(
+    ["bash", "-c", _recreation_harness(assertions, desired_hash=new_hash)],
+    capture_output=True,
+    text=True,
+  )
+
+  assert result.returncode == 0, result.stderr
+  assert result.stdout == f"needed=1 force=0 target={new_hash}\n"
+
+
+def test_same_image_same_compose_config_is_a_true_noop():
+  config_hash = "a" * 64
+  assertions = textwrap.dedent(f"""\
+    PREV_IMAGE=sha256:same
+    RUNNING_CONFIG_HASH={config_hash}
+    if compose_recreation_needed sha256:same; then
+      printf 'needed=1\\n'
+    else
+      printf 'needed=0 force=%s target=%s\\n' "$FORCE_APP_RECREATE" "$TARGET_CONFIG_HASH"
+    fi
+  """)
+  result = subprocess.run(
+    ["bash", "-c", _recreation_harness(assertions, desired_hash=config_hash)],
+    capture_output=True,
+    text=True,
+  )
+
+  assert result.returncode == 0, result.stderr
+  assert result.stdout == f"needed=0 force=0 target={config_hash}\n"
+
+
+def test_unknown_compose_hash_forces_a_handed_off_app_recreation():
+  assertions = textwrap.dedent("""\
+    PREV_IMAGE=sha256:same
+    RUNNING_CONFIG_HASH=
+    if compose_recreation_needed sha256:same; then
+      printf 'needed=%s force=%s\\n' 1 "$FORCE_APP_RECREATE"
+    else
+      printf 'needed=0\\n'
+    fi
+  """)
+  result = subprocess.run(
+    ["bash", "-c", _recreation_harness(assertions, desired_hash=None)],
+    capture_output=True,
+    text=True,
+  )
+
+  assert result.returncode == 0, result.stderr
+  assert result.stdout == "needed=1 force=1\n"
+
+
 def test_rollback_retags_previous_id_then_recreates_compose_image(tmp_path):
   docker_log = tmp_path / "docker.log"
   rollback = _function_source(

--- a/backend/tests/test_deployment_control.py
+++ b/backend/tests/test_deployment_control.py
@@ -13,7 +13,10 @@ def _install_control(tmp_path, monkeypatch):
   control = tmp_path / "mobius-rebuild"
   inbox = control / "inbox"
   inbox.mkdir(parents=True)
-  (control / "status.json").write_text('{"state":"idle"}', encoding="utf-8")
+  (control / "status.json").write_text(
+    '{"state":"idle","handoff":"external-cutover-v1"}',
+    encoding="utf-8",
+  )
   monkeypatch.setattr(dc, "_control_dir", lambda: control)
   return control, inbox
 
@@ -56,7 +59,8 @@ async def test_request_writes_only_the_derived_sha(tmp_path, monkeypatch):
 async def test_queued_request_masks_the_previous_terminal_status(tmp_path, monkeypatch):
   control, inbox = _install_control(tmp_path, monkeypatch)
   (control / "status.json").write_text(
-    '{"state":"succeeded","operation_id":"old"}', encoding="utf-8",
+    '{"state":"succeeded","operation_id":"old",'
+    '"handoff":"external-cutover-v1"}', encoding="utf-8",
   )
   (inbox / "request.json").write_text(json.dumps({
     "version": 1, "expected_sha": "e" * 40,
@@ -105,6 +109,24 @@ async def test_status_reports_unconfigured_self_host(monkeypatch):
 
   assert status["supported"] is False
   assert status["code"] == "not_configured"
+
+
+@pytest.mark.asyncio
+async def test_legacy_host_helper_is_visible_but_cannot_queue_replacement(
+  tmp_path, monkeypatch,
+):
+  control, inbox = _install_control(tmp_path, monkeypatch)
+  (control / "status.json").write_text('{"state":"idle"}', encoding="utf-8")
+  monkeypatch.setattr(dc.platform_activation, "deployment_kind", lambda: "self_hosted")
+
+  status = await dc.read_rebuild_status()
+
+  assert status["supported"] is False
+  assert status["code"] == "controller_upgrade_required"
+  with pytest.raises(dc.DeploymentControlError) as exc:
+    await dc.request_rebuild()
+  assert exc.value.code == "controller_upgrade_required"
+  assert not (inbox / "request.json").exists()
 
 
 def test_prepare_path_requires_matching_root_owned_operation(tmp_path, monkeypatch):

--- a/backend/tests/test_drain_for_restart.py
+++ b/backend/tests/test_drain_for_restart.py
@@ -409,6 +409,7 @@ def test_authenticated_restart_fallback_becomes_due_park():
 
   assert result.manual == []
   assert result.restart_parks == [cid]
+  assert result.restart_waiting == []
   assert _chat(cid)["running_status"] is None
   run = _run(cid)
   assert run["status"] == "parked"
@@ -441,6 +442,7 @@ def test_unacknowledged_restart_intent_remains_manual():
 
   assert result.manual == [cid]
   assert result.restart_parks == []
+  assert result.restart_waiting == []
   run = _run(cid)
   assert run["status"] == "interrupted"
   assert run["restart_nonce"] is None
@@ -499,6 +501,7 @@ def test_five_chat_restart_recovers_timeouts_and_finalize_failure(
     db.close()
   assert set(result.restart_parks) == {*timeout_ids, finalize_id}
   assert result.manual == []
+  assert result.restart_waiting == []
   assert all(_run(cid)["status"] == "parked" for cid in all_ids)
 
   scheduled = []
@@ -603,6 +606,49 @@ def test_reconcile_question_tail_note_is_not_resumable():
   # The question stays the tail block, and the inserted note is inert.
   assert blocks[-1].get("type") == "question"
   note = next(b for b in blocks if b.get("type") == "error")
+  assert "answer is still needed" in note["message"]
+  assert not note.get("resumable")
+
+
+def test_authenticated_restart_question_stays_waiting_not_manual():
+  """An exact restart must preserve a question without claiming it failed.
+
+  The owner still has to answer the card; neither automatic Continue nor the
+  generic "tap to resume" crash notification is a valid continuation.
+  """
+  cid = "reco-authenticated-question"
+  nonce = "restart-nonce-question"
+  _seed(cid, messages=[
+    {"role": "user", "content": "hi", "ts": 1},
+    {"role": "assistant", "ts": 2, "content": "", "blocks": [
+      {"type": "text", "content": "I need your approval."},
+      {"type": "question", "id": "q1", "text": "Restart now?"},
+    ]},
+  ])
+  db = SessionLocal()
+  try:
+    run = db.query(models.ChatRun).filter(
+      models.ChatRun.id == f"rt-{cid}",
+    ).one()
+    chat = db.query(models.Chat).filter(models.Chat.id == cid).one()
+    run.restart_nonce = nonce
+    chat.pending_question_id = "q1"
+    db.commit()
+    result = chat_mod.reconcile_startup_chats(
+      db, restart_authorization=nonce,
+    )
+  finally:
+    db.close()
+
+  assert result.manual == []
+  assert result.restart_parks == []
+  assert result.restart_waiting == [cid]
+  run = _run(cid)
+  assert run["status"] == "interrupted"
+  assert run["restart_nonce"] is None
+  blocks = _chat(cid)["messages"][-1]["blocks"]
+  assert blocks[-1]["type"] == "question"
+  note = next(block for block in blocks if block["type"] == "error")
   assert "answer is still needed" in note["message"]
   assert not note.get("resumable")
 

--- a/backend/tests/test_mobius_rebuild_host.py
+++ b/backend/tests/test_mobius_rebuild_host.py
@@ -274,6 +274,7 @@ def test_replacement_drains_then_rolls_back_after_cutover_error(tmp_path, monkey
   monkeypatch.setattr(
     host, "request_drain", lambda *_args: order.append("drain") or ready,
   )
+  monkeypatch.setattr(host, "restart_ledger", lambda *_args, **_kwargs: True)
 
   def compose(_config, *args, image=None, **_kwargs):
     order.append(f"compose:{image}")
@@ -295,6 +296,77 @@ def test_replacement_drains_then_rolls_back_after_cutover_error(tmp_path, monkey
   ]
   assert statuses[-1]["state"] == "rolled_back"
   assert statuses[-1]["code"] == "replacement_failed"
+
+
+def test_success_reports_when_chat_handoff_receipt_cannot_be_retired(
+  tmp_path, monkeypatch,
+):
+  _config, inbox = _worker_paths(tmp_path, monkeypatch)
+  expected = "9" * 40
+  (inbox / "request.json").write_text(
+    f'{{"version":1,"expected_sha":"{expected}"}}', encoding="utf-8",
+  )
+  monkeypatch.setattr(host, "app_container", lambda _config: ("cid", "old"))
+  monkeypatch.setattr(host, "require_pull_space", lambda _image: None)
+  monkeypatch.setattr(host.subprocess, "run", lambda *_args, **_kwargs: None)
+  monkeypatch.setattr(host, "inspect_image", lambda _image, template: (
+    expected if "revision" in template else
+    host.IMAGE_SOURCE if "source" in template else
+    "amd64" if "Architecture" in template else "new"
+  ))
+  monkeypatch.setattr(host, "request_drain", lambda *_args: None)
+  monkeypatch.setattr(host, "compose", lambda *_args, **_kwargs: None)
+  monkeypatch.setattr(host, "wait_healthy", lambda *_args, **_kwargs: True)
+  monkeypatch.setattr(host, "retain_images", lambda *_args: None)
+  monkeypatch.setattr(
+    host, "restart_ledger",
+    lambda _config, _cid, command, _operation, **_kwargs:
+      command != "finalize-cutover",
+  )
+  statuses = []
+  monkeypatch.setattr(
+    host, "write_status", lambda _config, **fields: statuses.append(fields) or fields,
+  )
+
+  assert host.run() == 0
+  assert statuses[-1]["state"] == "succeeded"
+  assert statuses[-1]["code"] == "handoff_finalize_failed"
+  assert "could not verify and retire" in statuses[-1]["message"]
+
+
+@pytest.mark.parametrize(
+  ("rearmed", "finalized", "expected_code", "message_fragment"),
+  [
+    (False, False, "handoff_rearm_failed", "may need manual Resume"),
+    (True, False, "handoff_finalize_failed", "could not verify and retire"),
+  ],
+)
+def test_healthy_rollback_reports_degraded_chat_handoff(
+  tmp_path, monkeypatch, rearmed, finalized, expected_code, message_fragment,
+):
+  config, _inbox = _worker_paths(tmp_path, monkeypatch)
+  operation = "a" * 32
+  expected = "b" * 40
+  monkeypatch.setattr(host, "app_container", lambda _config: ("cid", "old"))
+  monkeypatch.setattr(host, "compose", lambda *_args, **_kwargs: None)
+  monkeypatch.setattr(host, "wait_healthy", lambda *_args, **_kwargs: True)
+
+  def ledger(_config, _cid, command, _operation, **_kwargs):
+    assert _operation == operation
+    return rearmed if command == "rearm-cutover" else finalized
+
+  monkeypatch.setattr(host, "restart_ledger", ledger)
+  statuses = []
+  monkeypatch.setattr(
+    host, "write_status", lambda _config, **fields: statuses.append(fields) or fields,
+  )
+
+  assert host.rollback(
+    config, operation, expected, "health_check_failed", "new image unhealthy",
+  ) == 1
+  assert statuses[-1]["state"] == "rolled_back"
+  assert statuses[-1]["code"] == expected_code
+  assert message_fragment in statuses[-1]["message"]
 
 
 def test_reconcile_marks_interrupted_active_worker_failed(tmp_path, monkeypatch):
@@ -326,26 +398,30 @@ def test_reconcile_cleans_claim_abandoned_before_first_status(tmp_path, monkeypa
   assert not abandoned.exists()
 
 
-def test_drain_waits_for_the_root_supervisor_receipt(tmp_path, monkeypatch):
+def test_drain_requires_root_open_prepare_accept_order(tmp_path, monkeypatch):
   data = tmp_path / "data"
-  inbox = data / "mobius-rebuild" / "inbox"
-  ledger = data / ".restart-ledger"
-  inbox.mkdir(parents=True)
-  ledger.mkdir()
+  data.mkdir()
   operation = "a" * 32
+  order = []
 
-  def execute(*_args, **_kwargs):
-    (inbox / f"ready-{operation}").write_text("ready\n", encoding="utf-8")
-    (ledger / "accepted.json").write_text("{}", encoding="utf-8")
+  def ledger(_config, _cid, command, value, **_kwargs):
+    order.append(command)
+    assert value == operation
+    return True
+
+  def execute(args, **_kwargs):
+    order.append("prepare")
+    assert args[-1] == operation
     return subprocess.CompletedProcess([], 0)
 
+  monkeypatch.setattr(host, "restart_ledger", ledger)
   monkeypatch.setattr(host.subprocess, "run", execute)
-  monkeypatch.setattr(host.time, "time", lambda: 0)
 
-  ready = host.request_drain(
+  result = host.request_drain(
     {"data_dir": data, "control_dir": data / "mobius-rebuild"},
     operation,
     "container",
   )
 
-  assert ready == inbox / f"ready-{operation}"
+  assert result is None
+  assert order == ["open-cutover", "prepare", "accept-cutover"]

--- a/backend/tests/test_restart_ledger.py
+++ b/backend/tests/test_restart_ledger.py
@@ -47,6 +47,14 @@ def _bind(supervisor, root: Path, monkeypatch) -> None:
   monkeypatch.setattr(
     supervisor, "BOOT_PATH", root / ".restart-ledger" / "boot-id",
   )
+  monkeypatch.setattr(
+    supervisor, "CUTOVER_CHALLENGE_PATH",
+    root / ".restart-ledger" / "cutover-challenge.json",
+  )
+  monkeypatch.setattr(
+    supervisor, "CUTOVER_RECEIPT_PATH",
+    root / ".restart-ledger" / "cutover-receipt.json",
+  )
   monkeypatch.setattr(supervisor, "SUPERVISOR_UID", os.getuid())
   monkeypatch.setattr(supervisor, "SUPERVISOR_GID", os.getgid())
   monkeypatch.setattr(
@@ -91,6 +99,88 @@ def test_exact_accepted_restart_is_bound_to_immediately_following_boot(
 
   assert _authorized(tmp_path, target_boot) == nonce
   assert _authorized(tmp_path, source_boot) is None
+
+
+def test_root_opened_cutover_binds_replacement_boot_without_self_restart(
+  tmp_path, monkeypatch,
+):
+  supervisor = _load_supervisor()
+  _bind(supervisor, tmp_path, monkeypatch)
+  now = time.time()
+  source_boot = "boot-source-1234"
+  target_boot = "boot-target-1234"
+  cutover_id = "cutover-12345678"
+  nonce = "nonce-12345678"
+
+  supervisor.begin_boot(source_boot, now=now)
+  assert supervisor.open_cutover(cutover_id, now=now + 1)
+  assert platform_ledger.authorized_cutover_challenge(
+    cutover_id,
+    boot_id=source_boot,
+    now=now + 1,
+    trusted_uid=os.getuid(),
+    trusted_gid=os.getgid(),
+  )
+  platform_ledger.publish_cutover_intent(
+    boot_id=source_boot,
+    nonce=nonce,
+    cutover_id=cutover_id,
+    runs=[{"chat_id": "chat-12345678", "run_token": "run-12345678"}],
+    now=now + 1,
+  )
+
+  assert supervisor.accept_cutover(cutover_id, now=now + 2)
+  assert not supervisor.REQUEST_PATH.exists()
+  assert supervisor.begin_boot(target_boot, now=now + 3)
+  assert _authorized(tmp_path, target_boot) == nonce
+
+
+def test_cutover_requires_matching_root_challenge(tmp_path, monkeypatch):
+  supervisor = _load_supervisor()
+  _bind(supervisor, tmp_path, monkeypatch)
+  now = time.time()
+  source_boot = "boot-source-1234"
+  supervisor.begin_boot(source_boot, now=now)
+  platform_ledger.publish_cutover_intent(
+    boot_id=source_boot,
+    nonce="nonce-12345678",
+    cutover_id="cutover-12345678",
+    runs=[],
+    now=now,
+  )
+
+  assert not supervisor.accept_cutover("cutover-12345678", now=now + 1)
+  assert not supervisor.ACCEPTED_PATH.exists()
+
+
+def test_failed_cutover_can_rearm_exact_rollback_then_finalize(
+  tmp_path, monkeypatch,
+):
+  supervisor = _load_supervisor()
+  _bind(supervisor, tmp_path, monkeypatch)
+  now = time.time()
+  source_boot = "boot-source-1234"
+  failed_boot = "boot-failed-1234"
+  rollback_boot = "boot-rollback-1234"
+  cutover_id = "cutover-12345678"
+  nonce = "nonce-12345678"
+
+  supervisor.begin_boot(source_boot, now=now)
+  supervisor.open_cutover(cutover_id, now=now + 1)
+  platform_ledger.publish_cutover_intent(
+    boot_id=source_boot,
+    nonce=nonce,
+    cutover_id=cutover_id,
+    runs=[],
+    now=now + 1,
+  )
+  assert supervisor.accept_cutover(cutover_id, now=now + 2)
+  assert supervisor.begin_boot(failed_boot, now=now + 3)
+  assert supervisor.rearm_cutover(cutover_id, now=now + 4)
+  assert supervisor.begin_boot(rollback_boot, now=now + 5)
+  assert _authorized(tmp_path, rollback_boot) == nonce
+  assert supervisor.finalize_cutover(cutover_id, now=now + 6)
+  assert not supervisor.rearm_cutover(cutover_id, now=now + 7)
 
 
 def test_restart_intent_keeps_exact_runs_for_older_frozen_supervisors(

--- a/backend/tests/test_restart_util.py
+++ b/backend/tests/test_restart_util.py
@@ -144,3 +144,58 @@ def test_restart_handshake_failure_restarts_without_authorization(monkeypatch):
   asyncio.run(ru.restart_this_worker())
 
   assert calls == [(os.getpid(), signal.SIGTERM)]
+
+
+def test_external_cutover_drains_without_requesting_self_restart(monkeypatch):
+  _FakeTimer.instances = []
+  calls = []
+  published = []
+  fallback_requests = []
+  monkeypatch.setattr(ru.os, "kill", lambda pid, sig: calls.append((pid, sig)))
+  monkeypatch.setattr(ru.threading, "Timer", _FakeTimer)
+  monkeypatch.setattr(
+    restart_ledger, "authorized_cutover_challenge", lambda value: value == "cutover-12345678",
+  )
+  monkeypatch.setattr(restart_ledger, "current_boot_id", lambda: "boot-12345678")
+  monkeypatch.setattr(restart_ledger, "new_nonce", lambda: "nonce-12345678")
+  monkeypatch.setattr(
+    restart_ledger, "publish_cutover_intent",
+    lambda **kwargs: published.append(kwargs),
+  )
+  monkeypatch.setattr(
+    restart_ledger, "request_restart",
+    lambda **kwargs: fallback_requests.append(kwargs),
+  )
+
+  async def _prepare(_nonce):
+    return [{"chat_id": "chat-12345678", "run_token": "run-12345678"}]
+
+  async def _drain(timeout=0, *, restart_nonce="", prepared_runs=None):
+    del timeout, restart_nonce
+    return prepared_runs or []
+
+  monkeypatch.setattr(chat_mod, "prepare_restart_intents", _prepare)
+  monkeypatch.setattr(chat_mod, "drain_all_for_restart", _drain)
+  chat_mod.draining = False
+
+  result = asyncio.run(ru.prepare_container_cutover("cutover-12345678"))
+
+  assert result["status"] == "prepared"
+  assert result["run_count"] == 1
+  assert calls == []
+  assert fallback_requests == []
+  assert published == [{
+    "boot_id": "boot-12345678",
+    "nonce": "nonce-12345678",
+    "cutover_id": "cutover-12345678",
+    "runs": [{"chat_id": "chat-12345678", "run_token": "run-12345678"}],
+  }]
+  assert len(_FakeTimer.instances) == 1
+  watchdog = _FakeTimer.instances[0]
+  assert watchdog.interval == ru._CUTOVER_FAILSAFE_SECONDS
+  watchdog.fn()
+  assert fallback_requests == [{
+    "boot_id": "boot-12345678",
+    "nonce": "nonce-12345678",
+    "runs": [{"chat_id": "chat-12345678", "run_token": "run-12345678"}],
+  }]

--- a/scripts/CONTAINER-REBUILD.md
+++ b/scripts/CONTAINER-REBUILD.md
@@ -38,12 +38,27 @@ The worker:
 1. checks Docker free space and pulls `ghcr.io/mobius-os/mobius:sha-<sha>`;
 2. verifies the image source, revision, and amd64 architecture;
 3. returns `no_change` without disturbing chats if that image is already live;
-4. asks the running worker to use Möbius's existing restart drain, which closes
-   admission, parks active turns, and authorizes their boot continuation;
-5. recreates only `app` from the frozen topology and verifies health;
-6. restores the prior image on failure; and
-7. retains only the current helper-owned SHA tag plus one last-good rollback
+4. opens a root-owned one-boot cutover challenge, then asks the running worker
+   to close admission, park active turns, and bind them to that exact id;
+5. accepts the matching app intent without self-stopping, so Compose owns the
+   only stop and the authorization cannot be consumed by an intermediate boot;
+6. recreates only `app` from the frozen topology and verifies health;
+7. explicitly re-arms the same root receipt for one rollback boot if the new
+   container never becomes serviceable, then retires it after either healthy
+   outcome; and
+8. retains only the current helper-owned SHA tag plus one last-good rollback
    tag, without a host-wide prune.
+
+The canonical local `scripts/deploy-prod.sh` uses the same challenge → drain →
+accept contract when the image identity changes. A running image from before
+this protocol cannot provide the frozen root helper, so the first upgrade uses
+the existing owner-presence gate and says so explicitly; subsequent Host
+replacements preserve eligible active chats even with `--force-now`.
+
+An installation of the older Host helper is reported as **upgrade required**
+and cannot queue a Settings replacement. Re-run
+`sudo scripts/install-rebuild-helper.sh` from the current trusted checkout;
+the refusal happens before chat admission is closed or an image is touched.
 
 Möbius refuses the request when its activation receipt records local-only image
 or baked-runtime changes that the official target does not contain. Undeclared

--- a/scripts/deploy-prod.sh
+++ b/scripts/deploy-prod.sh
@@ -67,6 +67,8 @@ ALLOW_STALE="${ALLOW_STALE:-0}"
 ALLOW_LOW_DISK="${ALLOW_LOW_DISK:-0}"
 BUILT_THIS_RUN=0  # set to 1 once we actually build, so the verify step only
                   # compares the served SHA when THIS run produced the image
+CUTOVER_ID=""
+CUTOVER_PREPARED=0
 PREFLIGHT_WAIT_SECONDS="${PREFLIGHT_WAIT_SECONDS:-120}"
 DEPLOY_MIN_FREE_GB="${DEPLOY_MIN_FREE_GB:-15}"
 DEPLOY_BUILD_CACHE_MAX_AGE_HOURS="${DEPLOY_BUILD_CACHE_MAX_AGE_HOURS:-24}"
@@ -247,6 +249,112 @@ presence_gate() {
   done
   [ "$waited" -gt 0 ] && ok "owner turn finished — proceeding with $1"
   return 0
+}
+
+# Run one command through the frozen root-owned restart ledger. Prefer the live
+# container; during a failed cutover it may be crash-looping, so fall back to a
+# one-shot process using the previously serving image and the same /data mount.
+cutover_ledger() {
+  if docker exec "$CONTAINER" python3 -P \
+    /app/runtime/restart_ledger.py "$@" >/dev/null 2>&1; then
+    return 0
+  fi
+  [ -n "${PREV_IMAGE:-}" ] || return 1
+  docker run --rm --volumes-from "$CONTAINER" --entrypoint python3 \
+    "$PREV_IMAGE" -P /app/runtime/restart_ledger.py "$@" \
+    >/dev/null 2>&1
+}
+
+cutover_supported() {
+  docker exec "$CONTAINER" python3 -P \
+    /app/runtime/restart_ledger.py capabilities 2>/dev/null \
+    | grep -qx 'external-cutover-v1'
+}
+
+valid_compose_config_hash() {
+  [[ "${1:-}" =~ ^[0-9a-fA-F]{64}$ ]]
+}
+
+desired_compose_config_hash() {
+  local output hash
+  output=$(docker compose "${COMPOSE_ARGS[@]}" config --hash app 2>/dev/null) \
+    || return 1
+  hash=$(printf '%s\n' "$output" | awk '$1 == "app" && NF == 2 { print $2 }')
+  valid_compose_config_hash "$hash" || return 1
+  printf '%s\n' "$hash"
+}
+
+# Compose can replace a container even when its image ID is unchanged: an env,
+# mount, network, label, or other rendered service change is enough. Draining
+# only on image changes therefore loses active turns on a same-image recreate.
+# Compare both inputs Compose owns. If this Compose version cannot expose its
+# service hash, fail safe by deliberately forcing the app recreation *after*
+# the exact handoff rather than gambling that `up` will be a no-op.
+compose_recreation_needed() {
+  local target_image="$1"
+  TARGET_CONFIG_HASH=""
+  FORCE_APP_RECREATE=0
+
+  if [ "$target_image" != "$PREV_IMAGE" ]; then
+    info "replacement required: app image changed"
+    return 0
+  fi
+
+  if ! valid_compose_config_hash "${RUNNING_CONFIG_HASH:-}"; then
+    warn "the live container has no usable Compose config hash."
+    warn "Preparing an exact handoff and forcing only the app recreation."
+    FORCE_APP_RECREATE=1
+    return 0
+  fi
+  if ! TARGET_CONFIG_HASH=$(desired_compose_config_hash); then
+    warn "Docker Compose could not report the rendered app config hash."
+    warn "Preparing an exact handoff and forcing only the app recreation."
+    FORCE_APP_RECREATE=1
+    return 0
+  fi
+  if [ "$TARGET_CONFIG_HASH" != "$RUNNING_CONFIG_HASH" ]; then
+    info "replacement required: rendered app configuration changed"
+    return 0
+  fi
+  return 1
+}
+
+prepare_chat_cutover() {
+  CUTOVER_ID="cutover-$(python3 -c 'import secrets; print(secrets.token_hex(16))')"
+  if ! cutover_ledger open-cutover "$CUTOVER_ID"; then
+    CUTOVER_ID=""
+    return 1
+  fi
+  if ! docker exec "$CONTAINER" python3 \
+    /data/platform/backend/scripts/prepare-container-cutover.py "$CUTOVER_ID"; then
+    CUTOVER_ID=""
+    return 1
+  fi
+  if ! cutover_ledger accept-cutover "$CUTOVER_ID"; then
+    CUTOVER_ID=""
+    return 1
+  fi
+  CUTOVER_PREPARED=1
+  return 0
+}
+
+rearm_chat_cutover() {
+  [ "$CUTOVER_PREPARED" = "1" ] || return 0
+  if cutover_ledger rearm-cutover "$CUTOVER_ID"; then
+    return 0
+  fi
+  warn "the replacement failed before the exact chat handoff could be re-armed; chats may need manual Resume after rollback."
+  return 1
+}
+
+finalize_chat_cutover() {
+  [ "$CUTOVER_PREPARED" = "1" ] || return 0
+  if cutover_ledger finalize-cutover "$CUTOVER_ID"; then
+    CUTOVER_PREPARED=0
+    return 0
+  fi
+  warn "the new container is healthy, but its cutover receipt could not be retired; the receipt is inert unless a root Host command explicitly re-arms it."
+  return 1
 }
 
 source_env_file() {
@@ -900,6 +1008,11 @@ PREV_IMAGE=$(docker inspect -f '{{.Image}}' "$CONTAINER" 2>/dev/null || echo "")
 RUNNING_IMAGE_REF=$(
   docker inspect -f '{{.Config.Image}}' "$CONTAINER" 2>/dev/null || echo ""
 )
+RUNNING_CONFIG_HASH=$(
+  docker inspect -f \
+    '{{ index .Config.Labels "com.docker.compose.config-hash" }}' \
+    "$CONTAINER" 2>/dev/null || echo ""
+)
 # Ask Compose once instead of duplicating the prod and test defaults here. This
 # also honors an image configured in .env before we freeze the result for the
 # preflight, cutover, and rollback paths.
@@ -953,6 +1066,10 @@ attempt_rollback() {
     fail "no previous image captured — cannot auto-roll back; recover ${CONTAINER} manually."
     return 1
   fi
+  # The accepted handoff is one-boot by design. If the replacement boot never
+  # became serviceable, root explicitly re-arms the same receipt for the
+  # rollback boot; an unrelated later restart can never inherit it.
+  rearm_chat_cutover || true
   warn "auto-rolling back ${CONTAINER} to the previous image (${IMAGE_TAG} = ${PREV_IMAGE:0:19}…)"
   # With an external edge proxy on 80/443, an unselected recreate would also
   # start the bundled caddy service, whose port bindings collide with the
@@ -973,6 +1090,7 @@ attempt_rollback() {
   for i in $(seq 1 "$CUTOVER_WAIT_SECONDS"); do
     code=$(docker exec "$CONTAINER" sh -c "curl -s -o /dev/null -w '%{http_code}' '${INTERNAL_BASE}/api/health'" 2>/dev/null || echo "000")
     if [ "$code" = "200" ]; then
+      finalize_chat_cutover || true
       ok "rolled back — ${CONTAINER} healthy on the previous image again"
       return 0
     fi
@@ -1333,15 +1451,44 @@ fi
 # ── step 2: recreate container with the new image ──────────────────────
 step "[2/4] docker compose up -d (recreates ${CONTAINER})"
 presence_gate "cutover (recreate ${CONTAINER})"
+TARGET_IMAGE=$(docker image inspect -f '{{.Id}}' "$IMAGE_TAG" 2>/dev/null || true)
+FORCE_APP_RECREATE=0
+if [ "$TARGET" = "prod" ] && [ -n "$TARGET_IMAGE" ] && \
+   compose_recreation_needed "$TARGET_IMAGE"; then
+  if cutover_supported; then
+    info "preparing exact active-chat continuation for the replacement boot"
+    if ! prepare_chat_cutover; then
+      fail "the Host cutover handoff was not accepted; the live container was not replaced."
+      fail "The drained worker self-recovers through an ordinary restart if the Host abandons this cutover."
+      exit 1
+    fi
+    ok "active chats parked and bound to the exact replacement boot"
+  else
+    warn "the running image predates the external-cutover helper; this one replacement uses the legacy presence gate."
+    warn "After this image is live, later Host replacements preserve active chats automatically."
+  fi
+fi
 if external_prod_caddy_running; then
   info "external edge-caddy owns ports 80/443; updating app service"
   ensure_edge_network
   docker rm -f "${CONTAINER}-caddy-1" >/dev/null 2>&1 || true
-  intent "docker compose ${COMPOSE_ARGS[*]} up -d app"
-  docker compose "${COMPOSE_ARGS[@]}" up -d app
+  recreate_args=()
+  [ "$FORCE_APP_RECREATE" = "1" ] && recreate_args=(--force-recreate)
+  intent "docker compose ${COMPOSE_ARGS[*]} up -d ${recreate_args[*]} app"
+  if ! docker compose "${COMPOSE_ARGS[@]}" up -d "${recreate_args[@]}" app; then
+    fail "container replacement command failed before health verification"
+    attempt_rollback || true
+    exit 1
+  fi
 else
-  intent "docker compose ${COMPOSE_ARGS[*]} up -d"
-  docker compose "${COMPOSE_ARGS[@]}" up -d
+  recreate_args=()
+  [ "$FORCE_APP_RECREATE" = "1" ] && recreate_args=(--force-recreate app)
+  intent "docker compose ${COMPOSE_ARGS[*]} up -d ${recreate_args[*]}"
+  if ! docker compose "${COMPOSE_ARGS[@]}" up -d "${recreate_args[@]}"; then
+    fail "container replacement command failed before health verification"
+    attempt_rollback || true
+    exit 1
+  fi
 fi
 info "waiting up to ${CUTOVER_WAIT_SECONDS}s for ${INTERNAL_BASE}/api/health"
 wait_for_cutover \
@@ -1355,6 +1502,11 @@ info "waiting up to ${CUTOVER_WAIT_SECONDS}s for ${INTERNAL_BASE}/api/ready"
 wait_for_cutover "ready_code" "serviceable" \
   "readiness check never returned 200" \
   "report_readiness_failure"
+
+# Readiness means startup reconciliation has consumed the exact authorization.
+# Retire the root receipt now; it remains available only through this point so
+# an unhealthy first boot can explicitly authorize one rollback boot.
+finalize_chat_cutover || true
 
 run_deploy_canary
 

--- a/scripts/install-rebuild-helper.sh
+++ b/scripts/install-rebuild-helper.sh
@@ -23,6 +23,7 @@ git -C "$ROOT" rev-parse --is-inside-work-tree >/dev/null 2>&1 \
 git -C "$ROOT" ls-files --error-unmatch \
   scripts/install-rebuild-helper.sh scripts/mobius-rebuild-host.py \
   scripts/rebuild-topology.py backend/scripts/prepare-container-replacement.py \
+  backend/scripts/prepare-container-cutover.py \
   docker-compose.yml >/dev/null \
   || { echo "The replacement helper must be tracked in the trusted checkout." >&2; exit 1; }
 
@@ -51,11 +52,13 @@ done
 git -C "$ROOT" diff --quiet HEAD -- \
   scripts/install-rebuild-helper.sh scripts/mobius-rebuild-host.py \
   scripts/rebuild-topology.py backend/scripts/prepare-container-replacement.py \
+  backend/scripts/prepare-container-cutover.py \
   "${FILES[@]#"$ROOT/"}" \
   || { echo "Commit and review every helper and Compose input first." >&2; exit 1; }
 [[ -z $(git -C "$ROOT" status --porcelain=v1 --untracked-files=all -- \
   scripts/install-rebuild-helper.sh scripts/mobius-rebuild-host.py \
   scripts/rebuild-topology.py backend/scripts/prepare-container-replacement.py \
+  backend/scripts/prepare-container-cutover.py \
   "${FILES[@]#"$ROOT/"}") ]] \
   || { echo "The selected helper and Compose inputs must be clean." >&2; exit 1; }
 

--- a/scripts/mobius-rebuild-host.py
+++ b/scripts/mobius-rebuild-host.py
@@ -29,6 +29,7 @@ IMAGE = "ghcr.io/mobius-os/mobius"
 IMAGE_SOURCE = "https://github.com/mobius-os/mobius"
 ROLLBACK_TAG = f"{IMAGE}:mobius-rebuild-last-good"
 ACTIVE_STATES = {"queued", "preparing", "replacing", "verifying"}
+HANDOFF_VERSION = "external-cutover-v1"
 
 
 def now() -> str:
@@ -95,12 +96,14 @@ def write_status(config_value: dict, **fields) -> dict:
     current = {
         "supported": True, "operation_id": None, "state": "idle",
         "expected_sha": None, "code": None, "message": None,
+        "handoff": HANDOFF_VERSION,
     }
     try:
         current.update(read_json(STATUS))
     except (OSError, ValueError, json.JSONDecodeError):
         pass
     current.update(fields)
+    current["handoff"] = HANDOFF_VERSION
     current["updated_at"] = now()
     _atomic_json(STATUS, current)
     _atomic_json(config_value["control_dir"] / "status.json", current, 0o644)
@@ -173,39 +176,43 @@ def require_pull_space(current_image: str) -> None:
         )
 
 
-def request_drain(config_value: dict, operation: str, cid: str) -> Path:
-    ready = config_value["control_dir"] / "inbox" / f"ready-{operation}"
-    ready.unlink(missing_ok=True)
-    requested_at = time.time()
+def restart_ledger(config_value: dict, cid: str, command: str,
+                   operation: str, *, image: str | None = None) -> bool:
+    """Run one root ledger command, even when the app is crash-looping."""
+    invocation = ["python3", "-P", "/app/runtime/restart_ledger.py",
+                  command, operation]
+    result = subprocess.run(
+        ["docker", "exec", cid, *invocation],
+        text=True, capture_output=True,
+    )
+    if result.returncode == 0:
+        return True
+    if not image:
+        return False
+    # A failed replacement may not stay alive long enough for docker exec.
+    # The prior verified image carries the same frozen helper; mount only the
+    # persistent data root and run no entrypoint or application code.
+    result = subprocess.run(
+        ["docker", "run", "--rm", "--mount",
+         f"type=bind,src={config_value['data_dir']},dst=/data",
+         "--entrypoint", "python3", image, *invocation[1:]],
+        text=True, capture_output=True,
+    )
+    return result.returncode == 0
+
+
+def request_drain(config_value: dict, operation: str, cid: str) -> None:
+    if not restart_ledger(config_value, cid, "open-cutover", operation):
+        raise RuntimeError("the running image does not support safe Host cutover")
     result = subprocess.run(
         ["docker", "exec", cid, "python3",
-         "/data/platform/backend/scripts/prepare-container-replacement.py", operation],
+         "/data/platform/backend/scripts/prepare-container-cutover.py", operation],
         text=True, capture_output=True,
     )
     if result.returncode != 0:
-        raise RuntimeError("the running server could not begin a safe chat drain")
-    deadline = time.monotonic() + 45
-    while time.monotonic() < deadline:
-        if ready.is_file():
-            break
-        time.sleep(0.25)
-    else:
-        raise RuntimeError("active chats did not drain before the cutover deadline")
-    # The app writes `ready` after publishing its restart intent, but the
-    # root-owned entrypoint poller must accept that nonce before Docker removes
-    # the old container. Waiting for its fresh accepted receipt preserves the
-    # same authenticated continuation contract as the ordinary Restart button.
-    accepted = Path(config_value["data_dir"]) / ".restart-ledger" / "accepted.json"
-    request = Path(config_value["data_dir"]) / ".platform-restart-requested"
-    deadline = time.monotonic() + 15
-    while time.monotonic() < deadline:
-        try:
-            if accepted.stat().st_mtime >= requested_at and not request.exists():
-                return ready
-        except OSError:
-            pass
-        time.sleep(0.25)
-    raise RuntimeError("the restart supervisor did not accept the chat continuation")
+        raise RuntimeError("the running server could not complete a safe chat drain")
+    if not restart_ledger(config_value, cid, "accept-cutover", operation):
+        raise RuntimeError("the root supervisor did not accept the chat handoff")
 
 
 def _image_state() -> dict:
@@ -267,12 +274,41 @@ def rollback(config_value: dict, operation: str, expected: str,
     write_status(config_value, operation_id=operation, state="verifying",
                  expected_sha=expected, code=code,
                  message="Replacement failed; restoring the previous container.")
+    try:
+        cid, _current = app_container(config_value)
+    except Exception:
+        cid = ""
+    handoff_rearmed = restart_ledger(
+        config_value, cid, "rearm-cutover", operation, image=ROLLBACK_TAG,
+    )
     compose(config_value, "up", "-d", "--no-build", "--no-deps",
             "--force-recreate", "app", image=ROLLBACK_TAG)
     if wait_healthy(config_value, 120):
+        cid, _current = app_container(config_value)
+        handoff_finalized = restart_ledger(
+            config_value, cid, "finalize-cutover", operation,
+            image=ROLLBACK_TAG,
+        )
+        if handoff_finalized:
+            status_code = code
+            message = f"The previous container was restored: {detail}"
+        elif not handoff_rearmed:
+            status_code = "handoff_rearm_failed"
+            message = (
+                "The previous container was restored, but exact active-chat "
+                "continuation could not be re-armed; affected chats may need "
+                f"manual Resume. Original failure: {detail}"
+            )
+        else:
+            status_code = "handoff_finalize_failed"
+            message = (
+                "The previous container was restored, but the Host could not "
+                "verify and retire the exact chat handoff receipt. Check the "
+                f"affected chats. Original failure: {detail}"
+            )
         write_status(config_value, operation_id=operation, state="rolled_back",
-                     expected_sha=expected, code=code,
-                     message=f"The previous container was restored: {detail}"[:300])
+                     expected_sha=expected, code=status_code,
+                     message=message[:300])
         return 1
     write_status(config_value, operation_id=operation, state="needs_recovery",
                  expected_sha=expected, code="rollback_failed",
@@ -297,7 +333,6 @@ def run() -> int:
     image_ref = None
     pulled_recorded = False
     replacement_started = False
-    ready: Path | None = None
     try:
         with LOCK.open("a+") as lock:
             acquire_lock(lock)
@@ -343,7 +378,7 @@ def run() -> int:
                 return 0
             subprocess.run(["docker", "tag", previous, ROLLBACK_TAG], check=True,
                            text=True, capture_output=True)
-            ready = request_drain(config_value, operation, cid)
+            request_drain(config_value, operation, cid)
             write_status(config_value, operation_id=operation, state="replacing",
                          expected_sha=expected, code=None,
                          message="Replacing the container.")
@@ -359,10 +394,25 @@ def run() -> int:
                 )
                 discard_pulled_image(image_ref)
                 return result
+            cid, _current = app_container(config_value)
+            handoff_finalized = restart_ledger(
+                config_value, cid, "finalize-cutover", operation,
+                image=image_ref,
+            )
             retain_images(image_ref, previous)
+            if handoff_finalized:
+                status_code = None
+                message = "Container replaced successfully."
+            else:
+                status_code = "handoff_finalize_failed"
+                message = (
+                    "Container replaced successfully, but the Host could not "
+                    "verify and retire the exact chat handoff receipt. Check "
+                    "the affected chats."
+                )
             write_status(config_value, operation_id=operation, state="succeeded",
-                         expected_sha=expected, code=None,
-                         message="Container replaced successfully.")
+                         expected_sha=expected, code=status_code,
+                         message=message)
             return 0
     except BlockingIOError:
         write_status(config_value, operation_id=operation, state="failed",
@@ -395,8 +445,6 @@ def run() -> int:
             # A malformed path or other claim failure must not leave the path
             # unit continuously retriggering an unrecoverable request.
             request.unlink(missing_ok=True)
-        if ready is not None:
-            ready.unlink(missing_ok=True)
 
 
 def reconcile() -> int:


### PR DESCRIPTION
## Summary

Supported Host container replacements can stop the app without going through the ordinary in-process Restart path. That left active-chat continuation dependent on the replacement command happening to match the image-change case, and rollback could not always describe whether the exact handoff remained valid.

This change extends the existing planned-restart ledger across the full container cutover:

- the root-owned Host helper opens a short-lived challenge before the live worker drains;
- the worker parks and nonce-binds exact active runs, then publishes a cutover intent without self-terminating;
- the Host accepts that exact intent immediately before Compose owns the only stop;
- the replacement boot consumes the one-shot authorization, while a root receipt can explicitly re-arm the same handoff for one rollback boot;
- healthy success and rollback both report when receipt re-arm or retirement could not be verified;
- authenticated restart fallbacks blocked on an unanswered question remain truthfully waiting for that answer instead of being mislabeled as manual failures.

The production deploy path now detects both image changes and same-image Compose configuration changes. A true image/config no-op stays untouched; an unavailable Compose hash fails safe by preparing the exact handoff and forcing only the app recreation. Older Host helpers fail closed with an upgrade instruction rather than replacing the container through an unsafe path.

Raw `docker restart`, forced kills, and other unsupported replacement shortcuts still fall back conservatively to manual Resume; they are not disguised as planned cutovers.

## Verification

- 87 focused tests across the admin, deploy, Host controller, restart ledger, drain, and restart utility suites
- Python compilation
- Bash syntax checks
- ShellCheck for the changed deployment scripts
- real Host cutover exercise covering ordinary auto-resume and durable question handoffs