### PR TITLE
Recognize Goal controls when uploads are attached

### DIFF
--- a/backend/app/chat.py
+++ b/backend/app/chat.py
@@ -73,6 +73,7 @@ from app.chat_logging import (
   get_logger as _get_logger,
   safe_commit as _safe_commit,
 )
+from app.goal_commands import is_goal_continue
 from app.chat_writer import (
   AppendPending,
   Barrier,
@@ -3977,7 +3978,7 @@ async def _run_chat_impl_with_db(
   goal_objective = _goal_objective(raw_user_message)
   goal_clear = _goal_clear_requested(raw_user_message)
   goal_mode = _chat_has_goal_intent(messages)
-  goal_continue = (raw_user_message or "").strip().lower() == "continue"
+  goal_continue = is_goal_continue(raw_user_message or "")
   question_checkpoint = None
   if settings.ensure_chat_note and chat_id:
     async def question_checkpoint() -> None:

--- a/backend/app/chat_context.py
+++ b/backend/app/chat_context.py
@@ -20,6 +20,7 @@ from app.goal_commands import (
   goal_argument as _goal_argument,
   goal_clear_requested as _goal_clear_requested,
   goal_objective as _goal_objective,
+  is_goal_continue,
   is_goal_command as _is_goal_command,
 )
 
@@ -517,7 +518,7 @@ def _latest_goal_objective(
     if message.role != "user":
       continue
     content = message.content or ""
-    if content.strip().lower() == "continue":
+    if is_goal_continue(content):
       continue
     if _goal_clear_requested(content):
       return None
@@ -532,7 +533,7 @@ def _latest_goal_objective(
 
 def _goal_resume_requested(chat_row, text: str) -> bool:
   """Whether this ``continue`` is a recovery action rather than ordinary prose."""
-  if (text or "").strip().lower() != "continue" or chat_row is None:
+  if not is_goal_continue(text) or chat_row is None:
     return False
   durable = list(chat_row.messages or [])
   if not durable:

--- a/backend/app/chat_log_redaction.py
+++ b/backend/app/chat_log_redaction.py
@@ -44,6 +44,7 @@ from app.continuations import (
   continuation_actor_label,
   is_continuation_message,
 )
+from app.chat_message_content import strip_upload_augmentation
 from app.secure_inputs import redact_reveal_markers
 
 # Per-excerpt char cap for the list view, and per-message char cap for
@@ -117,23 +118,6 @@ def scrub_secrets(text: str) -> str:
   for pattern, repl in _SECRET_PATTERNS:
     text = pattern.sub(repl, text)
   return text
-
-
-# The upload augmentation block appended to user content before storage
-# (chats_stream._content_with_uploads). Matches the literal opener
-# `[Files in this session:` through its closing bracket, across lines.
-# Stripped whole so absolute /data/ paths + filenames never reach an app.
-_UPLOAD_AUG_RE = re.compile(
-  r"\n*\[Files in this session:.*?\]", re.DOTALL
-)
-
-
-def strip_upload_augmentation(content: str) -> str:
-  """Removes the `[Files in this session: ...]` fs-path block from a
-  user message's stored content. No-op when absent."""
-  if not content:
-    return content
-  return _UPLOAD_AUG_RE.sub("", content).rstrip()
 
 
 def _assistant_text(blocks: list, content: str) -> str:

--- a/backend/app/chat_message_content.py
+++ b/backend/app/chat_message_content.py
@@ -1,0 +1,20 @@
+"""Pure helpers for server-added chat message content."""
+
+from __future__ import annotations
+
+import re
+
+
+# The send path appends this trusted block so providers can inspect uploads.
+# Product logic must reason about the owner's text without treating that hidden
+# transport context as part of a command or control word.
+_UPLOAD_AUGMENTATION_RE = re.compile(
+  r"\n*\[Files in this session:\n.*\]\s*$", re.DOTALL
+)
+
+
+def strip_upload_augmentation(content: str) -> str:
+  """Return stored user content without its server-added upload manifest."""
+  if not content:
+    return content
+  return _UPLOAD_AUGMENTATION_RE.sub("", content).rstrip()

--- a/backend/app/goal_commands.py
+++ b/backend/app/goal_commands.py
@@ -4,11 +4,18 @@ from __future__ import annotations
 
 import re
 
+from app.chat_message_content import strip_upload_augmentation
+
 
 def _goal_match(text: str) -> re.Match[str] | None:
   """Match the same complete command boundary used by native dispatch."""
-  normalized = (text or "").lstrip("\n")
+  normalized = strip_upload_augmentation(text or "").lstrip("\n")
   return re.fullmatch(r"/goal(?:\s+([\s\S]*))?", normalized)
+
+
+def is_goal_continue(text: str) -> bool:
+  """Whether owner-visible text is the Goal resume control word."""
+  return strip_upload_augmentation(text or "").strip().lower() == "continue"
 
 
 def is_goal_command(text: str) -> bool:

--- a/backend/app/run_state.py
+++ b/backend/app/run_state.py
@@ -14,6 +14,7 @@ import uuid
 from sqlalchemy.orm import Session
 
 from app import models
+from app.goal_commands import goal_objective, is_goal_continue
 
 
 def goal_identity_for_run_start(
@@ -22,11 +23,10 @@ def goal_identity_for_run_start(
   message: Mapping[str, Any] | None,
 ) -> tuple[str | None, str | None]:
   """Resolve objective + stable Goal identity before prior runs are closed."""
-  from app.chat_context import _goal_objective
   from app.continuations import is_continuation_message
 
   content = message.get("content") if message is not None else ""
-  objective = _goal_objective(content if isinstance(content, str) else "")
+  objective = goal_objective(content if isinstance(content, str) else "")
   if objective is not None:
     return objective, str(uuid.uuid4())
   from app.continuations import DELEGATION_RESULT_MESSAGE_KIND
@@ -72,7 +72,7 @@ def goal_identity_for_run_start(
     return None, None
   previous = latest_run(db, chat_id)
   semantic_continuation = is_continuation_message(message)
-  literal_continue = str(content or "").strip().lower() == "continue"
+  literal_continue = is_goal_continue(str(content or ""))
   if not semantic_continuation and not literal_continue:
     return None, None
   if (

--- a/backend/tests/test_chat_log_redaction.py
+++ b/backend/tests/test_chat_log_redaction.py
@@ -78,6 +78,16 @@ def test_strip_upload_augmentation_removes_fs_path_block():
   assert "/data/chats" not in stripped
 
 
+def test_strip_upload_augmentation_handles_brackets_in_filenames():
+  content = (
+    "summarize this\n\n"
+    "[Files in this session:\n"
+    "- chart[final].png → /data/chats/c/chart[final].png "
+    "(image/png, 9 KB)]"
+  )
+  assert r.strip_upload_augmentation(content) == "summarize this"
+
+
 def test_scrub_secrets_catches_jwt_key_and_bearer_shapes():
   assert "eyJ" not in r.scrub_secrets(
     "tok eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhIn0.SIGNATUREXYZ here"

--- a/backend/tests/test_goal_identity.py
+++ b/backend/tests/test_goal_identity.py
@@ -63,6 +63,31 @@ def test_plain_continue_keeps_a_completed_physical_run_with_unfinished_plan(
   ) == ("Ship it", "stable-goal")
 
 
+def test_plain_continue_with_upload_manifest_resumes_the_same_goal(db, chat):
+  db.add(models.ChatRun(
+    id="planned-upload-goal",
+    root_run_id="planned-upload-goal",
+    chat_id=chat.id,
+    status="completed",
+    provider="codex",
+    goal_objective="Ship it",
+    goal_id="stable-upload-goal",
+    goal_plan_json={
+      "tasks": [{"id": "prepare", "status": "pending"}],
+    },
+  ))
+  db.commit()
+
+  assert goal_identity_for_run_start(db, chat.id, {
+    "content": (
+      "continue\n\n"
+      "[Files in this session:\n"
+      "- image.png → /data/chats/example/uploads/image.png "
+      "(image/png, 257 KB)]"
+    ),
+  }) == ("Ship it", "stable-upload-goal")
+
+
 def test_semantic_recovery_skips_intervening_no_goal_run_for_unfinished_plan(
   db, chat,
 ):

--- a/backend/tests/test_time_context.py
+++ b/backend/tests/test_time_context.py
@@ -180,6 +180,28 @@ def test_goal_intent_and_latest_objective_scan_durable_history():
   assert _latest_goal_objective(changed_subject) is None
 
 
+def test_goal_controls_ignore_the_server_upload_manifest():
+  manifest = (
+    "\n\n[Files in this session:\n"
+    "- image.png → /data/chats/example/uploads/image.png "
+    "(image/png, 257 KB)]"
+  )
+  assert _goal_objective("/goal ship it" + manifest) == "ship it"
+  assert _chat_has_goal_intent([
+    schemas.ChatMessage(role="user", content="/goal ship it" + manifest),
+  ])
+  assert _goal_resume_requested(SimpleNamespace(messages=[
+    {"role": "user", "content": "continue" + manifest, "kind": "auto_continuation"},
+  ]), "continue" + manifest)
+
+  bracketed_name = (
+    "\n\n[Files in this session:\n"
+    "- chart[final].png → /data/chats/example/uploads/chart[final].png "
+    "(image/png, 257 KB)]"
+  )
+  assert _goal_objective("/goal ship it" + bracketed_name) == "ship it"
+
+
 def test_legacy_goal_migration_requires_a_durable_resume_intent():
   assert _goal_resume_requested(SimpleNamespace(messages=[
     {"role": "assistant", "blocks": [{"type": "error", "resumable": True}]},


### PR DESCRIPTION
## Summary
- parse `/goal` and `continue` from the owner-visible message rather than the server-added upload manifest
- share one pure upload-manifest stripping helper with chat log redaction
- cover both Goal identity and prompt-context paths with regression tests

## Why
Attaching a file appends a trusted transport block to the stored user message. Exact Goal control parsing treated that block as owner text, so `/goal …` and `continue` stopped behaving as controls whenever an upload was present.

## Tests
- `scripts/wt-pytest.sh tests/test_goal_identity.py tests/test_time_context.py tests/test_chat_log_redaction.py -q` — 35 passed
- `scripts/test.sh --fast` — 84 passed
- `python3 -m compileall -q backend/app`
- `git diff --check origin/main..HEAD`