### PR TITLE
Keep Connect commands safe across transport loss

### DIFF
--- a/backend/app/connect_runner.py
+++ b/backend/app/connect_runner.py
@@ -18,6 +18,7 @@ Manage the installed service:
     python3 ~/.mobius-connect/runner.py --uninstall
 """
 import argparse
+from collections import deque
 import json
 import os
 import platform
@@ -25,6 +26,7 @@ import signal
 import ssl
 import subprocess
 import sys
+import threading
 import time
 import urllib.error
 import urllib.parse
@@ -140,7 +142,9 @@ def _install_systemd(py):
     with open(SYSTEMD_UNIT, "w", encoding="utf-8") as fh:
         fh.write(unit)
     _run(["systemctl", "--user", "daemon-reload"])
-    r = _run(["systemctl", "--user", "enable", "--now", "mobius-connect.service"])
+    r = _run(["systemctl", "--user", "enable", "mobius-connect.service"])
+    if r.returncode == 0:
+        r = _run(["systemctl", "--user", "restart", "mobius-connect.service"])
     if r.returncode != 0:
         print("systemctl --user failed: %s" % r.stderr.strip())
         return _install_background(py)
@@ -269,7 +273,7 @@ def _terminate_process_tree(proc):
             proc.wait()
 
 
-def _run_command(cmd, cwd, timeout):
+def _spawn_command(cmd, cwd):
     popen_args = {
         "shell": True,
         "stdout": subprocess.PIPE,
@@ -281,9 +285,13 @@ def _run_command(cmd, cwd, timeout):
         popen_args["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
     else:
         popen_args["start_new_session"] = True
+    return subprocess.Popen(cmd, **popen_args)
+
+
+def _run_command(cmd, cwd, timeout):
     proc = None
     try:
-        proc = subprocess.Popen(cmd, **popen_args)
+        proc = _spawn_command(cmd, cwd)
         stdout, stderr = proc.communicate(timeout=timeout)
         return stdout, stderr, proc.returncode, False
     except subprocess.TimeoutExpired:
@@ -299,31 +307,246 @@ def _run_command(cmd, cwd, timeout):
         return "", "runner error: %s" % exc, 1, False
 
 
+class _CommandRunner:
+    """Own one subprocess and retain lifecycle messages across reconnects."""
+
+    def __init__(self, base, token):
+        self.base = base
+        self.token = token
+        self.lock = threading.Lock()
+        self.flush_lock = threading.Lock()
+        self.active = None
+        self.outbox = deque()
+
+    def _retain(self, message):
+        with self.lock:
+            self.outbox.append(message)
+
+    def pending_messages(self):
+        with self.lock:
+            return list(self.outbox)
+
+    def acknowledge_message(self, message):
+        with self.lock:
+            for index, pending in enumerate(self.outbox):
+                if pending is message:
+                    del self.outbox[index]
+                    return
+
+    def snapshot(self):
+        with self.lock:
+            active_id = self.active["request_id"] if self.active else None
+            pending = [
+                message.get("request_id") for message in self.outbox
+                if message.get("type") == "result" and message.get("request_id")
+            ]
+        return active_id, pending
+
+    def flush_pending_results(self):
+        """Retry retained results without holding the subprocess-state lock."""
+        with self.flush_lock:
+            for message in self.pending_messages():
+                try:
+                    _post(
+                        self.base + "/api/connect/result", message,
+                        token=self.token,
+                    )
+                except (urllib.error.URLError, urllib.error.HTTPError) as exc:
+                    print("failed to report result: %s" % exc)
+                    return False
+                self.acknowledge_message(message)
+        return True
+
+    def _post_result(self, request_id, stdout, stderr, exit_code, outcome):
+        message = {
+            "type": "result",
+            "request_id": request_id,
+            "stdout": stdout,
+            "stderr": stderr,
+            "exit_code": exit_code,
+            "timed_out": outcome in ("timed_out", "expired"),
+            "outcome": outcome,
+        }
+        # Retain before attempting the network request. A concurrent stream
+        # rotation can now always announce this pending id, so the server will
+        # never mistake the just-finished command for lost work and replay it.
+        self._retain(message)
+        self.flush_pending_results()
+
+    def _post_started(self, request_id):
+        try:
+            _post(self.base + "/api/connect/state", {
+                "request_id": request_id, "state": "started",
+            }, token=self.token)
+        except urllib.error.HTTPError as exc:
+            # A runner can be upgraded before its server. Protocol v1 has no
+            # start endpoint but still accepts this runner's final result.
+            if exc.code not in (404, 405):
+                raise
+
+    def start(self, evt):
+        request_id = str(evt.get("request_id") or "")
+        not_after = float(evt.get("not_after") or 0)
+        if not_after and time.time() > not_after:
+            self._post_result(
+                request_id, "", "command expired before it could start", 124,
+                "expired",
+            )
+            return
+
+        record = {
+            "request_id": request_id,
+            "proc": None,
+            "reason": None,
+            "timeout": max(1, int(evt.get("timeout", 60))),
+        }
+        with self.lock:
+            if self.active is not None:
+                refused = True
+            else:
+                refused = False
+                self.active = record
+        if refused:
+            self._post_result(
+                request_id, "", "runner refused a parallel command", 125,
+                "expired",
+            )
+            return
+
+        try:
+            self._post_started(request_id)
+            # The state acknowledgement itself crosses the network and can
+            # outlive the server's dispatch window. Check the absolute
+            # deadline again at the last possible point before spawning so an
+            # expired request can never become delayed work on this machine.
+            if not_after and time.time() > not_after:
+                with self.lock:
+                    if self.active is record:
+                        self.active = None
+                self._post_result(
+                    request_id, "", "command expired before it could start",
+                    124, "expired",
+                )
+                return
+            proc = _spawn_command(evt.get("cmd", ""), evt.get("cwd"))
+            record["proc"] = proc
+            with self.lock:
+                reason = record["reason"]
+            if reason is not None:
+                _terminate_process_tree(proc)
+        except Exception as exc:  # noqa: BLE001 - report the spawn boundary
+            with self.lock:
+                if self.active is record:
+                    self.active = None
+            self._post_result(
+                request_id, "", "runner error: %s" % exc, 1, "completed",
+            )
+            return
+
+        threading.Thread(
+            target=self._wait, args=(record,), daemon=True,
+            name="mobius-connect-command",
+        ).start()
+
+    def _wait(self, record):
+        proc = record["proc"]
+        stdout = ""
+        stderr = ""
+        try:
+            stdout, stderr = proc.communicate(timeout=record["timeout"])
+        except subprocess.TimeoutExpired:
+            with self.lock:
+                if record["reason"] is None:
+                    record["reason"] = "timed_out"
+            _terminate_process_tree(proc)
+            stdout, stderr = proc.communicate()
+        except Exception as exc:  # noqa: BLE001 - preserve a final result
+            stderr = "runner error: %s" % exc
+
+        with self.lock:
+            reason = record["reason"]
+            if self.active is record:
+                self.active = None
+        if reason == "timed_out":
+            outcome, exit_code = "timed_out", 124
+            stderr = stderr or "command timed out after %ss" % record["timeout"]
+        elif reason is not None:
+            outcome, exit_code = "canceled", 130
+            stderr = stderr or "command canceled"
+        else:
+            outcome, exit_code = "completed", proc.returncode
+        self._post_result(
+            record["request_id"], stdout, stderr, exit_code, outcome,
+        )
+
+    def cancel(self, request_id, reason="canceled"):
+        with self.lock:
+            record = self.active
+            if record is None or (
+                request_id is not None and record["request_id"] != request_id
+            ):
+                return False
+            if record["reason"] is None:
+                record["reason"] = reason
+            proc = record["proc"]
+        if proc is not None:
+            _terminate_process_tree(proc)
+        return True
+
+
 def _serve(cfg):
     base = cfg["url"].rstrip("/")
     token = cfg["token"]
     ctx = ssl.create_default_context()
     plat = "%s %s" % (platform.system(), platform.release())
-    stream_url = base + "/api/connect/stream?platform=" + urllib.parse.quote(plat)
+    commands = _CommandRunner(base, token)
     backoff = 1
     print("Connecting to %s ..." % base)
     while True:
         try:
+            # Results are ordinary HTTPS requests. Attempt them before the
+            # next stream hello so its pending list reflects what still needs
+            # recovery, then again after connecting to close any race.
+            commands.flush_pending_results()
+            active_id, pending_ids = commands.snapshot()
+            query = [
+                ("protocol", "3"),
+                ("platform", plat),
+            ]
+            if active_id:
+                query.append(("active_request_id", active_id))
+            query.extend(
+                ("pending_result_id", request_id)
+                for request_id in pending_ids
+            )
+            stream_url = base + "/api/connect/stream?" + urllib.parse.urlencode(
+                query,
+            )
             req = urllib.request.Request(stream_url)
             req.add_header("Authorization", "Bearer " + token)
             req.add_header("Accept", "text/event-stream")
-            with urllib.request.urlopen(req, timeout=None, context=ctx) as stream:
+            with urllib.request.urlopen(
+                req, timeout=None, context=ctx,
+            ) as stream:
                 print("Connected. This machine is now reachable from Mobius.")
                 backoff = 1
+                commands.flush_pending_results()
                 for raw in stream:
-                    line = raw.decode("utf-8", "replace").rstrip("\n")
+                    # Heartbeat comments make this retry path run even while
+                    # the host has no new commands.
+                    commands.flush_pending_results()
+                    line = raw.decode("utf-8", "replace").rstrip("\r\n")
                     if not line.startswith("data:"):
                         continue
                     try:
                         evt = json.loads(line[5:].strip())
                     except ValueError:
                         continue
+                    if evt.get("type") == "cancel":
+                        commands.cancel(evt.get("request_id"))
+                        continue
                     if evt.get("type") == "disconnect":
+                        commands.cancel(None, "disconnect")
                         try:
                             _uninstall_service(stop_running=False)
                             payload = {
@@ -331,31 +554,31 @@ def _serve(cfg):
                                 "stdout": "Connect daemon removed.",
                                 "stderr": "", "exit_code": 0,
                             }
-                        except Exception as exc:  # report local cleanup failure
+                        except Exception as exc:  # local cleanup failure
                             payload = {
                                 "request_id": evt.get("request_id"),
-                                "stdout": "", "stderr": str(exc), "exit_code": 1,
+                                "stdout": "", "stderr": str(exc),
+                                "exit_code": 1,
                             }
                         try:
-                            _post(base + "/api/connect/result", payload, token=token)
-                        except urllib.error.URLError as exc:
+                            _post(
+                                base + "/api/connect/result", payload,
+                                token=token,
+                            )
+                        except (
+                            urllib.error.URLError,
+                            urllib.error.HTTPError,
+                        ) as exc:
                             print("failed to report disconnect: %s" % exc)
                         return
                     if evt.get("type") != "exec":
                         continue
                     print("$ " + evt.get("cmd", ""))
-                    out, err, rc, timed_out = _run_command(
-                        evt.get("cmd", ""), evt.get("cwd"),
-                        int(evt.get("timeout", 60)),
-                    )
-                    try:
-                        _post(base + "/api/connect/result", {
-                            "request_id": evt.get("request_id"),
-                            "stdout": out, "stderr": err, "exit_code": rc,
-                            "timed_out": timed_out,
-                        }, token=token)
-                    except urllib.error.URLError as exc:
-                        print("failed to report result: %s" % exc)
+                    commands.start(evt)
+            # Protocol v3 streams intentionally end before a hosting proxy's
+            # response cap. A command belongs to this runner, not the stream,
+            # so clean rotation is the same recovery path as any network loss.
+            print("stream rotated; reconnecting")
         except KeyboardInterrupt:
             print("\nStopped.")
             return

--- a/backend/app/connect_runner.py
+++ b/backend/app/connect_runner.py
@@ -317,10 +317,10 @@ class _CommandRunner:
         self.flush_lock = threading.Lock()
         self.active = None
         self.outbox = deque()
-
-    def _retain(self, message):
-        with self.lock:
-            self.outbox.append(message)
+        # A rotating stream can deliver the same event from the retiring and
+        # replacement connection. Request ids are idempotency keys: once this
+        # process accepts one, never spawn it a second time.
+        self.seen_request_ids = deque(maxlen=64)
 
     def pending_messages(self):
         with self.lock:
@@ -357,7 +357,9 @@ class _CommandRunner:
                 self.acknowledge_message(message)
         return True
 
-    def _post_result(self, request_id, stdout, stderr, exit_code, outcome):
+    def _post_result(
+        self, request_id, stdout, stderr, exit_code, outcome, record=None,
+    ):
         message = {
             "type": "result",
             "request_id": request_id,
@@ -370,7 +372,13 @@ class _CommandRunner:
         # Retain before attempting the network request. A concurrent stream
         # rotation can now always announce this pending id, so the server will
         # never mistake the just-finished command for lost work and replay it.
-        self._retain(message)
+        # Releasing the active slot and retaining its result must be one
+        # atomic state transition. Otherwise a reconnect can observe neither
+        # and tell the server that successfully completed work was lost.
+        with self.lock:
+            self.outbox.append(message)
+            if record is not None and self.active is record:
+                self.active = None
         self.flush_pending_results()
 
     def _post_started(self, request_id):
@@ -386,6 +394,14 @@ class _CommandRunner:
 
     def start(self, evt):
         request_id = str(evt.get("request_id") or "")
+        with self.lock:
+            if request_id in self.seen_request_ids:
+                return
+            if self.active is not None:
+                refused = True
+            else:
+                refused = False
+                self.seen_request_ids.append(request_id)
         not_after = float(evt.get("not_after") or 0)
         if not_after and time.time() > not_after:
             self._post_result(
@@ -400,18 +416,14 @@ class _CommandRunner:
             "reason": None,
             "timeout": max(1, int(evt.get("timeout", 60))),
         }
-        with self.lock:
-            if self.active is not None:
-                refused = True
-            else:
-                refused = False
-                self.active = record
         if refused:
             self._post_result(
                 request_id, "", "runner refused a parallel command", 125,
                 "expired",
             )
             return
+        with self.lock:
+            self.active = record
 
         try:
             self._post_started(request_id)
@@ -420,12 +432,9 @@ class _CommandRunner:
             # deadline again at the last possible point before spawning so an
             # expired request can never become delayed work on this machine.
             if not_after and time.time() > not_after:
-                with self.lock:
-                    if self.active is record:
-                        self.active = None
                 self._post_result(
                     request_id, "", "command expired before it could start",
-                    124, "expired",
+                    124, "expired", record=record,
                 )
                 return
             proc = _spawn_command(evt.get("cmd", ""), evt.get("cwd"))
@@ -435,11 +444,9 @@ class _CommandRunner:
             if reason is not None:
                 _terminate_process_tree(proc)
         except Exception as exc:  # noqa: BLE001 - report the spawn boundary
-            with self.lock:
-                if self.active is record:
-                    self.active = None
             self._post_result(
                 request_id, "", "runner error: %s" % exc, 1, "completed",
+                record=record,
             )
             return
 
@@ -465,8 +472,6 @@ class _CommandRunner:
 
         with self.lock:
             reason = record["reason"]
-            if self.active is record:
-                self.active = None
         if reason == "timed_out":
             outcome, exit_code = "timed_out", 124
             stderr = stderr or "command timed out after %ss" % record["timeout"]
@@ -477,6 +482,7 @@ class _CommandRunner:
             outcome, exit_code = "completed", proc.returncode
         self._post_result(
             record["request_id"], stdout, stderr, exit_code, outcome,
+            record=record,
         )
 
     def cancel(self, request_id, reason="canceled"):

--- a/backend/app/connect_runner.py
+++ b/backend/app/connect_runner.py
@@ -19,6 +19,7 @@ Manage the installed service:
 """
 import argparse
 from collections import deque
