### PR TITLE
Keep answered questions anchored through viewport changes

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -544,7 +544,7 @@ installing Möbius.
 
 ## Chat scroll + steer contract
 
-**Owner-authoritative contract — v1.21 (2026-08-20).** This section is the
+**Owner-authoritative contract — v1.22 (2026-08-23).** This section is the
 canonical source of truth for how a chat scrolls and steers. When implementation,
 comments, and this contract disagree, the implementation/comments are the bug:
 fix behavior to match this contract. If a real case is unspecified or the desired
@@ -594,10 +594,10 @@ and attaches their rule ids to new diagnostic chats. The Playwright lock-in spec
   participates—an older user row never gets a separate reservation. Durable anchor
   validation still rejects locations wholly inside reserved blank space, so
   restoring a chat lands on real conversation content. R6's transient
-  question-submit hold is the sole calculation exception: it may reserve only the
-  exact tail deficit required for a stable card handoff while the viewport size is
-  unchanged. It is never persisted and must release to the unanswered card's prior
-  mode before a keyboard or other viewport resize is laid out.
+  question-submit hold is the sole calculation exception: it reserves only the
+  exact tail deficit required to keep the card at its submitted viewport offset.
+  Responsive geometry recomputes that deficit and reapplies the same transient
+  anchor; viewport size never releases it. The overlay is never persisted.
 - **R2 — One send rule everywhere.** The first visible user message always pins to
   the viewport top. Every subsequent direct, queued, promoted, or steered message
   pins only when its submit-time DOM snapshot is at the one physical
@@ -750,7 +750,7 @@ and attaches their rule ids to new diagnostic chats. The Playwright lock-in spec
   physical tail without moving through blank room. The only ordinary mode change
   is R3's existing armed-pin handoff when the responsive spacer reaches zero; a
   settled pin never gains follow from resize geometry. The R6 question-submission
-  release and focused native-caret rebase remain the two explicit editing rules,
+  anchor and focused native-caret rebase remain the two explicit editing rules,
   not a general keyboard heuristic. Open/close cycles therefore repeat the same
   idempotent operation every time. Browser clamps and controller writes may emit
   `scroll` while the box is changing, but only a gesture-owned scroll may change
@@ -771,14 +771,13 @@ and attaches their rule ids to new diagnostic chats. The Playwright lock-in spec
   it. If response activity races the answer request, neither boundary moves the
   card alone: the release waits until both commits exist. A card that
   began in hold remains held, and a recovered `answer_turn: "new"` continuation
-  never gains follow. The exact temporary hold is scoped to the viewport where
-  Submit occurred. If the mobile keyboard changes the viewport first, the controller
-  restores the mode that owned the unanswered card before sizing the new geometry.
-  Acceptance therefore adds no movement; an already-followed tail begins moving
-  only with the response it is following. The keyboard still moves the card exactly
-  as it would have moved unanswered. The transient hold is stripped before
-  persistence. A failed answer keeps that settled reading anchor for the retryable
-  card rather than manufacturing follow intent again.
+  never gains follow. Keyboard, toolbar, orientation, and pane changes recompute
+  reachability and reapply that same transient anchor; responsive geometry never
+  restores the pre-submit mode. Acceptance therefore adds no movement, and an
+  already-followed tail begins moving only with the visible response it is
+  following. The transient hold is stripped before persistence. A failed answer
+  keeps that settled reading anchor for the retryable card rather than
+  manufacturing follow intent again.
   While the custom-answer field is focused, a visual-viewport change may rebase
   an ordinary `ANCHOR_AT` hold to the browser's current caret-visible position
   instead of reapplying its stale pre-edit offset. `PIN_USER_MSG`,
@@ -812,11 +811,11 @@ path means routing it through the same entries rather than inventing another rul
 | Viewport/keyboard changes | settled `PIN_USER_MSG` | same `PIN_USER_MSG` | Reapply the same pin; geometry never reclassifies it |
 | Viewport/keyboard changes | follow or anchor hold | same mode | Resize reservation to the visible scroll box, then reapply the physical tail or exact anchor; never create or retire follow |
 | Chat exits/backgrounds/returns | any | `ANCHOR_AT` | Restore exact saved anchor |
