### PR TITLE
Add managed Railway container replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,9 +112,16 @@ sed -i 's/^DOMAIN=.*/DOMAIN=mobius.example.com/' .env
 BUILD_SHA="$(git rev-parse HEAD)" \
 BUILD_DATE="$(git show -s --format=%cs HEAD)" \
 docker compose up -d --build
+sudo scripts/install-rebuild-helper.sh
 ```
 
 Caddy configures HTTPS. Open `https://mobius.example.com`, connect your provider, and start asking. Settings → Möbius applies platform updates; `docker compose exec -u 0 app bash` opens a root shell in the running container. See [.env.example](.env.example) and [ARCHITECTURE.md](ARCHITECTURE.md) for the trust boundaries.
+
+The final setup step installs the narrow host controller used by **Settings →
+Replace container**. It grants only that fixed operation, not general host or
+Docker access. Existing installations created before this step was added need
+to run it once from their trusted host checkout; new installations get it as
+part of the normal setup above.
 
 ## Contribute to the platform
 

--- a/backend/app/deployment_control.py
+++ b/backend/app/deployment_control.py
@@ -465,6 +465,7 @@ async def _request_managed_rebuild(expected_sha: str) -> RebuildStatus:
     await asyncio.sleep(0.25)
 
   drained = False
+  provider_start_attempted = False
   try:
     await restart_util.prepare_managed_container_cutover(operation_id)
     drained = True
@@ -475,6 +476,7 @@ async def _request_managed_rebuild(expected_sha: str) -> RebuildStatus:
           "controller_unavailable", "The container could not finish the Railway handoff."
         )
       await asyncio.sleep(0.25)
+    provider_start_attempted = True
     started = await asyncio.to_thread(
       _managed_request,
       "POST",
@@ -483,9 +485,11 @@ async def _request_managed_rebuild(expected_sha: str) -> RebuildStatus:
     )
     return _normalize_managed_status(started)
   except DeploymentControlError as exc:
-    if drained and exc.code == "controller_rejected":
-      # A definitive rejection proves the provider did not accept ownership.
-      # Ambiguous transport or response failures must not start a second,
-      # competing worker transition after Railway may have accepted the cutover.
+    if drained and (
+      not provider_start_attempted or exc.code == "controller_rejected"
+    ):
+      # Before the start request, the provider cannot own the transition. After
+      # it, only a definitive rejection proves local recovery cannot race an
+      # accepted Railway cutover.
       _schedule_managed_recovery(restart_util.restart_this_worker)
     raise

--- a/backend/app/deployment_control.py
+++ b/backend/app/deployment_control.py
@@ -1,9 +1,10 @@
-"""Self-hosted container replacement control for Settings.
+"""Container replacement control for Settings.
 
 The browser can request only one fixed operation: replace this installation's
