### PR TITLE
Render exact steer replays as continuous answers

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -544,7 +544,7 @@ installing Möbius.
 
 ## Chat scroll + steer contract
 
-**Owner-authoritative contract — v1.22 (2026-08-23).** This section is the
+**Owner-authoritative contract — v1.23 (2026-08-24).** This section is the
 canonical source of truth for how a chat scrolls and steers. When implementation,
 comments, and this contract disagree, the implementation/comments are the bug:
 fix behavior to match this contract. If a real case is unspecified or the desired
@@ -791,6 +791,26 @@ and attaches their rule ids to new diagnostic chats. The Playwright lock-in spec
   text block in event order, without hiding, duplicating, or reordering them. Only a
   recovered answer whose POST returns `started` creates a new hidden continuation.
   Switching sources preserves the active row's anchor identity and writes no scroll.
+- **R6a — Exact steer replay is one continuous answer.** A committed steer stamps
+  every inserted owner row with durable `steered: true` provenance. That marker,
+  not transcript adjacency or fuzzy content overlap, is the sole authority for
+  joining presentation across the boundary. When the first post-steer text block
+  starts with the complete sealed pre-steer text exactly, the repeated raw prefix
+  remains stored but only its unseen suffix renders below the owner row. While the
+  turn is active, a growing new text block that is itself still an exact prefix of
+  the sealed text stays provisionally hidden; the first mismatch immediately
+  reveals the complete accumulated block. A settled shorter response, an ordinary
+  send, multiple sealed text blocks, a tool/question/error before the continuation,
+  or a cut inside an open Markdown/container construct all fail closed and render
+  the post-steer response intact. A plain-text cut may split a word at any
+  Unicode grapheme boundary, but never splits a character reference. Literal
+  Markdown that later input could reinterpret also fails closed, so a
+  cut decision cannot reverse while the continuation grows. Leading thinking
+  remains visible, while thinking and tool blocks are
+  never compared, trimmed, reordered, or hidden by this rule. The same projection
+  consumes Claude and Codex's shared committed cut,
+  survives refresh/reconnect without rewriting `Chat.messages`, and changes no
+  message identity or scroll mode.
 The transition table is intentionally exhaustive; adding a new send or lifecycle
 path means routing it through the same entries rather than inventing another rule:
 

--- a/backend/app/chat_event_sink.py
+++ b/backend/app/chat_event_sink.py
@@ -168,6 +168,7 @@ def steered_into_turn_event(stored_messages: list[dict]) -> dict:
         "ts": msg.get("ts"),
         "cid": cid_of(msg),
         "content": msg.get("content", ""),
+        "steered": True,
         **({"attachments": msg.get("attachments")} if msg.get("attachments") else {}),
       }
       for msg in stored_messages

--- a/backend/app/chat_writer.py
+++ b/backend/app/chat_writer.py
@@ -2417,6 +2417,12 @@ class ChatWriterActor:
     stored_messages: list[dict] = []
     for raw_msg in raw_user_msgs:
       new_msg = dict(raw_msg)
