### PR TITLE
Discard an unconfirmed provider switch when the model picker closes

### DIFF
--- a/frontend/src/components/ChatView/ComposerPopover.jsx
+++ b/frontend/src/components/ChatView/ComposerPopover.jsx
@@ -46,6 +46,7 @@ import {
   clientPointToLayout,
 } from '../../lib/layoutSpace.js'
 import useModelSelectionPopover from './hooks/useModelSelectionPopover.js'
+import { clearProviderSwitch } from './providerSwitch.js'
 
 export default function ComposerPopover({
   chatInfo,
@@ -97,6 +98,21 @@ export default function ComposerPopover({
     composerInputRef,
   )
   const open = mode !== null
+
+  // Leaving the model picker with an unconfirmed cross-provider switch staged is
+  // a no-op: discard it so reopening the picker shows the current model, not a
+  // lingering "confirm?" for a model the owner picked but never confirmed. Only
+  // the staged `confirming` state is dropped — an in-flight `switching` or a
+  // committed `success` is left alone.
+  const prevModeRef = useRef(mode)
+  useEffect(() => {
+    const leftModelPicker = prevModeRef.current === 'model' && mode !== 'model'
+    prevModeRef.current = mode
+    if (leftModelPicker && providerSwitchState?.status === 'confirming') {
+      clearProviderSwitch(chatId)
+    }
+  }, [mode, providerSwitchState?.status, chatId])
+
   // Measured cap on the panel's height: the space above the trigger inside both
   // the chat pane (which clips with `overflow: hidden`) and the keyboard-shrunk
   // visible viewport. See composerPopoverHeight.js for why CSS viewport units

--- a/frontend/src/components/ChatView/ComposerPopover.jsx
+++ b/frontend/src/components/ChatView/ComposerPopover.jsx
@@ -46,7 +46,7 @@ import {
   clientPointToLayout,
 } from '../../lib/layoutSpace.js'
 import useModelSelectionPopover from './hooks/useModelSelectionPopover.js'
-import { clearProviderSwitch } from './providerSwitch.js'
+import useDiscardUnconfirmedSwitchOnPickerClose from './hooks/useDiscardUnconfirmedSwitchOnPickerClose.js'
 
 export default function ComposerPopover({
   chatInfo,
@@ -99,19 +99,7 @@ export default function ComposerPopover({
   )
   const open = mode !== null
 
-  // Leaving the model picker with an unconfirmed cross-provider switch staged is
-  // a no-op: discard it so reopening the picker shows the current model, not a
-  // lingering "confirm?" for a model the owner picked but never confirmed. Only
-  // the staged `confirming` state is dropped — an in-flight `switching` or a
-  // committed `success` is left alone.
-  const prevModeRef = useRef(mode)
-  useEffect(() => {
-    const leftModelPicker = prevModeRef.current === 'model' && mode !== 'model'
-    prevModeRef.current = mode
-    if (leftModelPicker && providerSwitchState?.status === 'confirming') {
-      clearProviderSwitch(chatId)
-    }
-  }, [mode, providerSwitchState?.status, chatId])
+  useDiscardUnconfirmedSwitchOnPickerClose(mode, providerSwitchState?.status, chatId)
 
   // Measured cap on the panel's height: the space above the trigger inside both
   // the chat pane (which clips with `overflow: hidden`) and the keyboard-shrunk

--- a/frontend/src/components/ChatView/hooks/__tests__/useDiscardUnconfirmedSwitchOnPickerClose.test.js
+++ b/frontend/src/components/ChatView/hooks/__tests__/useDiscardUnconfirmedSwitchOnPickerClose.test.js
@@ -1,0 +1,95 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  beginProviderSwitch,
+  completeProviderSwitch,
+  getProviderSwitchState,
+  resetProviderSwitchMemoryForTests,
+  stageProviderSwitch,
+} from '../../providerSwitch.js'
+import useDiscardUnconfirmedSwitchOnPickerClose from '../useDiscardUnconfirmedSwitchOnPickerClose.js'
+import { renderHook } from './react-hook-shim.mjs'
+
+// Renders the hook already "inside" the open picker (mode 'model'), then
+// returns a `closePicker` that drives the 'model' -> null transition the
+// component sees when the picker closes.
+function openPicker(chatId, status) {
+  const { rerender } = renderHook(
+    useDiscardUnconfirmedSwitchOnPickerClose,
+    'model',
+    status,
+    chatId,
+  )
+  return {
+    closePicker: () => rerender(null, status, chatId),
+    rerender,
+  }
+}
+
+test('closing the picker on an unconfirmed switch discards it', () => {
+  resetProviderSwitchMemoryForTests()
+  const chatId = 'chat-confirming'
+  stageProviderSwitch(chatId, { chatId, switchId: 'switch-1' })
+  assert.equal(getProviderSwitchState(chatId).status, 'confirming')
+
+  const { closePicker } = openPicker(chatId, 'confirming')
+  closePicker()
+
+  assert.equal(getProviderSwitchState(chatId).status, 'idle')
+})
+
+test('closing the picker leaves an in-flight switch untouched', () => {
+  resetProviderSwitchMemoryForTests()
+  const chatId = 'chat-switching'
+  const request = { chatId, switchId: 'switch-1' }
+  stageProviderSwitch(chatId, request)
+  beginProviderSwitch(chatId, request)
+  assert.equal(getProviderSwitchState(chatId).status, 'switching')
+
+  const { closePicker } = openPicker(chatId, 'switching')
+  closePicker()
+
+  assert.equal(getProviderSwitchState(chatId).status, 'switching')
+})
+
+test('closing the picker leaves a committed switch untouched', () => {
+  resetProviderSwitchMemoryForTests()
+  const chatId = 'chat-success'
+  const request = { chatId, switchId: 'switch-1' }
+  completeProviderSwitch(chatId, request, { provider: 'codex' })
+  assert.equal(getProviderSwitchState(chatId).status, 'success')
+
+  const { closePicker } = openPicker(chatId, 'success')
+  closePicker()
+
+  assert.equal(getProviderSwitchState(chatId).status, 'success')
+})
+
+test('closing the picker with no staged switch is a no-op', () => {
+  resetProviderSwitchMemoryForTests()
+  const chatId = 'chat-idle'
+
+  const { closePicker } = openPicker(chatId, undefined)
+  closePicker()
+
+  assert.equal(getProviderSwitchState(chatId).status, 'idle')
+})
+
+test('opening the picker does not discard a confirming switch', () => {
+  resetProviderSwitchMemoryForTests()
+  const chatId = 'chat-open'
+  stageProviderSwitch(chatId, { chatId, switchId: 'switch-1' })
+
+  // Start with the picker closed, then open it (null -> 'model'). Entering the
+  // picker is not a close, so the staged switch must survive to be shown.
+  const { rerender } = renderHook(
+    useDiscardUnconfirmedSwitchOnPickerClose,
+    null,
+    'confirming',
+    chatId,
+  )
+  rerender('model', 'confirming', chatId)
+
+  assert.equal(getProviderSwitchState(chatId).status, 'confirming')
+})

--- a/frontend/src/components/ChatView/hooks/useDiscardUnconfirmedSwitchOnPickerClose.js
+++ b/frontend/src/components/ChatView/hooks/useDiscardUnconfirmedSwitchOnPickerClose.js
@@ -1,0 +1,36 @@
+import { useEffect, useRef } from 'react'
+import { clearProviderSwitch } from '../providerSwitch.js'
+
+/**
+ * Leaving the model picker with an unconfirmed cross-provider switch staged is
+ * a no-op: discard it so reopening the picker shows the current model, not a
+ * lingering "confirm?" for a model the owner picked but never confirmed.
+ *
+ * `ComposerPopover` stays mounted across the picker's open/close (only the
+ * panel unmounts), so the composer `mode` leaving `'model'` is the reliable
+ * signal that the picker closed. Only the staged `'confirming'` state is
+ * dropped — an in-flight `'switching'` or a committed `'success'` is left
+ * alone, and entering the picker or any transition without a staged switch is
+ * a no-op. Chat navigation remounts this component, so it is not a picker
+ * close and keeps its existing restore behavior.
+ *
+ * @param {string|null} mode - the composer popover mode (`'model'` when the
+ *   picker is open).
+ * @param {string|undefined} providerSwitchStatus - the staged switch status for
+ *   this chat (`'confirming' | 'switching' | 'success' | 'error' | 'idle'`).
+ * @param {string} chatId - the chat whose staged switch is discarded.
+ */
+export default function useDiscardUnconfirmedSwitchOnPickerClose(
+  mode,
+  providerSwitchStatus,
+  chatId,
+) {
+  const prevModeRef = useRef(mode)
+  useEffect(() => {
+    const leftModelPicker = prevModeRef.current === 'model' && mode !== 'model'
+    prevModeRef.current = mode
+    if (leftModelPicker && providerSwitchStatus === 'confirming') {
+      clearProviderSwitch(chatId)
+    }
+  }, [mode, providerSwitchStatus, chatId])
+}


### PR DESCRIPTION
## Problem

Selecting a cross-provider model on a chat that already has history stages a provider switch that must be confirmed (sessions aren't portable across providers, so the incoming provider prepares a handoff). If the owner closes the model picker without confirming, the staged switch is preserved: `restorableProviderSwitch` keeps it across the panel remount as long as the chat and source provider are unchanged. Reopening the picker then shows a lingering "confirm?" for a model the owner picked but never confirmed, instead of the model the chat is actually on.

## Fix

Make leaving the model picker a no-op for an unconfirmed switch. `ComposerPopover` stays mounted across the picker's open/close (the panel itself unmounts), so it's the right place to detect the transition: when the composer `mode` leaves `'model'` while a switch is still in the staged `'confirming'` state, discard it with `clearProviderSwitch`. The current model and effort stay put.

An in-flight `'switching'` or a committed `'success'` is deliberately left untouched, and navigating between chats keeps its existing restore behavior (that path is not a picker close).

## Verification

The full frontend build passes with the change. Behaviour reasoned against the existing `providerSwitch` store contract (unit tests for `clearProviderSwitch` cover the store side).