+import ipaddress
 import json
 import os
 import platform
@@ -42,6 +43,61 @@ LAUNCHD_PLIST = os.path.expanduser("~/Library/LaunchAgents/%s.plist" % LAUNCHD_L
 SYSTEMD_UNIT = os.path.expanduser("~/.config/systemd/user/mobius-connect.service")
 
 
+def _validated_base_url(raw):
+    """Return a credential-safe Mobius origin or reject it.
+
+    Connect sends a long-lived host bearer on every request. Plain HTTP is
+    therefore acceptable only on the local loopback used for development;
+    remote instances must use HTTPS. Credentials and query/fragment material
+    do not belong in the persisted base URL.
+    """
+    value = str(raw or "").strip().rstrip("/")
+    parsed = urllib.parse.urlsplit(value)
+    if (
+        parsed.scheme not in ("http", "https")
+        or not parsed.netloc
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise ValueError("Connect requires a valid Mobius HTTPS URL.")
+    try:
+        hostname = parsed.hostname or ""
+        # Accessing port also validates malformed/non-numeric port text.
+        parsed.port
+    except ValueError as exc:
+        raise ValueError("Connect requires a valid Mobius HTTPS URL.") from exc
+    if not hostname:
+        raise ValueError("Connect requires a valid Mobius HTTPS URL.")
+    if parsed.scheme == "http":
+        local = hostname.casefold() == "localhost"
+        if not local:
+            try:
+                local = ipaddress.ip_address(hostname).is_loopback
+            except ValueError:
+                local = False
+        if not local:
+            raise ValueError(
+                "Connect refuses plaintext HTTP for a remote instance; use HTTPS."
+            )
+    return value
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    """Fail closed instead of forwarding pairing codes or host bearers."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+def _open_url(request, *, timeout, context=None):
+    handlers = [_NoRedirect()]
+    if context is not None:
+        handlers.append(urllib.request.HTTPSHandler(context=context))
+    return urllib.request.build_opener(*handlers).open(request, timeout=timeout)
+
+
 def _load_config():
     try:
         with open(CONFIG_PATH, "r", encoding="utf-8") as fh:
@@ -63,11 +119,12 @@ def _post(url, payload, token=None):
     req.add_header("Content-Type", "application/json")
     if token:
         req.add_header("Authorization", "Bearer " + token)
-    with urllib.request.urlopen(req, timeout=30) as resp:
+    with _open_url(req, timeout=30) as resp:
         return json.loads(resp.read().decode("utf-8"))
 
 
 def _pair(base, code):
+    base = _validated_base_url(base)
     out = _post(base + "/api/connect/pair", {"code": code})
     cfg = {"url": base, "host_id": out["host_id"], "token": out["token"]}
     _save_config(cfg)
@@ -89,7 +146,7 @@ def _run_required(cmd, action):
 
 def _self_download(base):
     os.makedirs(CONFIG_DIR, exist_ok=True)
-    with urllib.request.urlopen(base + "/api/connect/runner", timeout=30) as resp:
+    with _open_url(base + "/api/connect/runner", timeout=30) as resp:
         src = resp.read()
     with open(RUNNER_PATH, "wb") as fh:
         fh.write(src)
@@ -501,7 +558,7 @@ class _CommandRunner:
 
 
 def _serve(cfg):
-    base = cfg["url"].rstrip("/")
+    base = _validated_base_url(cfg["url"])
     token = cfg["token"]
     ctx = ssl.create_default_context()
     plat = "%s %s" % (platform.system(), platform.release())
@@ -531,7 +588,7 @@ def _serve(cfg):
             req = urllib.request.Request(stream_url)
             req.add_header("Authorization", "Bearer " + token)
             req.add_header("Accept", "text/event-stream")
-            with urllib.request.urlopen(
+            with _open_url(
                 req, timeout=None, context=ctx,
             ) as stream:
                 print("Connected. This machine is now reachable from Mobius.")
@@ -620,12 +677,18 @@ def main():
         return
 
     cfg = _load_config()
-    if args.pair:
-        base = (args.url or cfg.get("url") or "").rstrip("/")
-        if not base:
-            print("Missing --url")
-            sys.exit(2)
-        cfg = _pair(base, args.pair.strip())
+    try:
+        if args.pair:
+            base = args.url or cfg.get("url") or ""
+            if not base:
+                print("Missing --url")
+                sys.exit(2)
+            cfg = _pair(base, args.pair.strip())
+        elif cfg.get("url"):
+            cfg["url"] = _validated_base_url(cfg["url"])
+    except ValueError as exc:
+        print(str(exc))
+        sys.exit(2)
     if not cfg.get("token"):
         print("Not paired. Run with --pair CODE --url URL first.")
         sys.exit(2)

--- a/backend/app/deps.py
+++ b/backend/app/deps.py
@@ -6,6 +6,7 @@ from urllib.parse import urlparse
 from fastapi import Depends, Header, HTTPException, Request
 from fastapi.security import OAuth2PasswordBearer
 from sqlalchemy.orm import Session
+from starlette.requests import HTTPConnection
 
 from app import auth, models
 from app.config import get_settings
@@ -15,7 +16,7 @@ from app.timeutil import now_naive_utc
 _oauth2 = OAuth2PasswordBearer(tokenUrl="/api/auth/token")
 
 
-def reject_cross_site(request: Request) -> None:
+def reject_cross_site(request: HTTPConnection) -> None:
   """Defense-in-depth CSRF guard for state-changing endpoints.
 
   Möbius's baseline CSRF posture is "Authorization: Bearer + CORS" —

--- a/backend/app/routes/connect.py
+++ b/backend/app/routes/connect.py
@@ -57,6 +57,8 @@ from fastapi import (
 )
 from fastapi.responses import PlainTextResponse, StreamingResponse
 from pydantic import BaseModel, Field, field_validator
+from slowapi import Limiter
+from slowapi.util import get_remote_address
 
 from app import models
 from app.config import get_settings
@@ -67,6 +69,7 @@ router = APIRouter(
   tags=["connect"],
   dependencies=[Depends(reject_cross_site)],
 )
+_pair_limiter = Limiter(key_func=get_remote_address)
 
 # How long a freshly minted pairing code stays redeemable.
 _PAIRING_TTL_SECONDS = 15 * 60
@@ -960,7 +963,8 @@ async def _reconcile_runner(
 # Runner surface (host-token authenticated)
 # --------------------------------------------------------------------------- #
 @router.post("/pair")
-async def pair(body: PairBody) -> dict:
+@_pair_limiter.limit("10/minute")
+async def pair(request: Request, body: PairBody) -> dict:
   code = (body.code or "").strip().upper()
   if not code:
     raise HTTPException(status_code=400, detail="Missing pairing code.")

--- a/backend/app/routes/connect.py
+++ b/backend/app/routes/connect.py
@@ -1100,21 +1100,23 @@ async def legacy_command_socket(websocket: WebSocket) -> None:
   sender = asyncio.create_task(send_events())
   receiver = asyncio.create_task(receive_events())
   superseded = asyncio.create_task(ch.closed.wait())
+  tasks = {sender, receiver, superseded}
   try:
-    done, pending = await asyncio.wait(
-      {sender, receiver, superseded}, return_when=asyncio.FIRST_COMPLETED,
+    done, _ = await asyncio.wait(
+      tasks, return_when=asyncio.FIRST_COMPLETED,
     )
-    for task in pending:
-      task.cancel()
-    await asyncio.gather(*pending, return_exceptions=True)
     for task in done:
       try:
         task.result()
       except WebSocketDisconnect:
         pass
-  except WebSocketDisconnect:
+  except (asyncio.CancelledError, WebSocketDisconnect):
     pass
   finally:
+    for task in tasks:
+      if not task.done():
+        task.cancel()
+    await asyncio.gather(*tasks, return_exceptions=True)
     if _channels.get(host_id) is ch:
       del _channels[host_id]
     for fut in ch.control_pending.values():

--- a/backend/app/routes/connect.py
+++ b/backend/app/routes/connect.py
@@ -1101,6 +1101,7 @@ async def legacy_command_socket(websocket: WebSocket) -> None:
   receiver = asyncio.create_task(receive_events())
   superseded = asyncio.create_task(ch.closed.wait())
   tasks = {sender, receiver, superseded}
+  cancelled = False
   try:
     done, _ = await asyncio.wait(
       tasks, return_when=asyncio.FIRST_COMPLETED,
@@ -1110,7 +1111,13 @@ async def legacy_command_socket(websocket: WebSocket) -> None:
         task.result()
       except WebSocketDisconnect:
         pass
-  except (asyncio.CancelledError, WebSocketDisconnect):
+  except asyncio.CancelledError:
+    # Starlette's supported httpx2 test transport cancels the ASGI task as its
+    # WebSocket context closes. Finish channel teardown before preserving that
+    # cancellation; swallowing it leaves the transport future canceled, while
+    # re-raising from inside the cleanup can skip the offline transition.
+    cancelled = True
+  except WebSocketDisconnect:
     pass
   finally:
     for task in tasks:
@@ -1124,6 +1131,8 @@ async def legacy_command_socket(websocket: WebSocket) -> None:
         fut.cancel()
     ch.closed.set()
     _touch(host_id)
+  if cancelled:
+    raise asyncio.CancelledError
 
 
 @router.get("/stream")

--- a/backend/app/routes/connect.py
+++ b/backend/app/routes/connect.py
@@ -95,6 +95,10 @@ _SSE_PROTOCOL_VERSION = 3
 _STREAM_ROTATION_SECONDS = 10 * 60
 _START_ACK_TIMEOUT = 10
 _RESULT_GRACE_SECONDS = 15
+# Protocol 2 can acknowledge cancellation but cannot retry a dropped result.
+# Keep its command slot reserved briefly for the terminal report, then release
+# it on the next read if that one-shot report never arrived.
+_LEGACY_CANCEL_RESULT_GRACE_SECONDS = 15
 _RESULT_RETENTION_SECONDS = 15 * 60
 
 
@@ -202,6 +206,7 @@ class _ActiveCommand:
     started_at: float | None = None,
     state: str = "dispatching",
     not_after: float | None = None,
+    cancel_not_after: float | None = None,
     fingerprint: str | None = None,
   ) -> None:
     loop = asyncio.get_running_loop()
@@ -213,6 +218,7 @@ class _ActiveCommand:
     self.started_at = started_at
     self.state = state
     self.not_after = not_after
+    self.cancel_not_after = cancel_not_after
     self.fingerprint = fingerprint or _command_fingerprint(cmd, cwd, timeout)
     self.started = asyncio.Event()
     if started_at is not None:
@@ -236,6 +242,10 @@ class _ActiveCommand:
         float(record["not_after"])
         if record.get("not_after") is not None else None
       ),
+      cancel_not_after=(
+        float(record["cancel_not_after"])
+        if record.get("cancel_not_after") is not None else None
+      ),
       fingerprint=str(record.get("fingerprint") or ""),
     )
 
@@ -247,6 +257,7 @@ class _ActiveCommand:
       "started_at": self.started_at,
       "state": self.state,
       "not_after": self.not_after,
+      "cancel_not_after": self.cancel_not_after,
       "fingerprint": self.fingerprint,
     }
     # Replay needs the command only during the short pre-start dispatch window.
@@ -280,18 +291,6 @@ def _active_public(command: _ActiveCommand | None) -> dict | None:
   }
 
 
