### PR TITLE
Show per-turn token usage and cost in chat

### DIFF
--- a/backend/app/routes/chats.py
+++ b/backend/app/routes/chats.py
@@ -1722,6 +1722,7 @@ def get_chat_agent_context(
 @router.get("/{chat_id}/usage")
 def get_chat_usage(
   chat_id: str,
+  include_runs: bool = True,
   _: models.Owner = Depends(get_current_owner),
   db: Session = Depends(get_db),
 ):
@@ -1784,7 +1785,7 @@ def get_chat_usage(
         "usage": run.usage_json,
       }
       for run in runs
-    ],
+    ] if include_runs else [],
   }
 
 

--- a/backend/tests/test_chats.py
+++ b/backend/tests/test_chats.py
@@ -226,6 +226,15 @@ def test_chat_usage_reports_totals_and_historic_coverage(
   assert measured["model_context_window"] == 200_000
   assert measured["usage"]["calculation"] == "thread_delta"
 
+  summary_response = client.get(
+    f"/api/chats/{chat.id}/usage?include_runs=false", headers=auth,
+  )
+  assert summary_response.status_code == 200
+  summary = summary_response.json()
+  assert summary["coverage"] == payload["coverage"]
+  assert summary["totals"] == payload["totals"]
+  assert summary["runs"] == []
+
 
 def test_create_chat_rejects_cross_site_request(client, auth):
   cross = client.post(

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -464,6 +464,9 @@ export const api = {
     recover: (chatId) => listAffectingMutation(
       'chats', `/chats/${chatId}/recover`, { method: 'POST' },
     ),
+    usage: (chatId, options = {}) => apiFetch(
+      `/chats/${encodeURIComponent(chatId)}/usage`, options,
+    ),
   },
   secureInputs: {
     submit: (chatId, requestId, payload) => apiFetch(

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -467,6 +467,9 @@ export const api = {
     usage: (chatId, options = {}) => apiFetch(
       `/chats/${encodeURIComponent(chatId)}/usage`, options,
     ),
+    usageSummary: (chatId, options = {}) => apiFetch(
+      `/chats/${encodeURIComponent(chatId)}/usage?include_runs=false`, options,
+    ),
   },
   secureInputs: {
     submit: (chatId, requestId, payload) => apiFetch(

--- a/frontend/src/components/ChatView/ChatUsageInspector.jsx
+++ b/frontend/src/components/ChatView/ChatUsageInspector.jsx
@@ -1,0 +1,409 @@
+/**
+ * ChatUsageInspector — full token/cost breakdown for one chat, opened from
+ * the "Token usage & cost" row in ComposerPopover. Mirrors
+ * AgentContextInspector's overlay/dialog shape (same CSS class prefix
+ * pattern renamed to `cui`) so the two full-screen chat panels read as one
+ * family, but the content is a totals summary plus a per-turn list instead
+ * of markdown sections.
+ *
+ * Backed by GET /chats/{id}/usage, which already existed as an owner-only
+ * diagnostic (benchmark tooling reads it too) — this is the first UI surface
+ * for it. Historical runs created before usage capture render with "—" for
+ * missing fields rather than 0, so the owner can tell "not tracked yet" apart
+ * from "genuinely free."
+ */
+
+import { useRef } from 'react'
+import { InfoCircle } from '@openai/apps-sdk-ui/components/Icon'
+import useDialogFocus from '../../hooks/useDialogFocus.js'
+import { chatQueries } from '../../hooks/queries.js'
+import {
+  formatCostUsd,
+  formatTimestamp,
+  formatTokenCount,
+} from './chatUsageFormat.js'
+
+const CSS = `
+.cui__overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 1000;
+  display: grid;
+  place-items: center;
+  padding: 18px;
+  box-sizing: border-box;
+  background: rgba(0, 0, 0, 0.45);
+}
+
+[data-theme="light"] .cui__overlay {
+  background: rgba(15, 18, 25, 0.32);
+}
+
+.cui {
+  width: min(680px, 100%);
+  max-height: calc(100% - 36px);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  box-sizing: border-box;
+  border-radius: 18px;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text);
+  box-shadow: 0 18px 52px rgba(0, 0, 0, 0.32);
+}
+
+[data-theme="light"] .cui {
+  box-shadow:
+    0 4px 12px rgba(0, 0, 0, 0.08),
+    0 1px 3px rgba(0, 0, 0, 0.06);
+}
+
+.cui__head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 18px;
+  border-bottom: 1px solid var(--border);
+}
+
+.cui__title {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+  line-height: 1.25;
+}
+
+.cui__subtitle {
+  margin: 4px 0 0;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.cui__close {
+  flex-shrink: 0;
+  border: 0;
+  width: 40px;
+  height: 40px;
+  margin: -7px -7px 0 0;
+  border-radius: 9px;
+  padding: 0;
+  background: none;
+  color: var(--muted);
+  font: inherit;
+  font-size: 24px;
+  line-height: 1;
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s;
+}
+
+.cui__close:hover {
+  background: var(--surface2);
+  color: var(--text);
+}
+
+.cui__body {
+  min-height: 0;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 14px;
+  overscroll-behavior: contain;
+}
+
+.cui__state {
+  margin: 0;
+  padding: 18px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--bg);
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.cui__state--error { color: var(--danger); }
+
+.cui-totals {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
+  gap: 1px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+  background: var(--border);
+}
+
+.cui-totals__cell {
+  background: var(--bg);
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.cui-totals__label {
+  font-size: 11px;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.cui-totals__value {
+  font-size: 17px;
+  font-weight: 600;
+  color: var(--text);
+  font-variant-numeric: tabular-nums;
+}
+
+.cui__coverage {
+  margin: 0;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.5;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.cui-runs {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.cui-run {
+  border: 1px solid var(--border-light);
+  border-radius: 10px;
+  background: var(--bg);
+  overflow: hidden;
+}
+
+.cui-run__summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 10px 12px;
+  cursor: pointer;
+  user-select: none;
+  list-style: none;
+}
+
+.cui-run__summary::-webkit-details-marker { display: none; }
+
+.cui-run__when {
+  font-size: 12px;
+  color: var(--muted);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cui-run__meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.cui-run__provider {
+  font-size: 11px;
+  padding: 2px 7px;
+  border-radius: 999px;
+  background: var(--surface2);
+  color: var(--muted);
+  text-transform: capitalize;
+}
+
+.cui-run__cost {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+  font-variant-numeric: tabular-nums;
+  min-width: 44px;
+  text-align: right;
+}
+
+.cui-run__chevron {
+  color: var(--muted);
+  font-size: 16px;
+  line-height: 1;
+  transition: transform 0.12s ease;
+}
+
+.cui-run[open] .cui-run__chevron { transform: rotate(90deg); }
+
+.cui-run__detail {
+  margin: 0;
+  border-top: 1px solid var(--border);
+  padding: 10px 12px 12px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 8px 14px;
+}
+
+.cui-run__field {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.cui-run__field-label {
+  font-size: 10.5px;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.cui-run__field-value {
+  font-size: 13px;
+  color: var(--text);
+  font-variant-numeric: tabular-nums;
+}
+
+@media (max-width: 640px) {
+  .cui__overlay { align-items: end; padding: 10px; }
+  .cui { max-height: calc(100% - 20px); border-radius: 18px; }
+  .cui__head { padding: 16px; }
+  .cui__body { padding: 10px; }
+}
+`
+
+function TotalsCell({ label, value }) {
+  return (
+    <div className="cui-totals__cell">
+      <span className="cui-totals__label">{label}</span>
+      <span className="cui-totals__value">{value ?? '—'}</span>
+    </div>
+  )
+}
+
+function RunField({ label, value }) {
+  return (
+    <div className="cui-run__field">
+      <span className="cui-run__field-label">{label}</span>
+      <span className="cui-run__field-value">{value ?? '—'}</span>
+    </div>
+  )
+}
+
+function RunRow({ run }) {
+  const when = formatTimestamp(run.started_at) || 'Unknown time'
+  const cost = formatCostUsd(run.cost_usd)
+  return (
+    <details className="cui-run">
+      <summary className="cui-run__summary">
+        <span className="cui-run__when">{when}</span>
+        <span className="cui-run__meta">
+          {run.provider && <span className="cui-run__provider">{run.provider}</span>}
+          <span className="cui-run__cost">{cost ?? '—'}</span>
+          <span className="cui-run__chevron" aria-hidden="true">›</span>
+        </span>
+      </summary>
+      <div className="cui-run__detail">
+        <RunField label="Fresh input" value={formatTokenCount(run.usage?.uncached_input_tokens)} />
+        <RunField label="Cached input" value={formatTokenCount(run.cache_read_input_tokens)} />
+        <RunField label="Cache write" value={formatTokenCount(run.cache_creation_input_tokens)} />
+        <RunField label="Output" value={formatTokenCount(run.output_tokens)} />
+        <RunField label="Reasoning" value={formatTokenCount(run.reasoning_output_tokens)} />
+        <RunField label="Total tokens" value={formatTokenCount(run.total_tokens)} />
+        <RunField label="Model" value={run.usage?.provider_model_usage
+          ? Object.keys(run.usage.provider_model_usage)[0]
+          : (run.usage?.model || null)} />
+        <RunField label="Context window" value={formatTokenCount(run.model_context_window)} />
+        <RunField label="Status" value={run.status} />
+      </div>
+    </details>
+  )
+}
+
+export default function ChatUsageInspector({ chatId, onClose }) {
+  const dialogRef = useRef(null)
+  const closeRef = useRef(null)
+  const query = chatQueries.usage.useQuery(chatId, { enabled: !!chatId })
+
+  useDialogFocus({
+    containerRef: dialogRef,
+    initialFocusRef: onClose ? closeRef : dialogRef,
+    onClose,
+    closeOnEscape: !!onClose,
+  })
+
+  const data = query.data
+  const totals = data?.totals
+  const runs = Array.isArray(data?.runs) ? [...data.runs].reverse() : []
+  const coverage = data?.coverage
+
+  return (
+    <div className="cui__overlay" role="presentation" onClick={() => onClose?.()}>
+      <style>{CSS}</style>
+      <div
+        ref={dialogRef}
+        className="cui"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="cui-title"
+        tabIndex={-1}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="cui__head">
+          <div>
+            <h2 id="cui-title" className="cui__title">Token usage &amp; cost</h2>
+            <p className="cui__subtitle">Per-turn provider usage for this chat.</p>
+          </div>
+          {onClose && (
+            <button
+              ref={closeRef}
+              type="button"
+              className="cui__close"
+              onClick={onClose}
+              aria-label="Close"
+            >×</button>
+          )}
+        </div>
+
+        <div className="cui__body">
+          {query.isLoading && <p className="cui__state">Loading usage…</p>}
+          {query.isError && (
+            <p className="cui__state cui__state--error">
+              {query.error?.message || 'Could not load usage for this chat.'}
+            </p>
+          )}
+          {data && (
+            <>
+              <div className="cui-totals">
+                <TotalsCell label="Total cost" value={formatCostUsd(totals?.cost_usd)} />
+                <TotalsCell label="Total tokens" value={formatTokenCount(totals?.total_tokens)} />
+                <TotalsCell label="Input tokens" value={formatTokenCount(totals?.input_tokens)} />
+                <TotalsCell label="Output tokens" value={formatTokenCount(totals?.output_tokens)} />
+                <TotalsCell label="Cached input" value={formatTokenCount(totals?.cache_read_input_tokens)} />
+                <TotalsCell label="Reasoning" value={formatTokenCount(totals?.reasoning_output_tokens)} />
+              </div>
+              {coverage && (
+                <p className="cui__coverage">
+                  <InfoCircle width={14} height={14} aria-hidden="true" />
+                  {coverage.runs_with_usage} of {coverage.runs} turns have usage data
+                  {coverage.runs > coverage.runs_with_usage
+                    ? ' — older turns predate usage tracking.'
+                    : '.'}
+                </p>
+              )}
+              {runs.length === 0 ? (
+                <p className="cui__state">No turns recorded yet for this chat.</p>
+              ) : (
+                <div className="cui-runs">
+                  {runs.map(run => <RunRow key={run.id} run={run} />)}
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/ChatView/ChatUsageStrip.jsx
+++ b/frontend/src/components/ChatView/ChatUsageStrip.jsx
@@ -1,0 +1,39 @@
+/**
+ * ChatUsageStrip — the always-visible, subtle cost/token readout that sits
+ * directly above the composer (between the last transcript chrome and
+ * ChatInputBar in ChatView.jsx). Moved here from an overlay badge on the
+ * brain icon per owner feedback: that badge was easy to miss and had no
+ * room for more than one number. This strip has room for cost AND the
+ * input/output split, and sits somewhere the eye already lands right above
+ * where a turn's cost just changed.
+ *
+ * "Live" here means "updates the moment a turn's usage is durable" — the
+ * chat-usage query is invalidated on every stream 'done' in ChatView, so
+ * this repaints within a network round-trip of a turn finishing. It is NOT
+ * a token-by-token ticker: Claude's SDK only reports usage on the terminal
+ * result of a turn (no incremental figure exists mid-turn to show), so a
+ * running turn correctly shows the PRE-turn total until it completes rather
+ * than a fake live number.
+ *
+ * Clicking opens the same full breakdown as the popover's "Token usage &
+ * cost" row — one destination, two entry points.
+ */
+
+import { formatUsageStripText } from './chatUsageFormat.js'
+
+export default function ChatUsageStrip({ totals, onOpen }) {
+  const text = formatUsageStripText(totals)
+  if (!text) return null
+  return (
+    <div className="chat__usage-strip-wrap">
+      <button
+        type="button"
+        className="chat__usage-strip"
+        onClick={onOpen}
+        aria-label={`${text} for this chat. Open token usage and cost breakdown.`}
+      >
+        {text}
+      </button>
+    </div>
+  )
+}

--- a/frontend/src/components/ChatView/ChatView.css
+++ b/frontend/src/components/ChatView/ChatView.css
@@ -2114,7 +2114,8 @@
 .chat__foot .chat__progress-step--toggle,
 .chat__foot .slash-menu,
 .chat__foot .chat__pill,
-.chat__foot .composer-plus { pointer-events: auto; }
+.chat__foot .composer-plus,
+.chat__foot .chat__usage-strip { pointer-events: auto; }
 
 /* One geometry-neutral stack for every control that floats above the measured
    footer. The safe default keeps transient-only controls clear of the composer.
@@ -2639,9 +2640,48 @@
    too and there is nothing separate here to mark active. */
 .chat__brain-usage {
   align-self: flex-end;
+  position: relative;
 }
 .chat__brain-usage:focus { outline: none; }
 .chat__brain-usage:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+/* Always-visible cost/token readout directly above the composer — moved
+   here (from an overlay badge on the brain icon) so it has room for more
+   than one number and sits where the eye already lands after a turn
+   finishes. Deliberately understated: no border/background/pill, just
+   muted small text, consistent with "subtle" — this is ambient status, not
+   a call to action. */
+.chat__usage-strip-wrap {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 0 4px;
+  display: flex;
+}
+
+.chat__usage-strip {
+  border: 0;
+  background: none;
+  padding: 2px 6px;
+  margin: 0 0 2px;
+  color: var(--muted);
+  font-size: 11.5px;
+  line-height: 1.4;
+  font-variant-numeric: tabular-nums;
+  cursor: pointer;
+  border-radius: 6px;
+  transition: color 0.12s, background 0.12s;
+}
+
+.chat__usage-strip:hover {
+  color: var(--text);
+  background: color-mix(in srgb, var(--surface2) 60%, transparent);
+}
+
+.chat__usage-strip:focus { outline: none; }
+.chat__usage-strip:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
 
 /* ── Composer popover (Attach + Model picker) ────────── */
 

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -13,7 +13,7 @@ import { useQueryClient } from '@tanstack/react-query'
 import Check from 'lucide-react/dist/esm/icons/check.mjs'
 import ArrowDown from 'lucide-react/dist/esm/icons/arrow-down.mjs'
 import { apiFetch, getAuthHeaders, jsonOrThrow, BASE } from '../../api/client.js'
-import { chatMessagesQueryKey, settingsQueries } from '../../hooks/queries.js'
+import { chatMessagesQueryKey, chatQueries, settingsQueries } from '../../hooks/queries.js'
 import useStreamConnection from './useStreamConnection.js'
 import useScrollMode, {
   FOLLOW_STICK_BAND_PX,
@@ -43,6 +43,9 @@ import ChatInputBar from './ChatInputBar.jsx'
 import { hasSendablePayload } from './composerSubmission.js'
 import AgentContextInspector from './AgentContextInspector.jsx'
 import ChatSummaryViewer from './ChatSummaryViewer.jsx'
+import ChatUsageInspector from './ChatUsageInspector.jsx'
+import ChatUsageStrip from './ChatUsageStrip.jsx'
+import { formatUsageAriaSummary } from './chatUsageFormat.js'
 import ComposerPopover from './ComposerPopover.jsx'
 import BrainUsageButton from './BrainUsageButton.jsx'
 import ConnectionStatus from './ConnectionStatus.jsx'
@@ -330,6 +333,14 @@ export default function ChatView({
   onDisplayReady = null,
 }) {
   const queryClient = useQueryClient()
+  // Cheap per-chat token/cost summary for the always-visible composer badge
+  // and the full breakdown panel. Not fetched for embedded app-owned chats
+  // (matches BrainUsageButton's own usageEnabled gate) since the owner never
+  // sees the composer chrome there.
+  const chatUsageQuery = chatQueries.usage.useQuery(chatId, {
+    enabled: !embedded && !!chatId,
+  })
+  const chatUsageAriaSummary = formatUsageAriaSummary(chatUsageQuery.data?.totals)
   const hiddenRef = useRef(hidden)
   hiddenRef.current = hidden
   // A drawer search may target a ChatView that is already mounted. Subscribe
@@ -534,6 +545,7 @@ export default function ChatView({
   // cards themselves use to publish the node being observed.
   const [showInspector, setShowInspector] = useState(false)
   const [showSummary, setShowSummary] = useState(false)
+  const [showUsage, setShowUsage] = useState(false)
   const [visibleMessageMetaKey, setVisibleMessageMetaKey] = useState(null)
   const messageMetaTimerRef = useRef(null)
   const [previewReadyStatus, setPreviewReadyStatus] = useState('')
@@ -1373,6 +1385,13 @@ export default function ChatView({
         }
         setPinnedSettleSeq(seq => seq + 1)
       }
+      // A finished turn (successful or not) may have persisted a new run
+      // with its own cost/token usage row. Cost isn't in this stream event
+      // (Claude only reports it in the terminal DB write, not the wire
+      // payload), so the always-visible usage badge stays correct by
+      // refetching the cheap per-chat summary here rather than threading a
+      // second usage-carrying event through the whole reducer pipeline.
+      chatQueries.usage.invalidate(queryClient, chatId)
       onStreamEnd?.({ continues })
     },
     onSystemEvent: event => {
@@ -4484,6 +4503,12 @@ export default function ChatView({
           onClose={() => setShowSummary(false)}
         />
       )}
+      {!embedded && showUsage && (
+        <ChatUsageInspector
+          chatId={chatId}
+          onClose={() => setShowUsage(false)}
+        />
+      )}
       {showEmpty && (
         <div className="chat__empty-wrap">
           {embedded ? (
@@ -4835,6 +4860,12 @@ export default function ChatView({
             focusComposer={() => focusComposerElement(inputRef.current)}
           />
         )}
+        {!embedded && (
+          <ChatUsageStrip
+            totals={chatUsageQuery.data?.totals}
+            onOpen={() => setShowUsage(true)}
+          />
+        )}
         <ChatInputBar
           chatId={chatId}
           input={input}
@@ -4870,7 +4901,7 @@ export default function ChatView({
               {({ icon, ariaLabel }) => (
               <ComposerPopover
                 modelTriggerIcon={icon}
-                modelTriggerAriaLabel={ariaLabel}
+                modelTriggerAriaLabel={`${ariaLabel}. ${chatUsageAriaSummary}`}
                 triggerAriaLabel={embedded ? 'Attach files' : 'Attach files or view chat info'}
                 chatInfo={showPicker ? chatInfo : null}
                 chatId={chatId}
@@ -4901,6 +4932,7 @@ export default function ChatView({
                 modelSelectionRequest={modelSelectionRequest}
                 onOpenInspector={() => setShowInspector(true)}
                 onOpenSummary={() => setShowSummary(true)}
+                onOpenUsage={() => setShowUsage(true)}
                 embedded={embedded}
               />
               )}

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -337,7 +337,7 @@ export default function ChatView({
   // and the full breakdown panel. Not fetched for embedded app-owned chats
   // (matches BrainUsageButton's own usageEnabled gate) since the owner never
   // sees the composer chrome there.
-  const chatUsageQuery = chatQueries.usage.useQuery(chatId, {
+  const chatUsageQuery = chatQueries.usageSummary.useQuery(chatId, {
     enabled: !embedded && !!chatId,
   })
   const chatUsageAriaSummary = formatUsageAriaSummary(chatUsageQuery.data?.totals)
@@ -1392,6 +1392,7 @@ export default function ChatView({
       // refetching the cheap per-chat summary here rather than threading a
       // second usage-carrying event through the whole reducer pipeline.
       chatQueries.usage.invalidate(queryClient, chatId)
+      chatQueries.usageSummary.invalidate(queryClient, chatId)
       onStreamEnd?.({ continues })
     },
     onSystemEvent: event => {

--- a/frontend/src/components/ChatView/ComposerPopover.jsx
+++ b/frontend/src/components/ChatView/ComposerPopover.jsx
@@ -36,7 +36,7 @@
  */
 
 import { useEffect, useLayoutEffect, useRef, useState } from 'react'
-import { FileDocument, InfoCircle, Paperclip, Plus } from '@openai/apps-sdk-ui/components/Icon'
+import { DollarCircle, FileDocument, InfoCircle, Paperclip, Plus } from '@openai/apps-sdk-ui/components/Icon'
 import ChatSettingsPanel from './ChatSettingsPanel.jsx'
 import { popoverMaxHeight, nearestClipTop } from './composerPopoverHeight.js'
 import { focusComposerElement } from './composerFocusPolicy.js'
@@ -70,6 +70,7 @@ export default function ComposerPopover({
   modelSelectionRequest = 0,
   onOpenInspector,
   onOpenSummary,
+  onOpenUsage,
   embedded = false,
   pending = false,
   modelTriggerIcon = null,
@@ -222,6 +223,11 @@ export default function ComposerPopover({
     onOpenSummary?.()
   }
 
+  function handleOpenUsage() {
+    setMode(null)
+    onOpenUsage?.()
+  }
+
   function toggleMode(nextMode, nextTriggerRef) {
     const el = composerInputRef?.current
     const wasFocused = document.activeElement === el
@@ -344,6 +350,21 @@ export default function ComposerPopover({
                 <span className="composer-popover__row-title">What the agent knows</span>
                 <span className="composer-popover__row-sub">
                   System prompt and recent chats
+                </span>
+              </span>
+            </button>
+            <button
+              type="button"
+              className="composer-popover__row"
+              onClick={handleOpenUsage}
+            >
+              <span className="composer-popover__row-icon" aria-hidden="true">
+                <DollarCircle width={18} height={18} />
+              </span>
+              <span className="composer-popover__row-main">
+                <span className="composer-popover__row-title">Token usage &amp; cost</span>
+                <span className="composer-popover__row-sub">
+                  Per-turn breakdown for this chat
                 </span>
               </span>
             </button>

--- a/frontend/src/components/ChatView/chatUsageFormat.js
+++ b/frontend/src/components/ChatView/chatUsageFormat.js
@@ -1,0 +1,78 @@
+/**
+ * Shared formatting for the chat token-usage/cost surfaces (the composer
+ * badge and the full ChatUsageInspector breakdown). One place so the badge's
+ * compact numbers and the inspector's precise ones never drift apart.
+ */
+
+export function formatTokenCount(value) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return null
+  if (value < 1000) return String(Math.round(value))
+  if (value < 1_000_000) {
+    const thousands = value / 1000
+    return `${thousands.toFixed(thousands < 10 ? 1 : 0)}k`
+  }
+  const millions = value / 1_000_000
+  return `${millions.toFixed(millions < 10 ? 1 : 0)}M`
+}
+
+export function formatCostUsd(value, { compact = false } = {}) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return null
+  if (value <= 0) return compact ? '$0' : '$0.00'
+  if (value < 0.01) return '<$0.01'
+  if (compact && value >= 10) return `$${Math.round(value)}`
+  return `$${value.toFixed(2)}`
+}
+
+// The composer badge: cost is the number owners actually think in, tokens
+// are the secondary detail available on hover/aria-label and in the full
+// inspector.
+export function formatUsageBadge(totals) {
+  if (!totals) return null
+  const cost = formatCostUsd(totals.cost_usd, { compact: true })
+  if (cost !== null) return cost
+  const tokens = formatTokenCount(totals.total_tokens)
+  return tokens ? `${tokens} tok` : null
+}
+
+// The subtle always-visible strip above the composer: cost plus the input/
+// output split, since "other details" (not just the total) was explicitly
+// asked for. Exact (non-compact) cost — this line has room, unlike the
+// icon badge it replaced.
+export function formatUsageStripText(totals) {
+  if (!totals) return null
+  const cost = formatCostUsd(totals.cost_usd)
+  const total = formatTokenCount(totals.total_tokens)
+  const input = formatTokenCount(totals.input_tokens)
+  const output = formatTokenCount(totals.output_tokens)
+  if (cost === null && !total) return null
+  const parts = []
+  if (cost !== null) parts.push(cost)
+  if (total) {
+    parts.push(input && output
+      ? `${total} tokens (${input} in · ${output} out)`
+      : `${total} tokens`)
+  }
+  return parts.join(' · ')
+}
+
+export function formatUsageAriaSummary(totals) {
+  if (!totals) return 'Usage not yet available for this chat'
+  const cost = formatCostUsd(totals.cost_usd)
+  const tokens = formatTokenCount(totals.total_tokens)
+  const parts = []
+  if (cost !== null) parts.push(`cost ${cost}`)
+  if (tokens) parts.push(`${tokens} tokens`)
+  return parts.length ? `Chat usage so far: ${parts.join(', ')}` : 'Usage not yet available for this chat'
+}
+
+export function formatTimestamp(value) {
+  if (!value) return null
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return null
+  return date.toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  })
+}

--- a/frontend/src/hooks/queries.js
+++ b/frontend/src/hooks/queries.js
@@ -377,10 +377,26 @@ export const appQueries = {
   },
 }
 
+async function fetchChatUsage(chatId) {
+  const res = await api.chats.usage(chatId)
+  return jsonOrThrow(res, 'chat usage fetch failed:')
+}
+
+function useChatUsageQuery(chatId, { enabled = true } = {}) {
+  return useQuery({
+    queryKey: ['chat-usage', chatId],
+    queryFn: () => fetchChatUsage(chatId),
+    enabled: enabled && Boolean(chatId),
+    staleTime: 30_000,
+    retry: 1,
+  })
+}
+
 export const chatQueries = {
   keys: {
     all: chatsKey,
     messages: (chatId) => ['chat-messages', chatId],
+    usage: (chatId) => ['chat-usage', chatId],
   },
   list: {
     key: chatsKey,
@@ -392,6 +408,12 @@ export const chatQueries = {
     key: (chatId) => ['chat-messages', chatId],
     fetch: fetchChatMessages,
     remove: (queryClient, chatId) => queryClient.removeQueries({ queryKey: ['chat-messages', chatId] }),
+  },
+  usage: {
+    key: (chatId) => ['chat-usage', chatId],
+    fetch: fetchChatUsage,
+    useQuery: useChatUsageQuery,
+    invalidate: (queryClient, chatId) => queryClient.invalidateQueries({ queryKey: ['chat-usage', chatId] }),
   },
 }
 

--- a/frontend/src/hooks/queries.js
+++ b/frontend/src/hooks/queries.js
@@ -382,10 +382,25 @@ async function fetchChatUsage(chatId) {
   return jsonOrThrow(res, 'chat usage fetch failed:')
 }
 
+async function fetchChatUsageSummary(chatId) {
+  const res = await api.chats.usageSummary(chatId)
+  return jsonOrThrow(res, 'chat usage summary fetch failed:')
+}
+
 function useChatUsageQuery(chatId, { enabled = true } = {}) {
   return useQuery({
     queryKey: ['chat-usage', chatId],
     queryFn: () => fetchChatUsage(chatId),
+    enabled: enabled && Boolean(chatId),
+    staleTime: 30_000,
+    retry: 1,
+  })
+}
+
+function useChatUsageSummaryQuery(chatId, { enabled = true } = {}) {
+  return useQuery({
+    queryKey: ['chat-usage-summary', chatId],
+    queryFn: () => fetchChatUsageSummary(chatId),
     enabled: enabled && Boolean(chatId),
     staleTime: 30_000,
     retry: 1,
@@ -397,6 +412,7 @@ export const chatQueries = {
     all: chatsKey,
     messages: (chatId) => ['chat-messages', chatId],
     usage: (chatId) => ['chat-usage', chatId],
+    usageSummary: (chatId) => ['chat-usage-summary', chatId],
   },
   list: {
     key: chatsKey,
@@ -414,6 +430,12 @@ export const chatQueries = {
     fetch: fetchChatUsage,
     useQuery: useChatUsageQuery,
     invalidate: (queryClient, chatId) => queryClient.invalidateQueries({ queryKey: ['chat-usage', chatId] }),
+  },
+  usageSummary: {
+    key: (chatId) => ['chat-usage-summary', chatId],
+    fetch: fetchChatUsageSummary,
+    useQuery: useChatUsageSummaryQuery,
+    invalidate: (queryClient, chatId) => queryClient.invalidateQueries({ queryKey: ['chat-usage-summary', chatId] }),
   },
 }
 


### PR DESCRIPTION


https://github.com/user-attachments/assets/acf98d8b-33d9-4eb1-8d50-0d95acc534ae





## Summary
- Adds a subtle, always-visible cost/token readout above the chat composer, updating as soon as a turn's usage is durable.
- Adds a "Token usage & cost" panel (reachable from the composer's `+` menu) with a full per-turn breakdown: fresh vs. cached input tokens, cache-write tokens, output tokens, reasoning tokens, model, context window, and cost.
- Backed by the existing `GET /chats/{id}/usage` diagnostic endpoint, which already computed and stored this data per turn but had no UI surface.

## Why
Chat cost/token accounting was already tracked server-side per turn (provider-neutral, with Claude and Codex both normalized), but nothing in the UI ever showed it to the owner. This surfaces it without inventing new backend tracking: cost is the provider's standard per-token API rate applied to the turn's usage, which is the same notional-cost figure Claude Code's own SDK returns regardless of subscription vs. pay-as-you-go billing.

## What's intentionally NOT included
- Per-tool-call / per-file token attribution: providers only report usage at the whole-turn level, so a computed estimate would look precise without matching real billing. Left out rather than shown as a misleading number.
- A token-by-token live ticker: Claude's SDK only reports usage on a turn's terminal result (no incremental figure exists mid-turn), so the readout updates once per completed turn rather than faking continuous movement.

## Testing
- `npx eslint` on the changed files: no new errors (pre-existing warnings only).
- `npm run build`: production build succeeds.
- Manually verified in a live chat with real multi-turn usage: the composer strip and the full breakdown panel both render correct historical data end to end.