### PR TITLE
Add app-owned chat progress and stop controls

### DIFF
--- a/frontend/public/mobius-runtime.js
+++ b/frontend/public/mobius-runtime.js
@@ -2029,6 +2029,53 @@ function makeEmbedAuthorizationHandoff({ mint, post, onAttemptError = () => {}, 
 }
 const EMBED_BOOTSTRAP_TIMEOUT_MS = 15e3;
 function makeChat({ appId, getToken, storage }) {
+	const CONTROL_TIMEOUT_MS = 2e4;
+	let controlSequence = 0;
+	const pendingControls = /* @__PURE__ */ new Map();
+	let controlListening = false;
+	function cleanControlText(value, maximum = 256) {
+		return typeof value === "string" ? value.trim().slice(0, maximum) : "";
+	}
+	function onControlMessage(event) {
+		if (event.origin !== window.location.origin || event.source !== window.parent) return;
+		const message = event.data;
+		if (!message || message.type !== "moebius:chat-control-result") return;
+		const pending = pendingControls.get(message.requestId);
+		if (!pending) return;
+		pendingControls.delete(message.requestId);
+		clearTimeout(pending.timeout);
+		if (message.ok === true) pending.resolve(message.result);
+		else pending.reject(new Error(cleanControlText(message.error, 500) || "Chat control failed."));
+	}
+	function ensureControlListener() {
+		if (controlListening || typeof window === "undefined") return;
+		window.addEventListener("message", onControlMessage);
+		controlListening = true;
+	}
+	function requestChatControl(action, chatId) {
+		const id = cleanControlText(chatId, 128);
+		if (!id) return Promise.reject(/* @__PURE__ */ new Error("window.mobius.chat: chat id is required"));
+		if (typeof window === "undefined" || !window.parent || window.parent === window) return Promise.reject(/* @__PURE__ */ new Error("window.mobius.chat: trusted host is unavailable"));
+		ensureControlListener();
+		const requestId = `chat-control:${Date.now().toString(36)}:${(++controlSequence).toString(36)}`;
+		return new Promise((resolve, reject) => {
+			const timeout = setTimeout(() => {
+				pendingControls.delete(requestId);
+				reject(/* @__PURE__ */ new Error("Möbius did not answer the chat control request."));
+			}, CONTROL_TIMEOUT_MS);
+			pendingControls.set(requestId, {
+				resolve,
+				reject,
+				timeout
+			});
+			window.parent.postMessage({
+				type: "moebius:chat-control",
+				requestId,
+				action,
+				chatId: id
+			}, window.location.origin);
+		});
+	}
 	async function appChatFetch(url, init = {}) {
 		return fetchWithAppToken(getToken, url, init);
 	}
@@ -2519,6 +2566,18 @@ function makeChat({ appId, getToken, storage }) {
 		};
 	};
 	chat.start = startChat;
+	chat.list = listChats;
+	chat.status = (chatId) => requestChatControl("status", chatId);
+	chat.stop = (chatId) => requestChatControl("stop", chatId);
+	chat._destroy = () => {
+		if (controlListening && typeof window !== "undefined") window.removeEventListener("message", onControlMessage);
+		controlListening = false;
+		for (const pending of pendingControls.values()) {
+			clearTimeout(pending.timeout);
+			pending.reject(/* @__PURE__ */ new Error("Chat controls were replaced."));
+		}
+		pendingControls.clear();
+	};
 	return chat;
 }
 