-app container with the official image for its applied upstream revision.  The
-request and durable status cross the existing /data mount; a root-owned
-systemd.path job owns Docker, Compose topology, verification, and rollback.
+app container with the official image for its applied upstream revision.
+Self-hosting crosses the /data mount to a narrow host helper; managed Railway
+uses its account service, while the root-owned restart ledger preserves chat
+continuation across either cutover.
 """
 
 from __future__ import annotations
@@ -13,6 +14,9 @@ import json
 import os
 import re
 import secrets
+import time
+import urllib.error
+import urllib.request
 from pathlib import Path
 from typing import Any, Literal, TypedDict
 
@@ -150,6 +154,97 @@ def _normalize_status(
   )
 
 
+def _managed_headers() -> dict[str, str]:
+  settings = get_settings()
+  if not settings.mobius_sso_enabled:
+    raise DeploymentControlError(
+      "not_configured",
+      "This Railway deployment is not linked to its Möbius account service.",
+      status_code=409,
+    )
+  return {
+    "Authorization": f"Bearer {settings.mobius_sso_client_secret}",
+    "X-Mobius-Instance-Id": settings.mobius_sso_instance_id,
+    "Accept": "application/json",
+  }
+
+
+class _NoManagedRedirect(urllib.request.HTTPRedirectHandler):
+  def redirect_request(self, *_args: Any, **_kwargs: Any) -> None:
+    return None
+
+
+def _managed_request(method: str, suffix: str, payload: dict[str, str] | None = None) -> dict[str, Any]:
+  settings = get_settings()
+  body = None
+  headers = _managed_headers()
+  if payload is not None:
+    body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    headers["Content-Type"] = "application/json"
+  request_object = urllib.request.Request(
+    settings.mobius_account_origin + "/api/instance/v1/container-replacement/" + suffix,
+    data=body,
+    headers=headers,
+    method=method,
+  )
+  try:
+    with urllib.request.build_opener(_NoManagedRedirect()).open(
+      request_object, timeout=15,
+    ) as response:
+      raw = response.read(64 * 1024 + 1)
+      if len(raw) > 64 * 1024:
+        raise DeploymentControlError(
+          "controller_invalid_response", "The account service returned too much data."
+        )
+      value = json.loads(raw.decode("utf-8"))
+  except urllib.error.HTTPError as exc:
+    try:
+      error = json.loads(exc.read(16 * 1024).decode("utf-8"))
+      detail = str(error.get("detail") or error.get("message") or "")
+    except (ValueError, UnicodeError, AttributeError):
+      detail = ""
+    raise DeploymentControlError(
+      "controller_rejected",
+      detail[:360] or "The account service rejected container replacement.",
+      status_code=409 if exc.code in {400, 409} else 503,
+    ) from exc
+  except (urllib.error.URLError, TimeoutError, OSError, ValueError, UnicodeError) as exc:
+    raise DeploymentControlError(
+      "controller_unavailable", "The Möbius account service is unavailable."
+    ) from exc
+  if not isinstance(value, dict):
+    raise DeploymentControlError(
+      "controller_invalid_response", "The account service returned invalid status."
+    )
+  return value
+
+
+def _normalize_managed_status(raw: dict[str, Any]) -> RebuildStatus:
+  remote_state = str(raw.get("state") or "idle").lower()
+  states: dict[str, RebuildState] = {
+    "idle": "idle", "awaiting_handoff": "preparing", "queued": "queued",
+    "updating": "preparing", "deploying": "replacing",
+    "rolling_back": "verifying", "no_change": "no_change",
+    "succeeded": "succeeded", "rolled_back": "rolled_back",
+    "failed": "failed", "needs_recovery": "needs_recovery",
+  }
+  if remote_state not in states:
+    raise DeploymentControlError(
+      "controller_invalid_response", "The account service returned an unknown state."
+    )
+  expected = str(raw.get("expected_sha") or "").lower()
+  return RebuildStatus(
+    supported=True,
+    deployment="railway",
+    operation_id=str(raw.get("operation_id") or "") or None,
+    state=states[remote_state],
+    expected_sha=expected if _SHA_RE.fullmatch(expected) else None,
+    code=None,
+    message=str(raw.get("message") or "")[:360] or None,
+    updated_at=str(raw.get("updated_at") or "") or None,
+  )
+
+
 def _read_host_status() -> dict[str, Any]:
   try:
     value = json.loads(_status_path().read_text(encoding="utf-8"))
@@ -242,12 +337,18 @@ def replacement_ready_path(operation_id: str) -> Path:
 async def read_rebuild_status() -> RebuildStatus:
   deployment = platform_activation.deployment_kind()
   if deployment == "railway":
-    return _empty_status(
-      deployment,
-      supported=False,
-      code="not_supported",
-      message="Container replacement is not available on Railway yet.",
-    )
+    if not (Path(get_settings().data_dir) / "run" / "managed-cutover-ready").is_file():
+      return _empty_status(
+        deployment,
+        supported=False,
+        code="controller_upgrade_required",
+        message=(
+          "Install the current Möbius image once to enable managed container "
+          "replacement on Railway."
+        ),
+      )
+    raw = await asyncio.to_thread(_managed_request, "GET", "status")
+    return _normalize_managed_status(raw)
   if not _configured():
     return _empty_status(
       deployment,
@@ -271,24 +372,11 @@ async def read_rebuild_status() -> RebuildStatus:
 
 async def request_rebuild() -> RebuildStatus:
   deployment = platform_activation.deployment_kind()
-  if deployment == "railway":
-    raise DeploymentControlError(
-      "not_supported",
-      "Container replacement is not available on Railway yet.",
-      status_code=409,
-    )
-  if not _configured():
+  if deployment != "railway" and not _configured():
     raise DeploymentControlError(
       "not_configured",
       "Finish the one-time host setup by running sudo "
       "scripts/install-rebuild-helper.sh from the trusted Möbius checkout.",
-      status_code=409,
-    )
-  host_status = await asyncio.to_thread(_read_host_status)
-  if not _current_handoff(host_status):
-    raise DeploymentControlError(
-      "controller_upgrade_required",
-      _UPGRADE_MESSAGE,
       status_code=409,
     )
   expected_sha = _expected_upstream_sha()
@@ -306,6 +394,16 @@ async def request_rebuild() -> RebuildStatus:
       "Commit them upstream or remove them before replacing this container.",
       status_code=409,
     )
+  if deployment == "railway":
+    return await _request_managed_rebuild(expected_sha)
+
+  host_status = await asyncio.to_thread(_read_host_status)
+  if not _current_handoff(host_status):
+    raise DeploymentControlError(
+      "controller_upgrade_required",
+      _UPGRADE_MESSAGE,
+      status_code=409,
+    )
   current = _normalize_status(host_status)
   if current["state"] in _ACTIVE_STATES:
     raise DeploymentControlError(
@@ -319,3 +417,64 @@ async def request_rebuild() -> RebuildStatus:
     "expected_sha": expected_sha,
     "message": "Container replacement queued.",
   }, expected_sha=expected_sha)
+
+
+async def _request_managed_rebuild(expected_sha: str) -> RebuildStatus:
+  from app import restart_ledger, restart_util
+
+  marker = Path(get_settings().data_dir) / "run" / "managed-cutover-ready"
+  if not marker.is_file():
+    raise DeploymentControlError(
+      "controller_upgrade_required",
+      "Install the current Möbius image once to enable managed container replacement.",
+      status_code=409,
+    )
+  prepared = await asyncio.to_thread(
+    _managed_request, "POST", "prepare", {"expected_sha": expected_sha},
+  )
+  if prepared.get("state") == "no_change":
+    return _normalize_managed_status(prepared)
+  operation_id = str(prepared.get("operation_id") or "")
+  handoff_nonce = str(prepared.get("handoff_nonce") or "")
+  boot_id = restart_ledger.current_boot_id()
+  if not operation_id or not handoff_nonce or not boot_id:
+    raise DeploymentControlError(
+      "controller_invalid_response", "The managed replacement handoff is incomplete."
+    )
+  restart_ledger.request_managed_cutover(
+    boot_id=boot_id, cutover_id=operation_id,
+  )
+  deadline = time.monotonic() + 15
+  while not restart_ledger.authorized_cutover_challenge(operation_id):
+    if time.monotonic() >= deadline:
+      raise DeploymentControlError(
+        "controller_upgrade_required",
+        "The current container cannot authorize a Railway replacement.",
+      )
+    await asyncio.sleep(0.25)
+
+  drained = False
+  try:
+    await restart_util.prepare_managed_container_cutover(operation_id)
+    drained = True
+    deadline = time.monotonic() + 15
+    while not restart_ledger.accepted_cutover_receipt(operation_id):
+      if time.monotonic() >= deadline:
+        raise DeploymentControlError(
+          "controller_unavailable", "The container could not finish the Railway handoff."
+        )
+      await asyncio.sleep(0.25)
+    started = await asyncio.to_thread(
+      _managed_request,
+      "POST",
+      "start",
+      {"operation_id": operation_id, "handoff_nonce": handoff_nonce},
+    )
+    return _normalize_managed_status(started)
+  except Exception:
+    if drained:
+      # The provider never accepted ownership. Restart locally so parked chats
+      # are not left waiting indefinitely; this path fails closed to the normal
+      # restart ledger if the managed receipt cannot be reused.
+      asyncio.create_task(restart_util.restart_this_worker())
+    raise

--- a/backend/app/deployment_control.py
+++ b/backend/app/deployment_control.py
@@ -471,10 +471,10 @@ async def _request_managed_rebuild(expected_sha: str) -> RebuildStatus:
       {"operation_id": operation_id, "handoff_nonce": handoff_nonce},
     )
     return _normalize_managed_status(started)
-  except Exception:
-    if drained:
-      # The provider never accepted ownership. Restart locally so parked chats
-      # are not left waiting indefinitely; this path fails closed to the normal
-      # restart ledger if the managed receipt cannot be reused.
+  except DeploymentControlError as exc:
+    if drained and exc.code == "controller_rejected":
+      # A definitive rejection proves the provider did not accept ownership.
+      # Ambiguous transport or response failures must not start a second,
+      # competing worker transition after Railway may have accepted the cutover.
       asyncio.create_task(restart_util.restart_this_worker())
     raise

--- a/backend/app/deployment_control.py
+++ b/backend/app/deployment_control.py
@@ -211,13 +211,20 @@ def _managed_request(method: str, suffix: str, payload: dict[str, str] | None = 
   except urllib.error.HTTPError as exc:
     try:
       error = json.loads(exc.read(16 * 1024).decode("utf-8"))
-      detail = str(error.get("detail") or error.get("message") or "")
-    except (ValueError, UnicodeError, AttributeError):
+      detail = (
+        str(error.get("detail") or error.get("message") or "")
+        if isinstance(error, dict) else ""
+      )
+    except (ValueError, UnicodeError):
       detail = ""
+    if exc.code not in {400, 409} or not detail:
+      raise DeploymentControlError(
+        "controller_unavailable", "The Möbius account service is unavailable."
+      ) from exc
     raise DeploymentControlError(
       "controller_rejected",
-      detail[:360] or "The account service rejected container replacement.",
-      status_code=409 if exc.code in {400, 409} else 503,
+      detail[:360],
+      status_code=409,
     ) from exc
   except (urllib.error.URLError, TimeoutError, OSError, ValueError, UnicodeError) as exc:
     raise DeploymentControlError(

--- a/backend/app/deployment_control.py
+++ b/backend/app/deployment_control.py
@@ -390,13 +390,28 @@ async def read_rebuild_status() -> RebuildStatus:
 
 async def request_rebuild() -> RebuildStatus:
   deployment = platform_activation.deployment_kind()
-  if deployment != "railway" and not _configured():
-    raise DeploymentControlError(
-      "not_configured",
-      "Finish the one-time host setup by running sudo "
-      "scripts/install-rebuild-helper.sh from the trusted Möbius checkout.",
-      status_code=409,
-    )
+  if deployment != "railway":
+    if not _configured():
+      raise DeploymentControlError(
+        "not_configured",
+        "Finish the one-time host setup by running sudo "
+        "scripts/install-rebuild-helper.sh from the trusted Möbius checkout.",
+        status_code=409,
+      )
+    host_status = await asyncio.to_thread(_read_host_status)
+    if not _current_handoff(host_status):
+      raise DeploymentControlError(
+        "controller_upgrade_required",
+        _UPGRADE_MESSAGE,
+        status_code=409,
+      )
+    current = _normalize_status(host_status)
+    if current["state"] in _ACTIVE_STATES:
+      raise DeploymentControlError(
+        "already_running",
+        "A container replacement is already running.",
+        status_code=409,
+      )
   expected_sha = _expected_upstream_sha()
   if not expected_sha:
     raise DeploymentControlError(
@@ -414,21 +429,6 @@ async def request_rebuild() -> RebuildStatus:
     )
   if deployment == "railway":
     return await _request_managed_rebuild(expected_sha)
-
-  host_status = await asyncio.to_thread(_read_host_status)
-  if not _current_handoff(host_status):
-    raise DeploymentControlError(
-      "controller_upgrade_required",
-      _UPGRADE_MESSAGE,
-      status_code=409,
-    )
-  current = _normalize_status(host_status)
-  if current["state"] in _ACTIVE_STATES:
-    raise DeploymentControlError(
-      "already_running",
-      "A container replacement is already running.",
-      status_code=409,
-    )
   await asyncio.to_thread(_write_request, expected_sha)
   return _normalize_status({
     "state": "queued",

--- a/backend/app/deployment_control.py
+++ b/backend/app/deployment_control.py
@@ -17,6 +17,7 @@ import secrets
 import time
 import urllib.error
 import urllib.request
+from collections.abc import Awaitable, Callable
 from pathlib import Path
 from typing import Any, Literal, TypedDict
 
@@ -61,6 +62,7 @@ _KNOWN_STATES = {
 }
 _ACTIVE_STATES = {"queued", "preparing", "replacing", "verifying"}
 _HANDOFF_VERSION = "external-cutover-v1"
+_managed_recovery_tasks: set[asyncio.Task[None]] = set()
 _UPGRADE_MESSAGE = (
   "The Host replacement helper predates safe chat continuation. Re-run "
   "scripts/install-rebuild-helper.sh from the current trusted checkout."
@@ -84,6 +86,15 @@ def _empty_status(
     message=message,
     updated_at=None,
   )
+
+
+def _schedule_managed_recovery(
+  restart: Callable[[], Awaitable[None]],
+) -> None:
+  """Keep the sole post-rejection restart alive until it settles."""
+  task = asyncio.create_task(restart())
+  _managed_recovery_tasks.add(task)
+  task.add_done_callback(_managed_recovery_tasks.discard)
 
 
 def _expected_upstream_sha() -> str | None:
@@ -476,5 +487,5 @@ async def _request_managed_rebuild(expected_sha: str) -> RebuildStatus:
       # A definitive rejection proves the provider did not accept ownership.
       # Ambiguous transport or response failures must not start a second,
       # competing worker transition after Railway may have accepted the cutover.
-      asyncio.create_task(restart_util.restart_this_worker())
+      _schedule_managed_recovery(restart_util.restart_this_worker)
     raise

--- a/backend/app/deployment_control.py
+++ b/backend/app/deployment_control.py
@@ -253,7 +253,10 @@ async def read_rebuild_status() -> RebuildStatus:
       deployment,
       supported=False,
       code="not_configured",
-      message="Container replacement is not set up on this installation.",
+      message=(
+        "Finish the one-time host setup by running sudo "
+        "scripts/install-rebuild-helper.sh from the trusted Möbius checkout."
+      ),
     )
   raw = await asyncio.to_thread(_read_host_status)
   if not _current_handoff(raw):
@@ -277,7 +280,8 @@ async def request_rebuild() -> RebuildStatus:
   if not _configured():
     raise DeploymentControlError(
       "not_configured",
-      "Container replacement is not set up on this installation.",
+      "Finish the one-time host setup by running sudo "
+      "scripts/install-rebuild-helper.sh from the trusted Möbius checkout.",
       status_code=409,
     )
   host_status = await asyncio.to_thread(_read_host_status)

--- a/backend/app/restart_ledger.py
+++ b/backend/app/restart_ledger.py
@@ -155,6 +155,58 @@ def publish_cutover_intent(
   })
 
 
+def request_managed_cutover(
+  *, boot_id: str, cutover_id: str, now: float | None = None,
+) -> None:
+  """Ask the baked root poller to open one managed-platform handoff."""
+  if not boot_id or not cutover_id or len(cutover_id) > _CUTOVER_ID_MAX:
+    raise ValueError("invalid managed cutover")
+  root = Path(get_settings().data_dir)
+  _atomic_json(root / ".managed-cutover-request.json", {
+    "version": PROTOCOL_VERSION,
+    "action": "managed_cutover",
+    "cutover_id": cutover_id,
+    "source_boot_id": boot_id,
+    "created_at": time.time() if now is None else now,
+  })
+
+
+def accepted_cutover_receipt(
+  cutover_id: str,
+  *,
+  boot_id: str | None = None,
+  now: float | None = None,
+  trusted_uid: int = 0,
+  trusted_gid: int = 0,
+) -> bool:
+  """Whether root accepted this cutover for the current source boot."""
+  expected_boot = boot_id if boot_id is not None else current_boot_id()
+  if not expected_boot or not cutover_id:
+    return False
+  _, _, ledger_dir = _paths()
+  value = _read_trusted_json(
+    ledger_dir / "cutover-receipt.json",
+    mode=0o444,
+    trusted_uid=trusted_uid,
+    trusted_gid=trusted_gid,
+  )
+  if not value:
+    return False
+  try:
+    accepted_at = float(value.get("accepted_at"))
+  except (TypeError, ValueError):
+    return False
+  current = time.time() if now is None else now
+  return bool(
+    value.get("version") == PROTOCOL_VERSION
+    and value.get("action") == "external_cutover"
+    and value.get("cutover_id") == cutover_id
+    and value.get("source_boot_id") == expected_boot
+    and accepted_at <= current + 5
+    and current - accepted_at <= 120
+  )
+
+
 def authorized_cutover_challenge(
   cutover_id: str,
   *,

--- a/backend/app/restart_util.py
+++ b/backend/app/restart_util.py
@@ -149,7 +149,9 @@ async def restart_this_worker(ready_path: Path | None = None) -> None:
     os.kill(pid, signal.SIGTERM)
 
 
-async def prepare_container_cutover(cutover_id: str) -> dict[str, object]:
+async def prepare_container_cutover(
+  cutover_id: str, *, abandoned_timeout: float | None = _CUTOVER_FAILSAFE_SECONDS,
+) -> dict[str, object]:
   """Drain once for a Host-owned replacement without self-terminating.
 
   The root supervisor must first open the exact cutover challenge.  This
