### PR TITLE
Preserve assistant message identity across restart replay

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -409,8 +409,8 @@ The chat is large and self-contained; its hooks live beside it, not in `src/hook
 | `streamReducers.js` | Stream-event reducers |
 | `resolveStopResend.js` | Stop → collapse-queue → re-send logic |
 | `chatRuntimeState.js` | Pure queue/stream branch helpers (`canFastForwardQueue`, referenced by the steer contract below) |
-| `streamPromotion.js` | Pure helpers sealing live stream items into durable assistant messages on promote/steer (`promoteAssistantStream`, `streamItemsHaveRenderableContent`) — ChatView owns *when* promotion happens, this owns *how* |
-| `streamSnapshotCache.js` | Versioned `sessionStorage` cache of the visible streaming items (the R4 leave-and-return restore) |
+| `streamPromotion.js` | Pure helpers sealing live stream items into the exact identity-owned durable assistant row on promote/steer (`promoteAssistantStream`, `streamItemsHaveRenderableContent`) — ChatView owns *when* promotion happens, this owns *how* |
+| `streamSnapshotCache.js` | Versioned `sessionStorage` cache of the visible streaming items plus their assistant-message identity (the R4 leave-and-return restore) |
 | `msgText.js` | Strips `<agent_experience>` blocks + the hidden attachment manifest from message text |
 | `useStreamConnection.js` | SSE connection, text buffering, typewriter drain, sleep/wake reconnect |
 | `useScrollMode.js` | Scroll-mode state machine |
@@ -791,6 +791,13 @@ and attaches their rule ids to new diagnostic chats. The Playwright lock-in spec
   text block in event order, without hiding, duplicating, or reordering them. Only a
   recovered answer whose POST returns `started` creates a new hidden continuation.
   Switching sources preserves the active row's anchor identity and writes no scroll.
+  One durable assistant-message `id` follows every current segment from the run-start
+  live stub through sink snapshots/control events, `live_assistant`, the settled
+  transcript, SSE/session cache, active rendering, and terminal promotion. The same
+  id updates exactly that row even when later same-turn control rows follow it; a new
+  id appends at the tail. A steer seals one id and rotates to the next. Timestamp,
+  role, and content inference are reserved for id-less rolling history and may never
+  cross a later visible turn or a different explicit id.
 - **R6a — Exact steer replay is one continuous answer.** A committed steer stamps
   every inserted owner row with durable `steered: true` provenance. That marker,
   not transcript adjacency or fuzzy content overlap, is the sole authority for

--- a/backend/app/chat.py
+++ b/backend/app/chat.py
@@ -13,6 +13,7 @@ import math
 import os
 import re
 import time
+import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -696,8 +697,36 @@ def reconcile_startup_chats(
       # the danger-red error styling — a restart is a maintenance event, not
       # something the turn did wrong.
       err_block = _pause_note(note, kind="restart")
-      if msgs and msgs[-1].get("role") == "assistant":
-        blocks = list(msgs[-1].get("blocks") or [])
+      live_id = (
+        chat.live_assistant.get("id")
+        if isinstance(chat.live_assistant, dict) else None
+      )
+      recovery_message_id = live_id or (
+        restart_run.id if restart_run is not None else None
+      )
+      recovery_index = next((
+        index for index, message in enumerate(msgs)
+        if recovery_message_id is not None
+        and message.get("role") == "assistant"
+        and message.get("id") is not None
+        and str(message.get("id")) == str(recovery_message_id)
+      ), -1)
+      if (
+        recovery_index < 0
+        and msgs
+        and msgs[-1].get("role") == "assistant"
+        and (
+          recovery_message_id is None
+          or msgs[-1].get("id") is None
+        )
+      ):
+        # Rolling upgrade only: an id-less tail can be the interrupted row.
+        # If both rows have different explicit ids, the running segment is new
+        # and its restart note belongs at the transcript tail.
+        recovery_index = len(msgs) - 1
+      if recovery_index >= 0:
+        previous_message = msgs[recovery_index]
+        blocks = list(previous_message.get("blocks") or [])
         finalize_blocks(blocks)
         # A drain-gated restart (design §2.2) already wrote its own terminal
         # "paused for a platform update" note through the sink before the
@@ -784,16 +813,29 @@ def reconcile_startup_chats(
         # stable ts (the frontend bridge + React keys rely on it — a
         # ts-less message is dropped by useBridgePartial). Mirrors the
         # ts-carry in _update_last_assistant_message.
-        prev_ts = msgs[-1].get("ts")
-        msgs[-1] = build_assistant_message(blocks)
-        msgs[-1]["ts"] = (
-          prev_ts if prev_ts is not None else _next_message_ts(msgs[:-1])
+        prev_ts = previous_message.get("ts")
+        recovered_message = build_assistant_message(blocks)
+        recovered_message["id"] = (
+          previous_message.get("id")
+          or recovery_message_id
+          or f"assistant-{uuid.uuid4().hex}"
         )
+        recovered_message["ts"] = (
+          prev_ts
+          if prev_ts is not None
+          else _next_message_ts(
+            msgs[:recovery_index] + msgs[recovery_index + 1:]
+          )
+        )
+        msgs[recovery_index] = recovered_message
       else:
         # Process died before any assistant content persisted — surface
         # the interruption as a standalone assistant turn so the user
         # isn't left staring at their own unanswered message.
         new_msg = build_assistant_message([err_block])
+        new_msg["id"] = (
+          recovery_message_id or f"assistant-{uuid.uuid4().hex}"
+        )
         new_msg["ts"] = _next_message_ts(msgs)
         msgs.append(new_msg)
       # Preserve chat.pending_messages: closing the run leaves an idle queue

--- a/backend/app/chat_event_sink.py
+++ b/backend/app/chat_event_sink.py
@@ -88,6 +88,17 @@ def _pause_note(
 def register_active_sink(chat_id: str, sink: "ChatEventSink") -> None:
   """Publish the live sink for `chat_id` so the steer route can reach it."""
   _active_sinks[chat_id] = sink
+  # A subscriber can attach in the short interval after the broadcast exists
+  # but before the sink is registered, so it cannot receive a subscription
+  # snapshot yet. Publish the same identity as a replay-safe control fact; a
+  # later subscriber gets it from the snapshot instead.
+  raw_bc = getattr(sink, "bc", None)
+  assistant_message_id = getattr(sink, "assistant_message_id", None)
+  if callable(getattr(raw_bc, "publish", None)) and assistant_message_id:
+    raw_bc.publish({
+      "type": "assistant_identity",
+      "assistant_message_id": assistant_message_id,
+    })
 
 
 def get_active_sink(chat_id: str) -> "ChatEventSink | None":
@@ -95,8 +106,8 @@ def get_active_sink(chat_id: str) -> "ChatEventSink | None":
   return _active_sinks.get(chat_id)
 
 
-def active_sink_stream_snapshot(chat_id: str, broadcast) -> list[dict] | None:
-  """Freeze the current assistant items for one snapshot-capable subscriber.
+def active_sink_stream_snapshot(chat_id: str, broadcast) -> dict | None:
+  """Freeze the current assistant segment for one snapshot-capable subscriber.
 
   The sink is the reduction authority for a running turn: every content event
   reaches ``assistant_blocks`` before it reaches the broadcast.  Pairing by
@@ -108,7 +119,10 @@ def active_sink_stream_snapshot(chat_id: str, broadcast) -> list[dict] | None:
   sink = get_active_sink(chat_id)
   if sink is None or sink.bc is not broadcast:
     return None
-  return copy.deepcopy(sink.assistant_blocks)
+  return {
+    "items": copy.deepcopy(sink.assistant_blocks),
+    "assistant_message_id": sink.assistant_message_id,
+  }
 
 
 def unregister_active_sink(chat_id: str, sink: "ChatEventSink") -> None:
@@ -142,7 +156,14 @@ def active_sink_memory_diagnostics(*, include_payloads: bool = True) -> list[dic
   return diagnostics
 
 
-def steered_into_turn_event(stored_messages: list[dict]) -> dict:
+def steered_into_turn_event(
+  stored_messages: list[dict],
+  *,
+  assistant_message_id: str | None = None,
+  sealed_items: list[dict] | None = None,
+  next_assistant_message_id: str | None = None,
+  items: list[dict] | None = None,
+) -> dict:
   """Build the `steered_into_turn` SSE payload for a batch of steered rows.
 
   `steered_into_turn` is the AUTHORITATIVE CUT and the client's ONLY "seal the
@@ -177,6 +198,16 @@ def steered_into_turn_event(stored_messages: list[dict]) -> dict:
     # single steered row.
     "ts": stored_messages[-1].get("ts"),
     "content": stored_messages[-1].get("content", ""),
+    **(
+      {"assistant_message_id": assistant_message_id}
+      if assistant_message_id else {}
+    ),
+    **({"sealed_items": copy.deepcopy(sealed_items)} if sealed_items is not None else {}),
+    **(
+      {"next_assistant_message_id": next_assistant_message_id}
+      if next_assistant_message_id else {}
+    ),
+    **({"items": copy.deepcopy(items)} if items is not None else {}),
   }
 
 
@@ -280,6 +311,14 @@ class ChatEventSink:
     # `(chat_id, run_token)`. `""` for a tokenless legacy/test caller —
     # the actor tolerates an empty token (its own key).
     self.run_token = run_token
+    # One identity follows this assistant segment through the live stub,
+    # snapshots, SSE reconnects, terminal persistence, and browser promotion.
+    # The first segment reuses the durable physical-run id; a steer rotates to
+    # a run-scoped segment id after sealing the prior one.
+    self._assistant_segment = 0
+    self.assistant_message_id = (
+      run_token or f"assistant-{uuid.uuid4().hex}"
+    )
     self.assistant_blocks: list = []
     self.session_id: str | None = None
     self.cost_usd: float | None = None
@@ -321,10 +360,15 @@ class ChatEventSink:
       )
 
   def _deferred_snapshot(
-    self, blocks: list, *, complete_all: bool = False,
+    self,
+    blocks: list,
+    *,
+    complete_all: bool = False,
+    assistant_message_id: str | None = None,
   ) -> tuple[dict, list[StashThinkingTrace]]:
     """Build a bounded transcript snapshot plus its full-text sidecars."""
     snapshot = copy.deepcopy(build_assistant_message(blocks))
+    snapshot["id"] = assistant_message_id or self.assistant_message_id
     stashes: list[StashThinkingTrace] = []
     for source, persisted in zip(
       [b for b in blocks if b.get("type") != "text_boundary"],
@@ -745,6 +789,13 @@ class ChatEventSink:
     before Q2 on reload (card 166).
     """
     self._steering = True
+    sealed_message_id = self.assistant_message_id
+    self._assistant_segment += 1
+    self.assistant_message_id = (
+      f"{self.run_token}:assistant:{self._assistant_segment}"
+      if self.run_token
+      else f"assistant-{uuid.uuid4().hex}"
+    )
     try:
       sealed_blocks = self.assistant_blocks
       # Reset BEFORE the first await so the continuation accumulates into a
@@ -762,7 +813,9 @@ class ChatEventSink:
         and blocks_have_renderable_content(sealed_blocks)
       ):
         snapshot, stashes = self._deferred_snapshot(
-          sealed_blocks, complete_all=True,
+          sealed_blocks,
+          complete_all=True,
+          assistant_message_id=sealed_message_id,
         )
         ack = get_writer().submit(
           Finalize(
@@ -782,6 +835,8 @@ class ChatEventSink:
           # self.assistant_blocks (the reset list); prepend the sealed content
           # so the combined snapshot is complete.
           self.assistant_blocks = sealed_blocks + self.assistant_blocks
+          self.assistant_message_id = sealed_message_id
+          self._assistant_segment -= 1
           raise
       user_msgs = user_msg if isinstance(user_msg, list) else [user_msg]
       ack = get_writer().submit(
@@ -808,6 +863,8 @@ class ChatEventSink:
     has acknowledged the steering input.
     """
     user_msgs = user_msg if isinstance(user_msg, list) else [user_msg]
+    sealed_items = copy.deepcopy(self.assistant_blocks)
+    sealed_message_id = self.assistant_message_id
     stored_result = await self.split_for_steer(
       user_msgs, consume_pending_cids,
     )
@@ -819,7 +876,13 @@ class ChatEventSink:
     if not isinstance(stored_messages, list) or not stored_messages:
       stored_messages = user_msgs
     try:
-      self.bc.publish(steered_into_turn_event(stored_messages))
+      self.bc.publish(steered_into_turn_event(
+        stored_messages,
+        assistant_message_id=sealed_message_id,
+        sealed_items=sealed_items,
+        next_assistant_message_id=self.assistant_message_id,
+        items=self.assistant_blocks,
+      ))
     except Exception:
       # The transcript cut already committed. A lost notification must not be
       # reported as a delivery failure (which would falsely claim the rows are

--- a/backend/app/chat_message_identity.py
+++ b/backend/app/chat_message_identity.py
@@ -1,0 +1,38 @@
+"""Pure assistant-message identity matching shared by chat read/write paths."""
+
+from __future__ import annotations
+
+
+def assistant_message_index(messages: list, message: dict) -> int:
+  """Locate the assistant row owned by ``message``.
+
+  Current snapshots carry the segment's durable ``id`` and may update that
+  exact row even when a hidden same-turn answer follows it. Id-less snapshots
+  are historical/test compatibility only and retain the former trailing-row
+  rule. One rolling-upgrade exception lets an explicit id adopt a trailing
+  id-less assistant; it can never cross a later turn or a different id.
+  """
+  message_id = message.get("id") if isinstance(message, dict) else None
+  if message_id is not None:
+    target = str(message_id)
+    for index, candidate in enumerate(messages):
+      if (
+        isinstance(candidate, dict)
+        and candidate.get("role") == "assistant"
+        and candidate.get("id") is not None
+        and str(candidate.get("id")) == target
+      ):
+        return index
+    if (
+      messages
+      and messages[-1].get("role") == "assistant"
+      and messages[-1].get("id") is None
+    ):
+      # Rolling upgrade only: the former persistence shape has no identity to
+      # compare. A trailing id-less assistant is the one safe adoption point;
+      # any explicit id or later visible turn proves this is a new segment.
+      return len(messages) - 1
+    return -1
+  if messages and messages[-1].get("role") == "assistant":
+    return len(messages) - 1
+  return -1

--- a/backend/app/chat_transcript.py
+++ b/backend/app/chat_transcript.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import re
 
+from app.chat_message_identity import assistant_message_index
 from app.memory_recall import (
   RecallBinding,
   recall_from_command,
@@ -33,10 +34,11 @@ def materialized_messages(chat) -> list[dict]:
   # blank assistant row before the provider emits content.
   if not isinstance(blocks, list) or not blocks:
     return messages
-  if messages and messages[-1].get("role") == "assistant":
-    messages[-1] = live
-  else:
-    messages.append(live)
+  live_index = assistant_message_index(messages, live)
+  if live_index >= 0:
+    messages[live_index] = live
+    return messages
+  messages.append(live)
   return messages
 
 

--- a/backend/app/chat_writer.py
+++ b/backend/app/chat_writer.py
@@ -45,6 +45,7 @@ import secrets
 import sys
 import threading
 import time
+import uuid
 from concurrent.futures import Future, InvalidStateError
 from dataclasses import dataclass, field
 
@@ -52,6 +53,7 @@ from sqlalchemy import select, text, update
 from sqlalchemy.exc import SQLAlchemyError
 
 from app import models, schemas
+from app.chat_message_identity import assistant_message_index
 from app.chat_titles import first_message_title
 from app.json_safety import json_safe
 from app.events import (
@@ -1509,7 +1511,11 @@ class ChatWriterActor:
       # not promote the queue / schedule a continuation on a write that never
       # landed.
       outcome = self._finalize_required(
-        db, cmd.chat_id, cmd.snapshot, cmd.thinking_stashes,
+        db,
+        cmd.chat_id,
+        cmd.snapshot,
+        cmd.thinking_stashes,
+        run_token=cmd.run_token,
       )
       if outcome is not _WriteOutcome.APPLIED:
         raise _PersistFailed(f"Finalize did not persist ({outcome.value})")
@@ -1641,7 +1647,13 @@ class ChatWriterActor:
     return outcome
 
   def _finalize_required(
-    self, db, chat_id: str, snapshot: dict, thinking_stashes: list | None = None,
+    self,
+    db,
+    chat_id: str,
+    snapshot: dict,
+    thinking_stashes: list | None = None,
+    *,
+    run_token: str = "",
   ):
     """Force-complete tool blocks and write the terminal assistant message.
 
@@ -1667,9 +1679,16 @@ class ChatWriterActor:
     chat.pending_question_id = None
     if thinking_stashes:
       self._stage_thinking_stashes(db, thinking_stashes)
-    outcome = finalize_response_outcome(
-      db, chat_id, snapshot.get("blocks") or []
-    )
+    terminal_snapshot = copy.deepcopy(snapshot)
+    if not isinstance(terminal_snapshot, dict):
+      return _WriteOutcome.NOOP
+    # Current sinks stamp the exact assistant-segment identity. Setup-time
+    # failures can finalize before a sink exists, so fall back to the physical
+    # run identity there. Never rebuild a terminal message from blocks: doing
+    # so discards the identity that owns its durable row.
+    if terminal_snapshot.get("id") is None and run_token:
+      terminal_snapshot["id"] = run_token
+    outcome = finalize_response_outcome(db, chat_id, terminal_snapshot)
     if outcome is _WriteOutcome.NOOP:
       # The sink only submits Finalize with non-empty blocks, so a NOOP here
       # means the row had nothing to finalize onto. Distinguish two causes: a
@@ -2202,6 +2221,7 @@ class ChatWriterActor:
     # queue are already in memory. Streaming snapshots can then update only the
     # small live value without rereading the historical JSON blob.
     chat.live_assistant = {
+      "id": cmd.run_token,
       "role": "assistant",
       "blocks": [],
       "ts": next_message_ts(existing + pending),
@@ -2682,6 +2702,7 @@ class ChatWriterActor:
     chat.messages = existing + stored_messages
     chat.pending_messages = remaining_pending
     chat.live_assistant = {
+      "id": cmd.run_token,
       "role": "assistant",
       "blocks": [],
       "ts": next_message_ts(
@@ -2986,8 +3007,9 @@ class ChatWriterActor:
         and isinstance(live.get("blocks"), list)
         and live["blocks"]
       ):
-        if messages and messages[-1].get("role") == "assistant":
-          messages[-1] = live
+        live_index = assistant_message_index(messages, live)
+        if live_index >= 0:
+          messages[live_index] = live
         else:
           messages.append(live)
 
@@ -2995,8 +3017,23 @@ class ChatWriterActor:
       if not isinstance(note, dict) or note.get("type") != "error":
         raise _PersistFailed("RecoverWedgedRun requires an error block")
 
-      if messages and messages[-1].get("role") == "assistant":
-        previous = messages[-1]
+      recovery_identity = (
+        live
+        if isinstance(live, dict) and live.get("id") is not None
+        else {"id": cmd.run_token}
+      )
+      recovery_index = assistant_message_index(messages, recovery_identity)
+      if (
+        recovery_index < 0
+        and messages
+        and messages[-1].get("role") == "assistant"
+        and messages[-1].get("id") is None
+      ):
+        # Rolling upgrade only: an id-less tail may be the same physical run.
+        # A different explicit id is a different row and must never be patched.
+        recovery_index = len(messages) - 1
+      if recovery_index >= 0:
+        previous = messages[recovery_index]
         blocks = copy.deepcopy(previous.get("blocks") or [])
         finalize_blocks(blocks)
         # Keep unanswered question cards as the terminal affordance.  The
@@ -3014,14 +3051,24 @@ class ChatWriterActor:
         else:
           blocks.append(note)
         recovered = build_assistant_message(blocks)
+        recovered["id"] = (
+          previous.get("id")
+          or cmd.run_token
+          or f"assistant-{uuid.uuid4().hex}"
+        )
         recovered["ts"] = (
           previous.get("ts")
           if previous.get("ts") is not None
-          else next_message_ts(messages[:-1] + list(chat.pending_messages or []))
+          else next_message_ts(
+            messages[:recovery_index]
+            + messages[recovery_index + 1:]
+            + list(chat.pending_messages or [])
+          )
         )
-        messages[-1] = recovered
+        messages[recovery_index] = recovered
       else:
         recovered = build_assistant_message([note])
+        recovered["id"] = cmd.run_token or f"assistant-{uuid.uuid4().hex}"
         recovered["ts"] = next_message_ts(
           messages + list(chat.pending_messages or [])
         )
@@ -3936,13 +3983,15 @@ def _apply_last_assistant_message(db, chat_id: str, message: dict):
   if not chat or not chat.messages:
     return _WriteOutcome.NOOP
   msgs = list(chat.messages)
-  if msgs and msgs[-1].get("role") == "assistant":
+  assistant_index = assistant_message_index(msgs, message)
+  if assistant_index >= 0:
     # Carry answers forward: apply_answers_to_last_question writes
     # them here; the runner rebuilds from assistant_blocks (no
     # answers), so merge keyed by question_block_key to avoid wiping
     # them on writeback. Multi-question turns are supported.
     existing_answers_by_key = {}
-    for ob in msgs[-1].get("blocks") or []:
+    existing_message = msgs[assistant_index]
+    for ob in existing_message.get("blocks") or []:
       if ob.get("type") == "question" and ob.get("answers"):
         existing_answers_by_key[question_block_key(ob)] = ob["answers"]
     for nb in message.get("blocks") or []:
@@ -3958,7 +4007,7 @@ def _apply_last_assistant_message(db, chat_id: str, message: dict):
     # question/answer bug). Preserve the existing message's ts across
     # every streaming replace so the id stays stable for the whole turn;
     # backfill one only if an older, tsless message is being updated.
-    message["ts"] = msgs[-1].get("ts")
+    message["ts"] = existing_message.get("ts")
     if message["ts"] is None:
       # Backfilling an older, tsless assistant message. Allocate against
       # persisted messages EXCLUDING msgs[-1] (it's the tsless one being
@@ -3970,17 +4019,24 @@ def _apply_last_assistant_message(db, chat_id: str, message: dict):
       # unions in chat.messages), so the two allocators can't hand out the
       # same ms.
       message["ts"] = next_message_ts(
-        msgs[:-1] + list(chat.pending_messages or [])
+        msgs[:assistant_index]
+        + msgs[assistant_index + 1:]
+        + list(chat.pending_messages or [])
       )
-    msgs[-1] = message
+    msgs[assistant_index] = message
   else:
     # First write of this turn's assistant message — stamp a ts greater
     # than every persisted AND queued message so the bridge gate and the
     # frontend's ts-keyed rendering get a stable, collision-free id.
-    live_ts = (
-      chat.live_assistant.get("ts")
-      if isinstance(chat.live_assistant, dict) else None
+    live = chat.live_assistant if isinstance(chat.live_assistant, dict) else None
+    message_id = message.get("id")
+    live_id = live.get("id") if live is not None else None
+    same_live_segment = (
+      message_id is None
+      or live_id is None
+      or str(message_id) == str(live_id)
     )
+    live_ts = live.get("ts") if live is not None and same_live_segment else None
     message["ts"] = live_ts or next_message_ts(
       msgs + list(chat.pending_messages or [])
     )
@@ -4029,7 +4085,16 @@ def update_live_assistant(
   if not isinstance(snapshot, dict):
     return True
   state = None
-  answer_source = existing
+  answer_source = None
+  if existing is not None:
+    snapshot_id = snapshot.get("id")
+    existing_id = existing.get("id")
+    if (
+      snapshot_id is None
+      or existing_id is None
+      or str(snapshot_id) == str(existing_id)
+    ):
+      answer_source = existing
   if existing is None:
     # QuestionCommit intentionally clears the live field after merging the
     # barrier into history. The first resumed snapshot reads that trailing
@@ -4038,9 +4103,12 @@ def update_live_assistant(
       select(Chat.messages, Chat.pending_messages).where(Chat.id == chat_id)
     ).first()
     messages = list(state[0] or []) if state is not None else []
-    if messages and messages[-1].get("role") == "assistant":
-      answer_source = messages[-1]
+    assistant_index = assistant_message_index(messages, snapshot)
+    if assistant_index >= 0:
+      answer_source = messages[assistant_index]
   if answer_source is not None:
+    if snapshot.get("id") is None and answer_source.get("id") is not None:
+      snapshot["id"] = answer_source["id"]
     snapshot["ts"] = answer_source.get("ts")
     existing_answers = {
       question_block_key(block): block["answers"]
@@ -4074,21 +4142,25 @@ def update_live_assistant(
   return _commit_or_rollback(db)
 
 
-def finalize_response_outcome(db, chat_id: str, assistant_blocks: list):
+def finalize_response_outcome(db, chat_id: str, assistant_message: dict):
   """End-of-response cleanup, returning a `_WriteOutcome`.
 
   Empty blocks -> NOOP (no terminal state to write); otherwise force-complete
-  the tool blocks and delegate to `_apply_last_assistant_message`, which
-  distinguishes APPLIED / NOOP (missing row, empty transcript) / DROPPED.  A
-  must-persist `Finalize` raises on anything but APPLIED so it never acks
-  success on a write that did not land.
+  the tool blocks on the complete assistant snapshot and delegate to
+  `_apply_last_assistant_message`, which distinguishes APPLIED / NOOP (missing
+  row, empty transcript) / DROPPED. Preserving the complete snapshot is
+  load-bearing: its `id` owns the exact durable row. A must-persist `Finalize`
+  raises on anything but APPLIED so it never acks success on a write that did
+  not land.
   """
-  if not assistant_blocks:
+  if not isinstance(assistant_message, dict):
+    return _WriteOutcome.NOOP
+  terminal_message = copy.deepcopy(assistant_message)
+  assistant_blocks = terminal_message.get("blocks")
+  if not isinstance(assistant_blocks, list) or not assistant_blocks:
     return _WriteOutcome.NOOP
   finalize_blocks(assistant_blocks)
-  return _apply_last_assistant_message(
-    db, chat_id, build_assistant_message(assistant_blocks)
-  )
+  return _apply_last_assistant_message(db, chat_id, terminal_message)
 
 
 def apply_answers_to_last_question(

--- a/backend/app/claude_sdk_runner.py
+++ b/backend/app/claude_sdk_runner.py
@@ -697,9 +697,10 @@ async def _seal_steer_split(bc, active_client, chat_id: str) -> None:
   finally finds an empty buffer and appends nothing to the turn it just killed.
 
   A1 is the sink's accumulated pre-interrupt content — complete once the turn
-  closes — so `split_for_steer` seals it as its own message, appends the steered
-  row(s) after it, and resets the sink so A2 lands fresh: reload order Q1, A1,
-  Q2, A2.
+  closes — so the sink's authoritative `commit_steer_cut` seals it as its own
+  identified message, appends the steered row(s), rotates the segment identity,
+  and publishes the exact A1/A2 snapshots in one operation. Older sink-like
+  test doubles retain the split-then-publish compatibility path below.
 
   This is the fix for the steer-merge: the route cannot know where A1 ends (at
   HTTP arrival A1 has not streamed yet, so a route-side split sealed an empty
@@ -719,7 +720,7 @@ async def _seal_steer_split(bc, active_client, chat_id: str) -> None:
 
   Durability contract (adversarial-review hardening):
   - The rows are snapshotted BEFORE the await and only the snapshotted count is
-    removed on success, so a second steer landing during `split_for_steer`'s
+    removed on success, so a second steer landing during the cut's
     actor round-trips is not wiped (it survives for the next call / the
     finally).
   - On a persistence FAILURE the buffer is left intact so the turn-end
@@ -732,6 +733,7 @@ async def _seal_steer_split(bc, active_client, chat_id: str) -> None:
   if not rows:
     return
   consume = list(active_client._steer_consume_cids)
+  commit_cut = getattr(bc, "commit_steer_cut", None)
   split = getattr(bc, "split_for_steer", None)
   # Resolve the client-facing publisher BEFORE committing anything. Take the
   # broadcast off the SINK rather than re-resolving it by chat_id: the cut
@@ -748,13 +750,13 @@ async def _seal_steer_split(bc, active_client, chat_id: str) -> None:
   raw_bc = getattr(bc, "bc", None)
   if raw_bc is not None and not callable(getattr(raw_bc, "publish", None)):
     raw_bc = None
-  if split is not None and raw_bc is None:
+  if commit_cut is None and split is not None and raw_bc is None:
     log.error(
       "steer split has no broadcast to publish the cut on chat_id=%s; "
       "the transcript will be split but the client stream cannot re-base "
       "until it refetches", chat_id,
     )
-  if split is None:
+  if commit_cut is None and split is None:
     # No live sink (legacy/test caller): there is no streamed A1 to seal
     # against and no way to persist here — drop the buffer.
     active_client._steer_user_msgs = active_client._steer_user_msgs[len(rows):]
@@ -763,7 +765,11 @@ async def _seal_steer_split(bc, active_client, chat_id: str) -> None:
     )
     return
   try:
-    stored_result = await split(rows, consume)
+    stored_result = (
+      await commit_cut(rows, consume)
+      if commit_cut is not None
+      else await split(rows, consume)
+    )
   except Exception:
     # Leave the buffer intact so the turn-end finally retries the write.
     log.exception(
@@ -776,6 +782,11 @@ async def _seal_steer_split(bc, active_client, chat_id: str) -> None:
   active_client._steer_consume_cids = (
     active_client._steer_consume_cids[len(consume):]
   )
+  # Current sinks own persistence, segment rotation, and publication as one
+  # operation. The remainder is rolling compatibility for older sink-like test
+  # doubles that expose only split_for_steer.
+  if commit_cut is not None:
+    return
   # Publish the cut now that A1 + Q2 are committed, on the broadcast resolved
   # above. No await separates the split from this publish, so no continuation
   # block can slip in front of it.

--- a/backend/app/routes/chats.py
+++ b/backend/app/routes/chats.py
@@ -452,10 +452,9 @@ def _chat_detail_response(
   running = is_chat_running(chat.id) or has_running_run(db, chat.id)
   live_snapshot = chat.live_assistant
   live_message = (
-    all_msgs[-1]
+    next((message for message in all_msgs if message is live_snapshot), None)
     if running
-    and all_msgs
-    and all_msgs[-1] is live_snapshot
+    and isinstance(live_snapshot, dict)
     else None
   )
   # A genuinely streaming assistant row must remain self-contained: the live

--- a/backend/app/routes/chats_stream.py
+++ b/backend/app/routes/chats_stream.py
@@ -1375,10 +1375,10 @@ async def stream_chat(
     # the queue with no await in between), so the catch-up burst still
     # captures exactly the events present when this subscriber attaches.
     catch_up, queue = bc.subscribe()
-    snapshot_items = (
+    snapshot_state = (
       active_sink_stream_snapshot(chat_id, bc) if snapshot else None
     )
-    if snapshot_items is not None:
+    if snapshot_state is not None:
       catch_up = [
         event for event in catch_up
         if event.get("type") in _SNAPSHOT_REPLAY_EVENT_TYPES
@@ -1397,8 +1397,8 @@ async def stream_chat(
     try:
       if not embed_session_active():
         return
-      if snapshot_items is not None:
-        yield _sse({"type": "stream_snapshot", "items": snapshot_items})
+      if snapshot_state is not None:
+        yield _sse({"type": "stream_snapshot", **snapshot_state})
       # Send all events buffered before this client connected.
       has_done = False
       for event in catch_up:

--- a/backend/tests/test_chat_live_assistant.py
+++ b/backend/tests/test_chat_live_assistant.py
@@ -1,9 +1,11 @@
 """Streaming snapshots stay bounded without weakening transcript durability."""
 
 from app import models
+from app.chat_message_identity import assistant_message_index
 from app.chat_transcript import materialized_messages
 from app.chat_writer import (
   finalize_response_outcome,
+  update_last_assistant_message,
   update_live_assistant,
 )
 
@@ -24,6 +26,19 @@ def _chat(db, *, trailing_role="user"):
   db.add(chat)
   db.commit()
   return chat, messages
+
+
+def test_assistant_message_index_is_one_shared_identity_contract():
+  exact = {"id": "assistant-live", "role": "assistant"}
+  legacy = {"role": "assistant"}
+  hidden_answer = {"role": "user", "hidden": True}
+
+  assert assistant_message_index([exact, hidden_answer], exact) == 0
+  assert assistant_message_index([legacy], exact) == 0
+  assert assistant_message_index(
+    [exact, hidden_answer], {**exact, "id": "other"}
+  ) == -1
+  assert assistant_message_index([exact, hidden_answer], legacy) == -1
 
 
 def test_stream_snapshot_updates_only_live_value(db):
@@ -52,13 +67,20 @@ def test_finalize_merges_live_turn_once_and_clears_snapshot(db):
   })
 
   outcome = finalize_response_outcome(
-    db, chat.id, [{"type": "text", "text": "complete"}],
+    db,
+    chat.id,
+    {
+      "id": "assistant-current",
+      "role": "assistant",
+      "blocks": [{"type": "text", "text": "complete"}],
+    },
   )
 
   db.refresh(chat)
   assert outcome.value == "applied"
   assert chat.live_assistant is None
   assert len(chat.messages) == len(history) + 1
+  assert chat.messages[-1]["id"] == "assistant-current"
   assert chat.messages[-1]["ts"] == 4
   assert chat.messages[-1]["blocks"][0]["text"] == "complete"
   assert chat.updated_at != history_version
@@ -83,6 +105,161 @@ def test_materialized_snapshot_replaces_question_barrier_row():
   projected = materialized_messages(Row())
   assert len(projected) == 1
   assert projected[0] == Row.live_assistant
+
+
+def test_materialized_snapshot_updates_exact_row_before_hidden_same_turn_answer():
+  class Row:
+    messages = [
+      {
+        "id": "assistant-live",
+        "role": "assistant",
+        "blocks": [{"type": "question", "question_id": "q1"}],
+        "ts": 7,
+      },
+      {"role": "user", "hidden": True, "content": "answer", "ts": 8},
+    ]
+    live_assistant = {
+      "id": "assistant-live",
+      "role": "assistant",
+      "blocks": [
+        {"type": "question", "question_id": "q1", "answers": {"q": "a"}},
+        {"type": "text", "text": "continuing"},
+      ],
+      "ts": 7,
+    }
+
+  projected = materialized_messages(Row())
+  assert len(projected) == 2
+  assert projected[0] is Row.live_assistant
+  assert projected[1]["hidden"] is True
+
+
+def test_terminal_snapshot_updates_exact_assistant_before_hidden_answer(db):
+  chat = models.Chat(
+    id="same-turn-answer",
+    title="Same turn",
+    messages=[
+      {"role": "user", "content": "request", "ts": 1},
+      {
+        "id": "assistant-live",
+        "role": "assistant",
+        "blocks": [{"type": "question", "question_id": "q1"}],
+        "ts": 2,
+      },
+      {"role": "user", "hidden": True, "content": "answer", "ts": 3},
+    ],
+    live_assistant={
+      "id": "assistant-live", "role": "assistant", "blocks": [], "ts": 2,
+    },
+  )
+  db.add(chat)
+  db.commit()
+
+  assert update_last_assistant_message(db, chat.id, {
+    "id": "assistant-live",
+    "role": "assistant",
+    "content": "continued",
+    "blocks": [{"type": "text", "content": "continued"}],
+  }) is True
+
+  db.refresh(chat)
+  assert len(chat.messages) == 3
+  assert chat.messages[1]["id"] == "assistant-live"
+  assert chat.messages[1]["content"] == "continued"
+  assert chat.messages[2]["hidden"] is True
+
+
+def test_finalize_preserves_identity_before_hidden_same_turn_answer(db):
+  chat = models.Chat(
+    id="same-turn-finalize",
+    title="Same turn finalize",
+    messages=[
+      {"role": "user", "content": "request", "ts": 1},
+      {
+        "id": "assistant-live",
+        "role": "assistant",
+        "blocks": [{"type": "question", "question_id": "q1"}],
+        "ts": 2,
+      },
+      {"role": "user", "hidden": True, "content": "answer", "ts": 3},
+    ],
+    live_assistant={
+      "id": "assistant-live", "role": "assistant", "blocks": [], "ts": 2,
+    },
+  )
+  db.add(chat)
+  db.commit()
+
+  outcome = finalize_response_outcome(db, chat.id, {
+    "id": "assistant-live",
+    "role": "assistant",
+    "content": "continued",
+    "blocks": [{"type": "text", "content": "continued"}],
+  })
+
+  db.refresh(chat)
+  assert outcome.value == "applied"
+  assert len(chat.messages) == 3
+  assert chat.messages[1]["id"] == "assistant-live"
+  assert chat.messages[1]["content"] == "continued"
+  assert chat.messages[2]["hidden"] is True
+
+
+def test_unknown_assistant_identity_appends_instead_of_rewriting_old_tail(db):
+  chat = models.Chat(
+    id="new-segment",
+    title="New segment",
+    messages=[
+      {"role": "user", "content": "request", "ts": 1},
+      {"id": "assistant-old", "role": "assistant", "content": "old", "ts": 2},
+    ],
+    live_assistant={
+      "id": "assistant-new", "role": "assistant", "blocks": [], "ts": 3,
+    },
+  )
+  db.add(chat)
+  db.commit()
+
+  assert update_last_assistant_message(db, chat.id, {
+    "id": "assistant-new",
+    "role": "assistant",
+    "content": "new",
+    "blocks": [{"type": "text", "content": "new"}],
+  }) is True
+
+  db.refresh(chat)
+  assert [message.get("id") for message in chat.messages] == [
+    None, "assistant-old", "assistant-new",
+  ]
+  assert chat.messages[1]["content"] == "old"
+
+
+def test_identity_adopts_only_a_trailing_pre_identity_partial(db):
+  chat = models.Chat(
+    id="rolling-identity",
+    title="Rolling identity",
+    messages=[
+      {"role": "user", "content": "request", "ts": 1},
+      {"role": "assistant", "content": "partial", "ts": 2},
+    ],
+    live_assistant={
+      "id": "assistant-current", "role": "assistant", "blocks": [], "ts": 2,
+    },
+  )
+  db.add(chat)
+  db.commit()
+
+  assert update_last_assistant_message(db, chat.id, {
+    "id": "assistant-current",
+    "role": "assistant",
+    "content": "complete",
+    "blocks": [{"type": "text", "content": "complete"}],
+  }) is True
+
+  db.refresh(chat)
+  assert len(chat.messages) == 2
+  assert chat.messages[-1]["id"] == "assistant-current"
+  assert chat.messages[-1]["content"] == "complete"
 
 
 def test_codex_path_wrappers_are_normalized_before_json_storage(db):
@@ -112,11 +289,14 @@ def test_codex_path_wrappers_are_normalized_before_json_storage(db):
   assert block["cwd"] == "/data"
   assert block["paths"] == ["/data/platform"]
 
-  outcome = finalize_response_outcome(db, chat.id, [{
-    "type": "tool",
-    "name": "exec_command",
-    "cwd": ProviderPathWrapper("/data"),
-  }])
+  outcome = finalize_response_outcome(db, chat.id, {
+    "role": "assistant",
+    "blocks": [{
+      "type": "tool",
+      "name": "exec_command",
+      "cwd": ProviderPathWrapper("/data"),
+    }],
+  })
 
   db.refresh(chat)
   assert outcome.value == "applied"

--- a/backend/tests/test_chats_stream_steer.py
+++ b/backend/tests/test_chats_stream_steer.py
@@ -1527,7 +1527,9 @@ def test_claude_steer_cut_event_is_published_at_the_seal_not_at_http_arrival(
   # HTTP arrival publishes NOTHING on the deferred path: the response body is
   # the display signal. Publishing the cut here re-based the client's stream
   # too early.
-  assert [e.get("type") for e in bc.event_log] == ["text"]
+  assert [e.get("type") for e in bc.event_log] == [
+    "assistant_identity", "text",
+  ]
 
   async def _drive_runner():
     # The rest of A1 streams AFTER arrival — the duplication window.
@@ -1562,6 +1564,12 @@ def test_claude_steer_cut_event_is_published_at_the_seal_not_at_http_arrival(
   # The cut names the DURABLE rows the split committed, so the client inserts
   # the same identity the transcript now holds.
   cut = bc.event_log[cut_positions[0]]
+  assert cut["assistant_message_id"] == "run-cut-order"
+  assert cut["next_assistant_message_id"] == "run-cut-order:assistant:1"
+  assert cut["sealed_items"] == [{
+    "type": "text", "content": "A1 first A1 rest",
+  }]
+  assert cut["items"] == []
   steered_row = [m for m in _read_chat(chat_id).messages if m["role"] == "user"][-1]
   assert cut["messages"] == [{
     "role": "user",
@@ -1577,6 +1585,7 @@ def test_claude_steer_cut_event_is_published_at_the_seal_not_at_http_arrival(
     ("assistant", "A1 first A1 rest"),
     ("user", "Q2"),
   ]
+  assert _read_chat(chat_id).messages[1]["id"] == "run-cut-order"
 
 
 def test_codex_steer_publishes_cut_from_handle_owned_settlement(
@@ -1617,8 +1626,12 @@ def test_codex_steer_publishes_cut_from_handle_owned_settlement(
   assert body["pending_messages"] == []
 
   bc = get_broadcast(chat_id)
-  assert [e.get("type") for e in bc.event_log] == ["steered_into_turn"]
+  assert [e.get("type") for e in bc.event_log] == [
+    "assistant_identity", "steered_into_turn",
+  ]
   cut = [e for e in bc.event_log if e.get("type") == "steered_into_turn"][0]
+  assert cut["assistant_message_id"] == "run-codex-cut"
+  assert cut["next_assistant_message_id"] == "run-codex-cut:assistant:1"
   assert [m["content"] for m in cut["messages"]] == ["Q2"]
   assert [m["steered"] for m in cut["messages"]] == [True]
   # The owning sink sealed A1 and appended Q2 before publishing.

--- a/backend/tests/test_crash_recovery.py
+++ b/backend/tests/test_crash_recovery.py
@@ -142,6 +142,40 @@ def test_reconcile_merges_bounded_live_snapshot_before_restart_note(db):
   assert row.messages[-1]["blocks"][-1]["type"] == "error"
 
 
+def test_reconcile_never_rewrites_a_different_identified_assistant(db):
+  _make_chat(
+    db,
+    "identity-recovery",
+    running=True,
+    messages=[
+      {"role": "user", "content": "older request", "ts": 1},
+      {
+        "id": "assistant-older",
+        "role": "assistant",
+        "content": "older answer",
+        "blocks": [{"type": "text", "content": "older answer"}],
+        "ts": 2,
+      },
+    ],
+    live_assistant={
+      "id": "rt-identity-recovery",
+      "role": "assistant",
+      "blocks": [],
+      "ts": 3,
+    },
+  )
+
+  assert chat_mod.reconcile_interrupted_chats(db) == ["identity-recovery"]
+
+  db.expire_all()
+  row = db.get(models.Chat, "identity-recovery")
+  assert len(row.messages) == 3
+  assert row.messages[1]["id"] == "assistant-older"
+  assert row.messages[1]["content"] == "older answer"
+  assert row.messages[2]["id"] == "rt-identity-recovery"
+  assert row.messages[2]["blocks"][-1]["type"] == "error"
+
+
 def test_reconcile_rebuilds_open_question_barrier_from_repaired_tail(db):
   """A pre-crash Finalize clear cannot orphan an unanswered card.
 

--- a/backend/tests/test_system_broadcast.py
+++ b/backend/tests/test_system_broadcast.py
@@ -42,6 +42,7 @@ from app.chat_transcript import materialized_messages
 from app.chat_event_sink import (
   ChatEventSink,
   active_sink_stream_snapshot,
+  get_active_sink,
   register_active_sink,
   unregister_active_sink,
 )
@@ -120,9 +121,12 @@ def test_active_sink_snapshot_is_frozen_and_broadcast_identity_keyed():
   register_active_sink(bc.chat_id, sink)
   try:
     snapshot = active_sink_stream_snapshot(bc.chat_id, bc)
-    assert snapshot == sink.assistant_blocks
-    assert snapshot is not sink.assistant_blocks
-    snapshot[0]["content"] = "changed by subscriber"
+    assert snapshot == {
+      "items": sink.assistant_blocks,
+      "assistant_message_id": sink.assistant_message_id,
+    }
+    assert snapshot["items"] is not sink.assistant_blocks
+    snapshot["items"][0]["content"] = "changed by subscriber"
     assert sink.assistant_blocks[0]["content"] == "hello"
     assert active_sink_stream_snapshot(
       bc.chat_id,
@@ -130,6 +134,20 @@ def test_active_sink_snapshot_is_frozen_and_broadcast_identity_keyed():
     ) is None
   finally:
     unregister_active_sink(bc.chat_id, sink)
+
+
+def test_active_sink_registry_tolerates_a_successor_without_stream_state():
+  """Identity-keyed teardown can register a successor before it has a sink.
+
+  The registry ownership primitive must still preserve that opaque successor;
+  assistant identity publication is additive only when stream state exists.
+  """
+  successor = object()
+  register_active_sink("opaque-successor", successor)
+  try:
+    assert get_active_sink("opaque-successor") is successor
+  finally:
+    unregister_active_sink("opaque-successor", successor)
 
 
 def test_task_progress_coalesces_by_task_id_in_log():
@@ -951,7 +969,10 @@ async def test_snapshot_stream_sends_reduced_items_plus_control_tail(
   monkeypatch.setattr(
     stream_mod,
     "active_sink_stream_snapshot",
-    lambda chat_id, broadcast: snapshot_items
+    lambda chat_id, broadcast: {
+      "items": snapshot_items,
+      "assistant_message_id": "assistant-snapshot",
+    }
       if chat_id == chat.id and broadcast is bc else None,
   )
   try:
@@ -970,7 +991,11 @@ async def test_snapshot_stream_sends_reduced_items_plus_control_tail(
       if line.startswith("data: ")
     ]
 
-    assert payloads[0] == {"type": "stream_snapshot", "items": snapshot_items}
+    assert payloads[0] == {
+      "type": "stream_snapshot",
+      "items": snapshot_items,
+      "assistant_message_id": "assistant-snapshot",
+    }
     replay_types = [event.get("type") for event in payloads]
     assert "build_phase" in replay_types
     assert "answers_applied" in replay_types

--- a/backend/tests/test_terminal_completion.py
+++ b/backend/tests/test_terminal_completion.py
@@ -1161,6 +1161,13 @@ def test_no_connected_agent_streams_and_persists_guidance(
   # remove or replace it explicitly to guarantee the auth-error precondition.
   from app import auth as auth_mod
 
+  # The container's identity broker can expose a host-connected provider even
+  # when this test removes local credential files. Pin the product precondition
+  # instead of inheriting the developer machine's live connection state.
+  monkeypatch.setattr(
+    chat_mod, "authenticated_provider_ids", lambda _data_dir: [],
+  )
+
   creds = (
     pathlib.Path(os.environ["DATA_DIR"]) / "cli-auth" / "claude"
     / ".credentials.json"
@@ -1234,6 +1241,10 @@ def test_no_connected_agent_promotes_queued_message(monkeypatch):
   the guidance finalizes first, then the queued row gets a fresh run token."""
   from app import auth as auth_mod
 
+  monkeypatch.setattr(
+    chat_mod, "authenticated_provider_ids", lambda _data_dir: [],
+  )
+
   for creds in (
     pathlib.Path(os.environ["DATA_DIR"]) / "cli-auth" / "claude"
     / ".credentials.json",
@@ -1298,6 +1309,10 @@ def test_no_connected_agent_stopped_during_metrics_preserves_successor_sink(
   publishing obsolete guidance.
   """
   from app import auth as auth_mod
+
+  monkeypatch.setattr(
+    chat_mod, "authenticated_provider_ids", lambda _data_dir: [],
+  )
 
   for creds in (
     pathlib.Path(os.environ["DATA_DIR"]) / "cli-auth" / "claude"

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -783,12 +783,9 @@ export default function ChatView({
   const hadMessagesRef = useRef((cached?.messages?.length ?? 0) > 0)
   const promotedRef = useRef(false)
   const activeAssistantDataKeyRef = useRef(null)
-  // Bridge-partial gating decides whether the next promote REPLACES
-  // the kept DB partial (in-flight turn whose snapshot we mounted
-  // on top of) or APPENDS a fresh assistant message. The captured
-  // ts is sticky on first mount; markBridged() retires the gate
-  // after the first promote so subsequent turns always append.
-  // See hooks/useBridgePartial.js for the ts-based design.
+  // Current promotion is owned by the stream's durable assistant id. This
+  // sticky mount bridge is the id-less rolling-data fallback: its captured ts
+  // may identify the kept DB partial until markBridged() retires the gate.
   const [bridgeMountInputs, setBridgeMountInputs] = useState(() => ({
     runningAtMount: !!cached?.running,
     lastMsgAtMount: cached?.messages?.length
@@ -1288,6 +1285,8 @@ export default function ChatView({
   const {
     streamItems,
     latestItemsRef,
+    streamAssistantMessageId,
+    latestAssistantMessageIdRef,
     isStreaming,
     isStreamingRef,
     connectionError,
@@ -1430,7 +1429,13 @@ export default function ChatView({
     },
     onLiveQuestion: setLiveQuestionId,
     onQuestionResponseStart: handleQuestionResponseStart,
-    onSteeredIntoTurn: ({ ts, content, messages: steeredBatch }) => {
+    onSteeredIntoTurn: ({
+      ts,
+      content,
+      messages: steeredBatch,
+      assistantMessageId,
+      sealedItems,
+    }) => {
       // The steer's transcript split has COMMITTED (fired for both providers,
       // including when Stop is pressed with a queued message): the backend has
       // sealed the assistant text streamed up to the split, persisted the user
@@ -1471,7 +1476,11 @@ export default function ChatView({
         })
       const pinCid = cidOf(steeredMessages[0])
       const pinIntent = takeSendIntent(pinCid)
-      promoteStreamToMessages({ keepTurnOpen: true })
+      promoteStreamToMessages({
+        keepTurnOpen: true,
+        items: sealedItems,
+        assistantMessageId,
+      })
       const steeredIsFirstUser = isFirstVisibleUserMessage()
       // Arm the scroll mode BEFORE rendering the steered row. EventSource
       // callbacks are outside React's synthetic event layer, and query-cache
@@ -1740,21 +1749,25 @@ export default function ChatView({
   // Snapshot stream into a permanent message. Idempotent — both
   // handleStop and onStreamEnd may call this.
   //
-  // REPLACE if the last message in `prev` is already an assistant
-  // message — that's the DB partial we kept on mount when returning
-  // mid-stream (see fetch effect). Promoting alongside the partial
-  // would duplicate the in-flight content in the final transcript.
-  // APPEND otherwise (the normal first-time send path: `prev` ends in
-  // a user message, the assistant message hasn't been committed yet).
+  // The durable assistant id replaces exactly its owned row wherever it sits;
+  // a new id appends. Id-less rolling data can still use the guarded mount-ts
+  // bridge so returning mid-stream does not duplicate the kept DB partial.
   function promoteStreamToMessages({
     keepTurnOpen = false,
     followingMessages = [],
+    items: explicitItems = null,
+    assistantMessageId: explicitAssistantMessageId = undefined,
   } = {}) {
     const following = Array.isArray(followingMessages)
       ? followingMessages.filter(Boolean)
       : []
     if (promotedRef.current && !keepTurnOpen && following.length === 0) return
-    const items = latestItemsRef.current
+    const items = Array.isArray(explicitItems)
+      ? explicitItems
+      : latestItemsRef.current
+    const assistantMessageId = explicitAssistantMessageId === undefined
+      ? latestAssistantMessageIdRef.current
+      : explicitAssistantMessageId
     if (items.length === 0 && following.length === 0) return
     // A steer can cut over before the assistant emitted any real output — the
     // only buffered item is an empty/whitespace token. Sealing it would leave a
@@ -1770,12 +1783,9 @@ export default function ChatView({
     }
     promotedRef.current = true
 
-    // Decide REPLACE-vs-APPEND against the captured mounted partial.
-    // Usually that partial is still the last message. Fast-forward is the
-    // exception: it inserts a steered user row below the still-live partial,
-    // and the active stream continues after that row. The bridge must still
-    // replace the original partial by ts instead of appending duplicated
-    // assistant text below the steered row.
+    // Supply the historical bridge candidate as a fallback only. The promotion
+    // helper uses assistantMessageId first and refuses this ts if a different
+    // explicit id or a later visible turn proves it stale.
     const bridgeIdx = bridgeHook.findBridgeIndex(messagesRef.current)
     const trailingIdx = bridgeIdx >= 0 ? -1 : findTrailingAssistantPartialIndex(messagesRef.current)
     const bridgeTs = bridgeIdx >= 0
@@ -1796,6 +1806,7 @@ export default function ChatView({
       retiredItemsRef: retiredAssistantItemsRef,
       paintedItems: streamItems,
       promotedItems: items,
+      assistantMessageId,
       bridgeTs,
       followingMessages: following,
       commitMessages,
@@ -4140,11 +4151,13 @@ export default function ChatView({
     turnActive,
     messages,
     streamItems,
+    streamAssistantMessageId,
     liveItemsRetired: retiredAssistantItemsRef.current === streamItems,
     findBridgeIndex: bridgeHook.findBridgeIndex,
   }), [
     bridgeMountInputs,
     messages,
+    streamAssistantMessageId,
     streamItems,
     turnActive,
   ])
@@ -4335,12 +4348,11 @@ export default function ChatView({
   // partial's durable key, while a live-first answer keeps its absolute
   // transcript-position alias even if a related DB partial arrives later.
   //
-  // Fast-forward can insert a user row AFTER the mounted partial while the
-  // stream remains live. Therefore bridge identity is ts-based across the
-  // full message list, not "last message only." For multi-turn flow (no
-  // bridge), the previous assistant is rendered alongside the streaming
-  // <li> (different turns). The live row therefore uses the absolute index its
-  // eventual durable row will occupy, not the previous assistant's key.
+  // Fast-forward can insert a user row after the mounted partial while the
+  // stream remains live. Explicit assistant identity keeps that row stable
+  // across the split; the mount-ts bridge exists only for id-less history. For
+  // multi-turn flow with no mirror, the prior assistant and current stream are
+  // different rows, so the live row uses its eventual absolute index.
   const streamingDataKey = chooseActiveAssistantDataKey({
     latched: activeAssistantDataKeyRef.current,
     mirroredMsg: activeMirrorMsg,

--- a/frontend/src/components/ChatView/__tests__/activeAssistantSelection.test.js
+++ b/frontend/src/components/ChatView/__tests__/activeAssistantSelection.test.js
@@ -73,6 +73,65 @@ test('a durable pending question outranks a richer stale stream snapshot', () =>
   assert.equal(result.showActiveAssistantSurface, true)
 })
 
+test('a cached assistant identity followed by a newer turn is not current', () => {
+  const stale = {
+    id: 'assistant-before-restart',
+    role: 'assistant',
+    ts: 2,
+    blocks: [{ type: 'question', question_id: 'old-question', questions: [] }],
+  }
+  const current = {
+    id: 'assistant-after-restart',
+    role: 'assistant',
+    ts: 4,
+    blocks: [{ type: 'text', content: 'current reply' }],
+  }
+  const messages = [
+    { role: 'user', ts: 1, content: 'request' },
+    stale,
+    { role: 'user', ts: 3, kind: 'continuation', content: 'resume' },
+    current,
+  ]
+
+  const result = deriveActiveAssistantSelection({
+    turnActive: true,
+    messages,
+    streamItems: [{ type: 'question', question_id: 'old-question', questions: [] }],
+    streamAssistantMessageId: 'assistant-before-restart',
+    findBridgeIndex: () => 1,
+  })
+
+  assert.equal(result.activeMirrorMsg, current)
+  assert.equal(result.activeMirrorMsgIdx, 3)
+})
+
+
+test('same-turn hidden answer does not release the identified assistant row', () => {
+  const active = {
+    id: 'assistant-live',
+    role: 'assistant',
+    ts: 2,
+    blocks: [{ type: 'question', question_id: 'q1', questions: [] }],
+  }
+  const messages = [
+    { role: 'user', ts: 1, content: 'request' },
+    active,
+    { role: 'user', ts: 3, hidden: true, content: 'answer' },
+  ]
+
+  const result = deriveActiveAssistantSelection({
+    turnActive: true,
+    messages,
+    streamItems: [{ type: 'question', question_id: 'q1', questions: [] }],
+    streamAssistantMessageId: 'assistant-live',
+    findBridgeIndex: () => -1,
+  })
+
+  assert.equal(result.activeMirrorMsg, active)
+  assert.equal(result.activeMirrorMsgIdx, 1)
+})
+
+
 test('a source-rich promoted answer is not painted again from its retired live array', () => {
   const messages = [
     { role: 'user', content: 'initial request', ts: 1 },

--- a/frontend/src/components/ChatView/__tests__/chatRuntimeState.test.js
+++ b/frontend/src/components/ChatView/__tests__/chatRuntimeState.test.js
@@ -11,6 +11,7 @@ import {
   continuationRowsFromPromotedMessage,
   isContinuationMessage,
   isOwnerUserMessage,
+  startsFollowingTurn,
   jumpToLatestShown,
   openAppCtaViewModel,
   previewReadyAnnouncement,
@@ -61,6 +62,11 @@ test('automatic and manual continuations are product markers, not owner messages
   assert.equal(isOwnerUserMessage(marker), false)
   assert.equal(isOwnerUserMessage({ role: 'user', content: 'hello' }), true)
   assert.equal(isOwnerUserMessage({ role: 'user', hidden: true }), false)
+  // A continuation marker is still a turn boundary even though it is not an
+  // owner message — this is what releases the mount bridge after auto-resume.
+  assert.equal(startsFollowingTurn(marker), true)
+  assert.equal(startsFollowingTurn({ role: 'user', content: 'hello' }), true)
+  assert.equal(startsFollowingTurn({ role: 'assistant', content: 'reply' }), false)
 })
 
 test('the initial pageshow cannot retire a fast first-send pin', () => {

--- a/frontend/src/components/ChatView/__tests__/steerCutBoundary.test.js
+++ b/frontend/src/components/ChatView/__tests__/steerCutBoundary.test.js
@@ -73,9 +73,13 @@ test('only the cut re-bases the stream, and a replay refetches instead', () => {
   )
   const replay = sliceBranch(cut, 'if (isCatchUp) {', '} else {')
   assert.match(
-    replay, /catchUpItems = \[\]/,
-    'the cut is the boundary a reconnect reconstructs: drop everything '
-    + 'replayed before it, keep the continuation',
+    replay, /catchUpItems = Array\.isArray\(event\.items\)/,
+    'the cut replaces replayed pre-steer output with the server-owned '
+    + 'continuation snapshot',
+  )
+  assert.match(
+    replay, /event\.next_assistant_message_id/,
+    'the continuation snapshot carries the identity of its exact assistant row',
   )
   assert.ok(
     !replay.includes('onSteeredIntoTurnRef'),
@@ -126,8 +130,8 @@ test('the cut hands the steered rows off the tray and into the transcript', () =
   )
   assert.match(
     handler,
-    /promoteStreamToMessages\(\{ keepTurnOpen: true \}\)/,
-    'the cut seals the live segment as its own message',
+    /promoteStreamToMessages\(\{[\s\S]*?keepTurnOpen: true,[\s\S]*?items: sealedItems,[\s\S]*?assistantMessageId,[\s\S]*?\}\)/,
+    'the cut seals the server-owned items into their exact assistant row',
   )
   assert.match(
     handler,

--- a/frontend/src/components/ChatView/__tests__/streamPromotion.test.js
+++ b/frontend/src/components/ChatView/__tests__/streamPromotion.test.js
@@ -218,6 +218,63 @@ test('promoteAssistantStream replaces mounted partial even after steered user ro
   assert.equal(next[2].content, 'fast-forwarded q2')
 })
 
+test('assistant identity updates its exact row without using transcript position', () => {
+  const messages = [
+    { role: 'user', ts: 1, content: 'q1' },
+    { id: 'assistant-1', role: 'assistant', ts: 2, content: 'partial' },
+    { role: 'user', ts: 3, hidden: true, content: 'question answer' },
+  ]
+
+  const next = promoteAssistantStream(messages, {
+    assistantMessageId: 'assistant-1',
+    bridgeTs: 999,
+    items: [{ type: 'text', content: 'continued after the answer' }],
+  })
+
+  assert.equal(next.length, 3)
+  assert.equal(next[1].id, 'assistant-1')
+  assert.equal(next[1].content, 'continued after the answer')
+  assert.equal(next[2], messages[2])
+})
+
+test('a new assistant identity cannot replace a stale pre-restart bridge above later turns', () => {
+  const messages = [
+    { role: 'user', ts: 1, content: 'old request' },
+    { role: 'assistant', ts: 2, content: 'old pre-restart partial' },
+    { role: 'user', ts: 3, kind: 'continuation', content: 'resume' },
+    { id: 'assistant-older', role: 'assistant', ts: 4, content: 'older reply' },
+  ]
+
+  const next = promoteAssistantStream(messages, {
+    assistantMessageId: 'assistant-current',
+    bridgeTs: 2,
+    items: [{ type: 'question', question_id: 'restart-q', questions: [] }],
+  })
+
+  assert.equal(next.length, 5)
+  assert.equal(next[1].content, 'old pre-restart partial',
+    'the stale bridge remains untouched in history')
+  assert.equal(next.at(-1).id, 'assistant-current')
+  assert.equal(next.at(-1).blocks[0].question_id, 'restart-q')
+})
+
+test('an id-capable stream may adopt only a current id-less rolling partial', () => {
+  const messages = [
+    { role: 'user', ts: 1, content: 'request' },
+    { role: 'assistant', ts: 2, content: 'partial' },
+  ]
+
+  const next = promoteAssistantStream(messages, {
+    assistantMessageId: 'assistant-current',
+    bridgeTs: 2,
+    items: [{ type: 'text', content: 'complete' }],
+  })
+
+  assert.equal(next.length, 2)
+  assert.equal(next[1].id, 'assistant-current')
+  assert.equal(next[1].content, 'complete')
+})
+
 test('a restored continuation stays beside its bridged assistant, ahead of newer local rows', () => {
   const messages = [
     { role: 'user', ts: 1, content: 'original request' },
@@ -638,7 +695,7 @@ test('a later visible user row retires a stale mount bridge before new stream ou
   assert.equal(chooseActiveAssistantMirrorIndex({
     bridgeMsgIdx: 1,
     trailingAssistantPartialIdx: -1,
-    bridgeFollowedByVisibleUser: true,
+    bridgeFollowedByNewTurn: true,
     hasLivePayload: false,
     bridgeSurface: { hideMessage: false, suppressStream: false },
     surface: { hideMessage: false, suppressStream: false },

--- a/frontend/src/components/ChatView/__tests__/streamSnapshotCache.test.js
+++ b/frontend/src/components/ChatView/__tests__/streamSnapshotCache.test.js
@@ -23,21 +23,25 @@ function makeStorage() {
   }
 }
 
-test('stream snapshots use the v2 key and ignore empty reconnect state', () => {
+test('stream snapshots keep assistant identity and ignore empty reconnect state', () => {
   const storage = makeStorage()
   const items = [{ type: 'text', content: 'partial' }]
+  const snapshot = { items, assistantMessageId: 'assistant-1' }
 
-  writeStoredStreamSnapshot('chat-a', items, storage)
-  writeStoredStreamSnapshot('chat-a', [], storage)
+  writeStoredStreamSnapshot('chat-a', snapshot, storage)
+  writeStoredStreamSnapshot('chat-a', { items: [] }, storage)
 
-  assert.deepEqual(readStoredStreamSnapshot('chat-a', storage), items)
+  assert.deepEqual(readStoredStreamSnapshot('chat-a', storage), snapshot)
   assert.equal(storage.map.has(streamSnapshotKey('chat-a')), true)
   assert.equal(storage.calls.set, 1)
 })
 
 test('clear removes the current snapshot', () => {
   const storage = makeStorage()
-  writeStoredStreamSnapshot('chat-a', [{ type: 'text', content: 'new' }], storage)
+  writeStoredStreamSnapshot('chat-a', {
+    items: [{ type: 'text', content: 'new' }],
+    assistantMessageId: 'assistant-2',
+  }, storage)
 
   clearStoredStreamSnapshot('chat-a', storage)
 
@@ -47,19 +51,21 @@ test('clear removes the current snapshot', () => {
 test('quota reclamation drops only regenerable stream snapshots', () => {
   const storage = makeStorage()
   storage.setItem('draft:chat-a', 'owner data')
-  storage.setItem(streamSnapshotKey('running-chat'), '[{"type":"text"}]')
+  storage.setItem(streamSnapshotKey('running-chat'), '{"items":[{"type":"text"}]}')
+  storage.setItem('chat-stream-items:v2:old-chat', '[{"type":"text"}]')
 
-  assert.equal(reclaimStoredStreamSnapshots(storage), 1)
+  assert.equal(reclaimStoredStreamSnapshots(storage), 2)
   assert.equal(storage.getItem('draft:chat-a'), 'owner data')
   assert.equal(storage.getItem(streamSnapshotKey('running-chat')), null)
 })
 
-test('read returns [] for corrupt or absent values', () => {
+test('read returns an empty identity-bearing state for corrupt or absent values', () => {
   const storage = makeStorage()
   storage.setItem(streamSnapshotKey('bad'), '{nope')
 
-  assert.deepEqual(readStoredStreamSnapshot('missing', storage), [])
-  assert.deepEqual(readStoredStreamSnapshot('bad', storage), [])
+  const empty = { items: [], assistantMessageId: null }
+  assert.deepEqual(readStoredStreamSnapshot('missing', storage), empty)
+  assert.deepEqual(readStoredStreamSnapshot('bad', storage), empty)
 })
 
 test('default cache is optional when an opaque sandbox denies sessionStorage', () => {
@@ -69,8 +75,12 @@ test('default cache is optional when an opaque sandbox denies sessionStorage', (
     get() { throw new DOMException('Blocked by opaque sandbox', 'SecurityError') },
   })
   try {
-    assert.deepEqual(readStoredStreamSnapshot('chat-a'), [])
-    assert.doesNotThrow(() => writeStoredStreamSnapshot('chat-a', [{ type: 'text' }]))
+    assert.deepEqual(readStoredStreamSnapshot('chat-a'), {
+      items: [], assistantMessageId: null,
+    })
+    assert.doesNotThrow(() => writeStoredStreamSnapshot('chat-a', {
+      items: [{ type: 'text' }], assistantMessageId: 'assistant-3',
+    }))
     assert.doesNotThrow(() => clearStoredStreamSnapshot('chat-a'))
   } finally {
     if (descriptor) Object.defineProperty(globalThis, 'sessionStorage', descriptor)

--- a/frontend/src/components/ChatView/__tests__/streamingRobustness.test.js
+++ b/frontend/src/components/ChatView/__tests__/streamingRobustness.test.js
@@ -40,7 +40,7 @@ test('active DB, live deltas, and reconnect snapshots share one assistant surfac
   )
   assert.match(
     streamHookSource,
-    /seededByServerSnapshot[\s\S]*event\.type === 'steered_into_turn'[\s\S]*if \(!seededByServerSnapshot\) catchUpItems = \[\]/,
+    /seededByServerSnapshot[\s\S]*event\.type === 'steered_into_turn'[\s\S]*if \(!seededByServerSnapshot\) \{[\s\S]*catchUpItems = Array\.isArray\(event\.items\)/,
     'a reconnect snapshot already sits after prior steer cuts and must retain its continuation',
   )
 })

--- a/frontend/src/components/ChatView/activeAssistantSelection.js
+++ b/frontend/src/components/ChatView/activeAssistantSelection.js
@@ -1,6 +1,6 @@
 /* Active-assistant selection derives the stable DB/live rendering surface. */
 
-import { isOwnerUserMessage } from './chatRuntimeState.js'
+import { startsFollowingTurn } from './chatRuntimeState.js'
 import {
   chooseActiveAssistantMirrorIndex,
   chooseActiveAssistantSurface,
@@ -18,18 +18,55 @@ export function deriveActiveAssistantSelection({
   turnActive,
   messages,
   streamItems,
+  streamAssistantMessageId = null,
   liveItemsRetired = false,
   findBridgeIndex,
 }) {
-  const bridgeMsgIdx = turnActive ? findBridgeIndex(messages) : -1
-  const trailingAssistantPartialIdx = turnActive
+  const identityMsgIdx = turnActive && streamAssistantMessageId
+    ? messages.findIndex(message => (
+        message?.role === 'assistant'
+        && message.id != null
+        && String(message.id) === String(streamAssistantMessageId)
+      ))
+    : -1
+  const legacyBridgeMsgIdx = turnActive ? findBridgeIndex(messages) : -1
+  const legacyBridgeFollowedByNewTurn = legacyBridgeMsgIdx >= 0 && messages
+    .slice(legacyBridgeMsgIdx + 1)
+    .some(startsFollowingTurn)
+  const legacyBridgeAllowed = !streamAssistantMessageId || (
+    legacyBridgeMsgIdx >= 0
+    && messages[legacyBridgeMsgIdx]?.id == null
+    && !legacyBridgeFollowedByNewTurn
+  )
+  const bridgeMsgIdx = identityMsgIdx >= 0
+    ? identityMsgIdx
+    : (legacyBridgeAllowed ? legacyBridgeMsgIdx : -1)
+  let trailingAssistantPartialIdx = turnActive
     ? findTrailingAssistantPartialIndex(messages)
     : -1
-  const hasLiveAssistantPayload = turnActive && streamItems.length > 0
+  if (
+    streamAssistantMessageId
+    && identityMsgIdx < 0
+    && trailingAssistantPartialIdx >= 0
+    && messages[trailingAssistantPartialIdx]?.id != null
+  ) {
+    trailingAssistantPartialIdx = -1
+  }
   const bridgeMsg = bridgeMsgIdx >= 0 ? messages[bridgeMsgIdx] : null
-  const bridgeFollowedByVisibleUser = bridgeMsgIdx >= 0 && messages
+  const bridgeFollowedByNewTurn = bridgeMsgIdx >= 0 && messages
     .slice(bridgeMsgIdx + 1)
-    .some(isOwnerUserMessage)
+    .some(startsFollowingTurn)
+  // A sessionStorage snapshot can survive the restart that begins a successor
+  // turn. Its id is real but no longer current; a successor turn boundary
+  // proves the cached payload must not compete with the successor's DB row.
+  const staleIdentifiedPayload = !!(
+    streamAssistantMessageId
+    && identityMsgIdx >= 0
+    && bridgeFollowedByNewTurn
+  )
+  const hasLiveAssistantPayload = !!(
+    turnActive && streamItems.length > 0 && !staleIdentifiedPayload
+  )
   const trailingAssistantPartialMsg = trailingAssistantPartialIdx >= 0
     ? messages[trailingAssistantPartialIdx]
     : null
@@ -52,7 +89,7 @@ export function deriveActiveAssistantSelection({
   const activeMirrorMsgIdx = chooseActiveAssistantMirrorIndex({
     bridgeMsgIdx,
     trailingAssistantPartialIdx,
-    bridgeFollowedByVisibleUser,
+    bridgeFollowedByNewTurn,
     hasLivePayload: hasLiveAssistantPayload,
     bridgeSurface: bridgeAssistantSurface,
     surface: trailingAssistantSurface,
@@ -98,6 +135,7 @@ export function commitAssistantPromotion({
   retiredItemsRef,
   paintedItems,
   promotedItems,
+  assistantMessageId,
   bridgeTs,
   followingMessages = [],
   commitMessages,
@@ -106,6 +144,7 @@ export function commitAssistantPromotion({
   commitMessages(
     prev => promoteAssistantStreamWithFollowingMessages(prev, {
       items: promotedItems,
+      assistantMessageId,
       bridgeTs,
       followingMessages,
     }),

--- a/frontend/src/components/ChatView/chatRuntimeState.js
+++ b/frontend/src/components/ChatView/chatRuntimeState.js
@@ -23,6 +23,17 @@ export function isOwnerUserMessage(message) {
     && !isContinuationMessage(message)
 }
 
+/**
+ * A row that opens a new turn after an assistant partial: an owner message OR a
+ * continuation marker. The auto-resume "Resumed automatically" card is a
+ * role=user / kind=continuation row, so it IS a real turn boundary here even
+ * though isOwnerUserMessage excludes it for authorship purposes. The mount
+ * bridge that mirrors a kept partial must release once such a row follows it,
+ * otherwise a resumed turn renders above the pre-pause block it superseded. */
+export function startsFollowingTurn(message) {
+  return isOwnerUserMessage(message) || isContinuationMessage(message)
+}
+
 export function stripInternalUserMessageFields(raw) {
   if (!raw) return null
   // KEEP `cid` — it is now the durable row identity and must survive the

--- a/frontend/src/components/ChatView/hooks/useBridgePartial.js
+++ b/frontend/src/components/ChatView/hooks/useBridgePartial.js
@@ -1,26 +1,23 @@
 import { useLayoutEffect, useRef } from 'react'
 
 /**
- * Hook that decides whether the next persisted-message fetch should
- * REPLACE the existing last message (bridge an in-flight turn whose
- * partial we kept on mount) or APPEND a fresh assistant message
- * (a brand-new turn since mount).
+ * Legacy/mount-time fallback for deciding whether the next persisted-message
+ * fetch should replace an in-flight partial kept on mount or append a fresh
+ * assistant message.
  *
- * The decision is captured ONCE on mount as a ts (the unique
- * per-message timestamp persisted with every message) and then read
- * by ChatView's promoteStreamToMessages on each promote. After the
- * first promote calls markBridged(), subsequent promotes always
- * append.
+ * Current streams carry a durable assistant message id; active selection and
+ * promotion use that identity first. This hook deliberately retains the old
+ * timestamp bridge only for id-less stored data and the narrow first-paint
+ * mount handoff. Its caller must reject this fallback when a later visible
+ * turn or a different explicit id proves the candidate stale.
  *
- * Why ts-based, not role-based: messages have NO id field
- * (models.py:31 stores the messages array as a JSON column with
- * role/content/ts/blocks; routes/chats_stream.py:157-161 builds
- * messages with just those keys). The earlier role-based check
+ * Why the fallback is ts-based, not role-based: the earlier role-based check
  * ("last message is assistant") regressed when the parallel-agent
  * commit be32e58 started landing errors as the LAST message in a
  * chat — the assistant-role gate would still fire, bridging an
  * error message instead of appending a fresh assistant turn.
- * ts-based gating is stable: the kept-partial has a specific ts,
+ * Timestamp gating is stable inside the legacy path: the kept partial has a
+ * specific ts,
  * and any other last-message-ts (including error/system messages
  * persisted after mount) deterministically falls through to APPEND.
  *
@@ -39,9 +36,9 @@ import { useLayoutEffect, useRef } from 'react'
  * }}
  */
 export default function useBridgePartial({ runningAtMount, lastMsgAtMount }) {
-  // Captured at most ONCE per hook instance, the first time the
-  // arguments resolve to a "yes, bridge" state (running=true AND
-  // last message is an assistant message with a real ts). After
+  // Captured at most ONCE per hook instance, the first time the arguments
+  // resolve to a legacy bridge candidate (running=true AND last message is an
+  // assistant message with a real ts). After
   // that the captured ts is sticky — subsequent re-renders with
   // different args don't re-arm or clear the gate.
   //

--- a/frontend/src/components/ChatView/streamPromotion.js
+++ b/frontend/src/components/ChatView/streamPromotion.js
@@ -5,6 +5,7 @@
  */
 
 import { assistantAnchorKey } from '../../lib/chatDetailCache.js'
+import { startsFollowingTurn } from './chatRuntimeState.js'
 import { questionKey } from './questionKey.js'
 
 export function streamItemToBlock(item, { finalize = true } = {}) {
@@ -347,12 +348,12 @@ export function chooseActiveAssistantSurface(msg, items) {
 export function chooseActiveAssistantMirrorIndex({
   bridgeMsgIdx,
   trailingAssistantPartialIdx,
-  bridgeFollowedByVisibleUser = false,
+  bridgeFollowedByNewTurn = false,
   hasLivePayload,
   bridgeSurface,
   surface,
 }) {
-  if (bridgeMsgIdx >= 0 && !bridgeFollowedByVisibleUser) {
+  if (bridgeMsgIdx >= 0 && !bridgeFollowedByNewTurn) {
     // The mount bridge is captured before the authoritative chat fetch can
     // refresh an in-memory cache. If a new turn starts in that window, the
     // captured row can be the COMPLETED answer from the previous turn. Never
@@ -471,18 +472,52 @@ export function carryQuestionAnswers(blocks, existingBlocks = []) {
   })
 }
 
-export function promoteAssistantStream(messages, { items, bridgeTs = null }) {
+export function findAssistantPromotionIndex(
+  messages,
+  { assistantMessageId = null, bridgeTs = null } = {},
+) {
+  const source = Array.isArray(messages) ? messages : []
+  if (assistantMessageId) {
+    const target = String(assistantMessageId)
+    const exact = source.findIndex(message => (
+      message?.role === 'assistant'
+      && message.id != null
+      && String(message.id) === target
+    ))
+    if (exact >= 0) return exact
+  }
+  if (bridgeTs == null) return -1
+  const legacy = source.findIndex(message => (
+    message?.role === 'assistant' && message.ts === bridgeTs
+  ))
+  if (legacy < 0) return -1
+  if (!assistantMessageId) return legacy
+  // Rolling activation may pair an id-capable stream with a cached pre-id
+  // partial. Adopt it only while it is still the current turn. A durable id on
+  // the row, or any later visible turn boundary, proves it is not this stream.
+  if (source[legacy]?.id != null) return -1
+  if (source.slice(legacy + 1).some(startsFollowingTurn)) return -1
+  return legacy
+}
+
+
+export function promoteAssistantStream(
+  messages,
+  { items, assistantMessageId = null, bridgeTs = null },
+) {
   if (!Array.isArray(items) || items.length === 0) return messages
   const { content, blocks } = streamItemsToAssistantPayload(items)
 
-  const bridgeIdx = bridgeTs == null
-    ? -1
-    : messages.findIndex(m => m?.role === 'assistant' && m.ts === bridgeTs)
+  const bridgeIdx = findAssistantPromotionIndex(messages, {
+    assistantMessageId,
+    bridgeTs,
+  })
   const bridgedMsg = bridgeIdx >= 0 ? messages[bridgeIdx] : null
 
   if (bridgedMsg) {
     const merged = {
       ...bridgedMsg,
+      ...(assistantMessageId ? { id: assistantMessageId } : {}),
       content,
       blocks: carryQuestionAnswers(blocks, bridgedMsg.blocks || []),
     }
@@ -493,7 +528,12 @@ export function promoteAssistantStream(messages, { items, bridgeTs = null }) {
     ]
   }
 
-  return [...messages, { role: 'assistant', content, blocks }]
+  return [...messages, {
+    ...(assistantMessageId ? { id: assistantMessageId } : {}),
+    role: 'assistant',
+    content,
+    blocks,
+  }]
 }
 
 /**
@@ -508,13 +548,23 @@ export function promoteAssistantStream(messages, { items, bridgeTs = null }) {
  */
 export function promoteAssistantStreamWithFollowingMessages(
   messages,
-  { items, bridgeTs = null, followingMessages = [] },
+  {
+    items,
+    assistantMessageId = null,
+    bridgeTs = null,
+    followingMessages = [],
+  },
 ) {
   const source = Array.isArray(messages) ? messages : []
-  const bridgeIdx = bridgeTs == null
-    ? -1
-    : source.findIndex(m => m?.role === 'assistant' && m.ts === bridgeTs)
-  const promoted = promoteAssistantStream(source, { items, bridgeTs })
+  const bridgeIdx = findAssistantPromotionIndex(source, {
+    assistantMessageId,
+    bridgeTs,
+  })
+  const promoted = promoteAssistantStream(source, {
+    items,
+    assistantMessageId,
+    bridgeTs,
+  })
   const batch = Array.isArray(followingMessages)
     ? followingMessages.filter(Boolean)
     : []

--- a/frontend/src/components/ChatView/streamSnapshotCache.js
+++ b/frontend/src/components/ChatView/streamSnapshotCache.js
@@ -6,8 +6,9 @@
  * than on the frame-paced reveal path.
  */
 
-const STREAM_SNAPSHOT_VERSION = 2
-const STREAM_SNAPSHOT_PREFIX = `chat-stream-items:v${STREAM_SNAPSHOT_VERSION}:`
+const STREAM_SNAPSHOT_VERSION = 3
+const STREAM_SNAPSHOT_BASE_PREFIX = 'chat-stream-items:'
+const STREAM_SNAPSHOT_PREFIX = `${STREAM_SNAPSHOT_BASE_PREFIX}v${STREAM_SNAPSHOT_VERSION}:`
 
 export function streamSnapshotKey(chatId) {
   return `${STREAM_SNAPSHOT_PREFIX}${chatId}`
@@ -18,21 +19,36 @@ function defaultStorage() {
 }
 
 export function readStoredStreamSnapshot(chatId, storage = defaultStorage()) {
-  if (!storage || !chatId) return []
+  if (!storage || !chatId) return { items: [], assistantMessageId: null }
   try {
     const raw = storage.getItem(streamSnapshotKey(chatId))
-    if (!raw) return []
+    if (!raw) return { items: [], assistantMessageId: null }
     const parsed = JSON.parse(raw)
-    return Array.isArray(parsed) ? parsed : []
+    if (!parsed || !Array.isArray(parsed.items)) {
+      return { items: [], assistantMessageId: null }
+    }
+    return {
+      items: parsed.items,
+      assistantMessageId: typeof parsed.assistantMessageId === 'string'
+        ? parsed.assistantMessageId
+        : null,
+    }
   } catch {
-    return []
+    return { items: [], assistantMessageId: null }
   }
 }
 
-export function writeStoredStreamSnapshot(chatId, items, storage = defaultStorage()) {
+export function writeStoredStreamSnapshot(
+  chatId,
+  { items, assistantMessageId = null },
+  storage = defaultStorage(),
+) {
   if (!storage || !chatId || !Array.isArray(items) || items.length === 0) return
   try {
-    storage.setItem(streamSnapshotKey(chatId), JSON.stringify(items))
+    storage.setItem(streamSnapshotKey(chatId), JSON.stringify({
+      items,
+      assistantMessageId,
+    }))
   } catch {
     // Best-effort only. If sessionStorage is unavailable, the durable DB
     // partial plus SSE catch-up still reconstruct the stream.
@@ -63,7 +79,7 @@ export function reclaimStoredStreamSnapshots(storage = defaultStorage()) {
     const keys = []
     for (let index = 0; index < storage.length; index++) {
       const key = storage.key(index)
-      if (key?.startsWith(STREAM_SNAPSHOT_PREFIX)) keys.push(key)
+      if (key?.startsWith(STREAM_SNAPSHOT_BASE_PREFIX)) keys.push(key)
     }
     for (const key of keys) {
       storage.removeItem(key)

--- a/frontend/src/components/ChatView/useStreamConnection.js
+++ b/frontend/src/components/ChatView/useStreamConnection.js
@@ -108,8 +108,11 @@ const BROADCAST_REGISTRATION_WINDOW_MS = 1500
  * emitter AND the dispatch switch below in this file.
  *
  *   stream_snapshot       Server-reduced assistant items at the exact
- *                         subscription boundary { items }. Seeds reconnect
+ *                         subscription boundary
+ *                         { items, assistant_message_id }. Seeds reconnect
  *                         catch-up so prior deltas need not be replayed.
+ *   assistant_identity    Replay-safe row identity for a subscriber that
+ *                         attached before the sink could seed a snapshot.
  *   text                  Streamed assistant token chunk
  *                         { content }. Buffered + drained by rAF.
  *   text_boundary         Next text starts a fresh assistant block.
@@ -213,6 +216,8 @@ const BROADCAST_REGISTRATION_WINDOW_MS = 1500
  *     | {type: 'error', message: string}
  *   >,
  *   latestItemsRef: React.MutableRefObject<Array<object>>,
+ *   streamAssistantMessageId: string | null,
+ *   latestAssistantMessageIdRef: React.MutableRefObject<string | null>,
  *   isStreaming: boolean,
  *   isStreamingRef: React.MutableRefObject<boolean>,
  *   connectionError: string | null,
@@ -252,10 +257,18 @@ export default function useStreamConnection(chatId, {
 }) {
   // sessionStorage reads and JSON parsing are synchronous. Lazy initialization
   // keeps them off every frame-paced render while a reply is revealing.
+  const initialStreamSnapshotRef = useRef(null)
+  if (initialStreamSnapshotRef.current === null) {
+    initialStreamSnapshotRef.current = readStoredStreamSnapshot(chatId)
+  }
   const [streamItems, _setStreamItems] = useState(
-    () => readStoredStreamSnapshot(chatId),
+    () => initialStreamSnapshotRef.current.items,
+  )
+  const [streamAssistantMessageId, _setStreamAssistantMessageId] = useState(
+    () => initialStreamSnapshotRef.current.assistantMessageId,
   )
   const latestItemsRef = useRef(streamItems)
+  const latestAssistantMessageIdRef = useRef(streamAssistantMessageId)
   // Snapshot of the last non-empty latestItemsRef value. Written every
   // time items become non-empty; never cleared by a reconnect reset.
   // On retry exhaustion we promote from this ref so the user sees the
@@ -297,6 +310,12 @@ export default function useStreamConnection(chatId, {
     latestItemsRef.current = next
     _setStreamItems(next)
     return next !== previous
+  }, [])
+
+  const setStreamAssistantMessageId = useCallback((value) => {
+    const next = typeof value === 'string' && value ? value : null
+    latestAssistantMessageIdRef.current = next
+    _setStreamAssistantMessageId(next)
   }, [])
 
   const publishQuestionResponseStart = useCallback((questionResponseKey) => {
@@ -402,7 +421,10 @@ export default function useStreamConnection(chatId, {
   const persistLatestStreamSnapshot = useCallback(() => {
     writeStoredStreamSnapshot(
       activeStreamChatIdRef.current,
-      latestItemsRef.current,
+      {
+        items: latestItemsRef.current,
+        assistantMessageId: latestAssistantMessageIdRef.current,
+      },
     )
   }, [])
 
@@ -640,6 +662,7 @@ export default function useStreamConnection(chatId, {
     // completed old-chat frame before the next effect changes the active id.
     persistLatestStreamSnapshot()
     setStreamItems([])
+    setStreamAssistantMessageId(null)
     textBufferRef.current = ''
     textBufferItemIdRef.current = null
     forceNewTextBlockRef.current = false
@@ -657,15 +680,18 @@ export default function useStreamConnection(chatId, {
     clearQuestionResponseTracking,
     disconnect,
     persistLatestStreamSnapshot,
+    setStreamAssistantMessageId,
     setStreamItems,
   ])
 
   useEffect(() => {
     activeStreamChatIdRef.current = chatId
     const stored = readStoredStreamSnapshot(chatId)
-    latestItemsRef.current = stored
-    lastGoodItemsRef.current = stored
-    _setStreamItems(stored)
+    latestItemsRef.current = stored.items
+    lastGoodItemsRef.current = stored.items
+    latestAssistantMessageIdRef.current = stored.assistantMessageId
+    _setStreamItems(stored.items)
+    _setStreamAssistantMessageId(stored.assistantMessageId)
   }, [chatId])
 
   // Persist only at lifecycle boundaries. Chat switches and unmounts use the
@@ -831,6 +857,7 @@ export default function useStreamConnection(chatId, {
         clearStoredStreamSnapshot(activeStreamChatIdRef.current)
         lastGoodItemsRef.current = []
         setStreamItems([])
+        setStreamAssistantMessageId(null)
         textBufferRef.current = ''
         textBufferItemIdRef.current = null
         forceNewTextBlockRef.current = false
@@ -867,6 +894,7 @@ export default function useStreamConnection(chatId, {
       // temporary blank/thinking state while a long catch-up replay is parsed.
       let isCatchUp = true
       let catchUpItems = []
+      let catchUpAssistantMessageId = null
       let seededByServerSnapshot = false
 
       const applyStreamItems = (updater) => {
@@ -904,6 +932,7 @@ export default function useStreamConnection(chatId, {
           clearStoredStreamSnapshot(activeStreamChatIdRef.current)
           _setStreamItems([])
         }
+        setStreamAssistantMessageId(catchUpAssistantMessageId)
         catchUpItems = []
         isCatchUp = false
         catchUpStartedRef.current = false
@@ -962,6 +991,26 @@ export default function useStreamConnection(chatId, {
             continue
           }
 
+          // A subscription snapshot normally establishes identity first. The
+          // event-level copy closes the smaller race where the broadcast is
+          // visible before its sink can seed that snapshot. A different id is
+          // never adopted implicitly: only the explicit steer cut below may
+          // rotate an already-owned assistant segment.
+          if (event.type !== 'stream_snapshot'
+              && event.type !== 'steered_into_turn') {
+            const eventMessageId = (
+              typeof event.assistant_message_id === 'string'
+              && event.assistant_message_id
+            ) || null
+            if (eventMessageId) {
+              if (isCatchUp && catchUpAssistantMessageId === null) {
+                catchUpAssistantMessageId = eventMessageId
+              } else if (!isCatchUp && latestAssistantMessageIdRef.current === null) {
+                setStreamAssistantMessageId(eventMessageId)
+              }
+            }
+          }
+
           if (event.type === 'catch_up_done') {
             catchUpItems = anchorReplayedThinking(
               catchUpItems,
@@ -984,11 +1033,17 @@ export default function useStreamConnection(chatId, {
               catchUpItems = Array.isArray(event.items)
                 ? event.items.filter(Boolean)
                 : []
+              catchUpAssistantMessageId = (
+                typeof event.assistant_message_id === 'string'
+                && event.assistant_message_id
+              ) || null
               seededByServerSnapshot = true
               textBufferRef.current = ''
               textBufferItemIdRef.current = null
               forceNewTextBlockRef.current = false
             }
+          } else if (event.type === 'assistant_identity') {
+            // Identity was adopted above; it has no renderable payload.
           } else if (event.type === 'text_boundary') {
             flushBuffer()
             forceNewTextBlockRef.current = true
@@ -1270,7 +1325,15 @@ export default function useStreamConnection(chatId, {
               // prior cut, so it contains only the current A2 surface; keep
               // that payload while the authoritative DB refresh restores the
               // sealed A1 + user rows this socket may have missed.
-              if (!seededByServerSnapshot) catchUpItems = []
+              if (!seededByServerSnapshot) {
+                catchUpItems = Array.isArray(event.items)
+                  ? event.items.filter(Boolean)
+                  : []
+                catchUpAssistantMessageId = (
+                  typeof event.next_assistant_message_id === 'string'
+                  && event.next_assistant_message_id
+                ) || null
+              }
               forceNewTextBlockRef.current = false
               // Dropping the replayed segment only reconstructs the transcript
               // if those DB rows are actually loaded, and this branch is exactly
@@ -1288,7 +1351,23 @@ export default function useStreamConnection(chatId, {
                 ts: event.ts ?? null,
                 content: event.content || '',
                 messages: Array.isArray(event.messages) ? event.messages : null,
+                assistantMessageId: event.assistant_message_id || null,
+                sealedItems: Array.isArray(event.sealed_items)
+                  ? event.sealed_items.filter(Boolean)
+                  : null,
+                nextAssistantMessageId: event.next_assistant_message_id || null,
+                items: Array.isArray(event.items)
+                  ? event.items.filter(Boolean)
+                  : [],
               })
+              // The callback seals A1 synchronously. Re-base the hook onto the
+              // server's A2 snapshot before any later deltas are reduced.
+              setStreamAssistantMessageId(
+                event.next_assistant_message_id || null,
+              )
+              setStreamItems(
+                Array.isArray(event.items) ? event.items.filter(Boolean) : [],
+              )
             }
           } else if (event.type === 'steer_delivery_failed') {
             // Admission succeeded, but the provider control channel never
@@ -1436,6 +1515,7 @@ export default function useStreamConnection(chatId, {
     commitRenderableStreamItems,
     disconnect,
     flushBuffer,
+    setStreamAssistantMessageId,
     setStreamItems,
     startDraining,
   ])
@@ -1495,6 +1575,7 @@ export default function useStreamConnection(chatId, {
       clearStoredStreamSnapshot(activeStreamChatIdRef.current)
       lastGoodItemsRef.current = []
       setStreamItems([])
+      setStreamAssistantMessageId(null)
       textBufferRef.current = ''
       textBufferItemIdRef.current = null
       setIsStreaming(true)
@@ -1638,6 +1719,7 @@ export default function useStreamConnection(chatId, {
         clearStoredStreamSnapshot(activeStreamChatIdRef.current)
         lastGoodItemsRef.current = []
         setStreamItems([])
+        setStreamAssistantMessageId(null)
         textBufferRef.current = ''
         textBufferItemIdRef.current = null
         forceNewTextBlockRef.current = false
@@ -1657,6 +1739,7 @@ export default function useStreamConnection(chatId, {
         clearStoredStreamSnapshot(activeStreamChatIdRef.current)
         lastGoodItemsRef.current = []
         setStreamItems([])
+        setStreamAssistantMessageId(null)
         textBufferRef.current = ''
         textBufferItemIdRef.current = null
         forceNewTextBlockRef.current = false
@@ -1690,7 +1773,11 @@ export default function useStreamConnection(chatId, {
     // backend/app/routes/chats_stream.py:121-131.)
     connectRef.current?.(true)
     return responseData || { status: 'started' }
-  }, [clearQuestionResponseTracking, setStreamItems])
+  }, [
+    clearQuestionResponseTracking,
+    setStreamAssistantMessageId,
+    setStreamItems,
+  ])
 
   // Reconnect on visibility change or network recovery, but ONLY
   // when we believe a stream is active (isStreamingRef). Idle chats
@@ -1811,6 +1898,7 @@ export default function useStreamConnection(chatId, {
     // fast-forwarded queued message.
     lastGoodItemsRef.current = []
     setStreamItems([])
+    setStreamAssistantMessageId(null)
     textBufferRef.current = ''
     textBufferItemIdRef.current = null
     forceNewTextBlockRef.current = false
@@ -1857,6 +1945,8 @@ export default function useStreamConnection(chatId, {
   return {
     streamItems,
     latestItemsRef,
+    streamAssistantMessageId,
+    latestAssistantMessageIdRef,
     isStreaming,
     isStreamingRef,
     connectionError,


### PR DESCRIPTION
## Summary
- assign one durable assistant message identity at run start and carry it through live storage, stream snapshots, reconnect cache, rendering, and terminal persistence
- update or promote only the exact identity-owned row, with a bounded id-less rolling-upgrade fallback that cannot cross a successor turn
- rotate the identity at steer boundaries and preserve it through restart, crash recovery, and terminal finalization

## Why
After a restart, terminal stream promotion could reuse a stale timestamp bridge from an earlier assistant row. The server transcript remained correctly ordered, but the browser could replace that older row with the current unanswered question until a refresh rebuilt the view.

This makes row ownership explicit end to end instead of inferring it independently from role, timestamp, content, or transcript position. It builds on #880's question-authority and recovery work. The separate steer-replay presentation work in #889 is intentionally not duplicated here.

## Tests
- 196 focused backend lifecycle and identity tests
- 2,731 frontend unit and hook tests
- 84 fast backend contract tests
- frontend lint (0 errors; 46 pre-existing warnings)
- Ruff on changed Python files; mypy on the shared helper and transcript boundary
- canonical diff checks
