### PR TITLE
Derive the picker's provider from the live model on chat detail

### DIFF
--- a/backend/app/chat_provider.py
+++ b/backend/app/chat_provider.py
@@ -1,0 +1,35 @@
+"""One provider decision shared by chat display and execution."""
+
+from app import models, providers
+from app.chat_visibility import coerce_agent_settings
+
+
+def resolve_chat_provider(
+  chat: models.Chat,
+  *,
+  data_dir: str,
+  running: bool,
+  draining: bool,
+) -> str:
+  """Return the provider this chat should display and execute next.
+
+  An explicit per-chat model is the strongest durable choice. Without one, a
+  genuinely pristine owner chat follows the owner's latest picker default;
+  app-owned, queued, running, draining, and already-started chats keep the
+  provider committed on the chat row.
+  """
+  settings = coerce_agent_settings(chat.agent_settings_json)
+  model_provider = providers.provider_of_model(settings.get("model"))
+  if model_provider is not None:
+    return model_provider
+
+  follows_owner_default = (
+    chat.created_by_app_id is None
+    and not (chat.messages or [])
+    and not (chat.pending_messages or [])
+    and not running
+    and not draining
+  )
+  if follows_owner_default:
+    return providers.owner_default_provider(data_dir, chat.provider)
+  return chat.provider or "claude"

--- a/backend/app/routes/chats.py
+++ b/backend/app/routes/chats.py
@@ -17,6 +17,7 @@ from sqlalchemy.orm import Session
 from app import (
   activity, auth, chat_search, models, providers, questions, secure_inputs,
 )
