### PR TITLE
Validate app updates against the published source tree

### DIFF
--- a/backend/app/install.py
+++ b/backend/app/install.py
@@ -2424,6 +2424,7 @@ class ActivationPlan:
   """Source and manifest state selected by reconciliation for activation."""
 
   source_tree: dict[str, bytes]
+  published_source_tree: dict[str, bytes]
   static_assets: dict[str, bytes]
   dropped_source_paths: set[str]
   exec_paths: frozenset[str]
@@ -2528,7 +2529,12 @@ async def _activate_install_source(
       _check_source_completeness(
         app_name=str(manifest.get("name") or app.slug),
         manifest=manifest,
-        source_tree=plan.source_tree,
+        # Validate the published package against its own manifest, not the
+        # reconciled tree.  A clean update merge may legitimately retain
+        # locally applied sibling modules which the upstream manifest cannot
+        # declare; checking that merged tree makes every later synthetic
+        # fallback misdiagnose those preserved edits as a broken release.
+        source_tree=plan.published_source_tree,
         entry_key=plan.entry_key,
         static_dests=list(plan.static_assets),
         job_name=plan.job_name,
@@ -2720,6 +2726,10 @@ async def install_from_manifest(
     )
   if job_name and bundled_job is not None:
     source_tree[job_name] = bundled_job
+  # Keep the exact manifest-fetched package separate from the tree selected by
+  # Git reconciliation below. Source completeness is a publication contract;
+  # locally retained modules in a clean merge are outside that contract.
+  published_source_tree = dict(source_tree)
   repo_ref = (
     _derive_repo_ref(manifest_url) if manifest_url is not None else None
   )
@@ -3168,6 +3178,7 @@ async def install_from_manifest(
           manifest=manifest,
           plan=ActivationPlan(
             source_tree=source_tree,
+            published_source_tree=published_source_tree,
             static_assets=static_assets_fetched,
             dropped_source_paths=dropped_source_paths,
             exec_paths=exec_paths,

--- a/backend/tests/test_apps_install.py
+++ b/backend/tests/test_apps_install.py
@@ -4866,6 +4866,59 @@ def test_multifile_update_merges_local_sibling_edit(
   assert "<<<<<<<" not in merged
 
 
+def test_multifile_update_validates_published_tree_not_local_extensions(
+  client, auth, bypass_url_validation,
+):
+  """A clean update merge may retain a locally applied sibling module.
+
+  The upstream manifest cannot declare that local-only module. Source package
+  completeness therefore belongs to the exact fetched release tree, not the
+  later reconciled tree that is compiled and served.
+  """
+  base = "https://multi-local-extension.test/repo/"
+  r1 = _install_multi(
+    client, auth, base, MANIFEST_MULTI, JSX_IMPORTS_CARDS, CARDS_V1,
+  )
+  assert r1.status_code == 201, r1.text
+
+  data_dir = Path(get_settings().data_dir)
+  src = data_dir / "apps" / "multi-app"
+  local_index = (
+    "import { LOCAL_LABEL } from './local.js'\n" + JSX_IMPORTS_CARDS
+  ).replace(
+    "<div>{CARD_LABEL}</div>",
+    "<div>{CARD_LABEL}{LOCAL_LABEL}</div>",
+  )
+  (src / "index.jsx").write_text(local_index, encoding="utf-8")
+  (src / "local.js").write_text(
+    "export const LOCAL_LABEL = 'LOCAL_ONLY'\n", encoding="utf-8",
+  )
+  (src / "mobius.json").write_text(
+    json.dumps({
+      **MANIFEST_MULTI,
+      "source_files": ["cards.js", "local.js"],
+    }),
+    encoding="utf-8",
+  )
+
+  cards_v2 = CARDS_V1.replace("FOOTER_ORIGINAL", "FOOTER_UPSTREAM")
+  r2 = _install_multi(
+    client, auth, base,
+    {**MANIFEST_MULTI, "version": "2.0.0"}, JSX_IMPORTS_CARDS, cards_v2,
+  )
+
+  assert r2.status_code == 201, r2.text
+  assert r2.json()["mode"] == "update"
+  assert r2.json()["divergence"] == "clean_merge"
+  assert (src / "index.jsx").read_text() == local_index
+  assert (src / "local.js").read_text() == (
+    "export const LOCAL_LABEL = 'LOCAL_ONLY'\n"
+  )
+  bundle = Path(r2.json()["compiled_path"]).read_text()
+  assert "LOCAL_ONLY" in bundle
+  assert "FOOTER_UPSTREAM" in (src / "cards.js").read_text()
+
+
 def test_singlefile_install_unchanged_without_source_files(
   client, auth, bypass_url_validation,
 ):


### PR DESCRIPTION
## Summary
- validate package completeness against the exact published source tree
- preserve locally added modules during clean app update merges
- add regression coverage for synthetic update fallback with a local extension

## Testing
- scripts/test.sh --fast
- scripts/wt-pytest.sh -q backend/tests/test_apps_install.py backend/tests/test_app_source_check.py