+      # This provenance is part of the durable transcript contract, not a UI
+      # hint.  A normal Q1/A1/Q2/A2 exchange is indistinguishable from a
+      # mid-turn steer after reload unless the committed Q2 row names the
+      # boundary.  The renderer may then join an exact provider replay without
+      # guessing from content alone; every non-steer row fails closed.
+      new_msg["steered"] = True
       key = ensure_user_cid(new_msg)
       if key is not None and key in seen_cids:
         log.warning(

--- a/backend/tests/test_chat_writer_activation.py
+++ b/backend/tests/test_chat_writer_activation.py
@@ -702,6 +702,8 @@ def test_append_steered_user_message_lands_at_end_of_transcript():
   roles = [m["role"] for m in chat["messages"]]
   assert roles == ["user", "assistant", "user"]
   assert chat["messages"][-1]["content"] == "steered"
+  assert chat["messages"][-1]["steered"] is True
+  assert stored["steered"] is True
   # ts bumped past every transcript + pending ts (max was the queued 9).
   assert stored["ts"] > 9
   # The pending queue was untouched — a steer is NOT a queue append.
@@ -728,3 +730,5 @@ def test_append_steered_user_message_appends_when_no_assistant_yet():
 
   chat = _load("c-steer2")
   assert [m["content"] for m in chat["messages"]] == ["start", "steered"]
+  assert "steered" not in chat["messages"][0]
+  assert chat["messages"][1]["steered"] is True

--- a/backend/tests/test_chats_stream_steer.py
+++ b/backend/tests/test_chats_stream_steer.py
@@ -213,6 +213,7 @@ def test_steers_into_live_codex_turn_when_flag_on(
   assert roles == ["user", "assistant", "user"]
   assert chat.messages[-1]["content"] == "actually use blue"
   assert chat.messages[-1]["role"] == "user"
+  assert chat.messages[-1]["steered"] is True
 
   # A `steered_into_turn` event was broadcast for the inline render.
   bc = get_broadcast(chat_id)
@@ -227,6 +228,7 @@ def test_steers_into_live_codex_turn_when_flag_on(
       "ts": chat.messages[-1]["ts"],
       "cid": cid_of(chat.messages[-1]),
       "content": "actually use blue",
+      "steered": True,
     }
   ]
 
@@ -1566,7 +1568,9 @@ def test_claude_steer_cut_event_is_published_at_the_seal_not_at_http_arrival(
     "ts": steered_row["ts"],
     "cid": cid_of(steered_row),
     "content": "Q2",
+    "steered": True,
   }]
