### PR TITLE
Make the last-selected picker choice the provider source of truth

### DIFF
--- a/backend/app/providers.py
+++ b/backend/app/providers.py
@@ -779,6 +779,66 @@ def resolve_default_provider(
   return provider_id
 
 
+def provider_of_model(model: str | None) -> str | None:
+  """The provider a model id belongs to, or None for unknown/blank ids."""
+  if not isinstance(model, str) or not model:
+    return None
+  for provider_id, model_ids in KNOWN_MODELS.items():
+    if model in model_ids:
+      return provider_id
+  return None
+
+
+def owner_default_provider(
+  data_dir: str,
+  configured_provider: str | None = None,
+) -> str:
+  """The provider from the owner's latest atomic picker choice.
+
+  There is no separate provider selection in the UI: the owner picks a model,
+  and the provider is implied by it. `Owner.provider` and the global default
+  `model` are two independent last-writer-wins cells, so when several chats run
+  at once they drift apart (one chat's provider write + another chat's model
+  write). Anything that reads `Owner.provider` as "the default provider" can then
+  disagree with the model — most visibly, a new chat born on a provider whose
+  remembered model belongs to the OTHER family resolves to no model at all.
+
+  The picker mirrors its model and provider together in one atomic shared-file
+  update. Known catalog models remain self-identifying, which lets this reader
+  repair an older or contradictory mirror. For a live-discovered model outside
+  the static failure-fallback catalog, the provider stored alongside that model
+  is authoritative instead of guessing from a model naming convention.
+
+  `Owner.provider` is demoted to a fallback used only on the genuine first run,
+  when no picker choice has been remembered yet. Every "default provider" reader
+  routes through here so no code path can produce a provider that disagrees with
+  the latest complete picker choice.
+
+  With no remembered model, this delegates to `resolve_default_provider`, which
+  keeps the fresh-owner contract (fall forward to a connected provider instead of
+  surfacing a disconnected default, so a codex-only setup never dead-ends on
+  Claude). The picker still prompts because no model resolves.
+
+  Background agents are deliberately NOT routed here: they carry their own
+  configured provider/model block, a separate selection from the interactive
+  last-used model.
+  """
+  settings = _load_agent_settings(data_dir)
+  model = settings.get("model")
+  prov = provider_of_model(model)
+  if prov is not None and prov in PROVIDERS:
+    return prov
+  mirrored_provider = settings.get("provider")
+  if (
+    isinstance(model, str)
+    and model.strip()
+    and mirrored_provider in PROVIDERS
+    and not _model_belongs_to_other_provider(model, mirrored_provider)
+  ):
+    return mirrored_provider
+  return resolve_default_provider(data_dir, configured_provider)
+
+
 def get_provider(provider_id: str | None = None) -> BaseProvider:
   """Returns a provider by ID, falling back to the default."""
   return PROVIDERS.get(provider_id or DEFAULT_PROVIDER, PROVIDERS[DEFAULT_PROVIDER])

--- a/backend/app/routes/apps.py
+++ b/backend/app/routes/apps.py
@@ -1366,7 +1366,9 @@ async def create_conflict_resolver_chat(
         )
 
     title = f"Resolve {app.name} update conflict"
-    provider = providers.resolve_default_provider(
+    # Provider follows the last-selected model (the single source of truth),
+    # matching owner chat creation.
+    provider = providers.owner_default_provider(
       get_settings().data_dir, owner.provider if owner else None,
     )
     chat = models.Chat(

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -839,11 +839,14 @@ async def provider_status(
   for any registered provider, not just Claude. `authenticated` remains as a
   compatibility alias; neither field performs a remote token probe.
   """
-  from app.providers import get_provider
-  provider = get_provider(owner.provider)
+  from app.providers import get_provider, owner_default_provider
+  # The active provider is the one the last-selected model implies (the single
+  # source of truth), so this status matches the provider chats will actually use.
+  provider_id = owner_default_provider(get_settings().data_dir, owner.provider)
+  provider = get_provider(provider_id)
   error = provider.check_auth(get_settings().data_dir)
   return {
-    "provider": owner.provider or "claude",
+    "provider": provider_id,
     "provider_name": provider.name,
     "configured": error is None,
     "authenticated": error is None,

--- a/backend/app/routes/chats.py
+++ b/backend/app/routes/chats.py
@@ -251,7 +251,10 @@ def _mirror_agent_defaults(
   settings_obj: dict,
 ) -> None:
   """Repair the best-effort defaults mirrored from a committed chat choice."""
-  patch = {}
+  # Keep the model's provider in the SAME atomic shared-file update. Live model
+  # discovery can expose ids outside KNOWN_MODELS, so model text alone is not a
+  # durable provider classifier.
+  patch = {"provider": provider_id}
   for key in ("model", "effort", "effort_by_provider"):
     value = settings_obj.get(key)
     if value is not None:
@@ -873,7 +876,10 @@ def create_chat(
 
   owner = db.query(models.Owner).first()
   data_dir = get_settings().data_dir
-  provider = providers.resolve_default_provider(
+  # Provider follows the last-selected model (the single source of truth) so a
+  # new chat always starts on the family of the model it will actually use —
+  # never a provider whose remembered model belongs to the other family.
+  provider = providers.owner_default_provider(
     data_dir, owner.provider if owner else None,
   )
 
@@ -1255,7 +1261,9 @@ async def patch_chat(
       and settings_obj
       and picker_settings_changed
     ):
-      mirror_patch = {}
+      # Model + provider are one picker choice. Persist them in one atomic
+      # shared-file update so concurrent chats cannot split the pair.
+      mirror_patch = {"provider": chat.provider}
       for key in ("model", "effort", "effort_by_provider"):
         value = settings_obj.get(key)
         if value is not None:
@@ -2500,7 +2508,7 @@ def create_app_chat(
 
   owner = db.query(models.Owner).first()
   data_dir = get_settings().data_dir
-  provider = body.provider or providers.resolve_default_provider(
+  provider = body.provider or providers.owner_default_provider(
     data_dir, owner.provider if owner else None,
   )
   if provider not in ("claude", "codex"):

--- a/backend/app/routes/chats_stream.py
+++ b/backend/app/routes/chats_stream.py
@@ -41,7 +41,7 @@ from app.chat_visibility import coerce_agent_settings
 from app.providers import (
   _load_agent_settings,
   effective_agent_settings,
-  resolve_default_provider,
+  owner_default_provider,
 )
 from app.runner_registry import RunnerKind, registry
 from app.config import get_settings
@@ -117,7 +117,10 @@ def _next_execution_provider(db: Session, chat: models.Chat) -> str:
     and not is_draining()
   ):
     owner = db.query(models.Owner).first()
-    return resolve_default_provider(
+    # Provider follows the last-selected model, matching new-chat creation, so a
+    # pristine chat's first send can't re-diverge onto a family whose remembered
+    # model belongs to the other provider.
+    return owner_default_provider(
       get_settings().data_dir, owner.provider if owner else None,
     )
   return provider

--- a/backend/app/routes/settings.py
+++ b/backend/app/routes/settings.py
@@ -256,7 +256,10 @@ def get_settings_view(
   """
   data_dir = get_app_settings().data_dir
   codex_creds = Path(data_dir) / "cli-auth" / "codex" / "auth.json"
-  provider = providers.resolve_default_provider(data_dir, owner.provider)
+  # The displayed current provider follows the last-selected model (the single
+  # source of truth), so the picker never shows a provider that disagrees with
+  # the model it would resolve.
+  provider = providers.owner_default_provider(data_dir, owner.provider)
   agent_settings = providers.effective_agent_settings(
     data_dir, None, provider
   )
@@ -313,6 +316,10 @@ def update_settings(
         current["skills_enabled"] = bool(body.skills_enabled)
       if body.agent_settings is not None:
         current.update(_agent_settings_payload(body.agent_settings))
+        if body.provider in providers.PROVIDERS:
+          # Legacy owner settings still submit provider + model together. Keep
+          # that picker choice atomic for live model ids outside KNOWN_MODELS.
+          current["provider"] = body.provider
       if body.background_agents is not None:
         provider = providers.resolve_default_provider(data_dir, owner.provider)
         existing = providers.background_agent_settings(data_dir, provider)

--- a/backend/tests/test_app_chat_contract.py
+++ b/backend/tests/test_app_chat_contract.py
@@ -30,7 +30,9 @@ def test_app_token_can_create_and_send_to_own_chat(client, owner_token, db):
   # Create an app-owned chat.
   r = client.post(
     "/api/app-chats", json={
-      "title": "App conversation", "model": "claude-opus-4-8",
+      "title": "App conversation",
+      "provider": "claude",
+      "model": "claude-opus-4-8",
     },
     headers={"Authorization": f"Bearer {app_token}"},
   )
@@ -75,7 +77,7 @@ def test_app_chat_first_send_preserves_provider_selected_at_create(
 
   _, app_token = _make_app(client, owner_token, "provider-preserving-chat")
   monkeypatch.setattr(
-    chats_stream, "resolve_default_provider", lambda *_: "claude",
+    chats_stream, "owner_default_provider", lambda *_: "claude",
   )
 
   for sender_token in (app_token, owner_token):
@@ -121,7 +123,7 @@ def test_owner_chat_first_send_still_uses_latest_selected_provider(
   assert created.status_code == 200, created.text
   chat_id = created.json()["id"]
   monkeypatch.setattr(
-    chats_stream, "resolve_default_provider", lambda *_: "codex",
+    chats_stream, "owner_default_provider", lambda *_: "codex",
   )
   row = db.query(models.Chat).filter(models.Chat.id == chat_id).one()
   row.agent_settings_json = {"model": "gpt-5.6-sol"}
@@ -199,6 +201,7 @@ def test_app_chat_create_and_patch_store_custom_system_prompt(
     json={
       "title": "App conversation",
       "system_prompt": "You live inside the Notes app.",
+      "provider": "claude",
       "model": "claude-sonnet-4-6",
     },
     headers={"Authorization": f"Bearer {app_token}"},

--- a/backend/tests/test_chat_agent_settings.py
+++ b/backend/tests/test_chat_agent_settings.py
@@ -85,6 +85,110 @@ def test_effective_settings_has_no_model_until_manual_pick(tmp_path):
   assert result["effort"] == "medium"
 
 
+def test_new_chat_provider_follows_last_selected_model(tmp_path):
+  """A new chat's provider follows the remembered model's family, so it can't
+  be born on a provider whose model belongs to the OTHER family. The stored
+  provider (which can drift when many chats run at once) is ignored while a
+  model is remembered."""
+  from app.providers import owner_default_provider
+
+  shared = tmp_path / "shared"
+  shared.mkdir()
+  # Last-selected model is a Claude one; the drifted stored provider is codex.
+  (shared / "agent-settings.json").write_text(
+    json.dumps({"model": "claude-opus-4-8"})
+  )
+  assert owner_default_provider(str(tmp_path), "codex") == "claude"
+
+  # And the reverse: a remembered Codex model wins over a stale claude provider.
+  (shared / "agent-settings.json").write_text(
+    json.dumps({"model": "gpt-5.6-sol"})
+  )
+  assert owner_default_provider(str(tmp_path), "claude") == "codex"
+
+
+def test_new_chat_provider_follows_live_model_picker_pair(tmp_path):
+  """Live discovery is broader than KNOWN_MODELS. The provider persisted in
+  the same picker write keeps a newly released model usable without teaching
+  the backend its naming convention first."""
+  from app.providers import owner_default_provider
+
+  shared = tmp_path / "shared"
+  shared.mkdir()
+  (shared / "agent-settings.json").write_text(json.dumps({
+    "model": "future-catalog-id-with-no-family-prefix",
+    "provider": "codex",
+  }))
+  assert owner_default_provider(str(tmp_path), "claude") == "codex"
+
+
+def test_known_model_repairs_contradictory_picker_provider(tmp_path):
+  """A known model remains self-identifying if an old writer or manual edit
+  leaves a contradictory provider beside it."""
+  from app.providers import owner_default_provider
+
+  shared = tmp_path / "shared"
+  shared.mkdir()
+  (shared / "agent-settings.json").write_text(json.dumps({
+    "model": "claude-opus-4-8",
+    "provider": "codex",
+  }))
+  assert owner_default_provider(str(tmp_path), "codex") == "claude"
+
+
+def test_new_chat_provider_falls_back_to_stored_on_first_run(tmp_path):
+  """With no model ever selected, provider comes from the stored value and the
+  picker prompts on first send (the one legitimate no-model case)."""
+  from app.providers import owner_default_provider
+
+  shared = tmp_path / "shared"
+  shared.mkdir()
+  (shared / "agent-settings.json").write_text(json.dumps({}))
+  assert owner_default_provider(str(tmp_path), "codex") == "codex"
+  # And nothing resolves a model, so admission still asks for a pick.
+  assert effective_agent_settings(
+    str(tmp_path), None, provider="codex",
+  )["model"] is None
+
+
+def test_created_chat_provider_follows_remembered_model_over_drift(
+  client, auth, db,
+):
+  """End to end: a drifted owner.provider must not birth a mismatched chat.
+  With a Codex model remembered but owner.provider stuck on claude, a new chat
+  starts on codex so it resolves to that remembered model instead of nothing."""
+  from app import models
+
+  _write_global_settings({"model": "gpt-5.6-sol", "effort": "high"})
+  owner = db.query(models.Owner).first()
+  owner.provider = "claude"
+  db.commit()
+
+  created = client.post(
+    "/api/chats", headers=auth, json={"title": "fresh"},
+  ).json()
+  db.expire_all()
+  row = db.query(models.Chat).filter(models.Chat.id == created["id"]).first()
+  assert row.provider == "codex"
+
+
+def test_settings_view_provider_follows_remembered_model_over_drift(
+  client, auth, db,
+):
+  """GET /settings reports the provider the last-selected model implies, not a
+  drifted owner.provider, so the picker shows a consistent model + provider."""
+  from app import models
+
+  _write_global_settings({"model": "gpt-5.6-sol", "effort": "high"})
+  owner = db.query(models.Owner).first()
+  owner.provider = "claude"
+  db.commit()
+
+  body = client.get("/api/settings", headers=auth).json()
+  assert body["provider"] == "codex"
+  assert body["agent_settings"]["model"] == "gpt-5.6-sol"
+
+
 def test_patch_chat_writes_override(client, auth, chat):
   """PATCH /chats/{id} sets agent_settings_json and returns effective."""
   _write_global_settings({"model": "default-model"})
@@ -475,6 +579,7 @@ def test_patch_chat_provider_and_model_in_same_request(
   body = r.json()
   assert body["provider"] == "codex"
   assert body["agent_settings_json"] == {"model": "gpt-5.4-codex"}
+  assert _read_global_settings()["provider"] == "codex"
 
 
 def test_run_chat_passes_merged_settings_into_claude_sdk(


### PR DESCRIPTION
## Problem

The default provider and global model were mirrored through overlapping but separate writes. Concurrent chats could therefore leave a new chat on a provider whose remembered model belongs to another family, and explicit model selection would refuse to start that chat.

The narrower fix derived provider only from the static fallback catalog. That was still incomplete: the picker deliberately exposes live-discovered model IDs beyond the fallback list, so a valid new model could again fall back to stale provider state.

## Fix

Treat the latest picker choice as one atomic model/provider pair:

- chat picker changes, provider handoffs, and the legacy owner settings surface persist model and provider in the same shared-file update;
- known catalog models remain self-identifying and repair contradictory legacy data;
- live-discovered models use the provider captured beside the exact model choice rather than a naming heuristic;
- owner chat creation, app-created chats, pristine-chat first send, settings display, and provider status all resolve through the same default-provider helper.

The database provider remains only the genuine first-run fallback when no picker choice exists. Background agents remain separate because they carry their own explicit provider/model configuration.

This supersedes #902, which covers only the new-chat paths and still relies on static model classification.

## Tests

- 140 affected backend tests pass across chat settings, owner settings, provider status, app chats, and conflict-resolver creation.
- The 84-test hermetic backend contract suite passes.
- Changed Python modules compile; the exact full diff passes whitespace, privacy, and clean-worktree review.