### PR TITLE
Preserve navigation through shell rebuild handoffs

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -171,7 +171,6 @@
          while the new bundle restores the chosen destination. Ordinary links,
          auth redirects, and Back/Forward explicitly skip this opt-in below. -->
     <style data-mobius-shell-reload-transition>
-      @view-transition { navigation: auto; }
       @keyframes mobius-shell-reload-reveal {
         from { opacity: 1; }
         to { opacity: 0; }
@@ -204,13 +203,34 @@
         return typeof document.startViewTransition === 'function'
           && 'onpageswap' in window;
       }
+      function installNavigationOptIn() {
+        if (document.querySelector('style[data-mobius-shell-navigation-opt-in]')) return;
+        var style = document.createElement('style');
+        style.setAttribute('data-mobius-shell-navigation-opt-in', '');
+        style.textContent = '@view-transition { navigation: auto; }';
+        document.head.appendChild(style);
+      }
       if (hasShellReload() && supportsShellReloadTransition()) {
+        installNavigationOptIn();
         root.setAttribute('data-shell-reload-transition', 'incoming');
       }
 
-      // The at-rule is document-wide, but only the controlled shell replacement
-      // may retain pixels. Every unrelated cross-document navigation keeps its
-      // ordinary browser semantics.
+      // Cross-document view transitions are a document-wide opt-in. Installing
+      // that at-rule for every shell page and trying to skip unrelated
+      // navigations in `pageswap` is too late: the browser has already entered
+      // the transition lifecycle. Opt in only for the controlled replacement,
+      // immediately before navigation; the marked incoming document does the
+      // same above during pre-paint startup.
+      window.__mobiusPrepareShellReloadTransition = function () {
+        if (!supportsShellReloadTransition()) return false;
+        installNavigationOptIn();
+        root.setAttribute('data-shell-reload-transition', 'outgoing');
+        return true;
+      };
+
+      // Only a document that explicitly prepared the controlled replacement
+      // can receive a view transition here. Unrelated navigations never install
+      // the at-rule and therefore keep ordinary browser semantics.
       window.addEventListener('pageswap', function (event) {
         if (!event.viewTransition) return;
         if (hasShellReload()) {
@@ -220,6 +240,7 @@
           root.setAttribute('data-shell-reload-transition', 'outgoing');
           return;
         }
+        // Defensive only: a stale marker must not retain unrelated pixels.
         event.viewTransition.skipTransition();
       });
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -200,7 +200,13 @@
       function hasShellReload() {
         try { return !!sessionStorage.getItem('shell-reload'); } catch (e) { return false; }
       }
-      if (hasShellReload()) root.setAttribute('data-shell-reload-transition', 'incoming');
+      function supportsShellReloadTransition() {
+        return typeof document.startViewTransition === 'function'
+          && 'onpageswap' in window;
+      }
+      if (hasShellReload() && supportsShellReloadTransition()) {
+        root.setAttribute('data-shell-reload-transition', 'incoming');
+      }
 
       // The at-rule is document-wide, but only the controlled shell replacement
       // may retain pixels. Every unrelated cross-document navigation keeps its

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -166,6 +166,69 @@
     } catch (e) {}
   } catch (e) {}
 })();</script>
+    <!-- A controlled shell handoff is a same-origin replace navigation rather
+         than reload(), so supporting browsers can retain the old painted root
+         while the new bundle restores the chosen destination. Ordinary links,
+         auth redirects, and Back/Forward explicitly skip this opt-in below. -->
+    <style data-mobius-shell-reload-transition>
+      @view-transition { navigation: auto; }
+      @keyframes mobius-shell-reload-reveal {
+        from { opacity: 1; }
+        to { opacity: 0; }
+      }
+      html[data-shell-reload-transition]::view-transition-group(root) {
+        animation: none;
+      }
+      html[data-shell-reload-transition]::view-transition-old(root) {
+        animation: mobius-shell-reload-reveal 140ms ease-out both paused;
+      }
+      html[data-shell-reload-transition]::view-transition-new(root) {
+        animation: none;
+        opacity: 0;
+      }
+      html[data-shell-reload-transition][data-shell-reload-ready]::view-transition-old(root) {
+        animation-play-state: running;
+      }
+      @media (prefers-reduced-motion: reduce) {
+        html[data-shell-reload-transition]::view-transition-old(root) {
+          animation-duration: 1ms;
+        }
+      }
+    </style>
+    <script data-mobius-shell-reload-transition>(function () {
+      var root = document.documentElement;
+      function hasShellReload() {
+        try { return !!sessionStorage.getItem('shell-reload'); } catch (e) { return false; }
+      }
+      if (hasShellReload()) root.setAttribute('data-shell-reload-transition', 'incoming');
+
+      // The at-rule is document-wide, but only the controlled shell replacement
+      // may retain pixels. Every unrelated cross-document navigation keeps its
+      // ordinary browser semantics.
+      window.addEventListener('pageswap', function (event) {
+        if (!event.viewTransition) return;
+        if (hasShellReload()) {
+          // Mark the outgoing document before its root snapshot animates. The
+          // incoming document sets the same attribute above, so both halves of
+          // the cross-document transition share the controlled timing.
+          root.setAttribute('data-shell-reload-transition', 'outgoing');
+          return;
+        }
+        event.viewTransition.skipTransition();
+      });
+
+      // App releases this only after Shell reports a stable destination. The
+      // old root then fades directly to live React underneath; the static
+      // artwork-free theme cover never becomes the visible intermediate frame.
+      window.__mobiusReleaseShellReloadTransition = function () {
+        if (!root.hasAttribute('data-shell-reload-transition')) return;
+        root.setAttribute('data-shell-reload-ready', '');
+        setTimeout(function () {
+          root.removeAttribute('data-shell-reload-transition');
+          root.removeAttribute('data-shell-reload-ready');
+        }, 500);
+      };
+    })();</script>
   </head>
   <!-- Theme bg comes from var(--bg), set by the pre-paint script above. -->
   <body style="margin:0;background:var(--bg,#0d0d0d)">