-def _active_record_public(record: object) -> dict | None:
-  if not isinstance(record, dict) or not record.get("id"):
-    return None
-  return {
-    "id": record["id"],
-    "state": record.get("state") or "dispatching",
-    "created_at": record.get("created_at"),
-    "started_at": record.get("started_at"),
-    "timeout": record.get("timeout") or _DEFAULT_EXEC_TIMEOUT,
-  }
-
-
 def _persist_command(host_id: str, command: _ActiveCommand | None) -> None:
   host = _load_host(host_id)
   if host is None:
@@ -300,7 +299,7 @@ def _persist_command(host_id: str, command: _ActiveCommand | None) -> None:
   _save_host(host)
 
 
-def _ensure_command(host_id: str) -> _ActiveCommand | None:
+def _restore_command(host_id: str) -> _ActiveCommand | None:
   command = _commands.get(host_id)
   if command is not None:
     return command
@@ -310,6 +309,24 @@ def _ensure_command(host_id: str) -> _ActiveCommand | None:
     return None
   command = _ActiveCommand.from_record(record)
   _commands[host_id] = command
+  return command
+
+
+def _ensure_command(host_id: str) -> _ActiveCommand | None:
+  command = _restore_command(host_id)
+  if command is None:
+    return None
+  if (
+    command.state == "canceling"
+    and command.cancel_not_after is not None
+    and _now() >= command.cancel_not_after
+  ):
+    _finish_command_as_lost(
+      host_id,
+      command.request_id,
+      "legacy runner did not report a final result after cancellation",
+    )
+    return None
   return command
 
 
@@ -327,7 +344,7 @@ def _mark_command_started(host_id: str, request_id: str) -> bool:
 
 
 def _finish_command(host_id: str, request_id: str, result: dict) -> bool:
-  command = _ensure_command(host_id)
+  command = _restore_command(host_id)
   if command is None or command.request_id != request_id:
     return False
   public_result = _format_result(request_id, result)
@@ -358,6 +375,19 @@ def _finish_command(host_id: str, request_id: str, result: dict) -> bool:
   return True
 
 