@@ -3852,6 +3911,7 @@ function init({ appId, appInstanceId = null, getToken, capabilityContract = null
 		_runtimeContext.signal?._destroy?.();
 		_runtimeContext.storage?._destroy?.();
 		_runtimeContext.capabilities?._destroy?.();
+		_runtimeContext.chat?._destroy?.();
 	}
 	const tokenRef = { current: getToken };
 	const scopedToken = async (options) => {
@@ -3866,6 +3926,11 @@ function init({ appId, appInstanceId = null, getToken, capabilityContract = null
 	});
 	const signal = makeSignal(appId, storage, appInstanceId);
 	const capabilities = makeCapabilities({ declarations: capabilityContract?.runtime || {} });
+	const chat = makeChat({
+		appId,
+		getToken: scopedToken,
+		storage
+	});
 	const api = {
 		appId,
 		get online() {
@@ -3889,11 +3954,7 @@ function init({ appId, appInstanceId = null, getToken, capabilityContract = null
 		createUseDocument: (React) => createUseDocument(storage, React),
 		signal,
 		capabilities,
-		chat: makeChat({
-			appId,
-			getToken: scopedToken,
-			storage
-		}),
+		chat,
 		nav: makeNav(),
 		split: makeSplit(),
 		immersive: makeImmersive({ appId }),
@@ -3906,6 +3967,7 @@ function init({ appId, appInstanceId = null, getToken, capabilityContract = null
 		storage,
 		signal,
 		capabilities,
+		chat,
 		api
 	};
 	storage._drain();

--- a/frontend/public/mobius-runtime.js
+++ b/frontend/public/mobius-runtime.js
@@ -2037,7 +2037,7 @@ function makeChat({ appId, getToken, storage }) {
 		return typeof value === "string" ? value.trim().slice(0, maximum) : "";
 	}
 	function onControlMessage(event) {
-		if (event.origin !== window.location.origin || event.source !== window.parent) return;
+		if (event.source !== window.parent) return;
 		const message = event.data;
 		if (!message || message.type !== "moebius:chat-control-result") return;
 		const pending = pendingControls.get(message.requestId);
@@ -2073,7 +2073,7 @@ function makeChat({ appId, getToken, storage }) {
 				requestId,
 				action,
 				chatId: id
-			}, window.location.origin);
+			}, "*");
 		});
 	}
 	async function appChatFetch(url, init = {}) {

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -437,6 +437,19 @@ export const api = {
       method: 'POST',
       body: JSON.stringify(payload),
     }),
+    runtime: (chatId, options = {}) => apiFetch(
+      `/chats/${encodeURIComponent(chatId)}/runtime`,
+      options,
+    ),
+    goalPlan: (chatId, options = {}) => apiFetch(
+      `/chats/${encodeURIComponent(chatId)}/goal-plan`,
+      options,
+    ),
+    stop: (chatId, options = {}) => apiFetch('/chat/stop', {
+      ...options,
+      method: 'POST',
+      body: JSON.stringify({ chat_id: chatId }),
+    }),
     detail: (chatId, { limit, compact, anchor, signal, timeoutMs } = {}) => {
       const params = new URLSearchParams()
       if (limit !== undefined) params.set('limit', String(limit))

--- a/frontend/src/components/AppCanvas/AppCanvas.jsx
+++ b/frontend/src/components/AppCanvas/AppCanvas.jsx
@@ -98,6 +98,9 @@ function appFrameRequestUrl(appId, version, frameRev) {
 //      for the swap (a first-render throw aborts the commit; promoting on
 //      that lie would unmount the working frame for a dead one).
 //
+//   Host chat control: {type:'moebius:chat-control', requestId, action,
+//      chatId} frame → host, answered by moebius:chat-control-result. The host
+//      verifies immutable app ownership before exposing status or Stop.
 //   2b. {type: 'moebius:frame-error', appId}               frame → parent
 //      Fired by the frame on a TERMINAL load failure (bad import, no
 //      token, no default export, init timeout) instead of (2). Parent
@@ -904,7 +907,38 @@ const AppCanvas = forwardRef(function AppCanvas({
       // request, so no host needs to rediscover iframe identity.
       const hostRequest = appHostRequest(msg)
       if (hostRequest && onHostRequest) {
-        onHostRequest(appId, hostRequest)
+        if (hostRequest.type !== 'moebius:chat-control') {
+          onHostRequest(appId, hostRequest)
+          return
+        }
+        const responseTarget = e.source
+        const responseOrigin = e.origin === 'null' ? '*' : e.origin
+        const respond = (payload) => {
+          try { responseTarget?.postMessage(payload, responseOrigin) } catch { /* retired frame */ }
+        }
+        try {
+          Promise.resolve(onHostRequest(appId, hostRequest)).then(
+            result => respond({
+              type: 'moebius:chat-control-result',
+              requestId: hostRequest.requestId,
+              ok: true,
+              result: result ?? null,
+            }),
+            error => respond({
+              type: 'moebius:chat-control-result',
+              requestId: hostRequest.requestId,
+              ok: false,
+              error: error?.message || 'Chat control failed.',
+            }),
+          )
+        } catch (error) {
+          respond({
+            type: 'moebius:chat-control-result',
+            requestId: hostRequest.requestId,
+            ok: false,
+            error: error?.message || 'Chat control failed.',
+          })
+        }
         return
       }
 

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -21,6 +21,7 @@ import useNavigation, { deepLink } from '../../hooks/useNavigation.js'
 import useContextMenuOutsideDismiss from '../../hooks/useContextMenuOutsideDismiss.js'
 import { placeContextMenu } from '../../lib/contextMenuGeometry.js'
 import { captureLayoutSpace, clientPointToLayout } from '../../lib/layoutSpace.js'
+import { makeAppChatController } from '../../lib/appChatControl.js'
 import { parseNotificationTarget } from '../../lib/notificationTarget.js'
 import { recordClientError } from '../../lib/errorLog.js'
 import useSystemEventStream from '../../hooks/useSystemEventStream.js'
@@ -815,6 +816,14 @@ export default function Shell({ onInitialVisualReady }) {
   // re-registering every mounted AppCanvas message listener.
   const appsRef = useRef(apps)
   useEffect(() => { appsRef.current = apps }, [apps])
+  const appChatControllerRef = useRef(null)
+  if (!appChatControllerRef.current) {
+    appChatControllerRef.current = makeAppChatController({
+      knownChats: () => chatsRef.current,
+      chats: api.chats,
+      readJson: jsonOrThrow,
+    })
+  }
   // Latest-`newChat` ref so the stable handleAppError can start a fresh chat
   // for a crash report without depending on newChat's identity (newChat is a
   // per-render function declaration with volatile inputs — chats, streaming,
@@ -2047,8 +2056,11 @@ export default function Shell({ onInitialVisualReady }) {
   // AppCanvas owns exact-window attribution and wire-format narrowing for
   // every frame request. This callback owns the workspace outcome only, so the
   // standalone host and workspace cannot drift into separate message routers.
-  const handleAppHostRequest = useCallback((_appId, request) => {
-    void (async () => {
+  const handleAppHostRequest = useCallback((appId, request) => {
+    return (async () => {
+      if (request.type === 'moebius:chat-control') {
+        return appChatControllerRef.current(appId, request)
+      }
       if (request.type === 'moebius:new-chat') {
         await newChatRef.current?.({
           draft: request.draft || undefined,

--- a/frontend/src/components/StandaloneApp/StandaloneApp.jsx
+++ b/frontend/src/components/StandaloneApp/StandaloneApp.jsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import AppCanvas from '../AppCanvas/AppCanvas.jsx'
-import { api, BASE } from '../../api/client.js'
+import { api, BASE, jsonOrThrow } from '../../api/client.js'
 import { appQueries } from '../../hooks/queries.js'
 import useSystemEventStream from '../../hooks/useSystemEventStream.js'
 import { stageComposerHandoff } from '../ChatView/composerDraft.js'
@@ -18,6 +18,7 @@ import {
   standaloneAppVersion,
 } from '../../lib/standaloneBoot.js'
 import { readableAppDiagnostic } from '../../lib/appDiagnostic.js'
+import { makeAppChatController } from '../../lib/appChatControl.js'
 import {
   MAX_STANDALONE_HISTORY_ENTRIES,
   readStandaloneHistoryEntries,
@@ -54,6 +55,13 @@ export default function StandaloneApp({ initialApp }) {
   })
   const navEntriesRef = useRef(readStandaloneHistoryEntries(history.state))
   const localPopRef = useRef(false)
+  const appChatControllerRef = useRef(null)
+  if (!appChatControllerRef.current) {
+    appChatControllerRef.current = makeAppChatController({
+      chats: api.chats,
+      readJson: jsonOrThrow,
+    })
+  }
 
   const refreshApp = useCallback(async ({ apply = false } = {}) => {
     const rows = await queryClient.fetchQuery({
@@ -191,7 +199,10 @@ export default function StandaloneApp({ initialApp }) {
   }, [])
 
   const onHostRequest = useCallback((_appId, request) => {
-    void (async () => {
+    const run = async () => {
+      if (request.type === 'moebius:chat-control') {
+        return appChatControllerRef.current(initialApp.id, request)
+      }
       if (request.type === 'moebius:open-app') {
         window.location.href = shellUrl({ app: request.appId, intent: request.intent })
         return
@@ -214,11 +225,16 @@ export default function StandaloneApp({ initialApp }) {
         stageComposerHandoff(chat.id, request.draft, { autoSend: request.autoSend })
         window.location.href = shellUrl({ chat: chat.id })
       }
-    })().catch(error => captureCrash(
+      return null
+    }
+    const outcome = run()
+    if (request.requestId) return outcome
+    void outcome.catch(error => captureCrash(
       initialApp.id,
       `Möbius couldn't complete that request. ${readableAppDiagnostic(error)}`,
       null,
     ))
+    return undefined
   }, [captureCrash, initialApp.id])
 
   const refreshCrash = useCallback(() => {

--- a/frontend/src/lib/__tests__/appChatControl.test.js
+++ b/frontend/src/lib/__tests__/appChatControl.test.js
@@ -1,0 +1,68 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { makeAppChatAuthorizer, makeAppChatController } from '../appChatControl.js'
+
+test('app chat authorizer accepts known ownership without a detail read', async () => {
+  let reads = 0
+  const authorize = makeAppChatAuthorizer({
+    knownChats: () => [{ id: 'chat-1', created_by_app_id: 80 }],
+    loadChat: async () => { reads += 1; return null },
+  })
+  assert.equal(await authorize(80, 'chat-1'), true)
+  assert.equal(reads, 0)
+})
+
+test('app chat authorizer verifies an off-list chat once then caches ownership', async () => {
+  let reads = 0
+  const authorize = makeAppChatAuthorizer({
+    knownChats: () => [],
+    loadChat: async (id) => { reads += 1; return { id, created_by_app_id: 80 } },
+  })
+  assert.equal(await authorize(80, 'chat-2'), true)
+  assert.equal(await authorize(80, 'chat-2'), true)
+  assert.equal(reads, 1)
+})
+
+test('app chat authorizer rejects cross-app control', async () => {
+  const authorize = makeAppChatAuthorizer({
+    knownChats: () => [{ id: 'chat-3', created_by_app_id: 81 }],
+  })
+  await assert.rejects(authorize(80, 'chat-3'), /does not belong/)
+})
+
+
+test('app chat authorizer rejects ownership returned by a detail read', async () => {
+  const authorize = makeAppChatAuthorizer({
+    knownChats: () => [],
+    loadChat: async (id) => ({ id, created_by_app_id: 81 }),
+  })
+  await assert.rejects(authorize(80, 'chat-4'), /does not belong/)
+})
+
+test('app chat controller shares status enrichment and stop semantics', async () => {
+  const calls = []
+  const control = makeAppChatController({
+    knownChats: () => [{ id: 'chat-5', created_by_app_id: 80 }],
+    chats: {
+      detail: async () => { throw new Error('known chat should not be loaded') },
+      runtime: async (id, options) => { calls.push(['runtime', id, options]); return { kind: 'runtime' } },
+      goalPlan: async (id, options) => {
+        calls.push(['goal', id, options])
+        return { ok: true, json: async () => ({ plan: { current: 'review' } }) }
+      },
+      stop: async (id, options) => { calls.push(['stop', id, options]); return { kind: 'stop' } },
+    },
+    readJson: async value => value,
+  })
+
+  assert.deepEqual(await control(80, { action: 'status', chatId: 'chat-5' }), {
+    kind: 'runtime', goal_plan: { current: 'review' },
+  })
+  assert.deepEqual(await control(80, { action: 'stop', chatId: 'chat-5' }), { kind: 'stop' })
+  assert.deepEqual(calls, [
+    ['goal', 'chat-5', { timeoutMs: 5000 }],
+    ['runtime', 'chat-5', { timeoutMs: 5000 }],
+    ['stop', 'chat-5', { timeoutMs: 15000 }],
+  ])
+})

--- a/frontend/src/lib/__tests__/appHostRequest.test.js
+++ b/frontend/src/lib/__tests__/appHostRequest.test.js
@@ -17,3 +17,24 @@ test('app host requests expose only the reviewed navigation contract', () => {
   assert.equal(appHostRequest({ type: 'moebius:open-chat', chatId: '' }), null)
   assert.equal(appHostRequest({ type: 'unexpected', appId: 1 }), null)
 })
+
+test('chat controls retain only a correlated status or stop request', () => {
+  assert.deepEqual(appHostRequest({
+    type: 'moebius:chat-control',
+    requestId: 'chat-control:abc:1',
+    action: 'stop',
+    chatId: ' chat-123 ',
+    ownerToken: 'nope',
+  }), {
+    type: 'moebius:chat-control',
+    requestId: 'chat-control:abc:1',
+    action: 'stop',
+    chatId: 'chat-123',
+  })
+  assert.equal(appHostRequest({
+    type: 'moebius:chat-control', requestId: 'bad', action: 'status', chatId: '1',
+  }), null)
+  assert.equal(appHostRequest({
+    type: 'moebius:chat-control', requestId: 'chat-control:abc:2', action: 'delete', chatId: '1',
+  }), null)
+})

--- a/frontend/src/lib/__tests__/mobiusRuntime.test.js
+++ b/frontend/src/lib/__tests__/mobiusRuntime.test.js
@@ -170,11 +170,14 @@ test('chat.start rejects an empty first turn before creating a chat', async () =
   )
 })
 
-test('chat status and stop use correlated trusted-host controls', async () => {
+test('chat status and stop cross the opaque frame boundary through the trusted parent', async () => {
   await withFakeWindow(async ({ window, parent }) => {
+    window.location.origin = 'null'
     const chat = makeChat({ appId: 80, getToken: async () => 'app-token', storage: null })
     const statusPromise = chat.status('chat-cycle')
-    const statusRequest = parent.messages.at(-1).data
+    const statusEnvelope = parent.messages.at(-1)
+    const statusRequest = statusEnvelope.data
+    assert.equal(statusEnvelope.origin, '*')
     assert.equal(statusRequest.type, 'moebius:chat-control')
     assert.equal(statusRequest.action, 'status')
     assert.equal(statusRequest.chatId, 'chat-cycle')
@@ -182,19 +185,27 @@ test('chat status and stop use correlated trusted-host controls', async () => {
       type: 'moebius:chat-control-result',
       requestId: statusRequest.requestId,
       ok: true,
+      result: { running: false },
+    }, { origin: 'https://untrusted.test', source: {} })
+    window.emit({
+      type: 'moebius:chat-control-result',
+      requestId: statusRequest.requestId,
+      ok: true,
       result: { running: true },
-    })
+    }, { origin: 'https://mobius.test' })
     assert.deepEqual(await statusPromise, { running: true })
 
     const stopPromise = chat.stop('chat-cycle')
-    const stopRequest = parent.messages.at(-1).data
+    const stopEnvelope = parent.messages.at(-1)
+    const stopRequest = stopEnvelope.data
+    assert.equal(stopEnvelope.origin, '*')
     assert.equal(stopRequest.action, 'stop')
     window.emit({
       type: 'moebius:chat-control-result',
       requestId: stopRequest.requestId,
       ok: true,
       result: { stopped: true },
-    })
+    }, { origin: 'https://mobius.test' })
     assert.deepEqual(await stopPromise, { stopped: true })
     chat._destroy()
   })

--- a/frontend/src/lib/__tests__/mobiusRuntime.test.js
+++ b/frontend/src/lib/__tests__/mobiusRuntime.test.js
@@ -170,6 +170,73 @@ test('chat.start rejects an empty first turn before creating a chat', async () =
   )
 })
 
+test('chat status and stop use correlated trusted-host controls', async () => {
+  await withFakeWindow(async ({ window, parent }) => {
+    const chat = makeChat({ appId: 80, getToken: async () => 'app-token', storage: null })
+    const statusPromise = chat.status('chat-cycle')
+    const statusRequest = parent.messages.at(-1).data
+    assert.equal(statusRequest.type, 'moebius:chat-control')
+    assert.equal(statusRequest.action, 'status')
+    assert.equal(statusRequest.chatId, 'chat-cycle')
+    window.emit({
+      type: 'moebius:chat-control-result',
+      requestId: statusRequest.requestId,
+      ok: true,
+      result: { running: true },
+    })
+    assert.deepEqual(await statusPromise, { running: true })
+
+    const stopPromise = chat.stop('chat-cycle')
+    const stopRequest = parent.messages.at(-1).data
+    assert.equal(stopRequest.action, 'stop')
+    window.emit({
+      type: 'moebius:chat-control-result',
+      requestId: stopRequest.requestId,
+      ok: true,
+      result: { stopped: true },
+    })
+    assert.deepEqual(await stopPromise, { stopped: true })
+    chat._destroy()
+  })
+})
+
+test('chat controls reject direct top-level use without starting a timeout', async () => {
+  const previousWindow = globalThis.window
+  const fakeWindow = {
+    location: { origin: 'https://mobius.test' },
+    addEventListener() {},
+    removeEventListener() {},
+  }
+  fakeWindow.parent = fakeWindow
+  globalThis.window = fakeWindow
+  try {
+    const chat = makeChat({ appId: 80, getToken: async () => 'app-token', storage: null })
+    await assert.rejects(chat.status('chat-cycle'), /trusted host is unavailable/)
+    chat._destroy()
+  } finally {
+    globalThis.window = previousWindow
+  }
+})
+
+test('chat list exposes only the calling app chat index', async () => {
+  const previousFetch = globalThis.fetch
+  const calls = []
+  globalThis.fetch = async (url) => {
+    calls.push(url)
+    return new Response(JSON.stringify([{ id: 'cycle-chat' }]), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+  try {
+    const chat = makeChat({ appId: 80, getToken: async () => 'app-token', storage: null })
+    assert.deepEqual(await chat.list({ scope: 'contribute-cycle' }), [{ id: 'cycle-chat' }])
+    assert.deepEqual(calls, ['/api/app-chats?scope=contribute-cycle'])
+  } finally {
+    globalThis.fetch = previousFetch
+  }
+})
+
 async function withFakeWindow(fn) {
   const previousWindow = globalThis.window
   const listeners = new Set()

--- a/frontend/src/lib/appChatControl.js
+++ b/frontend/src/lib/appChatControl.js
@@ -1,0 +1,71 @@
+/**
+ * Authorize host-mediated control of an app-owned conversation once, then
+ * remember the immutable ownership result for later status polls. The exact
+ * AppCanvas window supplies appId; the app frame never supplies or receives
+ * owner credentials.
+ */
+export function makeAppChatAuthorizer({ knownChats, loadChat } = {}) {
+  const verified = new Set()
+
+  return async function authorizeAppChat(appId, chatId) {
+    const ownerId = String(appId)
+    const id = String(chatId)
+    const key = `${ownerId}:${id}`
+    if (verified.has(key)) return true
+
+    const known = typeof knownChats === 'function' ? knownChats() : []
+    let chat = Array.isArray(known)
+      ? known.find(row => String(row?.id) === id)
+      : null
+    if (chat && String(chat.created_by_app_id) !== ownerId) {
+      throw new Error('That conversation does not belong to this app.')
+    }
+    if (!chat) {
+      if (typeof loadChat !== 'function') {
+        throw new Error('That conversation is unavailable.')
+      }
+      chat = await loadChat(id)
+    }
+    if (!chat || String(chat.created_by_app_id) !== ownerId) {
+      throw new Error('That conversation does not belong to this app.')
+    }
+    verified.add(key)
+    return true
+  }
+}
+
+/**
+ * Keep the owner-authorized app chat control outcome identical in workspace
+ * and standalone hosts. Callers supply the chat client and response decoder;
+ * this controller owns timeouts, best-effort Goal enrichment, and Stop.
+ */
+export function makeAppChatController({ knownChats, chats, readJson }) {
+  const authorize = makeAppChatAuthorizer({
+    knownChats,
+    loadChat: async (id) => readJson(
+      await chats.detail(id, { limit: 1, compact: true, timeoutMs: 5000 }),
+      'Conversation check failed:',
+    ),
+  })
+
+  return async function controlAppChat(appId, request) {
+    await authorize(appId, request.chatId)
+    if (request.action === 'stop') {
+      return readJson(
+        await chats.stop(request.chatId, { timeoutMs: 15000 }),
+        'Could not stop the conversation:',
+      )
+    }
+    const goalPlanPromise = chats.goalPlan(
+      request.chatId,
+      { timeoutMs: 5000 },
+    ).then(async response => (
+      response.ok ? (await response.json())?.plan ?? null : null
+    )).catch(() => null)
+    const runtime = await readJson(
+      await chats.runtime(request.chatId, { timeoutMs: 5000 }),
+      'Could not read conversation progress:',
+    )
+    return { ...runtime, goal_plan: await goalPlanPromise }
+  }
+}

--- a/frontend/src/lib/appHostRequest.js
+++ b/frontend/src/lib/appHostRequest.js
@@ -3,6 +3,7 @@ const REQUEST_TYPES = new Set([
   'moebius:open-chat',
   'moebius:open-app',
   'moebius:open-settings',
+  'moebius:chat-control',
 ])
 
 /**
@@ -33,6 +34,22 @@ export function appHostRequest(message) {
       type: message.type,
       appId: message.appId,
       intent: typeof message.intent === 'string' ? message.intent : '',
+    }
+  }
+  if (message.type === 'moebius:chat-control') {
+    const actions = new Set(['status', 'stop'])
+    if (
+      typeof message.requestId !== 'string'
+      || !/^chat-control:[a-z0-9]+:[a-z0-9]+$/i.test(message.requestId)
+      || !actions.has(message.action)
+      || typeof message.chatId !== 'string'
+      || !message.chatId.trim()
+    ) return null
+    return {
+      type: message.type,
+      requestId: message.requestId,
+      action: message.action,
+      chatId: message.chatId.trim().slice(0, 128),
     }
   }
   return {

--- a/frontend/src/runtime/chat.js
+++ b/frontend/src/runtime/chat.js
@@ -293,7 +293,9 @@ export function makeChat({ appId, getToken, storage }) {
   }
 
   function onControlMessage(event) {
-    if (event.origin !== window.location.origin || event.source !== window.parent) return
+    // Mini-app frames have an opaque (`null`) origin. The direct parent window
+    // is the trust boundary; request ids correlate replies to this runtime.
+    if (event.source !== window.parent) return
     const message = event.data
     if (!message || message.type !== 'moebius:chat-control-result') return
     const pending = pendingControls.get(message.requestId)
@@ -329,7 +331,7 @@ export function makeChat({ appId, getToken, storage }) {
         requestId,
         action,
         chatId: id,
-      }, window.location.origin)
+      }, '*')
     })
   }
 

--- a/frontend/src/runtime/chat.js
+++ b/frontend/src/runtime/chat.js
@@ -283,6 +283,56 @@ export function makeEmbedAuthorizationHandoff({
 const EMBED_BOOTSTRAP_TIMEOUT_MS = 15000
 
 export function makeChat({ appId, getToken, storage }) {
+  const CONTROL_TIMEOUT_MS = 20_000
+  let controlSequence = 0
+  const pendingControls = new Map()
+  let controlListening = false
+
+  function cleanControlText(value, maximum = 256) {
+    return typeof value === 'string' ? value.trim().slice(0, maximum) : ''
+  }
+
+  function onControlMessage(event) {
+    if (event.origin !== window.location.origin || event.source !== window.parent) return
+    const message = event.data
+    if (!message || message.type !== 'moebius:chat-control-result') return
+    const pending = pendingControls.get(message.requestId)
+    if (!pending) return
+    pendingControls.delete(message.requestId)
+    clearTimeout(pending.timeout)
+    if (message.ok === true) pending.resolve(message.result)
+    else pending.reject(new Error(cleanControlText(message.error, 500) || 'Chat control failed.'))
+  }
+
+  function ensureControlListener() {
+    if (controlListening || typeof window === 'undefined') return
+    window.addEventListener('message', onControlMessage)
+    controlListening = true
+  }
+
+  function requestChatControl(action, chatId) {
+    const id = cleanControlText(chatId, 128)
+    if (!id) return Promise.reject(new Error('window.mobius.chat: chat id is required'))
+    if (typeof window === 'undefined' || !window.parent || window.parent === window) {
+      return Promise.reject(new Error('window.mobius.chat: trusted host is unavailable'))
+    }
+    ensureControlListener()
+    const requestId = `chat-control:${Date.now().toString(36)}:${(++controlSequence).toString(36)}`
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        pendingControls.delete(requestId)
+        reject(new Error('Möbius did not answer the chat control request.'))
+      }, CONTROL_TIMEOUT_MS)
+      pendingControls.set(requestId, { resolve, reject, timeout })
+      window.parent.postMessage({
+        type: 'moebius:chat-control',
+        requestId,
+        action,
+        chatId: id,
+      }, window.location.origin)
+    })
+  }
+
   // Lazily create a chat the agent turn can be attributed to, via the
   // app-attributed backend contract (design §1.1: POST /api/app-chats).
   // The ordinary /api/chats create route is owner-only and intentionally
@@ -940,5 +990,19 @@ export function makeChat({ appId, getToken, storage }) {
     }
   }
   chat.start = startChat
+  chat.list = listChats
+  chat.status = chatId => requestChatControl('status', chatId)
+  chat.stop = chatId => requestChatControl('stop', chatId)
+  chat._destroy = () => {
+    if (controlListening && typeof window !== 'undefined') {
+      window.removeEventListener('message', onControlMessage)
+    }
+    controlListening = false
+    for (const pending of pendingControls.values()) {
+      clearTimeout(pending.timeout)
+      pending.reject(new Error('Chat controls were replaced.'))
+    }
+    pendingControls.clear()
+  }
   return chat
 }

--- a/frontend/src/runtime/index.js
+++ b/frontend/src/runtime/index.js
@@ -162,6 +162,7 @@ export function init({ appId, appInstanceId = null, getToken, capabilityContract
     _runtimeContext.signal?._destroy?.()
     _runtimeContext.storage?._destroy?.()
     _runtimeContext.capabilities?._destroy?.()
+    _runtimeContext.chat?._destroy?.()
   }
 
   const tokenRef = { current: getToken }
@@ -177,6 +178,7 @@ export function init({ appId, appInstanceId = null, getToken, capabilityContract
   })
   const signal = makeSignal(appId, storage, appInstanceId)
   const capabilities = makeCapabilities({ declarations: capabilityContract?.runtime || {} })
+  const chat = makeChat({ appId, getToken: scopedToken, storage })
   const api = {
     appId,
     // Returns the probed reachability verdict (not raw navigator.onLine).
@@ -205,14 +207,14 @@ export function init({ appId, appInstanceId = null, getToken, capabilityContract
     createUseDocument: (React) => createUseDocument(storage, React),
     signal,
     capabilities,
-    chat: makeChat({ appId, getToken: scopedToken, storage }),
+    chat,
     nav: makeNav(),
     split: makeSplit(),
     immersive: makeImmersive({ appId }),
     clipboard: makeClipboard(),
   }
   window.mobius = api
-  _runtimeContext = { identityKey, tokenRef, storage, signal, capabilities, api }
+  _runtimeContext = { identityKey, tokenRef, storage, signal, capabilities, chat, api }
   storage._drain()    // flush anything left from a previous offline session
   storage._drainSignals() // independently flush retained telemetry
   // Ask for durable storage so the offline mirror + queued blob writes survive


### PR DESCRIPTION
## Summary
- let mini-apps list the conversations they created and read live progress or request Stop through the shared runtime
- authorize every status/stop request in the trusted host against immutable app ownership without exposing owner credentials
- keep workspace and standalone hosts on one controller, with bounded requests, correlated responses, cleanup, and generated-runtime parity

## Why
App-owned background work can start a conversation, but previously could not reattach to it or stop it. Apps had to invent fragile polling or abandon work when their frame changed. This adds the narrow lifecycle controls while keeping the owner credential and cross-app conversations outside the app frame.

## Tests
- `npm test` — 2,634 library tests and 87 hook tests passed
- `npm run runtime:check`
- `npm run lint` — 0 errors (46 existing warnings)
- `npm run build`
- structural-test ratchet held at 779 cases
- focused ownership, wire-format, direct-use, cleanup, status-enrichment, and Stop coverage