-| In-message question Submit begins | any | transient `ANCHOR_AT` over the prior mode | Hold exact visible anchor through the unresolved same-viewport card reflow |
+| In-message question Submit begins | any | transient `ANCHOR_AT` over the prior mode | Hold the exact visible anchor through acceptance; only response activity may restore captured follow |
 | Same running turn accepts a question answer | transient question anchor over any prior mode | same transient anchor; same active assistant row | None; acceptance alone does not move through blank tail room |
 | First renderable activity after an accepted same-turn answer | transient question anchor over prior follow, with no newer reader scroll/location | prior `FOLLOW_BOTTOM`; same active assistant row | Resume the one physical live tail with the response commit |
 | First renderable activity after an accepted same-turn answer | transient question anchor over hold, or superseded submit intent | existing hold | None; resumed output grows below the reader |
-| Viewport/keyboard changes after question submission | transient question anchor | pre-submit unanswered-card mode | Apply ordinary viewport behavior; answering adds no extra movement |
+| Viewport/keyboard/pane changes after question submission | transient question anchor | same transient question anchor | Recompute reachability and reapply the exact anchor; responsive geometry never releases submission |
 | Focused Q&A custom answer grows or its keyboard viewport changes | ordinary hold | current caret-visible `ANCHOR_AT` | Browser may reveal the caret once; controller rebases instead of snapping back. Pins, reserved-tail holds, follow, and submission overlay are unchanged |
 | Live assistant row settles to the durable transcript | any | same mode and row identity | None (except R3's exact spacer handoff) |
 | Offscreen question or paused-turn nudge tapped | any hold | `ANCHOR_AT` at physical tail | User-requested one-shot move; clears the overlaid composer |

--- a/frontend/src/components/ChatView/__tests__/chatContractStructure.test.js
+++ b/frontend/src/components/ChatView/__tests__/chatContractStructure.test.js
@@ -28,12 +28,12 @@ test('ChatView only consumes methods returned by the scroll controller', () => {
     `ChatView consumes missing useScrollMode members: ${missing.join(', ')}`)
 })
 
