### PR TITLE
Keep worktree tests independent of live origins

### DIFF
--- a/backend/tests/test_test_entrypoint.py
+++ b/backend/tests/test_test_entrypoint.py
@@ -45,3 +45,10 @@ def test_image_runtime_reports_when_its_python_lock_differs():
   assert 'cmp -s "$ROOT/backend/requirements.lock" /app/requirements.lock' in source
   assert "checkout requirements.lock differs from the image runtime" in source
   assert "not dependency-authoritative" in source
+
+
+def test_host_runner_clears_live_deployment_origin_derivation():
+  source = HOST_RUNNER.read_text()
+  assert "DOMAIN=localhost" in source
+  assert "FRONTEND_ORIGIN=http://localhost:5173" in source
+  assert "RAILWAY_PUBLIC_DOMAIN=" in source

--- a/scripts/wt-pytest.sh
+++ b/scripts/wt-pytest.sh
@@ -131,6 +131,9 @@ cd "$ROOT/backend" || exit 1
 # of the enclosing repo, and the app-git tests use explicit -C <tmp_path>.
 TEST_ENV=(env \
   GIT_CEILING_DIRECTORIES="$ROOT" \
+  DOMAIN=localhost \
+  FRONTEND_ORIGIN=http://localhost:5173 \
+  RAILWAY_PUBLIC_DOMAIN= \
   MOBIUS_TEST_RUNTIME=1 \
   MOEBIUS_SKIP_BOOTSTRAP=1 \
   API_BASE_URL=http://127.0.0.1:9 \


### PR DESCRIPTION
## What changed

- pins the worktree test runner to the test domain and frontend origin
- clears Railway domain derivation inherited from a live container
- adds a structural regression test for the hermetic origin contract

## Why

Running focused identity tests from a worktree inside a live Möbius container inherited `DOMAIN` / `RAILWAY_PUBLIC_DOMAIN`, so the supposedly isolated suite generated the owner's production URL and produced false failures. The test runner now establishes the deployment-origin boundary before Python imports settings.

## Verification

`tests/test_test_entrypoint.py tests/test_identity.py -q` — 21 passed.