### PR TITLE
Test Möbius bot contribution relay (draft only)

### DIFF
--- a/backend/tests/fixtures/contribution_bot_relay_smoke.txt
+++ b/backend/tests/fixtures/contribution_bot_relay_smoke.txt
@@ -1,0 +1,1 @@
+Möbius contribution relay: bot-authored draft smoke fixture.


### PR DESCRIPTION
Draft-only end-to-end test of the Möbius launcher contribution relay against the configured test fork. This adds one disposable source fixture to verify one-use capability minting, request-bound submission, status polling, and draft enforcement. It is not intended to merge.