-test('owner contract hands question anchors to visible responses without locking keyboard movement', () => {
+test('owner contract keeps question anchors through responsive geometry', () => {
   const architecture = readFileSync(
     new URL('../../../../../ARCHITECTURE.md', import.meta.url),
     'utf8',
   )
-  assert.match(architecture, /Owner-authoritative contract — v1\.21 \(2026-08-20\)/)
+  assert.match(architecture, /Owner-authoritative contract — v1\.22 \(2026-08-23\)/)
   assert.match(
     architecture,
     /In-message question Submit begins \| any \| transient `ANCHOR_AT` over the prior mode/,
@@ -41,13 +41,13 @@ test('owner contract hands question anchors to visible responses without locking
   )
   assert.match(
     architecture,
-    /question-submit hold is the sole calculation exception: it may reserve only the\s+exact tail deficit required for a stable card handoff while the viewport size is\s+unchanged/,
-    'question submission may reserve only its same-viewport reachability deficit',
+    /question-submit hold is the sole calculation exception: it reserves only the\s+exact tail deficit required to keep the card at its submitted viewport offset/,
+    'question submission reserves only its exact responsive reachability deficit',
   )
   assert.match(
     architecture,
-    /Viewport\/keyboard changes after question submission \| transient question anchor \| pre-submit unanswered-card mode/,
-    'keyboard movement must return to the unanswered card baseline',
+    /Viewport\/keyboard\/pane changes after question submission \| transient question anchor \| same transient question anchor/,
+    'responsive geometry must preserve the submitted question anchor',
   )
   assert.match(
     architecture,

--- a/frontend/src/components/ChatView/__tests__/questionResponseMode.test.js
+++ b/frontend/src/components/ChatView/__tests__/questionResponseMode.test.js
@@ -9,7 +9,6 @@ test('first post-answer activity resumes only the follow mode that submitted it'
     kind: 'ANCHOR_AT',
     key: 'assistant-with-question',
     offset: 60,
-    questionSubmitViewportH: 600,
     questionSubmitBaseMode: follow,
   }
   const submission = { mode: heldMode, readerIntentVersion: 7 }
@@ -23,7 +22,7 @@ test('first post-answer activity resumes only the follow mode that submitted it'
     currentMode: follow,
     submission,
     currentReaderIntentVersion: 7,
-  }), follow, 'a viewport release that already restored follow remains stable')
+  }), follow, 'an already-restored follow remains stable')
 
   const readerHold = { kind: 'ANCHOR_AT', key: 'older-row', offset: 20 }
   assert.equal(modeAfterQuestionResponseStart({
@@ -44,7 +43,6 @@ test('post-answer activity keeps a pre-submit reading hold', () => {
     kind: 'ANCHOR_AT',
     key: 'assistant-with-question',
     offset: 60,
-    questionSubmitViewportH: 600,
     questionSubmitBaseMode: baseMode,
   }
   assert.equal(modeAfterQuestionResponseStart({

--- a/frontend/src/components/ChatView/__tests__/scrollRepairDirection.test.js
+++ b/frontend/src/components/ChatView/__tests__/scrollRepairDirection.test.js
@@ -122,14 +122,13 @@ test('transition entry authority prevents layout and reader paths creating pins'
   assert.equal(modeForScrollTransition(hold, pin, 'send:pin-user-message'), pin)
 })
 
-test('question viewport and response-start releases restore only captured authority', () => {
+test('only response start may restore a question submission\'s captured follow authority', () => {
   const follow = { kind: 'FOLLOW_BOTTOM' }
   const pin = { kind: 'PIN_USER_MSG', cid: 'c-2', followWhenFilled: true }
   const followOverlay = {
     kind: 'ANCHOR_AT',
     key: 'q-1',
     offset: 40,
-    questionSubmitViewportH: 720,
     questionSubmitBaseMode: follow,
   }
   const pinOverlay = {
@@ -140,18 +139,8 @@ test('question viewport and response-start releases restore only captured author
   assert.equal(modeForScrollTransition(
     followOverlay,
     follow,
-    'layout:question-viewport-release',
-  ), follow)
-  assert.equal(modeForScrollTransition(
-    pinOverlay,
-    pin,
-    'layout:question-viewport-release',
-  ), pin)
-  assert.equal(modeForScrollTransition(
-    followOverlay,
-    { kind: 'FOLLOW_BOTTOM' },
-    'layout:question-viewport-release',
-  ), followOverlay, 'an equivalent-looking mode is not the overlay\'s authority')
+    'layout:viewport-change',
+  ), followOverlay, 'responsive geometry cannot release submission')
   assert.equal(modeForScrollTransition(
     followOverlay,
     follow,

--- a/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
+++ b/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
@@ -18,6 +18,7 @@ import {
   delayedSendWillPin,
   gestureLayoutRetryDelay,
   isNearPhysicalBottom,
+  isQuestionSubmissionMode,
   layoutMayOwnScroll,
   modeForChatExit,
   modeForDisclosureToggle,
@@ -35,7 +36,6 @@ import {
   readerInputMayScroll,
   readerInputNeedsFrameRelease,
   readerScrollEscapeDirection,
-  releaseQuestionSubmissionForViewport,
   settledPinMode,
   shouldPinSend,
 } from '../useScrollMode.js'
@@ -491,32 +491,22 @@ test('question submission freezes the visible row before same-turn output resume
       kind: 'ANCHOR_AT',
       key: 'assistant-with-question',
       offset: 60,
-      questionSubmitViewportH: 600,
       questionSubmitBaseMode: { kind: 'FOLLOW_BOTTOM' },
     },
   )
 })
 
-test('question submission releases to the unanswered mode only after viewport size changes', () => {
+test('question submission is a viewport-independent transient anchor', () => {
   const baseMode = { kind: 'PIN_USER_MSG', cid: 'latest' }
   const heldMode = {
     kind: 'ANCHOR_AT',
     key: 'assistant-with-question',
     offset: 60,
-    questionSubmitViewportH: 400,
     questionSubmitBaseMode: baseMode,
   }
 
-  assert.equal(
-    releaseQuestionSubmissionForViewport(heldMode, 400),
-    heldMode,
-    'same-size card reflow keeps the submit anchor exact',
-  )
-  assert.equal(
-    releaseQuestionSubmissionForViewport(heldMode, 700),
-    baseMode,
-    'keyboard growth restores the mode that owned the unanswered card',
-  )
+  assert.equal(isQuestionSubmissionMode(heldMode), true)
+  assert.equal(isQuestionSubmissionMode(baseMode), false)
 })
 
 test('question submission keeps the current mode when there is no visible row', () => {
@@ -1202,7 +1192,6 @@ test('question-only viewport overlay is never restored as durable reader state',
     kind: 'ANCHOR_AT',
     key: 'assistant-question',
     offset: 100,
-    questionSubmitViewportH: 400,
     questionSubmitBaseMode: { kind: 'FOLLOW_BOTTOM' },
   }
   const scrollEl = {
@@ -1655,7 +1644,6 @@ test('question submission reserves the exact room that keeps its anchor reachabl
     kind: 'ANCHOR_AT',
     key: 'assistant-question',
     offset: 60,
-    questionSubmitViewportH: 600,
     questionSubmitBaseMode: { kind: 'PIN_USER_MSG', cid: 'c-1' },
   }
   const listEl = { offsetHeight: 1400 }
@@ -1673,11 +1661,11 @@ test('question submission reserves the exact room that keeps its anchor reachabl
   assert.equal(
     _computeSpacerH(scrollEl, listEl, latestUser, mode),
     440,
-    'the same-viewport overlay keeps the exact anchor until resize releases it',
+    'the submission overlay keeps the exact anchor across responsive geometry',
   )
 })
 
-test('answered question uses the unanswered card spacer when the keyboard closes', () => {
+test('answered question keeps its exact submission anchor when the keyboard closes', () => {
   const anchor = { offsetTop: 1200, offsetHeight: 220 }
   const scrollEl = {
     clientHeight: 700,
@@ -1690,7 +1678,6 @@ test('answered question uses the unanswered card spacer when the keyboard closes
     kind: 'ANCHOR_AT',
     key: 'assistant-question',
     offset: 60,
-    questionSubmitViewportH: 400,
     questionSubmitBaseMode: baseMode,
   }
   const listEl = { offsetHeight: 1400 }
@@ -1703,21 +1690,14 @@ test('answered question uses the unanswered card spacer when the keyboard closes
   assert.equal(
     _computeSpacerH(scrollEl, listEl, latestUser, heldMode),
     440,
-    'without release the answered card would remain locked',
+    'the larger viewport reserves the exact 1140px anchor target',
   )
-  const released = releaseQuestionSubmissionForViewport(heldMode, 700)
-  const answeredSpacer = _computeSpacerH(
-    scrollEl, listEl, latestUser, released,
-  )
-  const unansweredSpacer = _computeSpacerH(
-    scrollEl, listEl, latestUser, baseMode,
-  )
-  assert.equal(answeredSpacer, unansweredSpacer)
-  assert.equal(answeredSpacer, 396)
   assert.equal(
-    listEl.offsetHeight + answeredSpacer - scrollEl.clientHeight,
-    1096,
-    'ordinary geometry moves the card instead of preserving scrollTop 1140',
+    listEl.offsetHeight
+      + _computeSpacerH(scrollEl, listEl, latestUser, heldMode)
+      - scrollEl.clientHeight,
+    1140,
+    'keyboard close keeps the question at the same 60px viewport offset',
   )
 })
 

--- a/frontend/src/components/ChatView/useScrollMode.js
+++ b/frontend/src/components/ChatView/useScrollMode.js
@@ -13,15 +13,14 @@
  *                                  — user msg at top (post-send), keyed on
  *                                    the stable client `cid` (data-cid)
  *   { kind: 'FOLLOW_BOTTOM' }     — sticky-bottom for streaming
- *   { kind: 'ANCHOR_AT', key, offset, part?, questionSubmitViewportH?,
- *     questionSubmitBaseMode? }
+ *   { kind: 'ANCHOR_AT', key, offset, part?, questionSubmitBaseMode? }
  *                                  — anchored at a message and, when that row
  *                                    is taller than the viewport, an ordered
  *                                    child-index path within it; `offset` is
  *                                    measured from the addressed element's
  *                                    top. An in-message question may
  *                                    temporarily preserve its submit-time
- *                                    position at one viewport size
+ *                                    position across responsive geometry
  *
  * Send pinning has one rule for direct, queued, and steered messages: the
  * first visible user message always pins; every later message pins only at the
@@ -40,9 +39,10 @@
  * active scroll-box height, so a keyboard first removes now-hidden blank room;
  * only content that no longer fits makes FOLLOW_BOTTOM move. The one explicit
  * exception is the transient
- * question-submit anchor: it reserves exactly enough tail room for a stable
- * same-viewport handoff. A keyboard resize restores the pre-submit mode before
- * sizing, so the answered card moves exactly as the unanswered card would.
+ * question-submit anchor: it reserves exactly enough tail room to preserve the
+ * same visible card offset through keyboard, toolbar, pane, and orientation
+ * changes. Visible response activity may restore a captured follow; a prior
+ * hold remains exact until newer reader intent replaces it.
  * Gesture-driven bottom detection reads the scroll container's geometry in
  * the scroll event itself. There is no second sentinel/observer authority
  * that can lag behind the reader and contradict the current viewport.
@@ -623,13 +623,8 @@ export function _anchorModeIntersectsContent(target, mode, viewportHeight) {
 
 
 function _durableQuestionSubmissionMode(mode) {
-  if (mode?.kind !== 'ANCHOR_AT') return mode
-  if (!Object.hasOwn(mode, 'questionSubmitViewportH')
-      && !Object.hasOwn(mode, 'questionSubmitBaseMode')) {
-    return mode
-  }
+  if (!isQuestionSubmissionMode(mode)) return mode
   const {
-    questionSubmitViewportH: _transientViewport,
     questionSubmitBaseMode: _transientBaseMode,
     ...durable
   } = mode
@@ -637,19 +632,13 @@ function _durableQuestionSubmissionMode(mode) {
 }
 
 
-/** A question answer temporarily overlays the reader's existing scroll mode
- * only while the viewport size is unchanged. Keyboard movement belongs to the
- * pre-submit mode: release the overlay before spacer sizing so the answered
- * card receives the same resize behavior as the unanswered card. */
-export function releaseQuestionSubmissionForViewport(mode, viewportHeight) {
-  if (mode?.kind !== 'ANCHOR_AT'
-      || !Number.isFinite(mode.questionSubmitViewportH)
-      || !Number.isFinite(viewportHeight)
-      || Math.abs(mode.questionSubmitViewportH - viewportHeight) <= 1) {
-    return mode
-  }
-  return mode.questionSubmitBaseMode
-    || _durableQuestionSubmissionMode(mode)
+/** A submitted in-message question temporarily overlays the reader's prior
+ * mode. The overlay is semantic rather than viewport-sized: keyboard, toolbar,
+ * pane, and orientation geometry must preserve it. Visible response activity
+ * may restore captured follow; otherwise newer reader intent replaces it. */
+export function isQuestionSubmissionMode(mode) {
+  return mode?.kind === 'ANCHOR_AT'
+    && Object.hasOwn(mode, 'questionSubmitBaseMode')
 }
 
 /** The ANCHOR_AT twin of `_pinReapplyNeeded` — the SAME two-case repair. A
@@ -785,8 +774,8 @@ export function _modeForPersistence(mode, messages, scrollEl) {
 
 /** Spacer height needed so the latest user message can sit near the
  *  top of the viewport, with the PIN_OFFSET breathing room above it, or so a
- *  transient question-submit anchor remains reachable while the submit-time
- *  viewport size is unchanged.
+ *  transient question-submit anchor remains reachable through responsive
+ *  viewport changes.
  *
  *  Tail geometry is the defining invariant. Reservation exists before a
  *  downward gesture reaches the latest row, so scrollHeight cannot grow at the
@@ -809,8 +798,8 @@ export function _modeForPersistence(mode, messages, scrollEl) {
  *  end-of-scroll rest ever feels cramped.)
  *
  *  A question-submit anchor instead reserves only its exact reachability
- *  deficit for a same-viewport handoff. A keyboard resize restores the mode
- *  that owned the unanswered card before this function runs again.
+ *  deficit. Viewport changes recompute that deficit and reapply the same
+ *  anchor, so submission remains visually fixed through its handoff policy.
  */
 const PIN_OFFSET = 4
 const PIN_BOTTOM_ROOM = 0
@@ -822,8 +811,7 @@ export function _computeSpacerH(
 ) {
   if (!scrollEl || !listEl) return 0
   const viewH = scrollEl.clientHeight
-  if (mode?.kind === 'ANCHOR_AT'
-      && Number.isFinite(mode.questionSubmitViewportH)) {
+  if (isQuestionSubmissionMode(mode)) {
     const anchorEl = _anchorEl(scrollEl, mode)
     if (!anchorEl) return 0
     const anchorTarget = Math.max(
@@ -1034,12 +1022,10 @@ const FOLLOW_ENTRY_EVENTS = new Set([
 export function modeForScrollTransition(previousMode, proposedMode, event) {
   if (!proposedMode) return previousMode
   const restoresQuestionSubmissionBase = (
-    event === 'layout:question-viewport-release'
-      || (event === 'stream:question-response-follow'
-        && proposedMode?.kind === 'FOLLOW_BOTTOM')
+    event === 'stream:question-response-follow'
+      && proposedMode?.kind === 'FOLLOW_BOTTOM'
   )
-    && previousMode?.kind === 'ANCHOR_AT'
-    && Number.isFinite(previousMode.questionSubmitViewportH)
+    && isQuestionSubmissionMode(previousMode)
     && previousMode.questionSubmitBaseMode === proposedMode
   if (restoresQuestionSubmissionBase) return proposedMode
 
@@ -1307,19 +1293,19 @@ export function modeForDisclosureToggle(scrollEl, currentMode) {
 
 
 /** Submitting an in-message question answer resumes output inside the same
- * assistant row and may replace the card's controls immediately. It is not a
- * request to follow the live tail. Freeze the exact visible row/offset before
- * that card-to-stream handoff so neither the control reflow nor resumed output
- * moves the reader. The overlay remembers the mode that owned the unanswered
- * card and is scoped to the current viewport height; a keyboard resize returns
- * to that base mode before layout is recomputed. */
+ * assistant row and may replace the card's controls immediately. Freeze the
+ * exact visible row/offset during that card-to-stream handoff. The overlay
+ * remembers the mode that owned the unanswered card: an accepted same-turn
+ * answer may restore its prior FOLLOW_BOTTOM, while a reading hold remains a
+ * hold. Keyboard, toolbar, pane, and orientation changes preserve the overlay;
+ * visible response activity may restore prior follow, while newer reader intent
+ * replaces an exact hold. */
 export function modeForQuestionSubmission(scrollEl, currentMode) {
   if (!scrollEl) return currentMode
   const anchor = anchorModeFromScroll(scrollEl)
   if (!anchor) return currentMode
   return {
     ...anchor,
-    questionSubmitViewportH: scrollEl.clientHeight,
     questionSubmitBaseMode:
       currentMode?.questionSubmitBaseMode || currentMode,
   }
@@ -2241,23 +2227,9 @@ export default function useScrollMode({
       viewportChange = false,
       authorityVersion = currentAuthority(),
     } = {}) {
-      // Question submission freezes the card-to-stream handoff, not the
-      // keyboard. Restore the unanswered card's mode before sizing a changed
-      // viewport so its ordinary reservation and clamp remain authoritative.
-      if (viewportChange) {
-        const released = releaseQuestionSubmissionForViewport(
-          modeRef.current,
-          scrollEl.clientHeight,
-        )
-        if (released !== modeRef.current) {
-          transitionMode(released, 'layout:question-viewport-release')
-          persistMode()
-        }
-      }
-      // Releasing the submitted-question overlay is a semantic state change,
-      // not a scroll write. It must happen even while the input gate retains
-      // viewport ownership; the deferred layout pass below then applies the
-      // restored mode after the reader yields.
+      // Responsive geometry never releases a submitted question. The same
+      // semantic anchor is resized and reapplied below; only its response
+      // handoff policy or newer reader intent may replace it.
       if (!layoutOwnsScroll(authorityVersion)) {
         deferLayoutUntilReaderYields(authorityVersion)
         return false

--- a/frontend/src/lib/__tests__/useScrollModeLifecycle.test.js
+++ b/frontend/src/lib/__tests__/useScrollModeLifecycle.test.js
@@ -48,7 +48,8 @@ function installBrowserEnvironment({ observers = [], frames = null } = {}) {
     removeEventListener() {},
   }
   globalThis.ResizeObserver = class {
-    constructor() {
+    constructor(callback) {
+      this.callback = callback
       this.disconnected = false
       observers.push(this)
     }
@@ -231,7 +232,8 @@ test('nested controls cannot relatch the transcript while they own the input', (
 })
 
 test('question response resumes the exact follow intent captured at submit', () => {
-  const restoreBrowser = installBrowserEnvironment()
+  const observers = []
+  const restoreBrowser = installBrowserEnvironment({ observers })
   try {
     const { hook, listeners, scroll } = mountTailController('question-follow-owner')
     const target = { parentElement: scroll, closest: () => null }
@@ -243,7 +245,13 @@ test('question response resumes the exact follow intent captured at submit', () 
 
     const submission = hook.result.current.freezeQuestionSubmission()
     assert.equal(submission.mode.kind, 'ANCHOR_AT')
+    assert.equal(submission.mode.questionSubmitBaseMode.kind, 'FOLLOW_BOTTOM')
     assert.equal(scroll.dataset.scrollMode, 'ANCHOR_AT')
+
+    scroll.clientHeight = 620
+    observers[0].callback([{ target: scroll }])
+    assert.equal(scroll.dataset.scrollMode, 'ANCHOR_AT',
+      'keyboard close cannot release the submission before response activity')
 
     hook.result.current.resumeQuestionSubmissionOnResponse(submission)
     assert.equal(scroll.dataset.scrollMode, 'FOLLOW_BOTTOM',

--- a/tests/chat-redesign.spec.mjs
+++ b/tests/chat-redesign.spec.mjs
@@ -756,7 +756,7 @@ test.describe('Q&A atomic write', () => {
     expect(laterReaderBottom).toBe(false)
   })
 
-  test('an Android viewport growth releases a submitted question to its unanswered mode', async ({ page }) => {
+  test('an Android viewport growth keeps a submitted question anchored', async ({ page }) => {
     const longLead = 'Context before the question. '.repeat(180)
     const streamBody = [
       `data: ${JSON.stringify({ type: 'text', content: longLead })}\n\n`,
@@ -847,18 +847,16 @@ test.describe('Q&A atomic write', () => {
       requestAnimationFrame(() => requestAnimationFrame(resolve))
     )))
     const after = await geometry()
-    const viewportRelease = await page.evaluate(() => (
-      window.__mobiusChatScrollTrace?.transitions?.find(
-        row => row.event === 'layout:question-viewport-release',
-      ) || null
+    const modeAfterResize = await page.evaluate(() => (
+      document.querySelector('[data-chat-surface="painted"] .chat__scroll')
+        ?.dataset.scrollMode || null
     ))
     releaseAnswer()
     await submitClick
 
     expect(after.viewport).toBeGreaterThan(before.viewport)
-    expect(viewportRelease).toBeTruthy()
-    expect(viewportRelease.from?.kind).toBe('ANCHOR_AT')
-    expect(Math.abs(after.cardTop - before.cardTop)).toBeGreaterThan(2)
+    expect(modeAfterResize).toBe('ANCHOR_AT')
+    expect(after.cardTop).toBeCloseTo(before.cardTop, 0)
   })
 })
 

--- a/tests/question-follow.spec.mjs
+++ b/tests/question-follow.spec.mjs
@@ -71,7 +71,12 @@ const questionFollowScenarios = [
     name: 'accepted same-turn answer waits for response activity before following',
     readerScrollBeforeSubmit: false,
     expectedMode: 'FOLLOW_BOTTOM',
-    viewport: { width: 412, initialHeight: 520, expandedHeight: 915 },
+    viewport: {
+      width: 412,
+      initialHeight: 520,
+      expandedHeight: 915,
+      postSubmitHeight: 1015,
+    },
   },
   {
     name: 'reader scroll immediately before Submit cancels stale follow restoration',
@@ -253,6 +258,27 @@ for (const scenario of questionFollowScenarios) test(scenario.name, async ({ pag
   )
   expect(cardTopAfterAcceptance).toBeCloseTo(cardTopBeforeSubmit, 0)
 
+  let cardTopBeforeResponse = cardTopAfterAcceptance
+  if (scenario.viewport.postSubmitHeight) {
+    // Model the software keyboard closing after answer acceptance but before
+    // the continuation begins. Responsive geometry must preserve the same
+    // submission anchor rather than restoring the pre-submit follow mode.
+    await page.setViewportSize({
+      width: scenario.viewport.width,
+      height: scenario.viewport.postSubmitHeight,
+    })
+    await page.evaluate(() => new Promise(resolve => (
+      requestAnimationFrame(() => requestAnimationFrame(resolve))
+    )))
+    await expect.poll(() => surface.locator('.chat__scroll').getAttribute(
+      'data-scroll-mode',
+    )).toBe('ANCHOR_AT')
+    cardTopBeforeResponse = await card.evaluate(
+      element => element.getBoundingClientRect().top,
+    )
+    expect(cardTopBeforeResponse).toBeCloseTo(cardTopAfterAcceptance, 0)
+  }
+
   // Only now let the provider emit its continuation. A previously-followed
   // card may move with this new content, never with the answer-only commit.
   await page.evaluate(() => window.__continueQuestionStream?.())
@@ -276,6 +302,6 @@ for (const scenario of questionFollowScenarios) test(scenario.name, async ({ pag
     const cardTopAfterResponse = await card.evaluate(
       element => element.getBoundingClientRect().top,
     )
-    expect(cardTopAfterResponse).toBeLessThan(cardTopAfterAcceptance - 40)
+    expect(cardTopAfterResponse).toBeLessThan(cardTopBeforeResponse - 40)
   }
 })


### PR DESCRIPTION
## Summary
- keep an answered question card at its exact visible position through keyboard, toolbar, orientation, and pane-size changes
- restore prior tail-following only when visible response activity begins
- preserve newer reader scrolls and pre-existing reading holds

## Context
This is a focused follow-up to #831. That change correctly separated answer acceptance from visible response activity, but its temporary question anchor was still tied to the submit-time viewport height. When a mobile keyboard closed before the reply rendered, viewport layout restored the pre-submit mode early and moved the card.

This change makes the submission anchor semantic rather than height-scoped. Responsive geometry recomputes the room needed to keep the same card offset; it cannot release the anchor. The existing response-activity handoff remains the only path that can restore captured following, and newer reader intent still wins.

An earlier permanent-hold direction was explored in #101; this keeps #831's response-start handoff and changes only viewport ownership.

## Testing
- `cd frontend && npm test` — 2,618 component/library checks and 87 hook checks passed
- `cd frontend && npm run lint` — 0 errors
- `cd frontend && npm run build`
- focused scroll/controller suite — 107 checks passed
- browser specs add both pending-answer and accepted-before-response viewport-growth coverage and passed syntax/list validation

Full hosted browser checks are recommended because the defect depends on scroll ordering and mobile viewport transitions.