+def _finish_command_as_lost(
+  host_id: str,
+  request_id: str,
+  stderr: str,
+) -> bool:
+  return _finish_command(host_id, request_id, {
+    "stdout": "",
+    "stderr": stderr,
+    "exit_code": 125,
+    "outcome": "lost",
+  })
+
+
 async def _request_command_cancel(
   host_id: str,
   command: _ActiveCommand,
@@ -370,8 +400,22 @@ async def _request_command_cancel(
   )
   if known_protocol < 2 or (ch is None and known_protocol < 3):
     return False
+  changed = False
   if command.state != "canceling":
     command.state = "canceling"
+    changed = True
+  if known_protocol < _RUNNER_PROTOCOL_VERSION:
+    if command.cancel_not_after is None:
+      command.cancel_not_after = (
+        _now() + _LEGACY_CANCEL_RESULT_GRACE_SECONDS
+      )
+      changed = True
+  elif command.cancel_not_after is not None:
+    # A current runner retries terminal results after reconnect, so it must not
+    # inherit a legacy one-shot reporting deadline after an in-place upgrade.
+    command.cancel_not_after = None
+    changed = True
+  if changed:
     _persist_command(host_id, command)
   if ch is not None:
     await ch.queue.put({"type": "cancel", "request_id": command.request_id})
@@ -475,11 +519,7 @@ def _public_host(host: dict) -> dict:
   """Registry view safe to hand to the owner/app (no token hash)."""
   ch = _channels.get(host["id"])
   _prune_last_command(host)
-  active = _commands.get(host["id"])
-  active_public = (
-    _active_public(active)
-    if active is not None else _active_record_public(host.get("active_command"))
-  )
+  active_public = _active_public(_ensure_command(host["id"]))
   runner_protocol = (
     ch.protocol_version if ch is not None
     else host.get("runner_protocol")
@@ -622,6 +662,11 @@ async def _await_command_result(
     cancel_sent = await _request_command_cancel(host_id, command)
     detail = "The command timed out and Connect asked the machine to stop it."
     if not cancel_sent:
+      _finish_command_as_lost(
+        host_id,
+        command.request_id,
+        "runner did not report a final result before its reporting grace elapsed",
+      )
       detail = (
         "The command timed out, but this machine’s runner is too old to stop "
         "it remotely. Update the runner in Connect."
@@ -839,7 +884,6 @@ async def cancel_host_command(
   host = _load_host(host_id)
   if host is None:
     raise HTTPException(status_code=404, detail="No such host.")
-  ch = _channels.get(host_id)
   command = _ensure_command(host_id)
   if command is None or command.request_id != request_id:
     raise HTTPException(status_code=404, detail="That command is no longer running.")
@@ -934,6 +978,9 @@ async def _reconcile_runner(
   if command.request_id == runner_active:
     _mark_command_started(host_id, command.request_id)
     if command.state == "canceling":
+      if ch.protocol_version >= _RUNNER_PROTOCOL_VERSION:
+        command.cancel_not_after = None
+        _persist_command(host_id, command)
       await ch.queue.put({"type": "cancel", "request_id": command.request_id})
     return
   if command.request_id in pending_ids:

--- a/backend/app/routes/connect.py
+++ b/backend/app/routes/connect.py
@@ -1,13 +1,21 @@
 """Pair external machines and dispatch owner-approved commands to them.
 
 A small runner on the target machine dials out to this owner-trusted Möbius
-instance and holds an SSE command channel open. Each machine authenticates with
-a per-host bearer token minted through a short-lived, one-time pairing code.
+instance and holds an HTTPS event stream open. Each machine authenticates with
+a per-host bearer token minted through a short-lived, one-time pairing code. A
+command belongs to the paired host, not to one stream or HTTP caller, so a
+reconnect can resume control without repeating work.
 
-Transport is plain HTTP so the runner needs only the Python stdlib:
+Protocol v3 intentionally rotates its event stream before common hosting
+response caps while keeping command execution alive. Older SSE behavior remains
+as an upgrade bridge for already-installed runners; the provisional WebSocket
+v3 route remains only long enough to offer its installed runner an in-place
+update:
 
   POST /api/connect/pair    {code}          -> {host_id, token}   (one-time)
+  WS   /api/connect/socket  (host bearer)   <-> provisional-v3 bridge
   GET  /api/connect/stream  (host bearer)   -> SSE stream of {exec} commands
+  POST /api/connect/state   (host bearer)   -> {request_id, state=started}
   POST /api/connect/result  (host bearer)   -> {request_id, stdout, ...}
   POST /api/connect/disconnect (host bearer) -> revoke this runner
 
@@ -19,33 +27,40 @@ Owner/app surface:
   GET    /api/connect/hosts/{id}/pairing  re-show/refresh the install command
   DELETE /api/connect/hosts/{id}          remove a host
   POST   /api/connect/hosts/{id}/exec     run a command on that host
+  POST   /api/connect/hosts/{id}/commands/{request_id}/cancel
+                                             stop that exact command
   GET    /api/connect/runner              download the runner script
 
-State is in-process — safe because the backend runs a single uvicorn worker,
-the same assumption broadcast.py already relies on. A live SSE channel per
-connected host holds an outbound command queue plus the pending result futures
-that /exec awaits.
+Live sockets and waiting callers are in-process — safe because the backend runs
+a single uvicorn worker, the same assumption broadcast.py already relies on.
+The active command and most recent result are also written into the host's
+registry record, so transport loss or a backend restart cannot duplicate work.
+Ordinary exec requests never queue behind one another.
 """
 
 from __future__ import annotations
 
 import asyncio
 import json
-import logging
 import secrets
 import time
 from hashlib import sha256
 from pathlib import Path
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import (
+  APIRouter,
+  Depends,
+  HTTPException,
+  Request,
+  WebSocket,
+  WebSocketDisconnect,
+)
 from fastapi.responses import PlainTextResponse, StreamingResponse
 from pydantic import BaseModel, Field, field_validator
 
 from app import models
 from app.config import get_settings
 from app.deps import get_owner_or_app_with_connect_manage, reject_cross_site
-
-log = logging.getLogger("moebius.connect")
 
 router = APIRouter(
   prefix="/api/connect",
@@ -70,6 +85,14 @@ _DISCONNECT_COMMAND = "python3 ~/.mobius-connect/runner.py --uninstall"
 _LEGACY_DISCONNECT_COMMAND = f'{_DISCONNECT_COMMAND}; kill -TERM "$PPID"'
 _DISCONNECT_ACK_TIMEOUT = 4
 _LEGACY_DISCONNECT_TIMEOUT = 4
+_RUNNER_PROTOCOL_VERSION = 3
+_SSE_PROTOCOL_VERSION = 3
+# Railway permits active HTTP responses for 15 minutes. Rotate current-runner
+# streams well inside that bound; the host-owned command continues separately.
+_STREAM_ROTATION_SECONDS = 10 * 60
+_START_ACK_TIMEOUT = 10
+_RESULT_GRACE_SECONDS = 15
+_RESULT_RETENTION_SECONDS = 15 * 60
 
 
 # --------------------------------------------------------------------------- #
@@ -135,26 +158,231 @@ def _now() -> float:
   return time.time()
 
 
+def _command_fingerprint(cmd: str, cwd: str | None, timeout: int) -> str:
+  payload = json.dumps(
+    [cmd, cwd, timeout], ensure_ascii=False, separators=(",", ":"),
+  )
+  return sha256(payload.encode("utf-8")).hexdigest()
+
+
 # --------------------------------------------------------------------------- #
 # In-memory live channels (one per connected runner)
 # --------------------------------------------------------------------------- #
 class _Channel:
-  """A live runner connection: an outbound command queue plus the futures the
-  exec endpoint is waiting on."""
+  """One replaceable transport for a host-owned command lifecycle."""
 
-  def __init__(self) -> None:
+  def __init__(
+    self,
+    protocol_version: int = 1,
+    *,
+    transport: str = "sse",
+  ) -> None:
     self.queue: asyncio.Queue[dict] = asyncio.Queue()
-    self.pending: dict[str, asyncio.Future] = {}
+    self.control_pending: dict[str, asyncio.Future] = {}
     self.closed = asyncio.Event()
     self.connected_at = _now()
+    self.protocol_version = protocol_version
+    self.transport = transport
+
+
+class _ActiveCommand:
+  """The one command owned by a paired host across transport reconnects."""
+
+  def __init__(
+    self,
+    request_id: str,
+    timeout: int,
+    *,
+    cmd: str = "",
+    cwd: str | None = None,
+    created_at: float | None = None,
+    started_at: float | None = None,
+    state: str = "dispatching",
+    not_after: float | None = None,
+    fingerprint: str | None = None,
+  ) -> None:
+    loop = asyncio.get_running_loop()
+    self.request_id = request_id
+    self.timeout = timeout
+    self.cmd = cmd
+    self.cwd = cwd
+    self.created_at = created_at if created_at is not None else _now()
+    self.started_at = started_at
+    self.state = state
+    self.not_after = not_after
+    self.fingerprint = fingerprint or _command_fingerprint(cmd, cwd, timeout)
+    self.started = asyncio.Event()
+    if started_at is not None:
+      self.started.set()
+    self.result: asyncio.Future = loop.create_future()
+
+  @classmethod
+  def from_record(cls, record: dict) -> _ActiveCommand:
+    return cls(
+      str(record["id"]),
+      max(1, int(record.get("timeout") or _DEFAULT_EXEC_TIMEOUT)),
+      cmd=str(record.get("cmd") or ""),
+      cwd=record.get("cwd"),
+      created_at=float(record.get("created_at") or _now()),
+      started_at=(
+        float(record["started_at"])
+        if record.get("started_at") is not None else None
+      ),
+      state=str(record.get("state") or "dispatching"),
+      not_after=(
+        float(record["not_after"])
+        if record.get("not_after") is not None else None
+      ),
+      fingerprint=str(record.get("fingerprint") or ""),
+    )
+
+  def record(self) -> dict:
+    record = {
+      "id": self.request_id,
+      "timeout": self.timeout,
+      "created_at": self.created_at,
+      "started_at": self.started_at,
+      "state": self.state,
+      "not_after": self.not_after,
+      "fingerprint": self.fingerprint,
+    }
+    # Replay needs the command only during the short pre-start dispatch window.
+    # Do not retain command text (which may contain sensitive arguments) for the
+    # remainder of a long-running command.
+    if self.state == "dispatching":
+      record["cmd"] = self.cmd
+      record["cwd"] = self.cwd
+    return record
+
+  def event(self) -> dict:
+    return {
+      "type": "exec",
+      "request_id": self.request_id,
+      "cmd": self.cmd,
+      "cwd": self.cwd,
+      "timeout": self.timeout,
+      "not_after": self.not_after,
+    }
+
+
+def _active_public(command: _ActiveCommand | None) -> dict | None:
+  if command is None:
+    return None
+  return {
+    "id": command.request_id,
+    "state": command.state,
+    "created_at": command.created_at,
+    "started_at": command.started_at,
+    "timeout": command.timeout,
+  }
+
+
+def _active_record_public(record: object) -> dict | None:
+  if not isinstance(record, dict) or not record.get("id"):
+    return None
+  return {
+    "id": record["id"],
+    "state": record.get("state") or "dispatching",
+    "created_at": record.get("created_at"),
+    "started_at": record.get("started_at"),
+    "timeout": record.get("timeout") or _DEFAULT_EXEC_TIMEOUT,
+  }
+
+
+def _persist_command(host_id: str, command: _ActiveCommand | None) -> None:
+  host = _load_host(host_id)
+  if host is None:
+    return
+  host["active_command"] = command.record() if command is not None else None
+  _save_host(host)
+
+
+def _ensure_command(host_id: str) -> _ActiveCommand | None:
+  command = _commands.get(host_id)
+  if command is not None:
+    return command
+  host = _load_host(host_id)
+  record = host.get("active_command") if host is not None else None
+  if not isinstance(record, dict) or not record.get("id"):
+    return None
+  command = _ActiveCommand.from_record(record)
+  _commands[host_id] = command
+  return command
+
+
+def _mark_command_started(host_id: str, request_id: str) -> bool:
+  command = _ensure_command(host_id)
+  if command is None or command.request_id != request_id:
+    return False
+  if command.started_at is None:
+    command.started_at = _now()
+    command.started.set()
+  if command.state != "canceling":
+    command.state = "running"
+  _persist_command(host_id, command)
+  return True
+
+
+def _finish_command(host_id: str, request_id: str, result: dict) -> bool:
+  command = _ensure_command(host_id)
+  if command is None or command.request_id != request_id:
+    return False
+  public_result = _format_result(request_id, result)
+  if not command.result.done():
+    command.result.set_result(public_result)
+  _commands.pop(host_id, None)
+  host = _load_host(host_id)
+  if host is not None:
+    finished_at = _now()
+    host["active_command"] = None
+    host["last_command"] = {
+      "id": request_id,
+      "fingerprint": command.fingerprint,
+      "finished_at": finished_at,
+      "result": public_result,
+    }
+    _save_host(host)
+    try:
+      asyncio.get_running_loop().call_later(
+        _RESULT_RETENTION_SECONDS + 1,
+        _expire_last_command,
+        host_id,
+        request_id,
+        finished_at,
+      )
+    except RuntimeError:
+      pass
+  return True
+
+
+async def _request_command_cancel(
+  host_id: str,
+  command: _ActiveCommand,
+) -> bool:
+  ch = _channels.get(host_id)
+  host = _load_host(host_id)
+  known_protocol = (
+    ch.protocol_version if ch is not None
+    else int((host or {}).get("runner_protocol") or 1)
+  )
+  if known_protocol < 2 or (ch is None and known_protocol < 3):
+    return False
+  if command.state != "canceling":
+    command.state = "canceling"
+    _persist_command(host_id, command)
+  if ch is not None:
+    await ch.queue.put({"type": "cancel", "request_id": command.request_id})
+  return True
 
 
 _channels: dict[str, _Channel] = {}
+_commands: dict[str, _ActiveCommand] = {}
 
 
 def _touch(host_id: str) -> None:
   host = _load_host(host_id)
   if host is not None:
+    _prune_last_command(host)
     host["last_seen"] = _now()
     _save_host(host)
 
@@ -162,7 +390,7 @@ def _touch(host_id: str) -> None:
 # --------------------------------------------------------------------------- #
 # Host-token auth (runner side) — separate from owner/app JWT auth
 # --------------------------------------------------------------------------- #
-def _auth_host(request: Request) -> dict:
+def _auth_host(request: Request | WebSocket) -> dict:
   header = request.headers.get("authorization", "")
   if not header.lower().startswith("bearer "):
     raise HTTPException(status_code=401, detail="Missing host token.")
@@ -197,12 +425,23 @@ class ResultBody(BaseModel):
   stderr: str = Field(default="", max_length=8 * 1024 * 1024)
   exit_code: int = 0
   timed_out: bool = False
+  outcome: str | None = Field(default=None, max_length=16)
 
 
 class ExecBody(BaseModel):
   cmd: str = Field(min_length=1, max_length=64 * 1024)
   cwd: str | None = Field(default=None, max_length=4096)
   timeout: int = Field(default=_DEFAULT_EXEC_TIMEOUT, ge=1, le=3600)
+  request_id: str | None = Field(
+    default=None, min_length=16, max_length=64, pattern=r"^[a-f0-9]+$",
+  )
+
+
+class CommandStateBody(BaseModel):
+  request_id: str = Field(
+    min_length=16, max_length=64, pattern=r"^[a-f0-9]+$",
+  )
+  state: str = Field(min_length=1, max_length=16)
 
 
 class RenameHostBody(BaseModel):
@@ -225,13 +464,50 @@ def _install_command(base: str, code: str) -> str:
   )
 
 
+def _update_command(base: str) -> str:
+  return f'curl -fsSL "{base}/api/connect/runner" | python3 - --install'
+
+
 def _public_host(host: dict) -> dict:
   """Registry view safe to hand to the owner/app (no token hash)."""
+  ch = _channels.get(host["id"])
+  _prune_last_command(host)
+  active = _commands.get(host["id"])
+  active_public = (
+    _active_public(active)
+    if active is not None else _active_record_public(host.get("active_command"))
+  )
+  runner_protocol = (
+    ch.protocol_version if ch is not None
+    else host.get("runner_protocol")
+  )
+  runner_transport = (
+    ch.transport if ch is not None else host.get("runner_transport")
+  )
+  # Protocol 3 existed briefly as the provisional WebSocket runner. Records
+  # written before transport persistence can therefore be identified safely:
+  # older SSE runners are protocol 1/2 and current SSE writes this field.
+  if runner_transport is None and runner_protocol == 3:
+    runner_transport = "websocket"
+  paired = bool(host.get("token_sha256"))
+  runner_update_available = bool(
+    paired and runner_protocol is not None and (
+      int(runner_protocol or 1) < _RUNNER_PROTOCOL_VERSION
+      or runner_transport != "sse"
+    )
+  )
   return {
     "id": host["id"],
     "name": host.get("name") or "Machine",
-    "paired": bool(host.get("token_sha256")),
-    "online": host["id"] in _channels,
+    "paired": paired,
+    "online": ch is not None,
+    "busy": active_public is not None,
+    "active_command": active_public,
+    "runner_protocol": runner_protocol,
+    "runner_update_available": runner_update_available,
+    "update_command": (
+      _update_command(_base_url()) if runner_update_available else None
+    ),
     "last_seen": host.get("last_seen"),
     "created_at": host.get("created_at"),
     "platform": host.get("platform"),
@@ -239,12 +515,43 @@ def _public_host(host: dict) -> dict:
   }
 
 
+def _prune_last_command(host: dict) -> None:
+  last = host.get("last_command")
+  if not isinstance(last, dict):
+    return
+  finished_at = float(last.get("finished_at") or 0)
+  if _now() - finished_at <= _RESULT_RETENTION_SECONDS:
+    return
+  host["last_command"] = None
+  _save_host(host)
+
+
+def _expire_last_command(
+  host_id: str,
+  request_id: str,
+  finished_at: float,
+) -> None:
+  host = _load_host(host_id)
+  last = host.get("last_command") if host is not None else None
+  if not isinstance(last, dict):
+    return
+  if last.get("id") != request_id or last.get("finished_at") != finished_at:
+    return
+  if _now() - finished_at < _RESULT_RETENTION_SECONDS:
+    return
+  host["last_command"] = None
+  _save_host(host)
+
+
 def _forget_host(host_id: str) -> None:
   ch = _channels.pop(host_id, None)
   if ch is not None:
-    for fut in ch.pending.values():
+    for fut in ch.control_pending.values():
       if not fut.done():
         fut.cancel()
+  command = _commands.pop(host_id, None)
+  if command is not None and not command.result.done():
+    command.result.cancel()
   _host_path(host_id).unlink(missing_ok=True)
 
 
@@ -252,7 +559,7 @@ async def _ask_runner_to_disconnect(ch: _Channel) -> str:
   request_id = secrets.token_hex(8)
   loop = asyncio.get_running_loop()
   fut: asyncio.Future = loop.create_future()
-  ch.pending[request_id] = fut
+  ch.control_pending[request_id] = fut
   await ch.queue.put({"type": "disconnect", "request_id": request_id})
   try:
     result = await asyncio.wait_for(
@@ -284,7 +591,7 @@ async def _ask_runner_to_disconnect(ch: _Channel) -> str:
       )
     return "legacy-stopped"
   finally:
-    ch.pending.pop(request_id, None)
+    ch.control_pending.pop(request_id, None)
     if not fut.done():
       fut.cancel()
   if int(result.get("exit_code", 1)) != 0:
@@ -293,6 +600,30 @@ async def _ask_runner_to_disconnect(ch: _Channel) -> str:
       detail=result.get("stderr") or "The machine could not stop its daemon.",
     )
   return "acknowledged"
+
+
+async def _await_command_result(
+  host_id: str,
+  command: _ActiveCommand,
+) -> dict:
+  begins_at = command.started_at or command.created_at
+  remaining = max(
+    0.01,
+    begins_at + command.timeout + _RESULT_GRACE_SECONDS - _now(),
+  )
+  try:
+    return await asyncio.wait_for(
+      asyncio.shield(command.result), timeout=remaining,
+    )
+  except asyncio.TimeoutError:
+    cancel_sent = await _request_command_cancel(host_id, command)
+    detail = "The command timed out and Connect asked the machine to stop it."
+    if not cancel_sent:
+      detail = (
+        "The command timed out, but this machine’s runner is too old to stop "
+        "it remotely. Update the runner in Connect."
+      )
+    raise HTTPException(status_code=504, detail=detail)
 
 
 @router.post("/hosts")
@@ -312,6 +643,10 @@ async def create_host(
     "paired_at": None,
     "last_seen": None,
     "platform": None,
+    "runner_protocol": None,
+    "runner_transport": None,
+    "active_command": None,
+    "last_command": None,
   }
   _save_host(host)
   base = _base_url()
@@ -413,44 +748,107 @@ async def exec_on_host(
   if host is None:
     raise HTTPException(status_code=404, detail="No such host.")
   ch = _channels.get(host_id)
+  request_id = body.request_id or secrets.token_hex(8)
+  fingerprint = _command_fingerprint(body.cmd, body.cwd, body.timeout)
+  _prune_last_command(host)
+  last = host.get("last_command")
+  if isinstance(last, dict) and last.get("id") == request_id:
+    if last.get("fingerprint") != fingerprint:
+      raise HTTPException(
+        status_code=409,
+        detail="That request id already belongs to a different command.",
+      )
+    result = last.get("result")
+    if isinstance(result, dict):
+      return result
+
+  command = _ensure_command(host_id)
+  if command is not None and command.request_id == request_id:
+    if command.fingerprint != fingerprint:
+      raise HTTPException(
+        status_code=409,
+        detail="That request id already belongs to a different command.",
+      )
+    # A caller can safely retry after losing its own HTTP connection. It joins
+    # the one host-owned command instead of dispatching the same work twice.
+    return await _await_command_result(host_id, command)
+  if command is not None:
+    raise HTTPException(
+      status_code=409,
+      detail=(
+        f"{host.get('name') or 'That machine'} is busy with another command. "
+        "Wait for it to finish or stop it in Connect."
+      ),
+    )
   if ch is None:
     raise HTTPException(
       status_code=409,
       detail=f"{host.get('name') or 'That machine'} is offline right now.",
     )
-  request_id = secrets.token_hex(8)
-  loop = asyncio.get_running_loop()
-  fut: asyncio.Future = loop.create_future()
-  ch.pending[request_id] = fut
-  timeout = max(1, min(int(body.timeout or _DEFAULT_EXEC_TIMEOUT), 3600))
-  await ch.queue.put(
-    {
-      "type": "exec",
-      "request_id": request_id,
-      "cmd": body.cmd,
-      "cwd": body.cwd,
-      "timeout": timeout,
-    }
+  timeout = body.timeout
+  not_after = _now() + _START_ACK_TIMEOUT
+  command = _ActiveCommand(
+    request_id,
+    timeout,
+    cmd=body.cmd,
+    cwd=body.cwd,
+    not_after=not_after,
+    fingerprint=fingerprint,
   )
+  _commands[host_id] = command
+  _persist_command(host_id, command)
+  if ch.protocol_version < _RUNNER_PROTOCOL_VERSION:
+    _mark_command_started(host_id, request_id)
+  await ch.queue.put(command.event())
   try:
-    # Give the runner its own command timeout plus a network grace margin.
-    result = await asyncio.wait_for(fut, timeout=timeout + 15)
-  except asyncio.TimeoutError:
-    raise HTTPException(status_code=504, detail="The command timed out.")
+    if ch.protocol_version >= _RUNNER_PROTOCOL_VERSION:
+      try:
+        await asyncio.wait_for(
+          command.started.wait(), timeout=_START_ACK_TIMEOUT,
+        )
+      except asyncio.TimeoutError:
+        await _request_command_cancel(host_id, command)
+        _finish_command(host_id, request_id, {
+          "stdout": "",
+          "stderr": "command expired before the runner confirmed it started",
+          "exit_code": 124,
+          "outcome": "expired",
+        })
+        raise HTTPException(
+          status_code=504,
+          detail="The machine did not start the command before it expired.",
+        )
+    # Execution time belongs to the runner and begins only after its start ack.
+    return await _await_command_result(host_id, command)
   except asyncio.CancelledError:
-    raise HTTPException(status_code=409, detail="The machine disconnected.")
-  finally:
-    ch.pending.pop(request_id, None)
-  stdout, stdout_truncated = _cap_stream(result.get("stdout", ""))
-  stderr, stderr_truncated = _cap_stream(result.get("stderr", ""))
-  exit_code = int(result.get("exit_code", 0))
-  return {
-    "stdout": stdout,
-    "stderr": stderr,
-    "exit_code": exit_code,
-    "truncated": stdout_truncated or stderr_truncated,
-    "timed_out": bool(result.get("timed_out", False)),
-  }
+    # HTTP caller lifetime and command lifetime are deliberately independent.
+    # `mach` sends an explicit cancel request on Ctrl-C; an edge timeout or
+    # backend shutdown must not silently kill remote work.
+    raise
+
+
+@router.post("/hosts/{host_id}/commands/{request_id}/cancel")
+async def cancel_host_command(
+  host_id: str,
+  request_id: str,
+  _owner: models.Owner = Depends(get_owner_or_app_with_connect_manage),
+) -> dict:
+  host = _load_host(host_id)
+  if host is None:
+    raise HTTPException(status_code=404, detail="No such host.")
+  ch = _channels.get(host_id)
+  command = _ensure_command(host_id)
+  if command is None or command.request_id != request_id:
+    raise HTTPException(status_code=404, detail="That command is no longer running.")
+  if not await _request_command_cancel(host_id, command):
+    raise HTTPException(
+      status_code=409,
+      detail=(
+        "This machine’s runner must be updated before commands can be stopped "
+        "remotely. The current command is still running."
+      ),
+    )
+  return {"ok": True, "request_id": request_id, "state": command.state}
 
 
 def _cap_stream(text: str) -> tuple[str, bool]:
@@ -461,6 +859,101 @@ def _cap_stream(text: str) -> tuple[str, bool]:
   head = (kept + 1) // 2
   tail = kept // 2
   return f"{text[:head]}{marker}{text[-tail:]}", True
+
+
+def _format_result(request_id: str, result: dict) -> dict:
+  stdout, stdout_truncated = _cap_stream(str(result.get("stdout") or ""))
+  stderr, stderr_truncated = _cap_stream(str(result.get("stderr") or ""))
+  exit_code = int(result.get("exit_code", 0))
+  outcome = result.get("outcome") or (
+    "timed_out" if result.get("timed_out") else "completed"
+  )
+  return {
+    "request_id": request_id,
+    "stdout": stdout,
+    "stderr": stderr,
+    "exit_code": exit_code,
+    "outcome": outcome,
+    "truncated": stdout_truncated or stderr_truncated,
+    "timed_out": outcome in ("timed_out", "expired"),
+    "canceled": outcome == "canceled",
+  }
+
+
+def _replace_channel(host_id: str, ch: _Channel) -> None:
+  old = _channels.get(host_id)
+  if old is not None:
+    for fut in old.control_pending.values():
+      if not fut.done():
+        fut.cancel()
+    old.closed.set()
+  _channels[host_id] = ch
+
+
+def _runner_result(host_id: str, body: ResultBody) -> None:
+  ch = _channels.get(host_id)
+  control = ch.control_pending.get(body.request_id) if ch is not None else None
+  if control is not None and not control.done():
+    control.set_result({
+      "stdout": body.stdout,
+      "stderr": body.stderr,
+      "exit_code": body.exit_code,
+    })
+    return
+  outcome = body.outcome if body.outcome in {
+    "completed", "canceled", "timed_out", "expired", "lost",
+  } else None
+  _finish_command(host_id, body.request_id, {
+    "stdout": body.stdout,
+    "stderr": body.stderr,
+    "exit_code": body.exit_code,
+    "timed_out": body.timed_out,
+    "outcome": outcome,
+  })
+
+
+async def _reconcile_runner(
+  host_id: str,
+  ch: _Channel,
+  hello: dict,
+) -> None:
+  """Join one runner's local state to the durable host-owned command."""
+  runner_active = str(hello.get("active_request_id") or "")
+  pending_ids = {
+    str(item) for item in (hello.get("pending_result_ids") or []) if item
+  }
+  command = _ensure_command(host_id)
+  if command is None:
+    if runner_active:
+      await ch.queue.put({"type": "cancel", "request_id": runner_active})
+    return
+
+  if command.request_id == runner_active:
+    _mark_command_started(host_id, command.request_id)
+    if command.state == "canceling":
+      await ch.queue.put({"type": "cancel", "request_id": command.request_id})
+    return
+  if command.request_id in pending_ids:
+    # The result follows the hello on this connection. Keeping the command here
+    # lets that late result resolve a waiting or retried caller exactly once.
+    return
+  if command.state == "dispatching" and (
+    command.not_after is None or _now() <= command.not_after
+  ):
+    await ch.queue.put(command.event())
+    return
+
+  # The backend remembered running work that this restarted runner no longer
+  # owns. Clear it honestly rather than either duplicating it or blocking the
+  # host forever.
+  _finish_command(host_id, command.request_id, {
+    "stdout": "",
+    "stderr": "runner restarted before the command result was reported",
+    "exit_code": 125,
+    "outcome": "lost",
+  })
+  if runner_active:
+    await ch.queue.put({"type": "cancel", "request_id": runner_active})
 
 
 # --------------------------------------------------------------------------- #
@@ -489,6 +982,97 @@ async def pair(body: PairBody) -> dict:
   raise HTTPException(status_code=400, detail="Invalid pairing code.")
 
 
+@router.websocket("/socket")
+async def legacy_command_socket(websocket: WebSocket) -> None:
+  """Upgrade bridge for the provisional WebSocket protocol-v3 runner.
+
+  New runners never use this route. Keeping the already-installed v3 runner
+  online lets Connect show its in-place update command instead of stranding the
+  paired machine when rotating SSE becomes active.
+  """
+  try:
+    host = _auth_host(websocket)
+  except HTTPException:
+    await websocket.close(code=1008, reason="Unknown or revoked host token.")
+    return
+  await websocket.accept()
+  try:
+    hello = await asyncio.wait_for(websocket.receive_json(), timeout=10)
+  except (asyncio.TimeoutError, WebSocketDisconnect, ValueError, TypeError):
+    await websocket.close(code=1002, reason="Runner hello required.")
+    return
+  if not isinstance(hello, dict) or hello.get("type") != "hello":
+    await websocket.close(code=1002, reason="Runner hello required.")
+    return
+
+  host_id = host["id"]
+  ch = _Channel(
+    protocol_version=_RUNNER_PROTOCOL_VERSION,
+    transport="websocket",
+  )
+  platform_name = str(hello.get("platform") or "")[:80]
+  if platform_name:
+    host["platform"] = platform_name
+  host["runner_protocol"] = _RUNNER_PROTOCOL_VERSION
+  host["runner_transport"] = "websocket"
+  _save_host(host)
+  _replace_channel(host_id, ch)
+  _touch(host_id)
+  await _reconcile_runner(host_id, ch, hello)
+  await websocket.send_json({"type": "welcome", "protocol": 3})
+
+  async def send_events() -> None:
+    while True:
+      await websocket.send_json(await ch.queue.get())
+
+  async def receive_events() -> None:
+    while True:
+      message = await websocket.receive_json()
+      if not isinstance(message, dict):
+        continue
+      kind = message.get("type")
+      if kind == "started":
+        request_id = str(message.get("request_id") or "")
+        if not _mark_command_started(host_id, request_id):
+          await ch.queue.put({"type": "cancel", "request_id": request_id})
+      elif kind == "result":
+        try:
+          body = ResultBody.model_validate(message)
+        except ValueError:
+          continue
+        _runner_result(host_id, body)
+        await ch.queue.put({
+          "type": "ack", "kind": "result", "request_id": body.request_id,
+        })
+      _touch(host_id)
+
+  sender = asyncio.create_task(send_events())
+  receiver = asyncio.create_task(receive_events())
+  superseded = asyncio.create_task(ch.closed.wait())
+  try:
+    done, pending = await asyncio.wait(
+      {sender, receiver, superseded}, return_when=asyncio.FIRST_COMPLETED,
+    )
+    for task in pending:
+      task.cancel()
+    await asyncio.gather(*pending, return_exceptions=True)
+    for task in done:
+      try:
+        task.result()
+      except WebSocketDisconnect:
+        pass
+  except WebSocketDisconnect:
+    pass
+  finally:
+    if _channels.get(host_id) is ch:
+      del _channels[host_id]
+    for fut in ch.control_pending.values():
+      if not fut.done():
+        fut.cancel()
+    ch.closed.set()
+    _touch(host_id)
+
+
 @router.get("/stream")
 async def stream(request: Request) -> StreamingResponse:
   host = _auth_host(request)
@@ -498,31 +1082,54 @@ async def stream(request: Request) -> StreamingResponse:
   if plat:
     host["platform"] = plat[:80]
     _save_host(host)
-  ch = _Channel()
+  try:
+    protocol_version = max(1, min(
+      int(request.query_params.get("protocol") or 1), _SSE_PROTOCOL_VERSION,
+    ))
+  except ValueError:
+    protocol_version = 1
+  ch = _Channel(protocol_version=protocol_version)
+  host["runner_protocol"] = protocol_version
+  host["runner_transport"] = "sse"
+  _save_host(host)
   # A reconnecting runner replaces any stale channel.
-  old = _channels.get(host_id)
-  if old is not None:
-    for fut in old.pending.values():
-      if not fut.done():
-        fut.cancel()
-  _channels[host_id] = ch
+  _replace_channel(host_id, ch)
   _touch(host_id)
+  if protocol_version >= 3:
+    await _reconcile_runner(host_id, ch, {
+      "active_request_id": request.query_params.get("active_request_id"),
+      "pending_result_ids": request.query_params.getlist("pending_result_id"),
+    })
 
   async def gen():
+    loop = asyncio.get_running_loop()
+    rotation_at = (
+      loop.time() + _STREAM_ROTATION_SECONDS
+      if protocol_version >= 3 else None
+    )
     try:
       yield ": connected\n\n"
       while True:
-        if await request.is_disconnected():
+        if ch.closed.is_set() or await request.is_disconnected():
           break
+        if rotation_at is not None and loop.time() >= rotation_at:
+          break
+        wait_seconds = _HEARTBEAT_SECONDS
+        if rotation_at is not None:
+          wait_seconds = min(wait_seconds, max(0.01, rotation_at - loop.time()))
         try:
-          evt = await asyncio.wait_for(ch.queue.get(), timeout=_HEARTBEAT_SECONDS)
+          evt = await asyncio.wait_for(ch.queue.get(), timeout=wait_seconds)
           yield f"data: {json.dumps(evt)}\n\n"
         except asyncio.TimeoutError:
+          if ch.closed.is_set() or (
+            rotation_at is not None and loop.time() >= rotation_at
+          ):
+            break
           yield ": ping\n\n"
     finally:
       if _channels.get(host_id) is ch:
         del _channels[host_id]
-      for fut in ch.pending.values():
+      for fut in ch.control_pending.values():
         if not fut.done():
           fut.cancel()
       ch.closed.set()
@@ -538,18 +1145,18 @@ async def stream(request: Request) -> StreamingResponse:
 @router.post("/result")
 async def result(body: ResultBody, request: Request) -> dict:
   host = _auth_host(request)
-  ch = _channels.get(host["id"])
-  if ch is not None:
-    fut = ch.pending.get(body.request_id)
-    if fut is not None and not fut.done():
-      fut.set_result(
-        {
-          "stdout": body.stdout,
-          "stderr": body.stderr,
-          "exit_code": body.exit_code,
-          "timed_out": body.timed_out,
-        }
-      )
+  _runner_result(host["id"], body)
+  _touch(host["id"])
+  return {"ok": True}
+
+
+@router.post("/state")
+async def command_state(body: CommandStateBody, request: Request) -> dict:
+  host = _auth_host(request)
+  if body.state != "started":
+    raise HTTPException(status_code=400, detail="Unknown command state.")
+  if not _mark_command_started(host["id"], body.request_id):
+    raise HTTPException(status_code=409, detail="That command is no longer active.")
   _touch(host["id"])
   return {"ok": True}
 

--- a/backend/tests/test_connect.py
+++ b/backend/tests/test_connect.py
@@ -763,6 +763,133 @@ async def test_protocol_two_does_not_claim_offline_cancellation(client, auth):
 
 
 @pytest.mark.asyncio
+async def test_legacy_timeout_without_result_releases_the_host(client, auth):
+  pairing, _ = _paired_host(client, auth)
+  channel = connect_routes._Channel(protocol_version=1)
+  connect_routes._channels[pairing["id"]] = channel
+  request_id = "1" * 16
+  command = connect_routes._ActiveCommand(
+    request_id,
+    1,
+    cmd="legacy task",
+    started_at=time.time() - 2,
+    state="running",
+  )
+  connect_routes._commands[pairing["id"]] = command
+  connect_routes._persist_command(pairing["id"], command)
+
+  with pytest.raises(connect_routes.HTTPException) as raised:
+    await connect_routes._await_command_result(pairing["id"], command)
+
+  assert raised.value.status_code == 504
+  assert connect_routes._ensure_command(pairing["id"]) is None
+  last = connect_routes._load_host(pairing["id"])["last_command"]
+  assert last["id"] == request_id
+  assert last["result"]["outcome"] == "lost"
+
+  next_request_id = "2" * 16
+  next_request = asyncio.create_task(connect_routes.exec_on_host(
+    pairing["id"],
+    connect_routes.ExecBody(
+      cmd="next task", timeout=30, request_id=next_request_id,
+    ),
+    _owner=object(),
+  ))
+  dispatched = await asyncio.wait_for(channel.queue.get(), timeout=1)
+  assert dispatched["request_id"] == next_request_id
+  connect_routes._finish_command(pairing["id"], next_request_id, {
+    "stdout": "ready", "stderr": "", "exit_code": 0,
+    "outcome": "completed",
+  })
+  assert (await next_request)["stdout"] == "ready"
+
+
+@pytest.mark.asyncio
+async def test_protocol_two_cancel_result_deadline_survives_restart(
+  client, auth, monkeypatch,
+):
+  pairing, _ = _paired_host(client, auth)
+  channel = connect_routes._Channel(protocol_version=2)
+  connect_routes._channels[pairing["id"]] = channel
+  request_id = "3" * 16
+  command = connect_routes._ActiveCommand(
+    request_id, 1, started_at=time.time() - 2, state="running",
+  )
+  connect_routes._commands[pairing["id"]] = command
+  connect_routes._persist_command(pairing["id"], command)
+
+  with pytest.raises(connect_routes.HTTPException) as raised:
+    await connect_routes._await_command_result(pairing["id"], command)
+
+  assert raised.value.status_code == 504
+  assert await asyncio.wait_for(channel.queue.get(), timeout=1) == {
+    "type": "cancel", "request_id": request_id,
+  }
+  persisted = connect_routes._load_host(pairing["id"])["active_command"]
+  assert persisted["state"] == "canceling"
+  assert persisted["cancel_not_after"] > time.time()
+
+  # A backend restart loses the in-memory command object, but the persisted
+  # reporting deadline still releases the host when it is next observed.
+  connect_routes._commands.clear()
+  monkeypatch.setattr(
+    connect_routes, "_now", lambda: persisted["cancel_not_after"] + 1,
+  )
+  public = connect_routes._public_host(
+    connect_routes._load_host(pairing["id"]),
+  )
+  assert public["busy"] is False
+  host = connect_routes._load_host(pairing["id"])
+  assert host["active_command"] is None
+  assert host["last_command"]["result"]["outcome"] == "lost"
+
+
+@pytest.mark.asyncio
+async def test_current_runner_keeps_retryable_result_after_server_timeout(
+  client, auth, monkeypatch,
+):
+  pairing, _ = _paired_host(client, auth)
+  channel = connect_routes._Channel(protocol_version=3)
+  connect_routes._channels[pairing["id"]] = channel
+  request_id = "4" * 16
+  command = connect_routes._ActiveCommand(
+    request_id, 1, started_at=time.time() - 2, state="running",
+  )
+  connect_routes._commands[pairing["id"]] = command
+  connect_routes._persist_command(pairing["id"], command)
+
+  with pytest.raises(connect_routes.HTTPException) as raised:
+    await connect_routes._await_command_result(pairing["id"], command)
+
+  assert raised.value.status_code == 504
+  assert await asyncio.wait_for(channel.queue.get(), timeout=1) == {
+    "type": "cancel", "request_id": request_id,
+  }
+  persisted = connect_routes._load_host(pairing["id"])["active_command"]
+  assert persisted["state"] == "canceling"
+  assert persisted["cancel_not_after"] is None
+
+  # Current runners retry terminal results after reconnect, so a long
+  # transport loss must not be mistaken for a permanently lost result.
+  connect_routes._commands.clear()
+  monkeypatch.setattr(connect_routes, "_now", lambda: time.time() + 3600)
+  assert connect_routes._public_host(
+    connect_routes._load_host(pairing["id"]),
+  )["busy"] is True
+  connect_routes._runner_result(pairing["id"], connect_routes.ResultBody(
+    request_id=request_id,
+    stdout="reported after reconnect",
+    exit_code=124,
+    timed_out=True,
+    outcome="timed_out",
+  ))
+  assert connect_routes._ensure_command(pairing["id"]) is None
+  assert connect_routes._load_host(
+    pairing["id"],
+  )["last_command"]["result"]["outcome"] == "timed_out"
+
+
+@pytest.mark.asyncio
 async def test_unacknowledged_dispatch_expires_and_sends_cancel(
   client, auth, monkeypatch,
 ):

--- a/backend/tests/test_connect.py
+++ b/backend/tests/test_connect.py
@@ -25,9 +25,11 @@ from app.schema_migrations import run_migrations, schema_migration_history
 def _clear_connect_channels():
   connect_routes._channels.clear()
   connect_routes._commands.clear()
+  connect_routes._pair_limiter.reset()
   yield
   connect_routes._channels.clear()
   connect_routes._commands.clear()
+  connect_routes._pair_limiter.reset()
 
 
 def _app_auth(client, auth, *, granted: bool) -> dict[str, str]:
@@ -61,6 +63,16 @@ def _paired_host(client, auth, name="Workstation"):
   )
   assert paired.status_code == 200, paired.text
   return pairing, paired.json()["token"]
+
+
+def test_pairing_code_exchange_is_rate_limited(client):
+  for _ in range(10):
+    response = client.post("/api/connect/pair", json={"code": "AAAA-AAAA"})
+    assert response.status_code == 400
+
+  blocked = client.post("/api/connect/pair", json={"code": "AAAA-AAAA"})
+
+  assert blocked.status_code == 429
 
 
 def test_app_token_requires_connect_manage(client, auth):

--- a/backend/tests/test_connect.py
+++ b/backend/tests/test_connect.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import shlex
 import sys
+import threading
 import time
 import urllib.error
 from pathlib import Path
@@ -928,6 +929,52 @@ def test_runner_retries_a_result_until_ordinary_https_succeeds(monkeypatch):
   assert runner.flush_pending_results() is True
   assert runner.pending_messages() == []
   assert len(attempts) == 2
+
+
+def test_runner_finishes_into_pending_result_atomically(monkeypatch):
+  runner = connect_runner._CommandRunner("https://example.test", "token")
+  record = {
+    "request_id": "a" * 16,
+    "proc": None,
+    "reason": None,
+    "timeout": 30,
+  }
+  runner.active = record
+  monkeypatch.setattr(runner, "flush_pending_results", lambda: False)
+
+  runner._post_result(
+    record["request_id"], "done", "", 0, "completed", record=record,
+  )
+
+  active_id, pending_ids = runner.snapshot()
+  assert active_id is None
+  assert pending_ids == [record["request_id"]]
+
+
+def test_runner_ignores_duplicate_delivery_of_an_accepted_request(monkeypatch):
+  runner = connect_runner._CommandRunner("https://example.test", "token")
+  spawned = []
+  monkeypatch.setattr(
+    connect_runner,
+    "_spawn_command",
+    lambda cmd, cwd: spawned.append((cmd, cwd)) or object(),
+  )
+  monkeypatch.setattr(runner, "_post_started", lambda _request_id: None)
+  monkeypatch.setattr(threading.Thread, "start", lambda self: None)
+  event = {
+    "request_id": "b" * 16,
+    "cmd": "do it once",
+    "cwd": None,
+    "timeout": 30,
+    "not_after": time.time() + 10,
+  }
+
+  runner.start(event)
+  runner.start(event)
+
+  assert spawned == [("do it once", None)]
+  assert runner.active["request_id"] == event["request_id"]
+  assert runner.pending_messages() == []
 
 
 def test_runner_rechecks_expiry_after_start_ack_before_spawning(monkeypatch):

--- a/backend/tests/test_connect.py
+++ b/backend/tests/test_connect.py
@@ -975,7 +975,7 @@ def test_runner_uses_standard_urllib_for_protocol_three_stream(monkeypatch):
     opened.append((request, kwargs))
     return Stream()
 
-  monkeypatch.setattr(connect_runner.urllib.request, "urlopen", fake_urlopen)
+  monkeypatch.setattr(connect_runner, "_open_url", fake_urlopen)
   monkeypatch.setattr(
     connect_runner, "_uninstall_service", lambda stop_running: None,
   )
@@ -1244,3 +1244,48 @@ def test_connect_manage_reaches_a_ledgered_database(tmp_path: Path):
   assert "0016_app_connect_manage" in {
     entry["version"] for entry in schema_migration_history(eng)
   }
+
+
+@pytest.mark.parametrize("url", [
+  "https://mobius.example",
+  "https://mobius.example:8443/base",
+  "http://localhost:8000",
+  "http://127.0.0.1:8000",
+  "http://[::1]:8000",
+])
+def test_connect_runner_accepts_credential_safe_base_urls(url):
+  assert connect_runner._validated_base_url(url + "/") == url
+
+
+@pytest.mark.parametrize("url", [
+  "http://mobius.example",
+  "http://localhost.example",
+  "file:///tmp/runner.py",
+  "https://",
+  "https://:443",
+  "https://user:password@mobius.example",
+  "https://mobius.example?redirect=elsewhere",
+  "https://mobius.example/#fragment",
+  "mobius.example",
+])
+def test_connect_runner_rejects_urls_that_can_leak_or_redirect_credentials(url):
+  with pytest.raises(ValueError):
+    connect_runner._validated_base_url(url)
+
+
+def test_connect_runner_never_redirects_an_authenticated_request():
+  request = connect_runner.urllib.request.Request(
+    "https://mobius.example/api/connect/result",
+    headers={"Authorization": "Bearer secret"},
+  )
+
+  redirected = connect_runner._NoRedirect().redirect_request(
+    request,
+    None,
+    302,
+    "Found",
+    {},
+    "https://elsewhere.example/collect",
+  )
+
+  assert redirected is None

--- a/backend/tests/test_connect.py
+++ b/backend/tests/test_connect.py
@@ -1,14 +1,17 @@
 """Pairing, daemon shutdown, and capability boundaries for Möbius Connect."""
 
 import asyncio
+import json
 import shlex
 import sys
 import time
+import urllib.error
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 from sqlalchemy import create_engine, inspect, text
+from starlette.requests import Request
 
 from app import connect_runner, models
 from app.connect_runner import _run_command
@@ -21,8 +24,10 @@ from app.schema_migrations import run_migrations, schema_migration_history
 @pytest.fixture(autouse=True)
 def _clear_connect_channels():
   connect_routes._channels.clear()
+  connect_routes._commands.clear()
   yield
   connect_routes._channels.clear()
+  connect_routes._commands.clear()
 
 
 def _app_auth(client, auth, *, granted: bool) -> dict[str, str]:
@@ -175,7 +180,7 @@ async def test_online_disconnect_waits_for_daemon_ack_before_revoking(client, au
   )
   event = await asyncio.wait_for(channel.queue.get(), timeout=1)
   assert event["type"] == "disconnect"
-  channel.pending[event["request_id"]].set_result({
+  channel.control_pending[event["request_id"]].set_result({
     "stdout": "Connect daemon removed.", "stderr": "", "exit_code": 0,
   })
 
@@ -199,7 +204,7 @@ async def test_failed_daemon_cleanup_keeps_the_connection(client, auth):
     connect_routes.delete_host(host_id, _owner=object()),
   )
   event = await asyncio.wait_for(channel.queue.get(), timeout=1)
-  channel.pending[event["request_id"]].set_result({
+  channel.control_pending[event["request_id"]].set_result({
     "stdout": "", "stderr": "systemd disable failed", "exit_code": 1,
   })
 
@@ -308,56 +313,304 @@ def test_exec_rejects_an_offline_machine(client, auth):
   assert response.json()["detail"] == "Workstation is offline right now."
 
 
+def test_provisional_websocket_runner_stays_online_for_in_place_update(
+  client, auth,
+):
+  pairing, runner_token = _paired_host(client, auth)
+  with client.websocket_connect(
+    "/api/connect/socket",
+    headers={"Authorization": f"Bearer {runner_token}"},
+  ) as websocket:
+    websocket.send_json({
+      "type": "hello",
+      "protocol": 3,
+      "platform": "ProvisionalOS 1",
+      "active_request_id": None,
+      "pending_result_ids": [],
+    })
+    assert websocket.receive_json() == {"type": "welcome", "protocol": 3}
+    host = client.get("/api/connect/hosts", headers=auth).json()["hosts"][0]
+    assert host["online"] is True
+    assert host["runner_protocol"] == 3
+    assert host["runner_update_available"] is True
+    assert "--install" in host["update_command"]
+    assert host["platform"] == "ProvisionalOS 1"
+
+  host = client.get("/api/connect/hosts", headers=auth).json()["hosts"][0]
+  assert host["online"] is False
+  assert host["runner_update_available"] is True
+  assert "--install" in host["update_command"]
+
+
+def test_pre_transport_protocol_three_record_offers_offline_update(client, auth):
+  pairing, _ = _paired_host(client, auth)
+  host = connect_routes._load_host(pairing["id"])
+  host["runner_protocol"] = 3
+  host.pop("runner_transport", None)
+  connect_routes._save_host(host)
+
+  public = client.get("/api/connect/hosts", headers=auth).json()["hosts"][0]
+
+  assert public["online"] is False
+  assert public["runner_update_available"] is True
+  assert "--install" in public["update_command"]
+
+
+@pytest.mark.asyncio
+async def test_protocol_three_stream_rotates_without_losing_running_command(
+  client, auth, monkeypatch,
+):
+  pairing, runner_token = _paired_host(client, auth)
+  request_id = "0" * 16
+  first = connect_routes._Channel(protocol_version=3)
+  connect_routes._channels[pairing["id"]] = first
+  caller = asyncio.create_task(connect_routes.exec_on_host(
+    pairing["id"],
+    connect_routes.ExecBody(
+      cmd="printf rotating", timeout=30, request_id=request_id,
+    ),
+    _owner=object(),
+  ))
+  assert (await first.queue.get())["request_id"] == request_id
+  connect_routes._mark_command_started(pairing["id"], request_id)
+
+  monkeypatch.setattr(connect_routes, "_STREAM_ROTATION_SECONDS", 0.01)
+  monkeypatch.setattr(connect_routes, "_HEARTBEAT_SECONDS", 0.01)
+
+  async def receive():
+    return {"type": "http.request", "body": b"", "more_body": False}
+
+  request = Request({
+    "type": "http",
+    "method": "GET",
+    "path": "/api/connect/stream",
+    "query_string": (
+      f"protocol=3&platform=TestOS%201&active_request_id={request_id}"
+    ).encode(),
+    "headers": [
+      (b"authorization", f"Bearer {runner_token}".encode()),
+    ],
+  }, receive)
+  response = await connect_routes.stream(request)
+  current = connect_routes._channels[pairing["id"]]
+  assert current is not first
+  assert current.queue.empty()
+  host = connect_routes._load_host(pairing["id"])
+  assert host["runner_protocol"] == 3
+  assert host["platform"] == "TestOS 1"
+  assert connect_routes._public_host(host)["runner_update_available"] is False
+
+  assert await response.body_iterator.__anext__() == ": connected\n\n"
+  with pytest.raises(StopAsyncIteration):
+    await response.body_iterator.__anext__()
+
+  assert pairing["id"] not in connect_routes._channels
+  assert connect_routes._ensure_command(pairing["id"]).request_id == request_id
+  assert not caller.done()
+  host = connect_routes._load_host(pairing["id"])
+  assert host["runner_transport"] == "sse"
+  assert connect_routes._public_host(host)["runner_update_available"] is False
+  connect_routes._runner_result(pairing["id"], connect_routes.ResultBody(
+    request_id=request_id,
+    stdout="rotating",
+    exit_code=0,
+    outcome="completed",
+  ))
+  assert (await caller)["stdout"] == "rotating"
+
+
+@pytest.mark.asyncio
+async def test_reconnect_keeps_one_command_and_returns_its_result(client, auth):
+  pairing, _ = _paired_host(client, auth)
+  request_id = "7" * 16
+  first = connect_routes._Channel(protocol_version=3)
+  connect_routes._channels[pairing["id"]] = first
+  caller = asyncio.create_task(connect_routes.exec_on_host(
+    pairing["id"],
+    connect_routes.ExecBody(
+      cmd="printf durable", timeout=30, request_id=request_id,
+    ),
+    _owner=object(),
+  ))
+  event = await first.queue.get()
+  assert event["request_id"] == request_id
+  connect_routes._mark_command_started(pairing["id"], request_id)
+
+  connect_routes._channels.pop(pairing["id"])
+  second = connect_routes._Channel(protocol_version=3)
+  connect_routes._replace_channel(pairing["id"], second)
+  await connect_routes._reconcile_runner(pairing["id"], second, {
+    "active_request_id": request_id, "pending_result_ids": [],
+  })
+  assert second.queue.empty()
+  connect_routes._runner_result(pairing["id"], connect_routes.ResultBody(
+    request_id=request_id,
+    stdout="durable",
+    exit_code=0,
+    outcome="completed",
+  ))
+  response = await caller
+  assert response["stdout"] == "durable"
+  # The same stable id is an idempotent read of the retained result, not work.
+  retry = await connect_routes.exec_on_host(
+    pairing["id"],
+    connect_routes.ExecBody(
+      cmd="printf durable", timeout=30, request_id=request_id,
+    ),
+    _owner=object(),
+  )
+  assert retry == response
+  with pytest.raises(connect_routes.HTTPException) as reused:
+    await connect_routes.exec_on_host(
+      pairing["id"],
+      connect_routes.ExecBody(
+        cmd="different work", timeout=30, request_id=request_id,
+      ),
+      _owner=object(),
+    )
+  assert reused.value.status_code == 409
+  assert "different command" in reused.value.detail
+
+
 @pytest.mark.asyncio
 async def test_exec_correlates_the_runner_result(client, auth):
   pairing, _ = _paired_host(client, auth)
-  channel = connect_routes._Channel()
+  channel = connect_routes._Channel(protocol_version=3)
   connect_routes._channels[pairing["id"]] = channel
+  request_id = "a" * 16
 
   request = asyncio.create_task(connect_routes.exec_on_host(
     pairing["id"],
-    connect_routes.ExecBody(cmd="printf ready", cwd="/tmp", timeout=7),
+    connect_routes.ExecBody(
+      cmd="printf ready", cwd="/tmp", timeout=7, request_id=request_id,
+    ),
     _owner=object(),
   ))
   event = await asyncio.wait_for(channel.queue.get(), timeout=1)
-  assert event == {
-    "type": "exec",
-    "request_id": event["request_id"],
-    "cmd": "printf ready",
-    "cwd": "/tmp",
-    "timeout": 7,
-  }
-  channel.pending[event["request_id"]].set_result({
+  assert event["type"] == "exec"
+  assert event["request_id"] == request_id
+  assert event["cmd"] == "printf ready"
+  assert event["cwd"] == "/tmp"
+  assert event["timeout"] == 7
+  assert event["not_after"] > time.time()
+  connect_routes._mark_command_started(pairing["id"], request_id)
+  connect_routes._finish_command(pairing["id"], request_id, {
     "stdout": "ready", "stderr": "", "exit_code": 0,
+    "outcome": "completed",
   })
 
   assert await request == {
+    "request_id": request_id,
     "stdout": "ready",
     "stderr": "",
     "exit_code": 0,
+    "outcome": "completed",
     "truncated": False,
     "timed_out": False,
+    "canceled": False,
   }
-  assert channel.pending == {}
+  assert connect_routes._ensure_command(pairing["id"]) is None
+
+
+@pytest.mark.asyncio
+async def test_persisted_running_command_accepts_result_after_runtime_restart(
+  client, auth, monkeypatch,
+):
+  pairing, _ = _paired_host(client, auth)
+  request_id = "8" * 16
+  command = connect_routes._ActiveCommand(
+    request_id,
+    30,
+    cmd="sensitive argument",
+    started_at=time.time(),
+    state="running",
+  )
+  connect_routes._commands[pairing["id"]] = command
+  connect_routes._persist_command(pairing["id"], command)
+  record = connect_routes._load_host(pairing["id"])["active_command"]
+  assert "cmd" not in record
+
+  # A backend restart drops futures and sockets, but the host record survives.
+  connect_routes._commands.clear()
+  channel = connect_routes._Channel(protocol_version=3)
+  await connect_routes._reconcile_runner(pairing["id"], channel, {
+    "active_request_id": None,
+    "pending_result_ids": [request_id],
+  })
+  assert channel.queue.empty()
+  restored = connect_routes._ensure_command(pairing["id"])
+  assert restored.request_id == request_id
+
+  connect_routes._runner_result(pairing["id"], connect_routes.ResultBody(
+    request_id=request_id,
+    stdout="finished after restart",
+    exit_code=0,
+    outcome="completed",
+  ))
+  assert connect_routes._ensure_command(pairing["id"]) is None
+  last = connect_routes._load_host(pairing["id"])["last_command"]
+  assert last["id"] == request_id
+  assert last["result"]["stdout"] == "finished after restart"
+  monkeypatch.setattr(
+    connect_routes,
+    "_now",
+    lambda: last["finished_at"] + connect_routes._RESULT_RETENTION_SECONDS + 1,
+  )
+  connect_routes._expire_last_command(
+    pairing["id"], request_id, last["finished_at"],
+  )
+  assert connect_routes._load_host(pairing["id"])["last_command"] is None
+
+
+@pytest.mark.asyncio
+async def test_offline_cancel_is_delivered_when_protocol_three_reconnects(
+  client, auth,
+):
+  pairing, _ = _paired_host(client, auth)
+  host = connect_routes._load_host(pairing["id"])
+  host["runner_protocol"] = 3
+  connect_routes._save_host(host)
+  request_id = "6" * 16
+  command = connect_routes._ActiveCommand(
+    request_id, 30, started_at=time.time(), state="running",
+  )
+  connect_routes._commands[pairing["id"]] = command
+  connect_routes._persist_command(pairing["id"], command)
+
+  response = await connect_routes.cancel_host_command(
+    pairing["id"], request_id, _owner=object(),
+  )
+  assert response["state"] == "canceling"
+  channel = connect_routes._Channel(protocol_version=3)
+  await connect_routes._reconcile_runner(pairing["id"], channel, {
+    "active_request_id": request_id,
+    "pending_result_ids": [],
+  })
+  assert await channel.queue.get() == {
+    "type": "cancel", "request_id": request_id,
+  }
 
 
 @pytest.mark.asyncio
 async def test_exec_caps_large_output_and_reports_runner_timeout(client, auth):
   pairing, _ = _paired_host(client, auth)
-  channel = connect_routes._Channel()
+  channel = connect_routes._Channel(protocol_version=3)
   connect_routes._channels[pairing["id"]] = channel
+  request_id = "b" * 16
   request = asyncio.create_task(connect_routes.exec_on_host(
     pairing["id"],
-    connect_routes.ExecBody(cmd="large command"),
+    connect_routes.ExecBody(cmd="large command", request_id=request_id),
     _owner=object(),
   ))
   event = await asyncio.wait_for(channel.queue.get(), timeout=1)
+  connect_routes._mark_command_started(pairing["id"], request_id)
   oversized = "head-" + ("x" * connect_routes._MAX_EXEC_STREAM) + "-tail"
-  channel.pending[event["request_id"]].set_result({
+  connect_routes._finish_command(pairing["id"], event["request_id"], {
     "stdout": oversized,
     "stderr": "runner timed out",
     "exit_code": 124,
     "timed_out": True,
+    "outcome": "timed_out",
   })
 
   result = await request
@@ -370,34 +623,160 @@ async def test_exec_caps_large_output_and_reports_runner_timeout(client, auth):
   assert result["exit_code"] == 124
   assert result["truncated"] is True
   assert result["timed_out"] is True
+  assert result["outcome"] == "timed_out"
 
 
 @pytest.mark.asyncio
-async def test_exec_timeout_clears_its_pending_request(client, auth, monkeypatch):
+async def test_busy_host_rejects_work_instead_of_queueing_it(client, auth):
   pairing, _ = _paired_host(client, auth)
-  channel = connect_routes._Channel()
+  channel = connect_routes._Channel(protocol_version=3)
   connect_routes._channels[pairing["id"]] = channel
-
-  async def timeout(_future, timeout):
-    assert timeout == 16
-    _future.cancel()
-    raise asyncio.TimeoutError
-
-  monkeypatch.setattr(connect_routes, "asyncio", SimpleNamespace(
-    CancelledError=asyncio.CancelledError,
-    TimeoutError=asyncio.TimeoutError,
-    get_running_loop=asyncio.get_running_loop,
-    wait_for=timeout,
+  request_id = "c" * 16
+  first = asyncio.create_task(connect_routes.exec_on_host(
+    pairing["id"],
+    connect_routes.ExecBody(cmd="first", request_id=request_id),
+    _owner=object(),
   ))
+  await asyncio.wait_for(channel.queue.get(), timeout=1)
 
-  with pytest.raises(connect_routes.HTTPException) as raised:
+  with pytest.raises(connect_routes.HTTPException) as blocked:
     await connect_routes.exec_on_host(
-      pairing["id"], connect_routes.ExecBody(cmd="sleep 60", timeout=1),
+      pairing["id"],
+      connect_routes.ExecBody(cmd="must not queue", request_id="d" * 16),
       _owner=object(),
     )
+  assert blocked.value.status_code == 409
+  assert "busy" in blocked.value.detail
+  assert channel.queue.empty()
+  assert connect_routes._public_host(
+    connect_routes._load_host(pairing["id"]),
+  )["busy"] is True
 
+  connect_routes._mark_command_started(pairing["id"], request_id)
+  connect_routes._finish_command(pairing["id"], request_id, {
+    "stdout": "", "stderr": "", "exit_code": 0,
+    "outcome": "completed",
+  })
+  await first
+
+
+@pytest.mark.asyncio
+async def test_cancel_keeps_host_busy_until_runner_confirms_exit(client, auth):
+  pairing, _ = _paired_host(client, auth)
+  channel = connect_routes._Channel(protocol_version=3)
+  connect_routes._channels[pairing["id"]] = channel
+  request_id = "e" * 16
+  running = asyncio.create_task(connect_routes.exec_on_host(
+    pairing["id"],
+    connect_routes.ExecBody(cmd="long task", request_id=request_id),
+    _owner=object(),
+  ))
+  await asyncio.wait_for(channel.queue.get(), timeout=1)
+  connect_routes._mark_command_started(pairing["id"], request_id)
+
+  canceled = await connect_routes.cancel_host_command(
+    pairing["id"], request_id, _owner=object(),
+  )
+  assert canceled["state"] == "canceling"
+  assert await asyncio.wait_for(channel.queue.get(), timeout=1) == {
+    "type": "cancel", "request_id": request_id,
+  }
+  assert connect_routes._ensure_command(pairing["id"]).state == "canceling"
+
+  connect_routes._finish_command(pairing["id"], request_id, {
+    "stdout": "", "stderr": "command canceled", "exit_code": 130,
+    "outcome": "canceled",
+  })
+  assert (await running)["canceled"] is True
+  assert connect_routes._ensure_command(pairing["id"]) is None
+
+
+@pytest.mark.asyncio
+async def test_old_runner_is_single_flight_but_does_not_claim_cancellation(
+  client, auth,
+):
+  pairing, _ = _paired_host(client, auth)
+  channel = connect_routes._Channel(protocol_version=1)
+  connect_routes._channels[pairing["id"]] = channel
+  request_id = "9" * 16
+  running = asyncio.create_task(connect_routes.exec_on_host(
+    pairing["id"],
+    connect_routes.ExecBody(cmd="legacy task", request_id=request_id),
+    _owner=object(),
+  ))
+  await asyncio.wait_for(channel.queue.get(), timeout=1)
+
+  public = connect_routes._public_host(
+    connect_routes._load_host(pairing["id"]),
+  )
+  assert public["busy"] is True
+  assert public["active_command"]["state"] == "running"
+  assert public["runner_update_available"] is True
+  assert public["update_command"].endswith("python3 - --install")
+
+  with pytest.raises(connect_routes.HTTPException) as raised:
+    await connect_routes.cancel_host_command(
+      pairing["id"], request_id, _owner=object(),
+    )
+  assert raised.value.status_code == 409
+  assert "updated" in raised.value.detail
+  assert connect_routes._ensure_command(pairing["id"]).request_id == request_id
+
+  connect_routes._finish_command(pairing["id"], request_id, {
+    "stdout": "", "stderr": "", "exit_code": 0,
+    "outcome": "completed",
+  })
+  await running
+
+
+@pytest.mark.asyncio
+async def test_protocol_two_does_not_claim_offline_cancellation(client, auth):
+  pairing, _ = _paired_host(client, auth)
+  host = connect_routes._load_host(pairing["id"])
+  host["runner_protocol"] = 2
+  connect_routes._save_host(host)
+  command = connect_routes._ActiveCommand(
+    "5" * 16, 30, started_at=time.time(), state="running",
+  )
+  connect_routes._commands[pairing["id"]] = command
+  connect_routes._persist_command(pairing["id"], command)
+
+  with pytest.raises(connect_routes.HTTPException) as raised:
+    await connect_routes.cancel_host_command(
+      pairing["id"], command.request_id, _owner=object(),
+    )
+  assert raised.value.status_code == 409
+  assert command.state == "running"
+
+
+@pytest.mark.asyncio
+async def test_unacknowledged_dispatch_expires_and_sends_cancel(
+  client, auth, monkeypatch,
+):
+  pairing, _ = _paired_host(client, auth)
+  channel = connect_routes._Channel(protocol_version=3)
+  connect_routes._channels[pairing["id"]] = channel
+  request_id = "f" * 16
+  monkeypatch.setattr(connect_routes, "_START_ACK_TIMEOUT", 0.01)
+  request = asyncio.create_task(connect_routes.exec_on_host(
+    pairing["id"],
+    connect_routes.ExecBody(cmd="must expire", request_id=request_id),
+    _owner=object(),
+  ))
+  dispatched = await asyncio.wait_for(channel.queue.get(), timeout=1)
+  assert dispatched["not_after"] > time.time()
+
+  with pytest.raises(connect_routes.HTTPException) as raised:
+    await request
   assert raised.value.status_code == 504
-  assert channel.pending == {}
+  assert "did not start" in raised.value.detail
+  assert await asyncio.wait_for(channel.queue.get(), timeout=1) == {
+    "type": "cancel", "request_id": request_id,
+  }
+  assert connect_routes._ensure_command(pairing["id"]) is None
+  assert connect_routes._load_host(
+    pairing["id"],
+  )["last_command"]["result"]["outcome"] == "expired"
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="POSIX process-group contract")
@@ -434,6 +813,196 @@ def test_runner_does_not_mislabel_command_exit_124_as_timeout():
   assert stderr == ""
   assert exit_code == 124
   assert timed_out is False
+
+
+def test_runner_uses_standard_urllib_for_protocol_three_stream(monkeypatch):
+  opened = []
+  posted = []
+
+  class Stream:
+    def __enter__(self):
+      return self
+
+    def __exit__(self, *_args):
+      return False
+
+    def __iter__(self):
+      return iter([
+        b'data: {"type":"disconnect","request_id":"abcd"}\n\n',
+      ])
+
+  def fake_urlopen(request, **kwargs):
+    opened.append((request, kwargs))
+    return Stream()
+
+  monkeypatch.setattr(connect_runner.urllib.request, "urlopen", fake_urlopen)
+  monkeypatch.setattr(
+    connect_runner, "_uninstall_service", lambda stop_running: None,
+  )
+  monkeypatch.setattr(
+    connect_runner, "_post",
+    lambda url, payload, token=None: posted.append((url, payload, token)),
+  )
+
+  connect_runner._serve({"url": "https://mobius.test", "token": "secret"})
+
+  request, kwargs = opened[0]
+  assert request.full_url.startswith(
+    "https://mobius.test/api/connect/stream?protocol=3&platform=",
+  )
+  assert request.get_header("Authorization") == "Bearer secret"
+  assert request.get_header("Accept") == "text/event-stream"
+  assert kwargs["timeout"] is None
+  assert posted == [(
+    "https://mobius.test/api/connect/result",
+    {
+      "request_id": "abcd",
+      "stdout": "Connect daemon removed.",
+      "stderr": "",
+      "exit_code": 0,
+    },
+    "secret",
+  )]
+
+
+def test_runner_refuses_expired_command_without_spawning(
+  monkeypatch,
+):
+  monkeypatch.setattr(
+    connect_runner, "_spawn_command",
+    lambda *args, **kwargs: pytest.fail("expired command was spawned"),
+  )
+  monkeypatch.setattr(
+    connect_runner,
+    "_post",
+    lambda *_args, **_kwargs: (_ for _ in ()).throw(
+      urllib.error.URLError("offline"),
+    ),
+  )
+  runner = connect_runner._CommandRunner("https://mobius.test", "token")
+
+  runner.start({
+    "request_id": "1" * 16,
+    "cmd": "must not run",
+    "timeout": 30,
+    "not_after": time.time() - 1,
+  })
+
+  messages = list(runner.outbox)
+  assert messages[-1]["outcome"] == "expired"
+  assert messages[-1]["exit_code"] == 124
+  assert runner.active is None
+
+
+def test_runner_retries_a_result_until_ordinary_https_succeeds(monkeypatch):
+  attempts = []
+
+  def post(_url, payload, token=None):
+    attempts.append((payload, token))
+    if len(attempts) == 1:
+      raise urllib.error.URLError("rotating")
+    return {"ok": True}
+
+  monkeypatch.setattr(connect_runner, "_post", post)
+  runner = connect_runner._CommandRunner("https://mobius.test", "token")
+  request_id = "4" * 16
+  runner._post_result(request_id, "ready", "", 0, "completed")
+
+  active_id, pending_ids = runner.snapshot()
+  assert active_id is None
+  assert pending_ids == [request_id]
+  assert len(runner.pending_messages()) == 1
+
+  assert runner.flush_pending_results() is True
+  assert runner.pending_messages() == []
+  assert len(attempts) == 2
+
+
+def test_runner_rechecks_expiry_after_start_ack_before_spawning(monkeypatch):
+  clock = iter((100.0, 102.0))
+  # Replace this module's clock reference rather than mutating the process-wide
+  # time module that pytest and database teardown also use.
+  monkeypatch.setattr(
+    connect_runner, "time", SimpleNamespace(time=lambda: next(clock)),
+  )
+  monkeypatch.setattr(
+    connect_runner, "_spawn_command",
+    lambda *args, **kwargs: pytest.fail("late command was spawned"),
+  )
+
+  def post(url, _payload, token=None):
+    if url.endswith("/result"):
+      raise urllib.error.URLError("offline")
+    return {"ok": True}
+
+  monkeypatch.setattr(connect_runner, "_post", post)
+  runner = connect_runner._CommandRunner("https://mobius.test", "token")
+
+  runner.start({
+    "request_id": "3" * 16,
+    "cmd": "must not run after a slow acknowledgement",
+    "timeout": 30,
+    "not_after": 101.0,
+  })
+
+  messages = list(runner.outbox)
+  assert [message["type"] for message in messages] == ["result"]
+  assert messages[-1]["outcome"] == "expired"
+  assert runner.active is None
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX cancellation timing")
+def test_runner_cancel_stops_process_tree_and_reports_once(monkeypatch):
+  def post(url, _payload, token=None):
+    if url.endswith("/result"):
+      raise urllib.error.URLError("offline")
+    return {"ok": True}
+
+  monkeypatch.setattr(connect_runner, "_post", post)
+  runner = connect_runner._CommandRunner("https://mobius.test", "token")
+  request_id = "2" * 16
+  started = time.monotonic()
+  runner.start({
+    "request_id": request_id,
+    "cmd": f'"{sys.executable}" -c "import time; time.sleep(30)"',
+    "timeout": 30,
+    "not_after": time.time() + 5,
+  })
+
+  assert runner.cancel(request_id) is True
+  deadline = time.monotonic() + 3
+  results = []
+  while time.monotonic() < deadline:
+    results = [message for message in runner.outbox if message["type"] == "result"]
+    if results:
+      break
+    time.sleep(0.025)
+
+  assert len(results) == 1
+  assert results[0]["outcome"] == "canceled"
+  assert results[0]["exit_code"] == 130
+  assert time.monotonic() - started < 3
+  assert runner.active is None
+
+
+def test_runner_systemd_update_restarts_the_existing_service(
+  tmp_path, monkeypatch,
+):
+  commands = []
+  monkeypatch.setattr(
+    connect_runner, "SYSTEMD_UNIT", str(tmp_path / "mobius-connect.service"),
+  )
+  monkeypatch.setattr(connect_runner, "RUNNER_PATH", "/tmp/runner.py")
+
+  def fake_run(command):
+    commands.append(command)
+    return SimpleNamespace(returncode=0, stderr="")
+
+  monkeypatch.setattr(connect_runner, "_run", fake_run)
+
+  assert connect_runner._install_systemd("/usr/bin/python3") is True
+  assert ["systemctl", "--user", "enable", "mobius-connect.service"] in commands
+  assert ["systemctl", "--user", "restart", "mobius-connect.service"] in commands
 
 
 def test_manifest_requires_boolean_connect_permission():

--- a/backend/tests/test_connect.py
+++ b/backend/tests/test_connect.py
@@ -349,6 +349,10 @@ def test_provisional_websocket_runner_stays_online_for_in_place_update(
     assert "--install" in host["update_command"]
     assert host["platform"] == "ProvisionalOS 1"
 
+  deadline = time.monotonic() + 1
+  while pairing["id"] in connect_routes._channels and time.monotonic() < deadline:
+    time.sleep(0.01)
+  assert pairing["id"] not in connect_routes._channels
   host = client.get("/api/connect/hosts", headers=auth).json()["hosts"][0]
   assert host["online"] is False
   assert host["runner_update_available"] is True


### PR DESCRIPTION
## Summary

- Keep one remote command alive and addressable when its caller disconnects, the runner reconnects, or an event stream rotates.
- Move current runners to proxy-friendly HTTPS event streams that rotate every ten minutes, while preserving an upgrade bridge for provisional WebSocket runners.
- Make retries idempotent, retain one recent result, and deliver cancellation after reconnect without retaining command text once execution starts.

Builds on #854 and #862; this follow-up addresses hosting response limits and command ownership across transport or caller loss.

## Testing

- `scripts/wt-pytest.sh backend/tests/test_connect.py -q` — 34 passed
- `scripts/test.sh --fast` — 85 passed
- Disposable Railway deployment: an 11-minute command survived the ten-minute stream rotation and a five-minute caller cutoff, then returned once when retried; cancellation also completed after reconnect.