@@ -206,12 +208,23 @@ async def prepare_container_cutover(cutover_id: str) -> dict[str, object]:
       )
       os.kill(pid, signal.SIGTERM)
 
-  watchdog = threading.Timer(_CUTOVER_FAILSAFE_SECONDS, _recover_abandoned_cutover)
-  watchdog.daemon = True
-  watchdog.start()
+  if abandoned_timeout is not None:
+    watchdog = threading.Timer(abandoned_timeout, _recover_abandoned_cutover)
+    watchdog.daemon = True
+    watchdog.start()
   return {
     "status": "prepared",
     "cutover_id": cutover_id,
     "boot_id": boot_id,
     "run_count": len(restart_runs),
   }
+
+
+async def prepare_managed_container_cutover(cutover_id: str) -> dict[str, object]:
+  """Prepare a cutover whose provider, rather than this process, stops it.
+
+  Once the account service accepts the operation it durably owns deployment
+  and rollback, so a local watchdog must not race Railway's volume-backed
+  cutover by restarting the old container mid-deploy.
+  """
+  return await prepare_container_cutover(cutover_id, abandoned_timeout=None)

--- a/backend/runtime/restart_ledger.py
+++ b/backend/runtime/restart_ledger.py
@@ -41,6 +41,7 @@ ACK_PATH = LEDGER_DIR / "ack.json"
 BOOT_PATH = LEDGER_DIR / "boot-id"
 CUTOVER_CHALLENGE_PATH = LEDGER_DIR / "cutover-challenge.json"
 CUTOVER_RECEIPT_PATH = LEDGER_DIR / "cutover-receipt.json"
