### PR TITLE
Test GitHub profile contribution path (draft only)

### DIFF
--- a/backend/tests/fixtures/contribution_relay_smoke.txt
+++ b/backend/tests/fixtures/contribution_relay_smoke.txt
@@ -1,0 +1,1 @@
+Möbius launcher relay: draft-only end-to-end smoke fixture.


### PR DESCRIPTION
Draft-only end-to-end test of the connected GitHub contribution path against mobius-os/mobius. This adds one disposable source fixture to verify reviewed-branch publication without changing runtime behavior. Not intended to merge.