### PR TITLE
Refetch chat transcript on foreground when the runtime version moved

### DIFF
--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -90,6 +90,7 @@ import {
   chatCacheEntryState,
   chatDetailCacheValue,
   chatSnapshotMatchesRuntime,
+  shouldRefetchTranscriptForRuntime,
   mergeRecentMessagesIntoLoadedWindow,
   messageKey,
   messageMatchesKey,
@@ -1191,6 +1192,21 @@ export default function ChatView({
           retireSettledStreamRef.current?.()
         }
         return
+      }
+      // A finalized reply can advance the durable transcript while this client
+      // holds a stale cache with no live turn to catch it up — a reply that
+      // landed while the tab was backgrounded, or one from another device. The
+      // mount path already trusts chatSnapshotMatchesRuntime to prove a cache
+      // current; reuse that same runtime read here so a foreground return that
+      // finds the version moved re-reads authoritatively instead of leaving the
+      // reply hidden until a full reload. A matching version does nothing.
+      if (shouldRefetchTranscriptForRuntime(
+        queryClient.getQueryData(chatMessagesQueryKey(chatId)),
+        data,
+        localAuthoritative,
+      )) {
+        await fetchMessages({ force: true, authoritative: true })
+        return runtime
       }
       if (data.running) {
         setSending(true)

--- a/frontend/src/components/ChatView/__tests__/chatDetailCache.test.js
+++ b/frontend/src/components/ChatView/__tests__/chatDetailCache.test.js
@@ -5,6 +5,7 @@ import {
   chatCacheEntryState,
   chatDetailCacheValue,
   chatSnapshotMatchesRuntime,
+  shouldRefetchTranscriptForRuntime,
   mergeRecentMessagesIntoLoadedWindow,
   messageKey,
   messageMatchesKey,
@@ -205,6 +206,22 @@ test('a retained snapshot requires both the row version and pending card', () =>
     updated_at,
     pending_question_id: 'question-2',
   }), false)
+})
+
+test('idle foreground reconciliation refetches only a disproven unowned snapshot', () => {
+  const cached = { updated_at: '2026-08-24T00:00:00Z', messages: [] }
+  const moved = { updated_at: '2026-08-24T00:00:01Z', running: false }
+  assert.equal(shouldRefetchTranscriptForRuntime(cached, moved), true)
+  assert.equal(shouldRefetchTranscriptForRuntime(cached, {
+    ...moved,
+    updated_at: cached.updated_at,
+  }), false, 'a matching durable version adds no transcript fetch')
+  assert.equal(shouldRefetchTranscriptForRuntime(cached, {
+    ...moved,
+    running: true,
+  }), false, 'an active runtime remains owned by the stream path')
+  assert.equal(shouldRefetchTranscriptForRuntime(cached, moved, true), false,
+    'an optimistic local turn cannot be overwritten by a foreground poll')
 })
 
 test('pending question lookup requires the exact unanswered owner row', () => {

--- a/frontend/src/lib/chatDetailCache.js
+++ b/frontend/src/lib/chatDetailCache.js
@@ -128,6 +128,19 @@ export function chatSnapshotMatchesRuntime(cached, runtime) {
     )
 }
 
+/** Decide whether an idle runtime read disproves the retained transcript.
+ * Live local work owns the surface until it settles; otherwise a missing or
+ * moved durable version requires the authoritative detail path. */
+export function shouldRefetchTranscriptForRuntime(
+  cached,
+  runtime,
+  localAuthoritative = false,
+) {
+  return !runtime?.running
+    && !localAuthoritative
+    && !chatSnapshotMatchesRuntime(cached, runtime)
+}
+
 export function chatDetailCacheValue(data = {}) {
   const sourceWindowValid = Array.isArray(data.messages)
     && Number.isInteger(data.offset)


### PR DESCRIPTION
## Problem
When the app returns to the foreground after being backgrounded (a mobile PWA resume, or switching back to the tab), an open but idle chat is never revalidated. If a reply was finalized while the app was away — or a message arrived from another device — the transcript keeps rendering the stale cached version and shows a blank gap where the reply belongs. It only appears after a full reload.

## Root cause
`refetchOnWindowFocus` is intentionally off for the query cache, and the stream-reconnect foreground handler only fires for an active turn. For an idle chat, nothing on foreground reconciles the transcript. `reconcileRuntimeState` does run on foreground and fetches the compact runtime version, but it only re-reads the transcript when this client had already observed the turn running and then settling. A reply that landed while the client never saw the turn falls through.

The mount path already uses `chatSnapshotMatchesRuntime` to decide whether a cached transcript is current; the foreground path just never applied that same check.

## Fix
Apply the existing `chatSnapshotMatchesRuntime` invariant at the foreground seam. When the runtime version no longer matches the cached transcript and no local turn owns the surface, re-read the transcript authoritatively. A matching version does nothing, so steady state adds no extra fetch. The decision is isolated in a small tested cache policy instead of being left as an untested component condition.

## Testing
- current-base focused cache-policy suite: 10 passed
- frontend library tests: 2,626 passed
- frontend hook tests: 87 passed
- structural-test ratchet: 779/779 cases
- ESLint: 0 errors (46 existing warnings, within the configured limit)