+MANAGED_CUTOVER_REQUEST_PATH = DATA_DIR / ".managed-cutover-request.json"
 
 PROTOCOL_VERSION = 1
 MAX_REQUEST_BYTES = 64 * 1024
@@ -282,6 +283,7 @@ def begin_boot(boot_id: str, *, now: float | None = None) -> bool:
   # belongs to an unrelated prior boot and must never authorize this one.
   _remove(INTENT_PATH)
   _remove(REQUEST_PATH)
+  _remove(MANAGED_CUTOVER_REQUEST_PATH)
   return authorized
 
 
@@ -311,7 +313,7 @@ def harden(boot_id: str) -> bool:
       os.chown(path, SUPERVISOR_UID, SUPERVISOR_GID)
       os.chmod(
         path,
-        0o600 if path in {ACCEPTED_PATH, CUTOVER_RECEIPT_PATH} else 0o444,
+        0o600 if path == ACCEPTED_PATH else 0o444,
       )
     os.chown(LEDGER_DIR, SUPERVISOR_UID, SUPERVISOR_GID)
     os.chmod(LEDGER_DIR, 0o755)
@@ -383,11 +385,55 @@ def accept_cutover(cutover_id: str, *, now: float | None = None) -> bool:
   _remove(ACCEPTED_PATH)
   if accepted is not None:
     _write_json(ACCEPTED_PATH, accepted, 0o600)