+from app.chat_provider import resolve_chat_provider
 from app.chat_visibility import coerce_agent_settings, visible_in_owner_drawer
 from app.chat_waits import (
   armed_wait_chat_ids,
@@ -537,30 +538,12 @@ def _chat_detail_response(
     page = next_page
 
   settings_obj = _coerce_agent_settings(chat.agent_settings_json) or None
-  # The picker's current model must match what a message would actually use. A
-  # chat with no per-chat model reads the LIVE global default model, but its
-  # stored provider was frozen at creation; if the global model's family has
-  # since changed, effective_agent_settings(provider=chat.provider) resolves no
-  # model and the picker shows nothing. Derive the display provider the same way
-  # the send path does: an explicit per-chat model wins; otherwise a genuinely
-  # pristine owner chat follows the current global model (the single source of
-  # truth). User/app history, queued work, a live run, and drain-mode sends all
-  # keep the chat's committed provider.
   _has_assistant_turns = any(m.get("role") == "assistant" for m in all_msgs)
-  _uses_live_default_provider = (
-    chat.created_by_app_id is None
-    and not all_msgs
-    and not (chat.pending_messages or [])
-    and not running
-    and not is_draining()
-  )
-  provider = (
-    providers.provider_of_model((settings_obj or {}).get("model"))
-    or (
-      providers.owner_default_provider(get_settings().data_dir, chat.provider)
-      if _uses_live_default_provider
-      else chat.provider or "claude"
-    )
+  provider = resolve_chat_provider(
+    chat,
+    data_dir=get_settings().data_dir,
+    running=running,
+    draining=is_draining(),
   )
   active_goal_objective = running_goal_objective(db, chat.id)
   response = {

--- a/backend/app/routes/chats.py
+++ b/backend/app/routes/chats.py
@@ -535,8 +535,24 @@ def _chat_detail_response(
       next_page[relative_index] = projected_message
     page = next_page
 
-  provider = chat.provider or "claude"
   settings_obj = _coerce_agent_settings(chat.agent_settings_json) or None
+  # The picker's current model must match what a message would actually use. A
+  # chat with no per-chat model reads the LIVE global default model, but its
+  # stored provider was frozen at creation; if the global model's family has
+  # since changed, effective_agent_settings(provider=chat.provider) resolves no
+  # model and the picker shows nothing. Derive the display provider the same way
+  # the send path does: an explicit per-chat model wins; otherwise a pristine
+  # chat follows the current global model (the single source of truth); a chat
+  # that already ran keeps its committed provider.
+  _has_assistant_turns = any(m.get("role") == "assistant" for m in all_msgs)
+  provider = (
+    providers.provider_of_model((settings_obj or {}).get("model"))
+    or (
+      chat.provider or "claude"
+      if _has_assistant_turns
+      else providers.owner_default_provider(get_settings().data_dir, chat.provider)
+    )
+  )
   active_goal_objective = running_goal_objective(db, chat.id)
   response = {
     "id": chat.id,
@@ -562,9 +578,7 @@ def _chat_detail_response(
       settings_obj,
       provider=provider,
     ),
-    "has_assistant_turns": any(
-      message.get("role") == "assistant" for message in all_msgs
-    ),
+    "has_assistant_turns": _has_assistant_turns,
     # Armed durable waits: the visible "Waiting for …" state. Refreshed by the
     # detail refetches the run lifecycle already triggers, so declare (during a
     # run) and resume (a new run) both reach the UI without extra plumbing.

--- a/backend/app/routes/chats.py
+++ b/backend/app/routes/chats.py
@@ -28,6 +28,7 @@ from app.chat import (
   _finish_run,
   bump_run_generation,
   is_chat_running,
+  is_draining,
   mark_chat_deleted,
   recover_chat_generation,
   stop_chat_for,
@@ -541,16 +542,24 @@ def _chat_detail_response(
   # stored provider was frozen at creation; if the global model's family has
   # since changed, effective_agent_settings(provider=chat.provider) resolves no
   # model and the picker shows nothing. Derive the display provider the same way
-  # the send path does: an explicit per-chat model wins; otherwise a pristine
-  # chat follows the current global model (the single source of truth); a chat
-  # that already ran keeps its committed provider.
+  # the send path does: an explicit per-chat model wins; otherwise a genuinely
+  # pristine owner chat follows the current global model (the single source of
+  # truth). User/app history, queued work, a live run, and drain-mode sends all
+  # keep the chat's committed provider.
   _has_assistant_turns = any(m.get("role") == "assistant" for m in all_msgs)
+  _uses_live_default_provider = (
+    chat.created_by_app_id is None
+    and not all_msgs
+    and not (chat.pending_messages or [])
+    and not running
+    and not is_draining()
+  )
   provider = (
     providers.provider_of_model((settings_obj or {}).get("model"))
     or (
-      chat.provider or "claude"
-      if _has_assistant_turns
-      else providers.owner_default_provider(get_settings().data_dir, chat.provider)
+      providers.owner_default_provider(get_settings().data_dir, chat.provider)
+      if _uses_live_default_provider
+      else chat.provider or "claude"
     )
   )
   active_goal_objective = running_goal_objective(db, chat.id)

--- a/backend/app/routes/chats_stream.py
+++ b/backend/app/routes/chats_stream.py
@@ -37,11 +37,11 @@ from app.chat_writer import (
   get_writer,
 )
 from app import claude_sdk_runner, codex_sdk_runner
+from app.chat_provider import resolve_chat_provider
 from app.chat_visibility import coerce_agent_settings
 from app.providers import (
   _load_agent_settings,
   effective_agent_settings,
-  owner_default_provider,
 )
 from app.runner_registry import RunnerKind, registry
 from app.config import get_settings
@@ -103,27 +103,14 @@ def _selected_model_for_chat(
   return model.strip() if isinstance(model, str) and model.strip() else None
 
 
-def _next_execution_provider(db: Session, chat: models.Chat) -> str:
+def _next_execution_provider(chat: models.Chat) -> str:
   """Match the provider the current send path will actually execute on."""
-  provider = chat.provider or "claude"
-  # StartTurn alone re-reads the owner's latest provider for a pristine owner
-  # chat. Queued, draining, app-owned, and already-started chats keep their
-  # durable provider, so the model check must evaluate against that same value.
-  if (
-    chat.created_by_app_id is None
-    and not (chat.messages or [])
-    and not (chat.pending_messages or [])
-    and not is_chat_running(chat.id)
-    and not is_draining()
-  ):
-    owner = db.query(models.Owner).first()
-    # Provider follows the last-selected model, matching new-chat creation, so a
-    # pristine chat's first send can't re-diverge onto a family whose remembered
-    # model belongs to the other provider.
-    return owner_default_provider(
-      get_settings().data_dir, owner.provider if owner else None,
-    )
-  return provider
+  return resolve_chat_provider(
+    chat,
+    data_dir=get_settings().data_dir,
+    running=is_chat_running(chat.id),
+    draining=is_draining(),
+  )
 
 # Keepalive interval for the SSE stream to prevent proxy timeouts.
 _KEEPALIVE_INTERVAL = 30  # seconds
@@ -871,7 +858,7 @@ async def _send_message_locked(
       status_code=403,
       detail="Only the owner can resume a paused chat.",
     )
-  next_execution_provider = _next_execution_provider(db, chat)
+  next_execution_provider = _next_execution_provider(chat)
   if _selected_model_for_chat(
     chat, provider=next_execution_provider,
   ) is None:

--- a/backend/tests/test_app_chat_contract.py
+++ b/backend/tests/test_app_chat_contract.py
@@ -73,11 +73,11 @@ def test_app_chat_first_send_preserves_provider_selected_at_create(
   client, owner_token, db, monkeypatch,
 ):
   """An unrelated owner default cannot replace an app chat's provider."""
-  from app.routes import chats_stream
+  from app import chat_provider
 
   _, app_token = _make_app(client, owner_token, "provider-preserving-chat")
   monkeypatch.setattr(
-    chats_stream, "owner_default_provider", lambda *_: "claude",
+    chat_provider.providers, "owner_default_provider", lambda *_: "claude",
   )
 
   for sender_token in (app_token, owner_token):
@@ -92,6 +92,11 @@ def test_app_chat_first_send_preserves_provider_selected_at_create(
     )
     assert created.status_code == 201, created.text
     chat_id = created.json()["id"]
+    # Use a live-discovered model id whose family the static catalog cannot
+    # infer, so this test isolates the app-owned provider gate.
+    row = db.query(models.Chat).filter(models.Chat.id == chat_id).one()
+    row.agent_settings_json = {"model": "codex-live-model"}
+    db.commit()
 
     sent = client.post(
       f"/api/chats/{chat_id}/messages",
@@ -113,7 +118,7 @@ def test_owner_chat_first_send_still_uses_latest_selected_provider(
   client, owner_token, db, monkeypatch,
 ):
   """The app-chat exception must not freeze an ordinary empty chat."""
-  from app.routes import chats_stream
+  from app import chat_provider
 
   created = client.post(
     "/api/chats",
@@ -123,15 +128,54 @@ def test_owner_chat_first_send_still_uses_latest_selected_provider(
   assert created.status_code == 200, created.text
   chat_id = created.json()["id"]
   monkeypatch.setattr(
-    chats_stream, "owner_default_provider", lambda *_: "codex",
+    chat_provider.providers, "owner_default_provider", lambda *_: "codex",
   )
   row = db.query(models.Chat).filter(models.Chat.id == chat_id).one()
-  row.agent_settings_json = {"model": "gpt-5.6-sol"}
+  # A live-discovered model cannot decide its provider by catalog lookup, so
+  # the pristine owner-chat fallback remains the behavior under test.
+  row.agent_settings_json = {"model": "codex-live-model"}
   db.commit()
 
   sent = client.post(
     f"/api/chats/{chat_id}/messages",
     json={"content": "use my latest selected provider"},
+    headers={"Authorization": f"Bearer {owner_token}"},
+  )
+  assert sent.status_code == 202, sent.text
+  db.expire_all()
+  row = db.query(models.Chat).filter(models.Chat.id == chat_id).one()
+  assert row.provider == "codex"
+  run = db.query(models.ChatRun).filter(
+    models.ChatRun.chat_id == chat_id,
+  ).order_by(models.ChatRun.started_at.desc()).first()
+  assert run is not None
+  assert run.provider == "codex"
+
+
+def test_first_send_repairs_provider_from_explicit_per_chat_model(
+  client, owner_token, db, monkeypatch,
+):
+  """Display and execution share the model-priority repair for legacy drift."""
+  from app import chat_provider
+
+  created = client.post(
+    "/api/chats",
+    json={"title": "Drifted provider"},
+    headers={"Authorization": f"Bearer {owner_token}"},
+  )
+  assert created.status_code == 200, created.text
+  chat_id = created.json()["id"]
+  monkeypatch.setattr(
+    chat_provider.providers, "owner_default_provider", lambda *_: "claude",
+  )
+  row = db.query(models.Chat).filter(models.Chat.id == chat_id).one()
+  row.provider = "claude"
+  row.agent_settings_json = {"model": "gpt-5.6-sol"}
+  db.commit()
+
+  sent = client.post(
+    f"/api/chats/{chat_id}/messages",
+    json={"content": "use the model's provider"},
     headers={"Authorization": f"Bearer {owner_token}"},
   )
   assert sent.status_code == 202, sent.text

--- a/backend/tests/test_chat_agent_settings.py
+++ b/backend/tests/test_chat_agent_settings.py
@@ -189,6 +189,30 @@ def test_settings_view_provider_follows_remembered_model_over_drift(
   assert body["agent_settings"]["model"] == "gpt-5.6-sol"
 
 
+def test_chat_detail_pristine_provider_follows_global_model_over_drift(
+  client, auth, db,
+):
+  """A pristine chat's picker shows the model it would actually use. With a
+  drifted stored provider and no per-chat model, the detail derives the provider
+  from the live global model instead of surfacing no model at all."""
+  from app import models
+
+  _write_global_settings({"model": "gpt-5.6-sol", "effort": "high"})
+  cid = client.post(
+    "/api/chats", headers=auth, json={"title": "drifted"},
+  ).json()["id"]
+  # Simulate a chat created before the global model's family changed: stored
+  # provider frozen on claude, no per-chat model, no assistant turns.
+  row = db.query(models.Chat).filter(models.Chat.id == cid).first()
+  row.provider = "claude"
+  row.agent_settings_json = None
+  db.commit()
+
+  body = client.get(f"/api/chats/{cid}", headers=auth).json()
+  assert body["provider"] == "codex"
+  assert body["effective_agent_settings"]["model"] == "gpt-5.6-sol"
+
+
 def test_patch_chat_writes_override(client, auth, chat):
   """PATCH /chats/{id} sets agent_settings_json and returns effective."""
   _write_global_settings({"model": "default-model"})

--- a/backend/tests/test_chat_agent_settings.py
+++ b/backend/tests/test_chat_agent_settings.py
@@ -241,6 +241,29 @@ def test_chat_detail_user_only_chat_keeps_its_committed_provider(
   assert body["effective_agent_settings"]["model"] is None
 
 
+def test_chat_detail_per_chat_model_outranks_stored_provider(
+  client, auth, db,
+):
+  """An explicit per-chat model decides the picker's provider. Stored provider
+  and global default both say claude here, so only the model-priority branch can
+  report the codex model's provider — and without it the response would filter
+  that per-chat model away to no model at all."""
+  from app import models
+
+  _write_global_settings({"model": "claude-sonnet-5", "effort": "high"})
+  cid = client.post(
+    "/api/chats", headers=auth, json={"title": "per-chat model"},
+  ).json()["id"]
+  row = db.query(models.Chat).filter(models.Chat.id == cid).first()
+  row.provider = "claude"
+  row.agent_settings_json = {"model": "gpt-5.6-sol"}
+  db.commit()
+
+  body = client.get(f"/api/chats/{cid}", headers=auth).json()
+  assert body["provider"] == "codex"
+  assert body["effective_agent_settings"]["model"] == "gpt-5.6-sol"
+
+
 def test_patch_chat_writes_override(client, auth, chat):
   """PATCH /chats/{id} sets agent_settings_json and returns effective."""
   _write_global_settings({"model": "default-model"})

--- a/backend/tests/test_chat_agent_settings.py
+++ b/backend/tests/test_chat_agent_settings.py
@@ -264,6 +264,57 @@ def test_chat_detail_per_chat_model_outranks_stored_provider(
   assert body["effective_agent_settings"]["model"] == "gpt-5.6-sol"
 
 
+def test_chat_detail_app_created_chat_keeps_its_committed_provider(
+  client, auth, db,
+):
+  """An app-owned chat is never pristine, even with no messages: the app chose
+  its provider, so the detail must not re-derive one from the owner's picker."""
+  from app import models
+
+  _write_global_settings({"model": "gpt-5.6-sol", "effort": "high"})
+  cid = client.post(
+    "/api/chats", headers=auth, json={"title": "app owned"},
+  ).json()["id"]
+  app = models.App(
+    slug="provider-gate-app",
+    source_dir="/tmp/mobius-tests/provider-gate-app",
+    name="Gate", description="", jsx_source="",
+  )
+  db.add(app)
+  db.flush()
+  row = db.query(models.Chat).filter(models.Chat.id == cid).first()
+  row.provider = "claude"
+  row.agent_settings_json = None
+  row.created_by_app_id = app.id
+  db.commit()
+
+  body = client.get(f"/api/chats/{cid}", headers=auth).json()
+  assert body["provider"] == "claude"
+  assert body["effective_agent_settings"]["model"] is None
+
+
+def test_chat_detail_draining_chat_keeps_its_committed_provider(
+  client, auth, db,
+):
+  """While the instance drains, a send keeps the chat's committed provider, so
+  the picker must show that provider too instead of the live global default."""
+  from app import models
+
+  _write_global_settings({"model": "gpt-5.6-sol", "effort": "high"})
+  cid = client.post(
+    "/api/chats", headers=auth, json={"title": "draining"},
+  ).json()["id"]
+  row = db.query(models.Chat).filter(models.Chat.id == cid).first()
+  row.provider = "claude"
+  row.agent_settings_json = None
+  db.commit()
+
+  with patch("app.routes.chats.is_draining", return_value=True):
+    body = client.get(f"/api/chats/{cid}", headers=auth).json()
+  assert body["provider"] == "claude"
+  assert body["effective_agent_settings"]["model"] is None
+
+
 def test_patch_chat_writes_override(client, auth, chat):
   """PATCH /chats/{id} sets agent_settings_json and returns effective."""
   _write_global_settings({"model": "default-model"})

--- a/backend/tests/test_chat_agent_settings.py
+++ b/backend/tests/test_chat_agent_settings.py
@@ -213,6 +213,34 @@ def test_chat_detail_pristine_provider_follows_global_model_over_drift(
   assert body["effective_agent_settings"]["model"] == "gpt-5.6-sol"
 
 
+def test_chat_detail_user_only_chat_keeps_its_committed_provider(
+  client, auth, db,
+):
+  """A failed/unfinished first turn is no longer pristine: its next send keeps
+  the provider committed when that turn began, even before an assistant row
+  exists."""
+  from app import models
+
+  _write_global_settings({"model": "gpt-5.6-sol", "effort": "high"})
+  cid = client.post(
+    "/api/chats",
+    headers=auth,
+    json={
+      "title": "started",
+      "messages": [{"role": "user", "content": "hello"}],
+    },
+  ).json()["id"]
+  row = db.query(models.Chat).filter(models.Chat.id == cid).first()
+  row.provider = "claude"
+  row.agent_settings_json = None
+  db.commit()
+
+  body = client.get(f"/api/chats/{cid}", headers=auth).json()
+  assert body["has_assistant_turns"] is False
+  assert body["provider"] == "claude"
+  assert body["effective_agent_settings"]["model"] is None
+
+
 def test_patch_chat_writes_override(client, auth, chat):
   """PATCH /chats/{id} sets agent_settings_json and returns effective."""
   _write_global_settings({"model": "default-model"})


### PR DESCRIPTION
## Follow-up to #907

#907 made `owner_default_provider` the single source of truth for the provider on chat creation, the send path, the settings view, and the provider-status endpoint. It missed one reader: the chat-detail/create response.

## Problem

The chat-detail response computed effective settings with the chat's **frozen** stored provider. A chat with no per-chat model reads the **live** global default model, but its provider was frozen at creation. Once the global model's family changes, the frozen provider no longer matches, so `effective_agent_settings` resolves no model and the picker shows nothing — even though a send would work (the send path already derives correctly).

## Fix

Derive the display provider the same way the send path does: an explicit per-chat model wins; otherwise a pristine chat follows the current global model (the single source of truth); a chat that already ran keeps its committed provider. This also heals existing drifted chats retroactively at read time, with no migration.

## Tests

Adds coverage that a pristine chat with a drifted stored provider and no per-chat model reports the live global model (and its provider) in the chat-detail response.