+  assert steered_row["steered"] is True
   # And A1 really was sealed at the boundary the cut names.
   assert [(m["role"], m.get("content")) for m in _read_chat(chat_id).messages] == [
     ("user", "Q1"),
@@ -1616,12 +1620,14 @@ def test_codex_steer_publishes_cut_from_handle_owned_settlement(
   assert [e.get("type") for e in bc.event_log] == ["steered_into_turn"]
   cut = [e for e in bc.event_log if e.get("type") == "steered_into_turn"][0]
   assert [m["content"] for m in cut["messages"]] == ["Q2"]
+  assert [m["steered"] for m in cut["messages"]] == [True]
   # The owning sink sealed A1 and appended Q2 before publishing.
   assert [(m["role"], m.get("content")) for m in _read_chat(chat_id).messages] == [
     ("user", "Q1"),
     ("assistant", "A1"),
     ("user", "Q2"),
   ]
+  assert _read_chat(chat_id).messages[-1]["steered"] is True
   assert sink.assistant_blocks == []
 
 

--- a/frontend/src/components/ChatView/ActiveAssistantSurface.jsx
+++ b/frontend/src/components/ChatView/ActiveAssistantSurface.jsx
@@ -6,6 +6,7 @@ import {
   carryQuestionAnswers,
   streamItemsToAssistantPayload,
 } from './streamPromotion.js'
+import { projectSteerContinuationMessage } from './steerContinuity.js'
 
 
 /**
@@ -38,26 +39,42 @@ function ActiveAssistantSurface({
   pendingQuestionRef,
   resumeCardRef,
   isStreaming,
+  sealedSteerAssistant,
 }) {
   const msg = useMemo(() => {
-    if (useDbActivePayload) return activeMirrorMsg
-    if (!hasLivePayload) return null
-    const livePayload = streamItemsToAssistantPayload(streamItems, { finalize: false })
-    return {
-      ...(activeMirrorMsg || {}),
-      role: 'assistant',
-      // Live rendering keeps running tool state and thinking clock anchors;
-      // final promotion converts the same items with finalize=true. The
-      // mirrored DB blocks supply only durable interaction state: a catch-up
-      // replay can be richer overall while still carrying the original blank
-      // form of a question whose answer has already committed.
-      ...livePayload,
-      blocks: carryQuestionAnswers(
-        livePayload.blocks,
-        activeMirrorMsg?.blocks || [],
-      ),
+    let source = null
+    if (useDbActivePayload) {
+      source = activeMirrorMsg
+    } else if (hasLivePayload) {
+      const livePayload = streamItemsToAssistantPayload(streamItems, { finalize: false })
+      source = {
+        ...(activeMirrorMsg || {}),
+        role: 'assistant',
+        // Live rendering keeps running tool state and thinking clock anchors;
+        // final promotion converts the same items with finalize=true. The
+        // mirrored DB blocks supply only durable interaction state: a catch-up
+        // replay can be richer overall while still carrying the original blank
+        // form of a question whose answer has already committed.
+        ...livePayload,
+        blocks: carryQuestionAnswers(
+          livePayload.blocks,
+          activeMirrorMsg?.blocks || [],
+        ),
+      }
     }
-  }, [activeMirrorMsg, hasLivePayload, streamItems, useDbActivePayload])
+    return projectSteerContinuationMessage(
+      sealedSteerAssistant,
+      source,
+      { active: isStreaming },
+    )
+  }, [
+    activeMirrorMsg,
+    hasLivePayload,
+    isStreaming,
+    sealedSteerAssistant,
+    streamItems,
+    useDbActivePayload,
+  ])
 
   if (!msg) return null
 

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -119,6 +119,10 @@ import {
   deriveActiveAssistantSelection,
 } from './activeAssistantSelection.js'
 import {
+  projectSettledSteerContinuations,
+  sealedAssistantBeforeSteer,
+} from './steerContinuity.js'
+import {
   answerKeepsCurrentTurn,
   builtAppPulseDecision,
   canFastForwardQueue,
@@ -1434,6 +1438,7 @@ export default function ChatView({
             content: m?.content || '',
             ts: tsv,
             cid: m?.cid ?? null,
+            steered: true,
             ...(m?.attachments ? { attachments: m.attachments } : {}),
           }
         })
@@ -4316,6 +4321,13 @@ export default function ChatView({
     hasLivePayload: hasLiveAssistantPayload,
     appendIndex: offset + messages.length,
   })
+  const activeSteerContinuationIndex = activeMirrorMsgIdx >= 0
+    ? activeMirrorMsgIdx
+    : messages.length
+  const sealedSteerAssistant = sealedAssistantBeforeSteer(
+    messages,
+    activeSteerContinuationIndex,
+  )
   useLayoutEffect(() => {
     if (!turnActive) {
       activeAssistantDataKeyRef.current = null
@@ -4374,9 +4386,13 @@ export default function ChatView({
   ).map(item => item.key === 'goal' && activeGoalPlan
     ? { ...item, details: <GoalPlanDetails plan={activeGoalPlan} /> }
     : item)
+  const displayedMessages = useMemo(
+    () => projectSettledSteerContinuations(messages),
+    [messages],
+  )
   let lastVisibleMessageIndex = -1
-  for (let i = messages.length - 1; i >= 0; i -= 1) {
-    if (!messages[i].hidden) {
+  for (let i = displayedMessages.length - 1; i >= 0; i -= 1) {
+    if (!displayedMessages[i].hidden) {
       lastVisibleMessageIndex = i
       break
     }
@@ -4513,7 +4529,7 @@ export default function ChatView({
             non-empty chat, including after unmount/remount. Keep the list's
             elastic min-height out of the spacer formula at all times. */}
         <ul className="chat__list" style={{ minHeight: 0 }}>
-          {messages.map((msg, i) => {
+          {displayedMessages.map((msg, i) => {
             if (msg.hidden) return null
             const continuationMarker = isContinuationMessage(msg)
             const isLastMsg = i === lastVisibleMessageIndex
@@ -4653,6 +4669,7 @@ export default function ChatView({
               // ", in progress" — instead of settling early. Source selection
               // still gates resume/question routing above (review 2026-07-17).
               isStreaming={activeAssistantIsStreaming || turnActive}
+              sealedSteerAssistant={sealedSteerAssistant}
             />
           )}
 

--- a/frontend/src/components/ChatView/__tests__/chatContractStructure.test.js
+++ b/frontend/src/components/ChatView/__tests__/chatContractStructure.test.js
@@ -33,7 +33,7 @@ test('owner contract keeps question anchors through responsive geometry', () => 
     new URL('../../../../../ARCHITECTURE.md', import.meta.url),
     'utf8',
   )
-  assert.match(architecture, /Owner-authoritative contract — v1\.22 \(2026-08-23\)/)
+  assert.match(architecture, /Owner-authoritative contract — v1\.23 \(2026-08-24\)/)
   assert.match(
     architecture,
     /In-message question Submit begins \| any \| transient `ANCHOR_AT` over the prior mode/,

--- a/frontend/src/components/ChatView/__tests__/steerContinuity.test.js
+++ b/frontend/src/components/ChatView/__tests__/steerContinuity.test.js
@@ -1,0 +1,242 @@
+/* Exact steer replay renders continuously without guessing or data loss. */
+
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  projectSettledSteerContinuations,
+  projectSteerContinuationMessage,
+  sealedAssistantBeforeSteer,
+} from '../steerContinuity.js'
+import { safeSteerMarkdownCut } from '../markdown/steerContinuation.js'
+
+
+function assistant(text, extras = {}) {
+  return {
+    role: 'assistant',
+    content: text,
+    blocks: [{ type: 'text', content: text }],
+    ...extras,
+  }
+}
+
+
+function steer(content = 'change course') {
+  return { role: 'user', content, steered: true }
+}
+
+
+test('an exact post-steer replay renders only its unseen suffix', () => {
+  const sealed = assistant('The key is')
+  const continuation = assistant('The key is preserving the boundary.')
+
+  const projected = projectSteerContinuationMessage(sealed, continuation)
+
+  assert.equal(projected.blocks[0].content, ' preserving the boundary.')
+  assert.equal(projected.content, ' preserving the boundary.')
+  assert.equal(continuation.blocks[0].content,
+    'The key is preserving the boundary.', 'durable source stays untouched')
+})
+
+
+test('a plain word may continue across the steered user row', () => {
+  const messages = [
+    assistant('The frame'),
+    steer('also cover reconnects'),
+    assistant('The framework survives reconnects.'),
+  ]
+
+  const displayed = projectSettledSteerContinuations(messages)
+
+  assert.equal(displayed[0].blocks[0].content, 'The frame')
+  assert.equal(displayed[1], messages[1])
+  assert.equal(displayed[2].blocks[0].content, 'work survives reconnects.')
+})
+
+
+test('a normal user row never authorizes prefix suppression', () => {
+  const messages = [
+    assistant('Repeat this'),
+    { role: 'user', content: 'say it again' },
+    assistant('Repeat this exactly.'),
+  ]
+
+  assert.deepEqual(projectSettledSteerContinuations(messages), messages)
+})
+
+
+test('a mismatch and a settled short response both fail closed', () => {
+  const sealed = assistant('Planned maintenance preserves active work.')
+  const mismatch = assistant('Unexpected crashes remain conservative.')
+  const shorter = assistant('Planned maintenance')
+
+  assert.equal(projectSteerContinuationMessage(sealed, mismatch), mismatch)
+  assert.equal(projectSteerContinuationMessage(sealed, shorter), shorter)
+})
+
+
+test('a matching live partial stays hidden until it catches up', () => {
+  const sealed = assistant('Planned maintenance preserves active work.')
+  const partial = assistant('Planned maintenance')
+  const projected = projectSteerContinuationMessage(
+    sealed,
+    partial,
+    { active: true },
+  )
+
+  assert.equal(projected.blocks[0].content, '')
+  assert.equal(projected.content, '')
+  assert.equal(partial.blocks[0].content, 'Planned maintenance')
+})
+
+
+test('a live partial reveals its complete text on the first divergence', () => {
+  const sealed = assistant('Planned maintenance preserves active work.')
+  const diverged = assistant('Planned replacement')
+
+  assert.equal(
+    projectSteerContinuationMessage(sealed, diverged, { active: true }),
+    diverged,
+  )
+})
+
+
+test('thinking is preserved while only the first continuation text is trimmed', () => {
+  const thinking = { type: 'thinking', content: 'Replanning', thinking_id: 't2' }
+  const tool = { type: 'tool', tool: 'Bash', status: 'done', output: 'ok' }
+  const continuation = {
+    role: 'assistant',
+    content: 'Answer continued.',
+    blocks: [
+      thinking,
+      { type: 'text', content: 'Answer continued.' },
+      tool,
+      { type: 'text', content: 'New result.' },
+    ],
+  }
+
+  const projected = projectSteerContinuationMessage(
+    assistant('Answer'),
+    continuation,
+  )
+
+  assert.equal(projected.blocks[0], thinking)
+  assert.equal(projected.blocks[1].content, ' continued.')
+  assert.equal(projected.blocks[2], tool)
+  assert.equal(projected.blocks[3].content, 'New result.')
+})
+
+
+test('a tool before the continuation text fails closed', () => {
+  const continuation = {
+    role: 'assistant',
+    content: 'Answer continued.',
+    blocks: [
+      { type: 'tool', tool: 'Bash', status: 'done', output: 'ok' },
+      { type: 'text', content: 'Answer continued.' },
+    ],
+  }
+
+  assert.equal(
+    projectSteerContinuationMessage(assistant('Answer'), continuation),
+    continuation,
+  )
+})
+
+
+test('multiple sealed text blocks fail closed instead of crossing activity', () => {
+  const sealed = {
+    role: 'assistant',
+    content: 'First\n\nSecond',
+    blocks: [
+      { type: 'text', content: 'First' },
+      { type: 'thinking', content: 'Between' },
+      { type: 'text', content: 'Second' },
+    ],
+  }
+  const continuation = assistant('First\n\nSecond plus more')
+
+  assert.equal(projectSteerContinuationMessage(sealed, continuation), continuation)
+})
+
+
+test('consecutive steered rows share the same sealed assistant', () => {
+  const messages = [
+    assistant('Prefix'),
+    steer('first steer'),
+    steer('second steer'),
+    assistant('Prefix suffix'),
+  ]
+
+  assert.equal(sealedAssistantBeforeSteer(messages, 3), messages[0])
+  assert.equal(
+    projectSettledSteerContinuations(messages)[3].blocks[0].content,
+    ' suffix',
+  )
+})
+
+
+test('each steer in a chain compares against the raw preceding response', () => {
+  const messages = [
+    assistant('A'),
+    steer('one'),
+    assistant('AB'),
+    steer('two'),
+    assistant('ABC'),
+  ]
+
+  const displayed = projectSettledSteerContinuations(messages)
+  assert.equal(displayed[2].blocks[0].content, 'B')
+  assert.equal(displayed[4].blocks[0].content, 'C')
+})
+
+
+test('Markdown cuts allow plain words and complete constructs only', () => {
+  assert.equal(safeSteerMarkdownCut('The framework continues', 9), true)
+  assert.equal(safeSteerMarkdownCut('**Planned', 6), false)
+  assert.equal(safeSteerMarkdownCut('**Planned', '**Planned'.length), false)
+  assert.equal(safeSteerMarkdownCut('**Planned**', '**Planned**'.length), true)
+  assert.equal(safeSteerMarkdownCut('**Planned** maintenance', 6), false)
+  assert.equal(safeSteerMarkdownCut('**Planned** maintenance', 11), true)
+  assert.equal(safeSteerMarkdownCut('Read https://exa', 'Read https://'.length), false)
+  assert.equal(safeSteerMarkdownCut('Read https://exa', 'Read https://exa'.length), false)
+  assert.equal(
+    safeSteerMarkdownCut(
+      '[Read](https://example.com)',
+      '[Read](https://example.com)'.length,
+    ),
+    true,
+  )
+  assert.equal(safeSteerMarkdownCut('- framework continues', 7), false)
+  assert.equal(safeSteerMarkdownCut('```js\nconst x = 1\n```', 12), false)
+})
+
+
+test('plain-text cuts preserve graphemes and character references', () => {
+  assert.equal(safeSteerMarkdownCut('woman 👩‍💻 works', 'woman 👩'.length), false)
+  assert.equal(safeSteerMarkdownCut('cafe\u0301 continues', 'cafe'.length), false)
+  assert.equal(safeSteerMarkdownCut('A &amp; B', 'A &'.length), false)
+  assert.equal(safeSteerMarkdownCut('A &amp; B', 'A &amp;'.length), true)
+  assert.equal(safeSteerMarkdownCut('A &amp', 'A &amp'.length), false)
+  assert.equal(safeSteerMarkdownCut('The framework continues', 'The frame'.length), true)
+})
+
+
+test('an unsafe Markdown split keeps the full post-steer response', () => {
+  const sealed = assistant('**Plan')
+  const continuation = assistant('**Planned** maintenance')
+  const activePartial = assistant('**Planned')
+  const activeExact = assistant('**Plan')
+
+  assert.equal(
+    projectSteerContinuationMessage(sealed, continuation),
+    continuation,
+  )
+  assert.equal(
+    projectSteerContinuationMessage(sealed, activePartial, { active: true }),
+    activePartial,
+  )
+  assert.equal(
+    projectSteerContinuationMessage(sealed, activeExact, { active: true }),
+    activeExact,
+  )
+})

--- a/frontend/src/components/ChatView/chatContract.js
+++ b/frontend/src/components/ChatView/chatContract.js
@@ -110,6 +110,14 @@ export const CHAT_CONTRACT = [
       + 'chosen) is covered by chooseActiveAssistantSurface\'s own unit tests.',
   },
   {
+    id: 'continuous-steer-replay',
+    title: 'Render exact steer replay as one continuous answer',
+    summary:
+      'A durable steer boundary may suppress only the exact assistant-text '
+      + 'prefix already visible above its user row. Stored content is unchanged; '
+      + 'ordinary sends, mismatches, and unsafe Markdown cuts render in full.',
+  },
+  {
     id: 'anchor-held-through-toggle',
     title: 'Hold the reader through disclosure toggles',
     summary:

--- a/frontend/src/components/ChatView/markdown/steerContinuation.js
+++ b/frontend/src/components/ChatView/markdown/steerContinuation.js
@@ -1,0 +1,133 @@
+/* Decide whether an exact steer-replay cut is safe for two Markdown segments. */
+
+import { Marked } from 'marked'
+import { mathTokens } from './mathTokens.js'
+
+const md = new Marked()
+md.use(mathTokens())
+const graphemeSegmenter = (
+  typeof Intl !== 'undefined' && typeof Intl.Segmenter === 'function'
+)
+  ? new Intl.Segmenter(undefined, { granularity: 'grapheme' })
+  : null
+const MARKDOWN_CONTROL = /[\\`*_~\[\]<>$&|]/
+const URLISH_TAIL = /(?:https?:\/\/|www\.)\S*$/i
+const EMAILISH_TAIL = /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]*$/
+
+
+function isGraphemeBoundary(source, cut) {
+  // Modern Möbius runtimes expose Intl.Segmenter. An older engine fails closed
+  // on nonterminal splits rather than guessing at a Unicode boundary.
+  if (!graphemeSegmenter) return false
+  for (const segment of graphemeSegmenter.segment(source)) {
+    if (segment.index === cut) return true
+    if (segment.index > cut) return false
+  }
+  return cut === source.length
+}
+
+
+function splitsCharacterReference(source, cut) {
+  const amp = source.slice(0, cut).lastIndexOf('&')
+  if (amp < 0) return false
+  const match = /^&(?:#[0-9]{1,7}|#[xX][0-9a-fA-F]{1,6}|[A-Za-z][A-Za-z0-9]{1,31});/
+    .exec(source.slice(amp))
+  return !!(match && cut < amp + match[0].length)
+}
+
+
+function isFutureStablePlainPrefix(rawPrefix) {
+  // Marked treats an unmatched delimiter as ordinary text until later input
+  // closes it. Trimming that temporary shape would be non-monotonic: the
+  // duplicate prefix would disappear, then reappear when the parser learned
+  // it was emphasis/link/code/math. Keep those literal controls intact.
+  const withoutCompleteReferences = rawPrefix.replace(
+    /&(?:#[0-9]{1,7}|#[xX][0-9a-fA-F]{1,6}|[A-Za-z][A-Za-z0-9]{1,31});/g,
+    '',
+  )
+  return !MARKDOWN_CONTROL.test(withoutCompleteReferences)
+    && !URLISH_TAIL.test(withoutCompleteReferences)
+    && !EMAILISH_TAIL.test(withoutCompleteReferences)
+}
+
+
+function isFutureStableParagraphEnd(block) {
+  const tokens = Array.isArray(block?.tokens) ? block.tokens : []
+  const last = tokens[tokens.length - 1]
+  if (!last) return true
+  const raw = String(last.raw || '')
+  if (last.type === 'text' && !Array.isArray(last.tokens)) {
+    return isFutureStablePlainPrefix(raw)
+  }
+  // Marked recognizes a bare URL/email as a link before the provider has
+  // necessarily finished typing it. Delimited links are closed constructs;
+  // bare ones may still grow and would move the safe boundary.
+  if (last.type === 'link') {
+    return !/^(?:https?:\/\/|www\.)/i.test(raw) && !EMAILISH_TAIL.test(raw)
+  }
+  return true
+}
+
+
+/**
+ * A steer can split a plain word at any character, but it must not split an
+ * open Markdown construct. Both transcript segments are rendered separately;
+ * cutting inside emphasis, a link, code, math, a list, or another container
+ * would make the suffix lose the syntax opened above the user row.
+ *
+ * `cut` is a raw-source offset in `text`. Fail closed on unknown token shapes.
+ */
+export function safeSteerMarkdownCut(text, cut) {
+  if (!Number.isInteger(cut) || cut <= 0 || cut > String(text || '').length) {
+    return false
+  }
+  const source = String(text || '')
+  if (!isGraphemeBoundary(source, cut) || splitsCharacterReference(source, cut)) {
+    return false
+  }
+
+  const blocks = md.lexer(source)
+  let blockStart = 0
+  for (const block of blocks) {
+    const raw = String(block?.raw || '')
+    const blockEnd = blockStart + raw.length
+    if (cut === blockStart || (cut === blockEnd && blockEnd < source.length)) {
+      return true
+    }
+    if (cut < blockStart || cut > blockEnd) {
+      blockStart = blockEnd
+      continue
+    }
+
+    // A top-level paragraph's direct plain-text token is the one construct
+    // that can be split mid-token without carrying syntax across the user row.
+    // Container blocks deliberately fail closed even when their leaf happens
+    // to be text: the list/quote/heading/code syntax still opened above it.
+    if (block?.type !== 'paragraph' || !Array.isArray(block.tokens)) {
+      return cut === blockEnd
+    }
+    if (cut === blockEnd && blockEnd === source.length) {
+      return isFutureStableParagraphEnd(block)
+    }
+    const localCut = cut - blockStart
+    let inlineStart = 0
+    for (const token of block.tokens) {
+      const inlineRaw = String(token?.raw || '')
+      const inlineEnd = inlineStart + inlineRaw.length
+      if (localCut === inlineStart) return true
+      if (localCut > inlineStart && localCut <= inlineEnd) {
+        if (token?.type !== 'text' || Array.isArray(token.tokens)) {
+          return localCut === inlineEnd
+        }
+        return isFutureStablePlainPrefix(
+          inlineRaw.slice(0, localCut - inlineStart),
+        )
+      }
+      inlineStart = inlineEnd
+    }
+    // Marked may leave only trailing paragraph whitespace outside inline
+    // tokens. A cut there carries no Markdown state.
+    return localCut >= inlineStart && localCut <= raw.length
+  }
+  return false
+}

--- a/frontend/src/components/ChatView/steerContinuity.js
+++ b/frontend/src/components/ChatView/steerContinuity.js
@@ -1,0 +1,120 @@
+/* Project exact post-steer text replay as one continuous assistant answer. */
+
+import { safeSteerMarkdownCut } from './markdown/steerContinuation.js'
+
+
+export function isSteeredUserMessage(message) {
+  return !!(
+    message
+    && message.role === 'user'
+    && !message.hidden
+    && message.steered === true
+  )
+}
+
+
+/** Return the sealed assistant immediately before one or more steered rows. */
+export function sealedAssistantBeforeSteer(messages, continuationIndex) {
+  if (!Array.isArray(messages) || !Number.isInteger(continuationIndex)) return null
+  let index = continuationIndex - 1
+  let sawSteer = false
+  while (index >= 0 && isSteeredUserMessage(messages[index])) {
+    sawSteer = true
+    index -= 1
+  }
+  if (!sawSteer || messages[index]?.role !== 'assistant') return null
+  return messages[index]
+}
+
+
+function soleTextBlockContent(message) {
+  if (!message) return ''
+  if (!Array.isArray(message.blocks) || message.blocks.length === 0) {
+    return typeof message.content === 'string' ? message.content : ''
+  }
+  const textBlocks = message.blocks.filter(block => (
+    block?.type === 'text' && typeof block.content === 'string' && block.content
+  ))
+  // Joining several text blocks would invent separators and could cross tool,
+  // question, or activity boundaries. Exactness is more important than reach.
+  return textBlocks.length === 1 ? textBlocks[0].content : ''
+}
+
+
+function firstContinuationTextBlock(blocks) {
+  if (!Array.isArray(blocks)) return -1
+  for (let index = 0; index < blocks.length; index += 1) {
+    const block = blocks[index]
+    if (block?.type === 'text') return index
+    // Thinking before the answer is provider-neutral activity. Any other
+    // visible block means prose did not actually begin the continuation.
+    if (block?.type !== 'thinking') return -1
+  }
+  return -1
+}
+
+
+function projectedText(prefix, text, { active }) {
+  if (!prefix || !text) return null
+  if (text.startsWith(prefix)) {
+    if (!safeSteerMarkdownCut(text, prefix.length)) return null
+    return text.slice(prefix.length)
+  }
+  // While the provider is replaying the already-visible prefix, hold that
+  // provisional duplicate off-screen. If one character diverges, this branch
+  // stops matching and the complete accumulated text appears unchanged.
+  if (active && prefix.startsWith(text)) return ''
+  return null
+}
+
+
+/**
+ * Return a presentation-only assistant message. Stored content is never
+ * rewritten: a mismatch, a settled short response, or an unsafe Markdown cut
+ * returns the original object by identity.
+ */
+export function projectSteerContinuationMessage(
+  sealedMessage,
+  continuationMessage,
+  { active = false } = {},
+) {
+  if (!sealedMessage || continuationMessage?.role !== 'assistant') {
+    return continuationMessage
+  }
+  const prefix = soleTextBlockContent(sealedMessage)
+  if (!prefix) return continuationMessage
+
+  const blocks = continuationMessage.blocks
+  if (Array.isArray(blocks) && blocks.length > 0) {
+    const textIndex = firstContinuationTextBlock(blocks)
+    if (textIndex < 0) return continuationMessage
+    const text = String(blocks[textIndex]?.content || '')
+    const projected = projectedText(prefix, text, { active })
+    if (projected == null) return continuationMessage
+    const nextBlocks = blocks.slice()
+    nextBlocks[textIndex] = { ...blocks[textIndex], content: projected }
+    return {
+      ...continuationMessage,
+      content: projected,
+      blocks: nextBlocks,
+    }
+  }
+
+  const text = String(continuationMessage.content || '')
+  const projected = projectedText(prefix, text, { active })
+  if (projected == null) return continuationMessage
+  return { ...continuationMessage, content: projected }
+}
+
+
+/** Apply the exact replay projection to settled transcript rows. */
+export function projectSettledSteerContinuations(messages) {
+  if (!Array.isArray(messages)) return []
+  return messages.map((message, index) => {
+    if (message?.role !== 'assistant') return message
+    return projectSteerContinuationMessage(
+      sealedAssistantBeforeSteer(messages, index),
+      message,
+    )
+  })
+}


### PR DESCRIPTION
## Summary
- persist an explicit steer boundary shared by Claude and Codex
- render an exact post-steer replay as only its unseen suffix while preserving the raw transcript
- fail closed for mismatches, activity boundaries, unsafe Markdown, Unicode graphemes, character references, and unstable streaming cuts

## Testing
- `npm test`
- `npm run lint`
- `npm run build`
- `./scripts/test.sh --fast`
- `scripts/wt-pytest.sh backend/tests/test_chat_writer_activation.py backend/tests/test_chats_stream_steer.py -q`