-    _write_json(CUTOVER_RECEIPT_PATH, accepted, 0o600)
+    # The app must verify this root-authored receipt before asking a managed
+    # provider to deploy. Root ownership + immutable mode is the trust
+    # boundary; confidentiality is neither required nor useful here.
+    _write_json(CUTOVER_RECEIPT_PATH, accepted, 0o444)
   _remove(CUTOVER_CHALLENGE_PATH)
   _remove(INTENT_PATH)
   _remove(REQUEST_PATH)
   return accepted is not None
+
+
+def service_managed_cutover(boot_id: str, *, now: float | None = None) -> bool:
+  """Open or accept one app-requested managed-platform cutover.
+
+  This is deliberately only a restart-continuation primitive. It grants no
+  provider credential and performs no deployment action; the account service
+  independently restricts that action to the caller's own managed instance.
+  """
+  current = time.time() if now is None else now
+  _prepare_ledger_dir()
+  try:
+    ledger_boot = BOOT_PATH.read_text(encoding="utf-8").strip()
+  except OSError:
+    ledger_boot = ""
+  request = _read_bounded_json(MANAGED_CUTOVER_REQUEST_PATH)
+  if not request or ledger_boot != boot_id or request.get("version") != PROTOCOL_VERSION:
+    _remove(MANAGED_CUTOVER_REQUEST_PATH)
+    return False
+  cutover_id = request.get("cutover_id")
+  try:
+    created_at = float(request.get("created_at"))
+  except (TypeError, ValueError):
+    created_at = 0
+  if (
+    request.get("action") != "managed_cutover"
+    or request.get("source_boot_id") != boot_id
+    or not _valid_token(cutover_id)
+    or created_at > current + 5
+    or current - created_at > MAX_REQUEST_AGE_SECONDS
+  ):
+    _remove(MANAGED_CUTOVER_REQUEST_PATH)
+    return False
+  challenge = _read_bounded_json(CUTOVER_CHALLENGE_PATH)
+  if not challenge or challenge.get("cutover_id") != cutover_id:
+    return open_cutover(cutover_id, now=current)
+  if _read_bounded_json(INTENT_PATH) is None:
+    return True
+  accepted = accept_cutover(cutover_id, now=current)
+  _remove(MANAGED_CUTOVER_REQUEST_PATH)
+  return accepted
 
 
 def _matching_cutover_receipt(
@@ -488,6 +534,8 @@ def _main(argv: list[str]) -> int:
       result = open_cutover(value)
     elif command == "accept-cutover":
       result = accept_cutover(value)
+    elif command == "managed-cutover":
+      result = service_managed_cutover(value)
     elif command == "rearm-cutover":
       result = rearm_cutover(value)
     elif command == "finalize-cutover":
@@ -503,7 +551,7 @@ def _main(argv: list[str]) -> int:
   # observable by the root entrypoint and must not trigger a restart.
   if command in {
     "accept", "harden", "open-cutover", "accept-cutover",
-    "rearm-cutover", "finalize-cutover",
+    "rearm-cutover", "finalize-cutover", "managed-cutover",
   } and not result:
     return 1
   return 0

--- a/backend/scripts/entrypoint.sh
+++ b/backend/scripts/entrypoint.sh
@@ -152,6 +152,8 @@ _restart_poller_started=0
 
 _start_platform_restart_poller() {
   [ "$_restart_poller_started" -eq 1 ] && return 0
+  : > /data/run/managed-cutover-ready
+  chown mobius:mobius /data/run/managed-cutover-ready 2>/dev/null || true
   (
     while true; do
       if [ -f /data/.platform-restart-requested ]; then
@@ -170,6 +172,16 @@ _start_platform_restart_poller() {
         # pid1 is now draining + exiting; give it a moment, then stop polling.
         sleep 5
         exit 0
+      fi
+      if [ -f /data/.managed-cutover-request.json ]; then
+        # Railway owns the eventual stop. This root-owned helper only opens
+        # and accepts the one-shot continuation intent; unlike an ordinary
+        # restart it must leave pid 1 alive until Railway performs cutover.
+        if ! DATA_DIR=/data python3 -P /app/runtime/restart_ledger.py \
+          managed-cutover "$MOBIUS_BOOT_ID"; then
+          rm -f /data/.managed-cutover-request.json 2>/dev/null || true
+          echo "O1: rejected managed cutover handoff; container stays running." >&2
+        fi
       fi
       sleep 2
     done

--- a/backend/tests/test_deployment_control.py
+++ b/backend/tests/test_deployment_control.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import asyncio
+import io
 import json
 from types import SimpleNamespace
+import urllib.error
 
 import pytest
 
@@ -21,6 +23,72 @@ def _install_control(tmp_path, monkeypatch):
   )
   monkeypatch.setattr(dc, "_control_dir", lambda: control)
   return control, inbox
+
+
+@pytest.mark.parametrize("status", [400, 409])
+def test_managed_request_recognizes_only_structured_client_rejections(
+  monkeypatch, status,
+):
+  settings = SimpleNamespace(
+    mobius_account_origin="https://account.example",
+    mobius_sso_enabled=True,
+    mobius_sso_client_secret="secret",
+    mobius_sso_instance_id="instance",
+  )
+  response = urllib.error.HTTPError(
+    "https://account.example/start", status, "rejected", {},
+    io.BytesIO(b'{"detail":"Replacement handoff rejected."}'),
+  )
+
+  def open_request(*_args, **_kwargs):
+    raise response
+
+  opener = SimpleNamespace(open=open_request)
+  monkeypatch.setattr(dc, "get_settings", lambda: settings)
+  monkeypatch.setattr(dc.urllib.request, "build_opener", lambda *_args: opener)
+
+  with pytest.raises(dc.DeploymentControlError) as exc:
+    dc._managed_request("POST", "start", {"operation_id": "replacement"})
+
+  assert exc.value.code == "controller_rejected"
+  assert exc.value.status_code == 409
+
+
+@pytest.mark.parametrize(
+  ("status", "body"),
+  [
+    (409, b"not-json"),
+    (502, b'{"detail":"Replacement could not start."}'),
+    (503, b'{"detail":"Replacement could not start."}'),
+    (504, b'{"detail":"Replacement could not start."}'),
+  ],
+)
+def test_managed_request_keeps_ambiguous_http_failures_ambiguous(
+  monkeypatch, status, body,
+):
+  settings = SimpleNamespace(
+    mobius_account_origin="https://account.example",
+    mobius_sso_enabled=True,
+    mobius_sso_client_secret="secret",
+    mobius_sso_instance_id="instance",
+  )
+  response = urllib.error.HTTPError(
+    "https://account.example/start", status, "gateway failure", {},
+    io.BytesIO(body),
+  )
+
+  def open_request(*_args, **_kwargs):
+    raise response
+
+  opener = SimpleNamespace(open=open_request)
+  monkeypatch.setattr(dc, "get_settings", lambda: settings)
+  monkeypatch.setattr(dc.urllib.request, "build_opener", lambda *_args: opener)
+
+  with pytest.raises(dc.DeploymentControlError) as exc:
+    dc._managed_request("POST", "start", {"operation_id": "replacement"})
+
+  assert exc.value.code == "controller_unavailable"
+  assert exc.value.status_code == 503
 
 
 def test_normalize_rejects_unknown_controller_state():

--- a/backend/tests/test_deployment_control.py
+++ b/backend/tests/test_deployment_control.py
@@ -28,16 +28,87 @@ def test_normalize_rejects_unknown_controller_state():
 
 
 @pytest.mark.asyncio
-async def test_railway_is_explicitly_deferred(monkeypatch):
+async def test_railway_requires_baked_managed_cutover_support(tmp_path, monkeypatch):
   monkeypatch.setattr(dc.platform_activation, "deployment_kind", lambda: "railway")
+  monkeypatch.setattr(dc, "get_settings", lambda: type("S", (), {"data_dir": str(tmp_path)})())
+  monkeypatch.setattr(dc, "_expected_upstream_sha", lambda: "a" * 40)
+  monkeypatch.setattr(dc.platform_update, "container_replacement_blockers", lambda: [])
 
   status = await dc.read_rebuild_status()
   assert status["supported"] is False
-  assert status["code"] == "not_supported"
+  assert status["code"] == "controller_upgrade_required"
 
   with pytest.raises(dc.DeploymentControlError) as exc:
     await dc.request_rebuild()
-  assert exc.value.code == "not_supported"
+  assert exc.value.code == "controller_upgrade_required"
+
+
+@pytest.mark.asyncio
+async def test_railway_status_uses_account_service(tmp_path, monkeypatch):
+  (tmp_path / "run").mkdir()
+  (tmp_path / "run" / "managed-cutover-ready").touch()
+  settings = type("S", (), {"data_dir": str(tmp_path)})()
+  monkeypatch.setattr(dc.platform_activation, "deployment_kind", lambda: "railway")
+  monkeypatch.setattr(dc, "get_settings", lambda: settings)
+  monkeypatch.setattr(dc, "_managed_request", lambda method, suffix: {
+    "operation_id": "replace_123", "state": "deploying",
+    "expected_sha": "a" * 40, "message": "Railway is replacing the container.",
+  })
+
+  status = await dc.read_rebuild_status()
+
+  assert status["supported"] is True
+  assert status["deployment"] == "railway"
+  assert status["state"] == "replacing"
+  assert status["expected_sha"] == "a" * 40
+
+
+@pytest.mark.asyncio
+async def test_request_rebuild_selects_managed_railway_handoff(tmp_path, monkeypatch):
+  from app import restart_ledger, restart_util
+
+  (tmp_path / "run").mkdir()
+  (tmp_path / "run" / "managed-cutover-ready").touch()
+  settings = type("S", (), {"data_dir": str(tmp_path)})()
+  monkeypatch.setattr(dc.platform_activation, "deployment_kind", lambda: "railway")
+  monkeypatch.setattr(dc, "get_settings", lambda: settings)
+  monkeypatch.setattr(dc, "_expected_upstream_sha", lambda: "a" * 40)
+  monkeypatch.setattr(dc.platform_update, "container_replacement_blockers", lambda: [])
+  calls = []
+
+  def managed_request(method, suffix, payload=None):
+    calls.append((method, suffix, payload))
+    if suffix == "prepare":
+      return {
+        "operation_id": "replace_12345678", "handoff_nonce": "nonce-secret",
+        "state": "awaiting_handoff", "expected_sha": "a" * 40,
+      }
+    return {
+      "operation_id": "replace_12345678", "state": "queued",
+      "expected_sha": "a" * 40, "message": "Replacement queued.",
+    }
+
+  async def prepare(cutover_id):
+    assert cutover_id == "replace_12345678"
+    return {"status": "prepared"}
+
+  monkeypatch.setattr(dc, "_managed_request", managed_request)
+  monkeypatch.setattr(restart_ledger, "current_boot_id", lambda: "boot-12345678")
+  monkeypatch.setattr(restart_ledger, "request_managed_cutover", lambda **_kw: None)
+  monkeypatch.setattr(restart_ledger, "authorized_cutover_challenge", lambda _id: True)
+  monkeypatch.setattr(restart_ledger, "accepted_cutover_receipt", lambda _id: True)
+  monkeypatch.setattr(restart_util, "prepare_managed_container_cutover", prepare)
+
+  status = await dc.request_rebuild()
+
+  assert status["deployment"] == "railway"
+  assert status["state"] == "queued"
+  assert calls == [
+    ("POST", "prepare", {"expected_sha": "a" * 40}),
+    ("POST", "start", {
+      "operation_id": "replace_12345678", "handoff_nonce": "nonce-secret",
+    }),
+  ]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_deployment_control.py
+++ b/backend/tests/test_deployment_control.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from types import SimpleNamespace
 
 import pytest
 
@@ -160,6 +161,61 @@ async def test_managed_start_failure_restarts_only_after_definitive_rejection(
 
   assert exc.value.code == error_code
   assert len(restarts) == restart_count
+
+
+@pytest.mark.asyncio
+async def test_pre_start_receipt_timeout_recovers_the_drained_worker(
+  tmp_path, monkeypatch,
+):
+  from app import restart_ledger, restart_util
+
+  _install_control(tmp_path, monkeypatch)
+  (tmp_path / "run").mkdir()
+  (tmp_path / "run" / "managed-cutover-ready").touch()
+  settings = type("S", (), {"data_dir": str(tmp_path)})()
+  monkeypatch.setattr(dc.platform_activation, "deployment_kind", lambda: "railway")
+  monkeypatch.setattr(dc, "get_settings", lambda: settings)
+  monkeypatch.setattr(dc, "_expected_upstream_sha", lambda: "a" * 40)
+  monkeypatch.setattr(dc.platform_update, "container_replacement_blockers", lambda: [])
+
+  requests = []
+
+  def managed_request(method, suffix, payload=None):
+    requests.append((method, suffix, payload))
+    return {
+      "state": "awaiting_handoff",
+      "operation_id": "replace_12345678",
+      "handoff_nonce": "nonce-secret",
+    }
+
+  restarts = []
+
+  async def restart():
+    restarts.append(True)
+
+  times = iter((0, 0, 16))
+  monkeypatch.setattr(
+    dc, "time", SimpleNamespace(monotonic=lambda: next(times)),
+  )
+  monkeypatch.setattr(dc, "_managed_request", managed_request)
+  monkeypatch.setattr(restart_ledger, "current_boot_id", lambda: "boot-12345678")
+  monkeypatch.setattr(restart_ledger, "request_managed_cutover", lambda **_kw: None)
+  monkeypatch.setattr(restart_ledger, "authorized_cutover_challenge", lambda _id: True)
+  monkeypatch.setattr(restart_ledger, "accepted_cutover_receipt", lambda _id: False)
+  monkeypatch.setattr(
+    restart_util, "prepare_managed_container_cutover", lambda _id: asyncio.sleep(0),
+  )
+  monkeypatch.setattr(restart_util, "restart_this_worker", restart)
+
+  with pytest.raises(dc.DeploymentControlError) as exc:
+    await dc.request_rebuild()
+  await asyncio.sleep(0)
+
+  assert exc.value.code == "controller_unavailable"
+  assert requests == [(
+    "POST", "prepare", {"expected_sha": "a" * 40},
+  )]
+  assert restarts == [True]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_deployment_control.py
+++ b/backend/tests/test_deployment_control.py
@@ -163,6 +163,63 @@ async def test_managed_start_failure_restarts_only_after_definitive_rejection(
 
 
 @pytest.mark.asyncio
+async def test_definitive_rejection_owns_recovery_until_restart_settles(
+  tmp_path, monkeypatch,
+):
+  from app import restart_ledger, restart_util
+
+  _install_control(tmp_path, monkeypatch)
+  (tmp_path / "run").mkdir()
+  (tmp_path / "run" / "managed-cutover-ready").touch()
+  settings = type("S", (), {"data_dir": str(tmp_path)})()
+  monkeypatch.setattr(dc.platform_activation, "deployment_kind", lambda: "railway")
+  monkeypatch.setattr(dc, "get_settings", lambda: settings)
+  monkeypatch.setattr(dc, "_expected_upstream_sha", lambda: "a" * 40)
+  monkeypatch.setattr(dc.platform_update, "container_replacement_blockers", lambda: [])
+
+  def managed_request(method, suffix, _payload=None):
+    if suffix == "prepare":
+      return {
+        "state": "awaiting_handoff",
+        "operation_id": "replace_12345678",
+        "handoff_nonce": "nonce-secret",
+      }
+    raise dc.DeploymentControlError("controller_rejected", "rejected")
+
+  started = asyncio.Event()
+  release = asyncio.Event()
+
+  async def restart():
+    started.set()
+    await release.wait()
+
+  owned = set()
+  monkeypatch.setattr(dc, "_managed_recovery_tasks", owned)
+  monkeypatch.setattr(dc, "_managed_request", managed_request)
+  monkeypatch.setattr(restart_ledger, "current_boot_id", lambda: "boot-12345678")
+  monkeypatch.setattr(restart_ledger, "request_managed_cutover", lambda **_kw: None)
+  monkeypatch.setattr(restart_ledger, "authorized_cutover_challenge", lambda _id: True)
+  monkeypatch.setattr(restart_ledger, "accepted_cutover_receipt", lambda _id: True)
+  monkeypatch.setattr(
+    restart_util, "prepare_managed_container_cutover", lambda _id: asyncio.sleep(0),
+  )
+  monkeypatch.setattr(restart_util, "restart_this_worker", restart)
+
+  with pytest.raises(dc.DeploymentControlError, match="rejected"):
+    await dc.request_rebuild()
+  await started.wait()
+
+  assert len(owned) == 1
+  task = next(iter(owned))
+  assert not task.done()
+
+  release.set()
+  await task
+  await asyncio.sleep(0)
+  assert owned == set()
+
+
+@pytest.mark.asyncio
 async def test_request_writes_only_the_derived_sha(tmp_path, monkeypatch):
   _control, inbox = _install_control(tmp_path, monkeypatch)
   monkeypatch.setattr(dc.platform_activation, "deployment_kind", lambda: "self_hosted")

--- a/backend/tests/test_deployment_control.py
+++ b/backend/tests/test_deployment_control.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 
 import pytest
@@ -109,6 +110,56 @@ async def test_request_rebuild_selects_managed_railway_handoff(tmp_path, monkeyp
       "operation_id": "replace_12345678", "handoff_nonce": "nonce-secret",
     }),
   ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+  ("error_code", "restart_count"),
+  [("controller_rejected", 1), ("controller_unavailable", 0),
+   ("controller_invalid_response", 0)],
+)
+async def test_managed_start_failure_restarts_only_after_definitive_rejection(
+  tmp_path, monkeypatch, error_code, restart_count,
+):
+  from app import restart_ledger, restart_util
+
+  _install_control(tmp_path, monkeypatch)
+  (tmp_path / "run").mkdir()
+  (tmp_path / "run" / "managed-cutover-ready").touch()
+  settings = type("S", (), {"data_dir": str(tmp_path)})()
+  monkeypatch.setattr(dc.platform_activation, "deployment_kind", lambda: "railway")
+  monkeypatch.setattr(dc, "get_settings", lambda: settings)
+  monkeypatch.setattr(dc, "_expected_upstream_sha", lambda: "a" * 40)
+  monkeypatch.setattr(dc.platform_update, "container_replacement_blockers", lambda: [])
+
+  def managed_request(method, suffix, payload=None):
+    if suffix == "prepare":
+      return {
+        "state": "prepared",
+        "operation_id": "replace_12345678",
+        "handoff_nonce": "nonce-secret",
+      }
+    raise dc.DeploymentControlError(error_code, "start failed")
+
+  restarts = []
+
+  async def restart():
+    restarts.append(True)
+
+  monkeypatch.setattr(dc, "_managed_request", managed_request)
+  monkeypatch.setattr(restart_ledger, "current_boot_id", lambda: "boot-12345678")
+  monkeypatch.setattr(restart_ledger, "request_managed_cutover", lambda **_kw: None)
+  monkeypatch.setattr(restart_ledger, "authorized_cutover_challenge", lambda _id: True)
+  monkeypatch.setattr(restart_ledger, "accepted_cutover_receipt", lambda _id: True)
+  monkeypatch.setattr(restart_util, "prepare_managed_container_cutover", lambda _id: asyncio.sleep(0))
+  monkeypatch.setattr(restart_util, "restart_this_worker", restart)
+
+  with pytest.raises(dc.DeploymentControlError) as exc:
+    await dc.request_rebuild()
+  await asyncio.sleep(0)
+
+  assert exc.value.code == error_code
+  assert len(restarts) == restart_count
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_restart_ledger.py
+++ b/backend/tests/test_restart_ledger.py
@@ -55,6 +55,10 @@ def _bind(supervisor, root: Path, monkeypatch) -> None:
     supervisor, "CUTOVER_RECEIPT_PATH",
     root / ".restart-ledger" / "cutover-receipt.json",
   )
+  monkeypatch.setattr(
+    supervisor, "MANAGED_CUTOVER_REQUEST_PATH",
+    root / ".managed-cutover-request.json",
+  )
   monkeypatch.setattr(supervisor, "SUPERVISOR_UID", os.getuid())
   monkeypatch.setattr(supervisor, "SUPERVISOR_GID", os.getgid())
   monkeypatch.setattr(
@@ -131,6 +135,38 @@ def test_root_opened_cutover_binds_replacement_boot_without_self_restart(
 
   assert supervisor.accept_cutover(cutover_id, now=now + 2)
   assert not supervisor.REQUEST_PATH.exists()
+  assert supervisor.begin_boot(target_boot, now=now + 3)
+  assert _authorized(tmp_path, target_boot) == nonce
+
+
+def test_managed_cutover_poller_opens_then_accepts_exact_handoff(
+  tmp_path, monkeypatch,
+):
+  supervisor = _load_supervisor()
+  _bind(supervisor, tmp_path, monkeypatch)
+  now = time.time()
+  source_boot = "boot-source-1234"
+  target_boot = "boot-target-1234"
+  cutover_id = "replace_12345678"
+  nonce = "nonce-12345678"
+
+  supervisor.begin_boot(source_boot, now=now)
+  platform_ledger.request_managed_cutover(
+    boot_id=source_boot, cutover_id=cutover_id, now=now + 1,
+  )
+  assert supervisor.service_managed_cutover(source_boot, now=now + 1)
+  assert platform_ledger.authorized_cutover_challenge(
+    cutover_id, boot_id=source_boot, now=now + 1,
+    trusted_uid=os.getuid(), trusted_gid=os.getgid(),
+  )
+  platform_ledger.publish_cutover_intent(
+    boot_id=source_boot, nonce=nonce, cutover_id=cutover_id, runs=[], now=now + 2,
+  )
+  assert supervisor.service_managed_cutover(source_boot, now=now + 2)
+  assert platform_ledger.accepted_cutover_receipt(
+    cutover_id, boot_id=source_boot, now=now + 2,
+    trusted_uid=os.getuid(), trusted_gid=os.getgid(),
+  )
   assert supervisor.begin_boot(target_boot, now=now + 3)
   assert _authorized(tmp_path, target_boot) == nonce
 


### PR DESCRIPTION
## Summary

- make the existing Settings **Replace container** action work for managed Railway deployments
- reuse the existing chat drain and root-owned restart ledger across provider cutover
- call the account service with only the derived official upstream SHA; Railway/project/service/image selection remains server-side
- preserve the existing self-host helper path and add its one-time installer to the standard setup instructions
- report an upgrade-required state on older images that lack the baked managed-cutover capability
- retain the sole post-rejection recovery task until its worker restart settles
- recover a drained worker when the local handoff receipt fails before any provider start request
- keep gateway and server failures after the start request ambiguous so local recovery cannot race Railway

## Managed cutover contract

1. Möbius derives the exact applied upstream SHA and checks for local runtime changes.
2. The account service prepares a verified immutable image operation for this authenticated instance.
3. The baked root supervisor opens a one-shot continuation challenge.
4. Möbius parks active chats and publishes the matching cutover intent.
5. Root accepts the intent without stopping pid 1; Railway owns the eventual stop.
6. Only after that receipt does Möbius tell the account service to deploy.
7. The next boot consumes the existing one-shot ledger acknowledgement and resumes parked chats.

No Railway credentials enter the container, and the browser cannot supply provider resource IDs, image references, branches, commands, or paths.

## Railway cost / small-plan behavior

The companion launcher operation selects a prebuilt immutable GHCR image and invokes an explicit service deploy. Railway performs no source build, avoiding build-time RAM and disk pressure on Free or smaller plans. Volume-backed services retain Railway's normal brief cutover downtime.

## Dependency

Companion launcher support landed in mobius-os/mobius.you#124 and must be deployed before an image containing this integration is released.

## Testing

- focused replacement/restart-ledger suite: 35 passed
- adjacent deployment/restart/drain/activation/update suite: 152 passed
- frontend library suite: passed on the preceding exact public head
- clean merge tree against current `origin/main`
- syntax/private-path gates: passed

The full Docker-backed backend suite cannot run inside the normal Möbius container because it intentionally has no Docker socket; PR CI remains the authoritative full gate.