@@ -215,6 +278,9 @@
             '. If it still won’t load, open Recovery from your deployment control panel.',
           )
           document.body.appendChild(d)
+          if (window.__mobiusReleaseShellReloadTransition) {
+            window.__mobiusReleaseShellReloadTransition()
+          }
         }
       }, 8000)
     </script>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -13,6 +13,7 @@ import { startInstallPromptCapture } from './lib/installPrompt.js'
 import { readInstallPass, withoutInstallPass } from './lib/installPassUrl.js'
 import { safeReturnPath } from './lib/safeReturnPath.js'
 import { readStandaloneBoot } from './lib/standaloneBoot.js'
+import { shellReloadNavigationTransitionIsActive } from './lib/shellReloadNavigationTransition.js'
 
 // These flows are mutually exclusive. Keep setup, login, the full shell, and
 // the opaque embed out of one another's startup path; first boot should not
@@ -365,8 +366,8 @@ function StartupError({ title, message, retrying = false, onRetry }) {
 
 function removeSplash() {
   const splash = document.getElementById('splash')
-  const shellReloadTransition = document.documentElement.hasAttribute(
-    'data-shell-reload-transition',
+  const shellReloadTransition = shellReloadNavigationTransitionIsActive(
+    document.documentElement,
   )
   if (shellReloadTransition) {
     // The outgoing document is still the visible view-transition layer. Drop

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -365,6 +365,17 @@ function StartupError({ title, message, retrying = false, onRetry }) {
 
 function removeSplash() {
   const splash = document.getElementById('splash')
+  const shellReloadTransition = document.documentElement.hasAttribute(
+    'data-shell-reload-transition',
+  )
+  if (shellReloadTransition) {
+    // The outgoing document is still the visible view-transition layer. Drop
+    // the incoming static cover before releasing that layer, so it fades
+    // directly onto Shell's stable destination instead of a blank theme frame.
+    splash?.remove()
+    window.__mobiusReleaseShellReloadTransition?.()
+    return
+  }
   if (splash) {
     // Drop pointer-events as we start the fade: the overlay is fixed at
     // z-index 9999 over the whole viewport and lingers ~400ms after opacity

--- a/frontend/src/components/Shell/__tests__/shellReloadController.test.js
+++ b/frontend/src/components/Shell/__tests__/shellReloadController.test.js
@@ -6,6 +6,66 @@ import useShellReloadController, {
 } from '../useShellReloadController.js'
 import { renderHook } from '../../ChatView/hooks/__tests__/react-hook-shim.mjs'
 
+
+const tick = () => new Promise(resolve => setImmediate(resolve))
+
+function controllerHarness() {
+  const ref = current => ({ current })
+  const winListeners = new Map()
+  const replacements = []
+  const stored = new Map()
+  let scheduledChecks = 0
+  const doc = {
+    activeElement: null,
+    visibilityState: 'visible',
+    addEventListener() {},
+    removeEventListener() {},
+  }
+  const win = {
+    Event: class Event { constructor(type) { this.type = type } },
+    addEventListener(type, fn) {
+      if (!winListeners.has(type)) winListeners.set(type, new Set())
+      winListeners.get(type).add(fn)
+    },
+    removeEventListener(type, fn) { winListeners.get(type)?.delete(fn) },
+    emit(type) { for (const fn of winListeners.get(type) || []) fn() },
+    clearTimeout() {},
+    setTimeout() { scheduledChecks += 1; return scheduledChecks },
+    dispatchEvent() {},
+    location: { replace(url) { replacements.push(url) } },
+  }
+  return {
+    win,
+    inputs: {
+      win,
+      doc,
+      nav: { onLine: true, serviceWorker: { getRegistration: async () => null } },
+      storage: {
+        getItem: key => stored.get(key) ?? null,
+        setItem: (key, value) => { stored.set(key, String(value)) },
+        removeItem: key => { stored.delete(key) },
+      },
+      queryClient: {
+        getMutationCache: () => ({ getAll: () => [] }),
+        getQueryCache: () => ({ getAll: () => [] }),
+      },
+      persistWorkspaceSnapshot() {},
+      workspaceStateRef: ref({ ws: paneModel.seedFromFlatTabs([]) }),
+      activeViewRef: ref('settings'),
+      activeChatIdRef: ref(null),
+      drawerOpenRef: ref(false),
+      multiPaneBuilderVisibleRef: ref(false),
+      streamingChatIdsRef: ref(new Set()),
+      voiceDictationActiveRef: ref(false),
+      activeView: 'settings',
+      activeChatId: null,
+      multiPaneBuilderVisible: false,
+    },
+    replacements,
+    stored,
+  }
+}
+
 test('reload snapshot derives content from the current workspace authority', () => {
   // In single mode the reload authority is the Standard SLOT (never the focused
   // Builder pane). The slot app is the reload surface; the tree chat is irrelevant.
@@ -95,7 +155,7 @@ test('an in-flight passive reload does not swallow disruptive chat navigation', 
     clearTimeout() {},
     setTimeout() { return 1 },
     dispatchEvent() {},
-    location: { reload() {} },
+    location: { replace() {} },
   }
   const doc = {
     activeElement: null,
@@ -132,4 +192,63 @@ test('an in-flight passive reload does not swallow disruptive chat navigation', 
   assert.equal(result.current.claimPendingShellReloadNavigation({
     view: 'chat', chatId: 'next', appId: null,
   }), false)
+})
+
+
+test('a fresh press holds an old pending apply until its destination is claimed', async () => {
+  const previousHistory = globalThis.history
+  const previousNow = Date.now
+  globalThis.history = { state: null, replaceState() {} }
+  let now = 1000
+  Date.now = () => now
+  try {
+    const harness = controllerHarness()
+    const { result } = renderHook(useShellReloadController, harness.inputs)
+
+    harness.win.emit('input')
+    result.current.requestShellReload()
+    now = 8000
+
+    harness.win.emit('pointerdown')
+    result.current.checkPendingShellReload()
+    await tick()
+    assert.equal(harness.replacements.length, 0)
+
+    assert.equal(result.current.claimPendingShellReloadNavigation({
+      view: 'chat', chatId: 'chosen-chat', appId: null,
+    }), true)
+    await tick()
+    await tick()
+
+    assert.deepEqual(harness.replacements, ['/shell/'])
+    assert.equal(JSON.parse(harness.stored.get('shell-reload')).activeChatId, 'chosen-chat')
+  } finally {
+    Date.now = previousNow
+    globalThis.history = previousHistory
+  }
+})
+
+test('an expired non-navigation interaction cannot starve an old pending apply', async () => {
+  const previousHistory = globalThis.history
+  const previousNow = Date.now
+  globalThis.history = { state: null, replaceState() {} }
+  let now = 1000
+  Date.now = () => now
+  try {
+    const harness = controllerHarness()
+    const { result } = renderHook(useShellReloadController, harness.inputs)
+
+    harness.win.emit('input')
+    result.current.requestShellReload()
+    now = 8000
+    result.current.checkPendingShellReload()
+    await tick()
+    await tick()
+    await tick()
+
+    assert.deepEqual(harness.replacements, ['/shell/'])
+  } finally {
+    Date.now = previousNow
+    globalThis.history = previousHistory
+  }
 })

--- a/frontend/src/components/Shell/__tests__/shellReloadController.test.js
+++ b/frontend/src/components/Shell/__tests__/shellReloadController.test.js
@@ -121,6 +121,7 @@ test('a claimed Settings destination is serialized before the outgoing view pain
     drawerOpen: true,
     destination: { view: 'settings', chatId: 'kept', appId: null },
   }), {
+    destinationClaimed: true,
     activeView: 'settings',
     activeAppId: null,
     activeChatId: 'kept',
@@ -139,6 +140,7 @@ test('a claimed content destination becomes the reload route', () => {
       view: 'chat', chatId: 'new', appId: null,
     },
   }), {
+    destinationClaimed: true,
     activeView: 'chat',
     activeAppId: null,
     activeChatId: 'new',

--- a/frontend/src/components/Shell/useShellReloadController.js
+++ b/frontend/src/components/Shell/useShellReloadController.js
@@ -27,6 +27,7 @@ export function deriveShellReloadState({
   const destinationView = destination?.view
   const destinationIsSettings = destinationView === 'settings'
   return {
+    ...(destination ? { destinationClaimed: true } : {}),
     activeView: destinationIsSettings
       ? 'settings'
       : (destinationView || (activeView === 'settings' ? 'settings' : content.view)),

--- a/frontend/src/components/Shell/useShellReloadController.js
+++ b/frontend/src/components/Shell/useShellReloadController.js
@@ -6,7 +6,10 @@ import {
   flushPersistedQueryCache,
 } from '../../queryClient.js'
 import * as paneModel from './paneModel.js'
-import { shouldDeferShellReload } from './shellReloadPolicy.js'
+import {
+  RECENT_SHELL_INTERACTION_MS,
+  shouldDeferShellReload,
+} from './shellReloadPolicy.js'
 import {
   inspectShellUpdate,
   releaseWaitingShellUpdate,
@@ -51,6 +54,7 @@ export default function useShellReloadController(inputs) {
   const passiveRef = useRef(false)
   const timerRef = useRef(null)
   const lastInteractionAtRef = useRef(0)
+  const lastNavigationGestureAtRef = useRef(0)
   const heldSinceRef = useRef(0)
   const performingRef = useRef(false)
   const performingPassiveRef = useRef(false)
@@ -71,6 +75,12 @@ export default function useShellReloadController(inputs) {
   function interactionGraceSpent() {
     return heldSinceRef.current > 0
       && Date.now() - heldSinceRef.current >= RECHECK_MS
+  }
+
+  function navigationGestureInProgress() {
+    const startedAt = lastNavigationGestureAtRef.current
+    return startedAt > 0
+      && Date.now() - startedAt < RECENT_SHELL_INTERACTION_MS
   }
 
   function hasStableVisibleHold(passive) {
@@ -103,7 +113,8 @@ export default function useShellReloadController(inputs) {
       streamingChatIds: streamingChatIdsRef.current,
       passiveRebuild: passive,
       voiceDictationActive: voiceDictationActiveRef.current,
-      lastUserInteractionAt: ignoreRecentInteraction || interactionGraceSpent()
+      lastUserInteractionAt: ignoreRecentInteraction
+        || (interactionGraceSpent() && !navigationGestureInProgress())
         ? 0
         : lastInteractionAtRef.current,
       visibilityState: doc.visibilityState,
@@ -196,7 +207,11 @@ export default function useShellReloadController(inputs) {
         destination: destinationRef.current,
       })))
       replaceNavEntry('base', '/shell/')
-      win.location.reload()
+      // A same-origin replacement keeps this history position while allowing
+      // supporting browsers to retain the outgoing pixels until the incoming
+      // shell reports its destination ready. Reload is excluded from
+      // cross-document view transitions.
+      win.location.replace('/shell/')
     }
     // Release the worker, but never wait for its activation to make the
     // navigation fresh. Online shell navigation owns freshness; activation
@@ -257,7 +272,12 @@ export default function useShellReloadController(inputs) {
 
   useEffect(() => {
     const { win, doc } = inputsRef.current
-    const record = () => { lastInteractionAtRef.current = Date.now() }
+    const recordInteraction = () => { lastInteractionAtRef.current = Date.now() }
+    const recordNavigationGesture = () => {
+      const now = Date.now()
+      lastInteractionAtRef.current = now
+      lastNavigationGestureAtRef.current = now
+    }
     const releaseWhenHidden = () => {
       if (doc.visibilityState === 'hidden') checkPendingImpl()
     }
@@ -270,16 +290,16 @@ export default function useShellReloadController(inputs) {
     // a keydown, all of which are still recorded, and typing is separately
     // protected by hasProtectedEditingContent.
     const opts = { capture: true, passive: true }
-    win.addEventListener('pointerdown', record, opts)
-    win.addEventListener('touchstart', record, opts)
-    win.addEventListener('keydown', record, opts)
-    win.addEventListener('input', record, opts)
+    win.addEventListener('pointerdown', recordNavigationGesture, opts)
+    win.addEventListener('touchstart', recordNavigationGesture, opts)
+    win.addEventListener('keydown', recordNavigationGesture, opts)
+    win.addEventListener('input', recordInteraction, opts)
     doc.addEventListener('visibilitychange', releaseWhenHidden)
     return () => {
-      win.removeEventListener('pointerdown', record, opts)
-      win.removeEventListener('touchstart', record, opts)
-      win.removeEventListener('keydown', record, opts)
-      win.removeEventListener('input', record, opts)
+      win.removeEventListener('pointerdown', recordNavigationGesture, opts)
+      win.removeEventListener('touchstart', recordNavigationGesture, opts)
+      win.removeEventListener('keydown', recordNavigationGesture, opts)
+      win.removeEventListener('input', recordInteraction, opts)
       doc.removeEventListener('visibilitychange', releaseWhenHidden)
       if (timerRef.current) win.clearTimeout(timerRef.current)
     }

--- a/frontend/src/components/Shell/useShellReloadController.js
+++ b/frontend/src/components/Shell/useShellReloadController.js
@@ -211,6 +211,7 @@ export default function useShellReloadController(inputs) {
       // supporting browsers to retain the outgoing pixels until the incoming
       // shell reports its destination ready. Reload is excluded from
       // cross-document view transitions.
+      win.__mobiusPrepareShellReloadTransition?.()
       win.location.replace('/shell/')
     }
     // Release the worker, but never wait for its activation to make the

--- a/frontend/src/hooks/useNavigation.js
+++ b/frontend/src/hooks/useNavigation.js
@@ -1185,7 +1185,48 @@ export default function useNavigation({
         }
         bootPaneId = workspaceStateRef.current.ws.focusedPaneId
       }
-      if (deepLink?.view === 'canvas' && Number.isFinite(deepLink.appId)) {
+      const claimedReloadDestination = shellReload?.destinationClaimed
+        ? {
+            view: shellReload.activeView,
+            appId: shellReload.activeAppId ?? null,
+            chatId: shellReload.activeChatId ?? null,
+          }
+        : null
+      if (claimedReloadDestination) {
+        if (
+          claimedReloadDestination.view === 'canvas'
+          && Number.isFinite(claimedReloadDestination.appId)
+        ) {
+          bootDeepLink(
+            {
+              view: 'canvas',
+              appId: claimedReloadDestination.appId,
+              chatId: null,
+              paneId: bootPaneId,
+            },
+            tabModel.makeTab('app', claimedReloadDestination.appId),
+          )
+        } else if (
+          claimedReloadDestination.view === 'chat'
+          && claimedReloadDestination.chatId
+        ) {
+          bootDeepLink(
+            {
+              view: 'chat',
+              chatId: claimedReloadDestination.chatId,
+              appId: null,
+              paneId: bootPaneId,
+            },
+            tabModel.makeTab('chat', claimedReloadDestination.chatId),
+          )
+        } else if (
+          claimedReloadDestination.view === 'settings'
+          && workspaceStateRef.current.ws.viewMode === 'panes'
+        ) {
+          applySettingsDestination(bootPaneId)
+          bootPaneId = workspaceStateRef.current.ws.focusedPaneId
+        }
+      } else if (deepLink?.view === 'canvas' && Number.isFinite(deepLink.appId)) {
         bootDeepLink(
           { view: 'canvas', appId: deepLink.appId, chatId: null, paneId: bootPaneId },
           tabModel.makeTab('app', deepLink.appId),

--- a/frontend/src/lib/__tests__/shellReloadNavigationTransition.test.js
+++ b/frontend/src/lib/__tests__/shellReloadNavigationTransition.test.js
@@ -1,0 +1,44 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  shellReloadNavigationTransitionIsActive,
+  supportsShellReloadNavigationTransition,
+} from '../shellReloadNavigationTransition.js'
+
+const supportedWindow = { onpageswap: null }
+const supportedDocument = { startViewTransition() {} }
+
+test('shell reload navigation transitions require cross-document browser support', () => {
+  assert.equal(
+    supportsShellReloadNavigationTransition(supportedWindow, supportedDocument),
+    true,
+  )
+  assert.equal(supportsShellReloadNavigationTransition({}, supportedDocument), false)
+  assert.equal(supportsShellReloadNavigationTransition(supportedWindow, {}), false)
+})
+
+test('the splash bypasses its fade only while a supported transition is active', () => {
+  const activeRoot = { hasAttribute: () => true }
+  const inactiveRoot = { hasAttribute: () => false }
+  assert.equal(
+    shellReloadNavigationTransitionIsActive(
+      activeRoot,
+      supportedWindow,
+      supportedDocument,
+    ),
+    true,
+  )
+  assert.equal(
+    shellReloadNavigationTransitionIsActive(activeRoot, {}, supportedDocument),
+    false,
+  )
+  assert.equal(
+    shellReloadNavigationTransitionIsActive(
+      inactiveRoot,
+      supportedWindow,
+      supportedDocument,
+    ),
+    false,
+  )
+})

--- a/frontend/src/lib/shellReloadNavigationTransition.js
+++ b/frontend/src/lib/shellReloadNavigationTransition.js
@@ -1,0 +1,17 @@
+export function supportsShellReloadNavigationTransition(
+  windowValue = globalThis.window,
+  documentValue = globalThis.document,
+) {
+  return typeof documentValue?.startViewTransition === 'function'
+    && !!windowValue
+    && 'onpageswap' in windowValue
+}
+
+export function shellReloadNavigationTransitionIsActive(
+  root,
+  windowValue = globalThis.window,
+  documentValue = globalThis.document,
+) {
+  return root?.hasAttribute?.('data-shell-reload-transition') === true
+    && supportsShellReloadNavigationTransition(windowValue, documentValue)
+}

--- a/tests/shell-update-idle.spec.mjs
+++ b/tests/shell-update-idle.spec.mjs
@@ -428,16 +428,21 @@ test.describe('shell update — apply on idle, SW on a leash', () => {
     // owned fixtures as populated instead of depending on incidental account
     // history.
     const visibleFixtures = new Map(
-      [target, current].map(chat => [String(chat.id), chat]),
+      [target, current].map((chat, index) => [String(chat.id), {
+        ...chat,
+        // Drawer recents deliberately re-sort API rows by activity. Give only
+        // these owned fixtures deterministic leading recency so a busy shared
+        // test account cannot virtualize the navigation target away.
+        activity_at: `9999-01-01T00:00:0${2 - index}`,
+      }]),
     )
     await page.route(/\/api\/chats(?:\?.*)?$/, async route => {
       if (route.request().method() !== 'GET') return route.fallback()
       const response = await route.fetch()
       const chats = await response.json()
-      // The drawer intentionally renders only the leading recents. Keep these
-      // two owned fixtures at the front even when a lifecycle refetch omits
-      // the empty server rows; appending them behind a busy account's history
-      // leaves valid fixtures outside the rendered recent window.
+      // A lifecycle refetch may omit empty fixtures entirely. Reinsert only
+      // this test's owned rows; their owned activity stamps above keep them in
+      // the drawer's leading virtualized window after its intentional sort.
       const visibleChats = [
         ...[...visibleFixtures.values()].map(chat => ({ ...chat, has_messages: true })),
         ...chats.filter(chat => !visibleFixtures.has(String(chat.id))),

--- a/tests/shell-update-idle.spec.mjs
+++ b/tests/shell-update-idle.spec.mjs
@@ -168,6 +168,33 @@ async function sendMessage(page, text) {
 }
 
 test.describe('shell update — apply on idle, SW on a leash', () => {
+  test('ordinary same-origin reload skips the document-wide view transition', async ({ page }) => {
+    await setup(page, {
+      streamRoute: route => route.fulfill(fulfillStream(sse([{ type: 'done' }]))),
+      systemBody: sse([{ type: 'system_stream_open' }]),
+    })
+    await page.evaluate(() => {
+      sessionStorage.removeItem('shell-reload')
+      sessionStorage.removeItem('__ordinary_navigation_transition')
+      window.addEventListener('pageswap', event => {
+        if (!event.viewTransition) {
+          sessionStorage.setItem('__ordinary_navigation_transition', 'unsupported')
+          return
+        }
+        event.viewTransition.ready.then(
+          () => sessionStorage.setItem('__ordinary_navigation_transition', 'retained'),
+          () => sessionStorage.setItem('__ordinary_navigation_transition', 'skipped'),
+        )
+      }, { once: true })
+    })
+
+    await page.reload({ waitUntil: 'domcontentloaded' })
+    await page.waitForFunction(() => (
+      sessionStorage.getItem('__ordinary_navigation_transition') === 'skipped'
+    ))
+    await expect(page.locator('html[data-shell-reload-transition]')).toHaveCount(0)
+  })
+
   test('an unfinished question turn survives a hidden-page shell update', async ({ page }) => {
     // The chat stream parks on a question without `done`, so the active turn
     // remains unfinished. shell_rebuilt arrives on the GLOBAL system stream,

--- a/tests/shell-update-idle.spec.mjs
+++ b/tests/shell-update-idle.spec.mjs
@@ -482,13 +482,16 @@ test.describe('shell update — apply on idle, SW on a leash', () => {
     await page.waitForTimeout(7000)
     expect(await loadCount(page)).toBe(0)
 
-    await page.evaluate(() => {
+    await targetRow.evaluate(element => {
       Object.defineProperty(document, 'visibilityState', {
         configurable: true,
         value: 'visible',
       })
       document.dispatchEvent(new Event('visibilitychange'))
-      document.documentElement.dispatchEvent(new PointerEvent('pointerdown', {
+      // Use the actual navigation target for the fresh press. Dispatching on
+      // the document root is an outside press and correctly dismisses the
+      // mobile drawer before the paired click can supply its destination.
+      element.dispatchEvent(new PointerEvent('pointerdown', {
         bubbles: true,
         pointerType: 'touch',
       }))

--- a/tests/shell-update-idle.spec.mjs
+++ b/tests/shell-update-idle.spec.mjs
@@ -168,7 +168,7 @@ async function sendMessage(page, text) {
 }
 
 test.describe('shell update — apply on idle, SW on a leash', () => {
-  test('ordinary same-origin reload skips the document-wide view transition', async ({ page }) => {
+  test('ordinary same-origin reload never opts into a document transition', async ({ page }) => {
     await setup(page, {
       streamRoute: route => route.fulfill(fulfillStream(sse([{ type: 'done' }]))),
       systemBody: sse([{ type: 'system_stream_open' }]),
@@ -190,8 +190,9 @@ test.describe('shell update — apply on idle, SW on a leash', () => {
 
     await page.reload({ waitUntil: 'domcontentloaded' })
     await page.waitForFunction(() => (
-      sessionStorage.getItem('__ordinary_navigation_transition') === 'skipped'
+      sessionStorage.getItem('__ordinary_navigation_transition') === 'unsupported'
     ))
+    await expect(page.locator('style[data-mobius-shell-navigation-opt-in]')).toHaveCount(0)
     await expect(page.locator('html[data-shell-reload-transition]')).toHaveCount(0)
   })
 

--- a/tests/shell-update-idle.spec.mjs
+++ b/tests/shell-update-idle.spec.mjs
@@ -434,16 +434,14 @@ test.describe('shell update — apply on idle, SW on a leash', () => {
       if (route.request().method() !== 'GET') return route.fallback()
       const response = await route.fetch()
       const chats = await response.json()
-      const visibleChats = chats.map(chat => visibleFixtures.has(String(chat.id))
-        ? { ...chat, has_messages: true }
-        : chat)
-      const returnedIds = new Set(visibleChats.map(chat => String(chat.id)))
-      for (const [id, chat] of visibleFixtures) {
-        // A lifecycle refetch may ask the production recent-chat query, which
-        // intentionally omits empty chats. Reinsert only this test's owned
-        // fixtures so the drawer target remains stable across that refresh.
-        if (!returnedIds.has(id)) visibleChats.push({ ...chat, has_messages: true })
-      }
+      // The drawer intentionally renders only the leading recents. Keep these
+      // two owned fixtures at the front even when a lifecycle refetch omits
+      // the empty server rows; appending them behind a busy account's history
+      // leaves valid fixtures outside the rendered recent window.
+      const visibleChats = [
+        ...[...visibleFixtures.values()].map(chat => ({ ...chat, has_messages: true })),
+        ...chats.filter(chat => !visibleFixtures.has(String(chat.id))),
+      ]
       await route.fulfill({
         response,
         json: visibleChats,

--- a/tests/shell-update-idle.spec.mjs
+++ b/tests/shell-update-idle.spec.mjs
@@ -385,6 +385,95 @@ test.describe('shell update — apply on idle, SW on a leash', () => {
     )
   })
 
+  test('an aged apply and the next chat press share one painted destination handoff', async ({ page }) => {
+    let armApply
+    const armed = new Promise(resolve => { armApply = resolve })
+    await setup(page, {
+      streamRoute: route => route.fulfill(fulfillStream(sse([{ type: 'done' }]))),
+      systemRoute: oneShotSystemEventRoute('shell_apply_now', armed),
+    })
+    const target = await createTaggedChat(page, 'handoff-target')
+    const current = await createTaggedChat(page, 'handoff-current')
+    await page.goto(`${BASE}/shell/?chat=${current.id}`, { waitUntil: 'domcontentloaded' })
+    await expect(page.locator(`[data-chat-id="${current.id}"][data-chat-surface="painted"]`)).toBeVisible({ timeout: 8000 })
+    await resetLoadCount(page)
+
+    await page.getByRole('button', { name: 'Toggle navigation' }).click()
+    const targetRow = page.locator(`[data-drawer-key="chat:${target.id}"]`)
+    await expect(targetRow).toBeVisible()
+
+    // Hold worker inspection so the test can place a fresh pointerdown inside
+    // the exact async gap that used to commit the old route before click.
+    await page.evaluate(() => {
+      const container = navigator.serviceWorker
+      let releaseInspection
+      const inspectionGate = new Promise(resolve => { releaseInspection = resolve })
+      const original = container.getRegistration.bind(container)
+      Object.defineProperty(container, 'getRegistration', {
+        configurable: true,
+        value: async () => {
+          await inspectionGate
+          return original()
+        },
+      })
+      window.__releaseShellInspection = releaseInspection
+      window.addEventListener('mobius:before-shell-reload', () => {
+        sessionStorage.setItem('__before_shell_reload_seen', '1')
+      })
+      window.addEventListener('pageswap', event => {
+        sessionStorage.setItem(
+          '__shell_reload_view_transition',
+          event.viewTransition ? 'yes' : 'no',
+        )
+      }, { once: true })
+      Object.defineProperty(document, 'visibilityState', {
+        configurable: true,
+        value: 'hidden',
+      })
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+
+    armApply()
+    await page.waitForTimeout(7000)
+    expect(await loadCount(page)).toBe(0)
+
+    await page.evaluate(() => {
+      Object.defineProperty(document, 'visibilityState', {
+        configurable: true,
+        value: 'visible',
+      })
+      document.dispatchEvent(new Event('visibilitychange'))
+      document.documentElement.dispatchEvent(new PointerEvent('pointerdown', {
+        bubbles: true,
+        pointerType: 'touch',
+      }))
+      window.__releaseShellInspection()
+    })
+    await page.waitForFunction(
+      () => sessionStorage.getItem('__before_shell_reload_seen') === '1',
+      { timeout: 3000 },
+    )
+    // Let the first apply reach its final safety check. The press keeps it in
+    // this document; the click below then supplies the destination atomically.
+    await page.waitForTimeout(100)
+    expect(await loadCount(page)).toBe(0)
+
+    await targetRow.evaluate(element => element.click())
+    await page.waitForFunction(
+      () => Number(sessionStorage.getItem('__load_count') || '0') === 1,
+      { timeout: 8000 },
+    )
+    await expect(page.locator(
+      `[data-chat-id="${target.id}"][data-chat-surface="painted"]`,
+    )).toBeVisible({ timeout: 8000 })
+    expect(await page.evaluate(() => (
+      sessionStorage.getItem('__shell_reload_view_transition')
+    ))).toBe('yes')
+    await page.waitForTimeout(700)
+    expect(await page.locator('html[data-shell-reload-transition]').count()).toBe(0)
+    expect(await loadCount(page)).toBe(1)
+  })
+
   test('shell_apply_now on the global system stream while idle applies immediately', async ({ page }) => {
     // No turn is streaming; the global system stream delivers shell_apply_now at
     // load. Idle → immediate apply → one reload. Loop prevention is single

--- a/tests/shell-update-idle.spec.mjs
+++ b/tests/shell-update-idle.spec.mjs
@@ -434,14 +434,20 @@ test.describe('shell update — apply on idle, SW on a leash', () => {
       ...chat,
       has_messages: true,
     }))
-    await page.route(/\/api\/chats(?:\?.*)?$/, async route => {
-      if (route.request().method() !== 'GET') return route.fallback()
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        json: visibleFixtures,
-      })
-    })
+    await page.addInitScript(fixtures => {
+      const realFetch = window.fetch.bind(window)
+      window.fetch = (input, init) => {
+        const url = new URL(String(input?.url || input), window.location.href)
+        const method = String(init?.method || input?.method || 'GET').toUpperCase()
+        if (method === 'GET' && url.pathname === '/api/chats') {
+          return Promise.resolve(new Response(JSON.stringify(fixtures), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }))
+        }
+        return realFetch(input, init)
+      }
+    }, visibleFixtures)
     await page.goto(`${BASE}/shell/?chat=${current.id}`, { waitUntil: 'domcontentloaded' })
     await expect(page.locator(`[data-chat-id="${current.id}"][data-chat-surface="painted"]`)).toBeVisible({ timeout: 8000 })
     await resetLoadCount(page)

--- a/tests/shell-update-idle.spec.mjs
+++ b/tests/shell-update-idle.spec.mjs
@@ -427,29 +427,19 @@ test.describe('shell update — apply on idle, SW on a leash', () => {
     // rows because it exercises a real drawer press, so expose only these
     // owned fixtures as populated instead of depending on incidental account
     // history.
-    const visibleFixtures = new Map(
-      [target, current].map((chat, index) => [String(chat.id), {
-        ...chat,
-        // Drawer recents deliberately re-sort API rows by activity. Give only
-        // these owned fixtures deterministic leading recency so a busy shared
-        // test account cannot virtualize the navigation target away.
-        activity_at: `9999-01-01T00:00:0${2 - index}`,
-      }]),
-    )
+    // Own the complete list boundary for this page. Merging the shared CI
+    // account's concurrently changing chats makes this navigation contract
+    // depend on unrelated workers and the drawer's virtualization window.
+    const visibleFixtures = [target, current].map(chat => ({
+      ...chat,
+      has_messages: true,
+    }))
     await page.route(/\/api\/chats(?:\?.*)?$/, async route => {
       if (route.request().method() !== 'GET') return route.fallback()
-      const response = await route.fetch()
-      const chats = await response.json()
-      // A lifecycle refetch may omit empty fixtures entirely. Reinsert only
-      // this test's owned rows; their owned activity stamps above keep them in
-      // the drawer's leading virtualized window after its intentional sort.
-      const visibleChats = [
-        ...[...visibleFixtures.values()].map(chat => ({ ...chat, has_messages: true })),
-        ...chats.filter(chat => !visibleFixtures.has(String(chat.id))),
-      ]
       await route.fulfill({
-        response,
-        json: visibleChats,
+        status: 200,
+        contentType: 'application/json',
+        json: visibleFixtures,
       })
     })
     await page.goto(`${BASE}/shell/?chat=${current.id}`, { waitUntil: 'domcontentloaded' })

--- a/tests/shell-update-idle.spec.mjs
+++ b/tests/shell-update-idle.spec.mjs
@@ -427,16 +427,26 @@ test.describe('shell update — apply on idle, SW on a leash', () => {
     // rows because it exercises a real drawer press, so expose only these
     // owned fixtures as populated instead of depending on incidental account
     // history.
-    const visibleIds = new Set([target.id, current.id].map(String))
+    const visibleFixtures = new Map(
+      [target, current].map(chat => [String(chat.id), chat]),
+    )
     await page.route(/\/api\/chats(?:\?.*)?$/, async route => {
       if (route.request().method() !== 'GET') return route.fallback()
       const response = await route.fetch()
       const chats = await response.json()
+      const visibleChats = chats.map(chat => visibleFixtures.has(String(chat.id))
+        ? { ...chat, has_messages: true }
+        : chat)
+      const returnedIds = new Set(visibleChats.map(chat => String(chat.id)))
+      for (const [id, chat] of visibleFixtures) {
+        // A lifecycle refetch may ask the production recent-chat query, which
+        // intentionally omits empty chats. Reinsert only this test's owned
+        // fixtures so the drawer target remains stable across that refresh.
+        if (!returnedIds.has(id)) visibleChats.push({ ...chat, has_messages: true })
+      }
       await route.fulfill({
         response,
-        json: chats.map(chat => visibleIds.has(String(chat.id))
-          ? { ...chat, has_messages: true }
-          : chat),
+        json: visibleChats,
       })
     })
     await page.goto(`${BASE}/shell/?chat=${current.id}`, { waitUntil: 'domcontentloaded' })

--- a/tests/shell-update-idle.spec.mjs
+++ b/tests/shell-update-idle.spec.mjs
@@ -422,6 +422,23 @@ test.describe('shell update — apply on idle, SW on a leash', () => {
     })
     const target = await createTaggedChat(page, 'handoff-target')
     const current = await createTaggedChat(page, 'handoff-current')
+    // API-created fixtures are intentionally empty, while the production
+    // drawer omits chats until their first message. This scenario needs both
+    // rows because it exercises a real drawer press, so expose only these
+    // owned fixtures as populated instead of depending on incidental account
+    // history.
+    const visibleIds = new Set([target.id, current.id].map(String))
+    await page.route(/\/api\/chats(?:\?.*)?$/, async route => {
+      if (route.request().method() !== 'GET') return route.fallback()
+      const response = await route.fetch()
+      const chats = await response.json()
+      await route.fulfill({
+        response,
+        json: chats.map(chat => visibleIds.has(String(chat.id))
+          ? { ...chat, has_messages: true }
+          : chat),
+      })
+    })
     await page.goto(`${BASE}/shell/?chat=${current.id}`, { waitUntil: 'domcontentloaded' })
     await expect(page.locator(`[data-chat-id="${current.id}"][data-chat-surface="painted"]`)).toBeVisible({ timeout: 8000 })
     await resetLoadCount(page)


### PR DESCRIPTION
## Summary
- keep a fresh pointer or keyboard navigation gesture authoritative even after an older shell apply has exhausted its generic interaction grace period
- commit the claimed destination through a same-origin replacement so supporting browsers can retain the outgoing painted shell
- release the retained pixels only after the incoming shell has restored its destination, with reduced-motion and startup-failure fallbacks

## Why
Follow-up to #760. An aged pending shell generation could pass its final safety check between a new pointer press and the matching destination click. The update then reopened the old route, making the owner’s navigation appear to vanish and briefly exposing the launch cover.

## Tests
- `npm test` — 2,627 library tests and 87 hook tests passed
- `npm run lint` — 0 errors (46 existing warnings)
- `npm run build`
- structural-test ratchet held at 779 cases
- added focused controller coverage plus a hosted-browser regression for the complete aged-apply → fresh press → restored destination path