### PR TITLE
Align activity and Goal status text sizes

### DIFF
--- a/frontend/src/components/ChatView/ChatView.css
+++ b/frontend/src/components/ChatView/ChatView.css
@@ -103,6 +103,7 @@
      reserve for the chip tray when it caps its own growth. Changing it here
      keeps a pending attachment and a sent one the same square. */
   --attach-card: 96px;
+  --chat-status-font-size: 12px;
   display: flex;
   flex-direction: column;
   height: 100%;
@@ -3300,7 +3301,7 @@
   border: 1px solid var(--border-light); /* CONTRACT: subtle 1px hairline on the frosted card */
   backdrop-filter: blur(16px) saturate(140%);
   -webkit-backdrop-filter: blur(16px) saturate(140%);
-  font-size: 12px;
+  font-size: var(--chat-status-font-size);
   line-height: 1.3;
   animation: progress-rail-in 0.22s ease both;
 }
@@ -3460,7 +3461,7 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   color: var(--text);
-  font-size: 12px;
+  font-size: var(--chat-status-font-size);
 }
 
 .chat__wait-meta {

--- a/frontend/src/components/ChatView/ChatView.css
+++ b/frontend/src/components/ChatView/ChatView.css
@@ -1683,7 +1683,7 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   color: var(--muted); /* CONTRACT: calm prose voice — regular UI font, NOT --mono; identifiers live in the expanded ToolBlock */
-  font-size: 13px;
+  font-size: 12px;
 }
 
 /* Liveness IS the label — a masked solid-text sweep (the sibling's chat-

--- a/frontend/src/components/ChatView/ChatView.css
+++ b/frontend/src/components/ChatView/ChatView.css
@@ -1683,7 +1683,7 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   color: var(--muted); /* CONTRACT: calm prose voice — regular UI font, NOT --mono; identifiers live in the expanded ToolBlock */
-  font-size: 12px;
+  font-size: 13px;
 }
 
 /* Liveness IS the label — a masked solid-text sweep (the sibling's chat-
@@ -3460,6 +3460,7 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   color: var(--text);
+  font-size: 12px;
 }
 
 .chat__wait-meta {

--- a/frontend/src/components/ChatView/__tests__/chatUiPolish.test.js
+++ b/frontend/src/components/ChatView/__tests__/chatUiPolish.test.js
@@ -81,24 +81,22 @@ test('mobile messages preserve native text selection and its action menu', () =>
     'messages must not suppress the native selection action menu')
 })
 
-test('web tool activity uses the assistant reading width', () => {
+test('activity surfaces use their intended width and compact status type', () => {
   const css = stripComments(chatCss)
   const desktopRule = css.match(/@media\s*\(min-width:\s*720px\)\s*\{\s*\.chat__tools\s*\{[^}]*\}/)?.[0] || ''
+  const chatRule = css.match(/\.chat\s*\{[^}]*\}/)?.[0] || ''
+  const goalRailRule = css.match(/\.chat__progress-rail\s*\{[^}]*\}/)?.[0] || ''
+  const waitTextRule = (css.match(/\.chat__wait-text\s*\{[^}]*\}/g) || [])
+    .find(rule => /font-size:/.test(rule)) || ''
 
   assert.match(desktopRule, /width:\s*min\(100%,\s*720px\)/,
     'tool activity should grow to the assistant reading measure on web')
-})
-
-test('Waiting descriptions share the Goal rail text size', () => {
-  const css = stripComments(chatCss)
-  const waitTextRule = (css.match(/\.chat__wait-text\s*\{[^}]*\}/g) || [])
-    .find(rule => /font-size:/.test(rule)) || ''
-  const goalRailRule = css.match(/\.chat__progress-rail\s*\{[^}]*\}/)?.[0] || ''
-
-  assert.match(waitTextRule, /font-size:\s*12px/,
-    'the Waiting description should use the compact Goal text size')
-  assert.match(goalRailRule, /font-size:\s*12px/,
-    'the Goal rail remains the reference size for above-composer status UI')
+  assert.match(chatRule, /--chat-status-font-size:\s*12px/,
+    'above-composer status surfaces should share one compact type token')
+  assert.match(goalRailRule, /font-size:\s*var\(--chat-status-font-size\)/,
+    'the Goal rail should use the shared status type token')
+  assert.match(waitTextRule, /font-size:\s*var\(--chat-status-font-size\)/,
+    'Waiting descriptions should use the shared status type token')
 })
 
 test('message references use a bounded responsive two-column grid', () => {

--- a/frontend/src/components/ChatView/__tests__/chatUiPolish.test.js
+++ b/frontend/src/components/ChatView/__tests__/chatUiPolish.test.js
@@ -89,6 +89,18 @@ test('web tool activity uses the assistant reading width', () => {
     'tool activity should grow to the assistant reading measure on web')
 })
 
+test('activity labels share the Goal rail text size', () => {
+  const css = stripComments(chatCss)
+  const activityRule = (css.match(/\.chat__activity-label\s*\{[^}]*\}/g) || [])
+    .find(rule => /font-size:/.test(rule)) || ''
+  const goalRailRule = css.match(/\.chat__progress-rail\s*\{[^}]*\}/)?.[0] || ''
+
+  assert.match(activityRule, /font-size:\s*12px/,
+    'Monitor and other activity labels should use the compact Goal text size')
+  assert.match(goalRailRule, /font-size:\s*12px/,
+    'the Goal rail remains the reference size for above-composer status UI')
+})
+
 test('message references use a bounded responsive two-column grid', () => {
   const css = stripComments(chatCss)
   const sourcesRule = css.match(/\.chat__sources\s*\{[^}]*\}/)?.[0] || ''

--- a/frontend/src/components/ChatView/__tests__/chatUiPolish.test.js
+++ b/frontend/src/components/ChatView/__tests__/chatUiPolish.test.js
@@ -89,14 +89,14 @@ test('web tool activity uses the assistant reading width', () => {
     'tool activity should grow to the assistant reading measure on web')
 })
 
-test('activity labels share the Goal rail text size', () => {
+test('Waiting descriptions share the Goal rail text size', () => {
   const css = stripComments(chatCss)
-  const activityRule = (css.match(/\.chat__activity-label\s*\{[^}]*\}/g) || [])
+  const waitTextRule = (css.match(/\.chat__wait-text\s*\{[^}]*\}/g) || [])
     .find(rule => /font-size:/.test(rule)) || ''
   const goalRailRule = css.match(/\.chat__progress-rail\s*\{[^}]*\}/)?.[0] || ''
 
-  assert.match(activityRule, /font-size:\s*12px/,
-    'Monitor and other activity labels should use the compact Goal text size')
+  assert.match(waitTextRule, /font-size:\s*12px/,
+    'the Waiting description should use the compact Goal text size')
   assert.match(goalRailRule, /font-size:\s*12px/,
     'the Goal rail remains the reference size for above-composer status UI')
 })


### PR DESCRIPTION
## Summary
- match Monitor and other activity labels to the compact Goal progress text
- leave composer and message typography unchanged
- preserve the shared size with a focused regression check

## Testing
- `node --loader=./src/lib/__tests__/vite-env-loader.mjs --test src/components/ChatView/__tests__/chatUiPolish.test.js`