### PR TITLE
Start new chats on the last-selected model's provider

### DIFF
--- a/backend/app/providers.py
+++ b/backend/app/providers.py
@@ -779,6 +779,40 @@ def resolve_default_provider(
   return provider_id
 
 
+def provider_of_model(model: str | None) -> str | None:
+  """The provider a model id belongs to, or None for unknown/blank ids."""
+  if not isinstance(model, str) or not model:
+    return None
+  for provider_id, model_ids in KNOWN_MODELS.items():
+    if model in model_ids:
+      return provider_id
+  return None
+
+
+def default_provider_for_new_chat(
+  data_dir: str,
+  configured_provider: str | None = None,
+) -> str:
+  """Provider a NEW chat should start on.
+
+  There is no separate provider selection in the UI — the owner picks a model,
+  and the provider is implied by it. `Owner.provider` and the global default
+  `model` are two independent last-writer-wins cells, so when several chats run
+  at once they drift apart (one chat's provider write + another chat's model
+  write) and a new chat could be born on a provider whose remembered model
+  belongs to the OTHER family — resolving to no model at all.
+
+  Make provider follow the single source of truth the picker writes: the last
+  selected model. Only when no model has been remembered yet (the genuine first
+  run) do we fall back to the stored provider, and the picker prompts.
+  """
+  model = _load_agent_settings(data_dir).get("model")
+  prov = provider_of_model(model)
+  if prov is not None and prov in PROVIDERS:
+    return prov
+  return resolve_default_provider(data_dir, configured_provider)
+
+
 def get_provider(provider_id: str | None = None) -> BaseProvider:
   """Returns a provider by ID, falling back to the default."""
   return PROVIDERS.get(provider_id or DEFAULT_PROVIDER, PROVIDERS[DEFAULT_PROVIDER])

--- a/backend/app/routes/chats.py
+++ b/backend/app/routes/chats.py
@@ -873,7 +873,11 @@ def create_chat(
 
   owner = db.query(models.Owner).first()
   data_dir = get_settings().data_dir
-  provider = providers.resolve_default_provider(
+  # Provider follows the last-selected model (the single source of truth the
+  # picker writes) so a new chat always starts on the family of the model it
+  # will actually use — never a provider whose remembered model belongs to the
+  # other family.
+  provider = providers.default_provider_for_new_chat(
     data_dir, owner.provider if owner else None,
   )
 

--- a/backend/app/routes/chats_stream.py
+++ b/backend/app/routes/chats_stream.py
@@ -41,7 +41,7 @@ from app.chat_visibility import coerce_agent_settings
 from app.providers import (
   _load_agent_settings,
   effective_agent_settings,
-  resolve_default_provider,
+  default_provider_for_new_chat,
 )
 from app.runner_registry import RunnerKind, registry
 from app.config import get_settings
@@ -117,7 +117,10 @@ def _next_execution_provider(db: Session, chat: models.Chat) -> str:
     and not is_draining()
   ):
     owner = db.query(models.Owner).first()
-    return resolve_default_provider(
+    # Provider follows the last-selected model, matching new-chat creation, so a
+    # pristine chat's first send can't re-diverge onto a family whose remembered
+    # model belongs to the other provider.
+    return default_provider_for_new_chat(
       get_settings().data_dir, owner.provider if owner else None,
     )
   return provider

--- a/backend/tests/test_chat_agent_settings.py
+++ b/backend/tests/test_chat_agent_settings.py
@@ -85,6 +85,64 @@ def test_effective_settings_has_no_model_until_manual_pick(tmp_path):
   assert result["effort"] == "medium"
 
 
+def test_new_chat_provider_follows_last_selected_model(tmp_path):
+  """A new chat's provider follows the remembered model's family, so it can't
+  be born on a provider whose model belongs to the OTHER family. The stored
+  provider (which can drift when many chats run at once) is ignored while a
+  model is remembered."""
+  from app.providers import default_provider_for_new_chat
+
+  shared = tmp_path / "shared"
+  shared.mkdir()
+  # Last-selected model is a Claude one; the drifted stored provider is codex.
+  (shared / "agent-settings.json").write_text(
+    json.dumps({"model": "claude-opus-4-8"})
+  )
+  assert default_provider_for_new_chat(str(tmp_path), "codex") == "claude"
+
+  # And the reverse: a remembered Codex model wins over a stale claude provider.
+  (shared / "agent-settings.json").write_text(
+    json.dumps({"model": "gpt-5.6-sol"})
+  )
+  assert default_provider_for_new_chat(str(tmp_path), "claude") == "codex"
+
+
+def test_new_chat_provider_falls_back_to_stored_on_first_run(tmp_path):
+  """With no model ever selected, provider comes from the stored value and the
+  picker prompts on first send (the one legitimate no-model case)."""
+  from app.providers import default_provider_for_new_chat
+
+  shared = tmp_path / "shared"
+  shared.mkdir()
+  (shared / "agent-settings.json").write_text(json.dumps({}))
+  assert default_provider_for_new_chat(str(tmp_path), "codex") == "codex"
+  # And nothing resolves a model, so admission still asks for a pick.
+  assert effective_agent_settings(
+    str(tmp_path), None, provider="codex",
+  )["model"] is None
+
+
+def test_created_chat_provider_follows_remembered_model_over_drift(
+  client, auth, db,
+):
+  """End to end: a drifted owner.provider must not birth a mismatched chat.
+  With a Codex model remembered but owner.provider stuck on claude, a new chat
+  starts on codex so it resolves to that remembered model instead of nothing."""
+  from app import models
+
+  _write_global_settings({"model": "gpt-5.6-sol", "effort": "high"})
+  owner = db.query(models.Owner).first()
+  owner.provider = "claude"
+  db.commit()
+
+  created = client.post(
+    "/api/chats", headers=auth, json={"title": "fresh"},
+  ).json()
+  db.expire_all()
+  row = db.query(models.Chat).filter(models.Chat.id == created["id"]).first()
+  assert row.provider == "codex"
+
+
 def test_patch_chat_writes_override(client, auth, chat):
   """PATCH /chats/{id} sets agent_settings_json and returns effective."""
   _write_global_settings({"model": "default-model"})


### PR DESCRIPTION
## Problem

A new chat can be created on a provider whose remembered model belongs to the *other* model family, leaving the chat with no usable model. Because explicit model selection is enforced end to end (#869), the chat then refuses to start. The most visible symptom is an `AskUserQuestion` card asked before a restart that cannot be answered afterward: submitting it starts a hidden continuation, which has no model, so the send is rejected.

The root cause is that two independent, last-writer-wins settings drift apart:

- the owner's default provider (`Owner.provider`), and
- the global default model (`shared/agent-settings.json` `model`).

There is no separate provider selection in the UI — the owner picks a model and the provider is implied — but when several chats are active at once, one chat writes the provider while another writes the model. A newly created chat then inherits a provider from one and a model from another, and `effective_agent_settings` filters that cross-family model to `None`.

## Fix

Derive the new-chat provider from the single source of truth the picker actually writes: the last-selected model. Both new-chat creation (`create_chat`) and the pristine-chat send path (`_next_execution_provider`) now use a new `default_provider_for_new_chat`, which resolves the provider from the remembered model and falls back to the stored provider only on the genuine first run (no model ever picked), where the picker still prompts.

This is the runtime complement to migration `0018_explicit_legacy_chat_models`, which one-time-heals *existing* established chats that are missing a model. This change prevents *new* chats from drifting into that state in the first place.

## Tests

- `default_provider_for_new_chat` follows the remembered model's family and ignores a drifted stored provider, in both directions.
- It falls back to the stored provider on first run, where no model resolves and the picker still prompts.
- End-to-end: a chat created while `Owner.provider` is stale starts on the remembered model's provider.