### PR TITLE
Support private bot bridges in installed apps

### DIFF
--- a/backend/app/app_capabilities.py
+++ b/backend/app/app_capabilities.py
@@ -434,6 +434,8 @@ def contract_from_manifest(manifest: dict[str, Any]) -> dict[str, Any]:
       "connections_manage": bool(perms.get("connections_manage", False)),
       "connect_manage": bool(perms.get("connect_manage", False)),
       "identity_manage": bool(perms.get("identity_manage", False)),
+      "credentialed_fetch": deepcopy(perms.get("credentialed_fetch") or {}),
+      "owner_screenshot": bool(perms.get("owner_screenshot", False)),
       "railway_manage": bool(perms.get("railway_manage", False)),
     },
     "background": (
@@ -522,6 +524,12 @@ def contract_from_app_state(
       # projection. Do not inherit an older accepted value: omission revokes.
       "identity_manage": bool(
         (contract_permissions or {}).get("identity_manage", False)
+      ),
+      "credentialed_fetch": deepcopy(
+        (contract_permissions or {}).get("credentialed_fetch") or {}
+      ),
+      "owner_screenshot": bool(
+        (contract_permissions or {}).get("owner_screenshot", False)
       ),
       "railway_manage": bool(
         (contract_permissions or {}).get("railway_manage", False)

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -215,6 +215,34 @@ def create_media_token(chat_id: str, owner_username: str, token_epoch: int) -> s
   )
 
 
+def create_app_chat_output_media_token(
+  *,
+  owner_username: str,
+  token_epoch: int,
+  app_id: int,
+  app_nonce: str,
+  chat_id: str,
+  expires_delta: timedelta = timedelta(minutes=15),
+) -> str:
+  """Create read-only media access for one live app-owned chat.
+
+  This capability is intended for an app's background job to hand a durable
+  output image URL to a third-party renderer. It cannot read uploads or temp
+  images, and every use rechecks both the app nonce and chat ownership.
+  """
+  return create_access_token(
+    {
+      "sub": owner_username,
+      "scope": "app_chat_output_media",
+      "app_id": app_id,
+      "app_nonce": app_nonce,
+      "media_chat": chat_id,
+    },
+    expires_delta=expires_delta,
+    token_epoch=token_epoch,
+  )
+
+
 def create_chat_embed_media_token(
   *,
   owner_username: str,

--- a/backend/app/deps.py
+++ b/backend/app/deps.py
@@ -210,6 +210,7 @@ def resolve_owner_only(token: str, db: Session) -> models.Owner:
 
 def resolve_media_or_header_owner(
   token: str, db: Session, *, chat_id: str, from_query: bool,
+  allow_app_output: bool = False,
 ) -> models.Owner:
   """Resolves an owner for media-serving routes.
 
@@ -242,7 +243,10 @@ def resolve_media_or_header_owner(
         ),
       )
     return owner
-  if scope not in {"media", "chat_embed_media"}:
+  allowed_scopes = {"media", "chat_embed_media"}
+  if allow_app_output:
+    allowed_scopes.add("app_chat_output_media")
+  if scope not in allowed_scopes:
     raise HTTPException(status_code=403, detail="Token scope is not valid for media.")
   if payload.get("media_chat") != chat_id:
     raise HTTPException(
@@ -286,6 +290,29 @@ def resolve_media_or_header_owner(
       raise HTTPException(
         status_code=401,
         detail="Embedded-chat media session is no longer valid.",
+      )
+  elif scope == "app_chat_output_media":
+    app_id = payload.get("app_id")
+    app_nonce = payload.get("app_nonce")
+    app = db.query(models.App).filter(
+      models.App.id == app_id,
+      models.App.deleted_at.is_(None),
+    ).first() if isinstance(app_id, int) else None
+    chat = db.query(models.Chat).filter(
+      models.Chat.id == chat_id,
+      models.Chat.deleted_at.is_(None),
+    ).first()
+    if (
+      not isinstance(app_id, int)
+      or not isinstance(app_nonce, str)
+      or app is None
+      or app.token_nonce != app_nonce
+      or chat is None
+      or chat.created_by_app_id != app_id
+    ):
+      raise HTTPException(
+        status_code=401,
+        detail="App-chat output media token is no longer valid.",
       )
   return owner
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -627,7 +627,7 @@ app.add_middleware(
   # All sensitive endpoints are independently protected by JWT.
   allow_origins=[settings.frontend_origin, "null"],
   allow_credentials=False,
-  allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+  allow_methods=["GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
   # The app runtime uses X-Mobius-Version to opt into ETag reads, then
   # If-Match / If-None-Match for conflict-safe writes. Sandboxed app frames
   # have the opaque `null` origin, so Chromium preflights these non-simple

--- a/backend/app/manifest_contract.py
+++ b/backend/app/manifest_contract.py
@@ -18,6 +18,7 @@ RECOGNIZED_CAPABILITIES = (
   "connections_manage",
   "connect_manage",
   "identity_manage",
+  "owner_screenshot",
   "railway_manage",
 )
 SOURCE_FILES_COUNT_MAX = 50
@@ -232,6 +233,67 @@ def validate_manifest_contract(manifest) -> None:
   for field in RECOGNIZED_CAPABILITIES:
     if field in permissions and not isinstance(permissions[field], bool):
       _fail(f"Manifest `permissions.{field}` must be a boolean.")
+
+  credentialed_fetch = permissions.get("credentialed_fetch", {})
+  if not isinstance(credentialed_fetch, Mapping):
+    _fail("Manifest `permissions.credentialed_fetch` must be an object.")
+  if len(credentialed_fetch) > 8:
+    _fail("Manifest `permissions.credentialed_fetch` allows at most 8 providers.")
+  provider_name = re.compile(r"^[a-z][a-z0-9-]{0,31}$")
+  secret_name = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,63}$")
+  for provider, config in credentialed_fetch.items():
+    label = f"permissions.credentialed_fetch.{provider}"
+    if not isinstance(provider, str) or not provider_name.fullmatch(provider):
+      _fail("Credentialed-fetch provider names must be lowercase slugs.")
+    if not isinstance(config, Mapping):
+      _fail(f"Manifest `{label}` must be an object.")
+    config_keys = set(config)
+    base_keys = {"secret", "origin", "paths"}
+    placement_keys = config_keys - base_keys
+    if (
+      not base_keys.issubset(config_keys)
+      or placement_keys not in ({"query_parameter"}, {"path_prefix"})
+    ):
+      _fail(
+        f"Manifest `{label}` must contain secret, origin, paths, and exactly "
+        "one credential placement: query_parameter or path_prefix."
+      )
+    if not isinstance(config["secret"], str) or not secret_name.fullmatch(config["secret"]):
+      _fail(f"Manifest `{label}.secret` is invalid.")
+    origin = config["origin"]
+    if not isinstance(origin, str) or not re.fullmatch(
+      r"https://[A-Za-z0-9.-]+(?::[0-9]{1,5})?", origin
+    ):
+      _fail(f"Manifest `{label}.origin` must be an HTTPS origin.")
+    paths = config["paths"]
+    if (
+      not isinstance(paths, list) or not paths or len(paths) > 16
+      or any(
+        not isinstance(path, str) or not path.startswith("/")
+        or "?" in path or "#" in path or ".." in path
+        for path in paths
+      )
+    ):
+      _fail(f"Manifest `{label}.paths` must be 1–16 absolute path prefixes.")
+    if "query_parameter" in config:
+      query_parameter = config["query_parameter"]
+      if not isinstance(query_parameter, str) or not re.fullmatch(
+        r"[A-Za-z][A-Za-z0-9_.-]{0,63}", query_parameter
+      ):
+        _fail(f"Manifest `{label}.query_parameter` is invalid.")
+    else:
+      path_prefix = config["path_prefix"]
+      if not isinstance(path_prefix, str) or not re.fullmatch(
+        r"/[A-Za-z0-9._~-]{1,63}", path_prefix
+      ):
+        _fail(f"Manifest `{label}.path_prefix` is invalid.")
+      if not any(
+        path == path_prefix + "/" or path.startswith(path_prefix + "/")
+        for path in paths
+      ):
+        _fail(
+          f"Manifest `{label}.paths` must include a path beneath path_prefix."
+        )
 
   # An app declares the platform capabilities it cannot function without. A name
   # this build does not recognize means the running Möbius predates the feature

--- a/backend/app/manifest_contract.py
+++ b/backend/app/manifest_contract.py
@@ -5,11 +5,7 @@ from urllib.parse import unquote, urlparse
 import re
 
 REQUIRED_STRING_FIELDS = ("id", "name", "version", "description", "entry")
-# Capability permissions this Möbius build recognizes. An app MAY list any of
-# these in `requires` to demand the platform actually provides them; requiring a
-# name absent here fails the install loudly instead of granting nothing in
-# silence. Extending a capability (e.g. the identity bridge) adds its name here.
-RECOGNIZED_CAPABILITIES = (
+BOOLEAN_PERMISSION_FIELDS = (
   "manage_apps",
   "manage_skills",
   "github_access",
@@ -20,6 +16,16 @@ RECOGNIZED_CAPABILITIES = (
   "identity_manage",
   "owner_screenshot",
   "railway_manage",
+)
+# Capabilities this Möbius build recognizes. An app MAY list any of these in
+# `requires` to demand the platform actually provides them; requiring a name
+# absent here fails the install loudly instead of granting nothing in silence.
+# Keep this compatibility registry distinct from boolean permission validation:
+# some capabilities, such as credentialed_fetch, use a structured declaration.
+RECOGNIZED_CAPABILITIES = (
+  *BOOLEAN_PERMISSION_FIELDS,
+  "credentialed_fetch",
+  "app_chat_output_media",
 )
 SOURCE_FILES_COUNT_MAX = 50
 SKILLS_COUNT_MAX = 5
@@ -230,7 +236,7 @@ def validate_manifest_contract(manifest) -> None:
       f"Manifest permission {names} has been removed; server-side app jobs "
       "run as ordinary Möbius processes."
     )
-  for field in RECOGNIZED_CAPABILITIES:
+  for field in BOOLEAN_PERMISSION_FIELDS:
     if field in permissions and not isinstance(permissions[field], bool):
       _fail(f"Manifest `permissions.{field}` must be a boolean.")
 

--- a/backend/app/routes/app_schedules.py
+++ b/backend/app/routes/app_schedules.py
@@ -464,6 +464,7 @@ def get_app_job_context(
     "source_dir": app.source_dir,
     "primary": choices.get("primary"),
     "fallback": choices.get("fallback"),
+    "public_origin": get_settings().frontend_origin.rstrip("/"),
     # This is the same normalized, non-secret receipt the owner reviewed.
     # Jobs such as Memory may verify their installed data/schedule contract
     # against it; it is not a filesystem sandbox or mount plan.

--- a/backend/app/routes/chats.py
+++ b/backend/app/routes/chats.py
@@ -1,10 +1,16 @@
 """Routes for chat CRUD operations."""
 
+import asyncio
 import hashlib
 import json
 import logging
+import os
 import re
+import subprocess
+import time
+import uuid
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 from typing import Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -2260,7 +2266,7 @@ def _clean_app_chat_text(value: str | None, max_len: int, field: str) -> str | N
 
 
 class AppChatCreate(BaseModel):
-  title: str | None = None
+  title: str | None = Field(default=None, max_length=500)
   system_prompt: str | None = Field(default=None, max_length=20000)
   model: str | None = Field(default=None, max_length=256)
   provider: str | None = None
@@ -2270,6 +2276,11 @@ class AppChatCreate(BaseModel):
   scope: str | None = Field(default=None, max_length=_CHAT_SCOPE_MAX)
   scope_label: str | None = Field(default=None, max_length=_CHAT_SCOPE_LABEL_MAX)
   owner_visible: bool = False
+
+  @field_validator("title")
+  @classmethod
+  def _validate_title(cls, value: str | None) -> str | None:
+    return _clean_app_chat_text(value, 500, "title")
 
   @field_validator("project_id")
   @classmethod
@@ -2309,11 +2320,18 @@ class AppChatCreate(BaseModel):
 
 
 class AppChatPatch(BaseModel):
+  title: str | None = Field(default=None, max_length=500)
   system_prompt: str | None = Field(default=None, max_length=20000)
   model: str | None = Field(default=None, max_length=256)
   provider: str | None = None
   scope: str | None = Field(default=None, max_length=_CHAT_SCOPE_MAX)
   scope_label: str | None = Field(default=None, max_length=_CHAT_SCOPE_LABEL_MAX)
+  owner_visible: bool | None = None
+
+  @field_validator("title")
+  @classmethod
+  def _validate_title(cls, value: str | None) -> str | None:
+    return _clean_app_chat_text(value, 500, "title")
 
   @field_validator("scope")
   @classmethod
@@ -2326,6 +2344,10 @@ class AppChatPatch(BaseModel):
     return _clean_app_chat_text(
       value, _CHAT_SCOPE_LABEL_MAX, "scope_label",
     )
+
+
+class AppOwnerScreenshotRequest(BaseModel):
+  warm_only: bool = False
 
 
 def _merge_app_chat_settings(
@@ -2429,6 +2451,7 @@ def _app_chat_sort_ts(chat: models.Chat) -> float:
 
 
 def _app_chat_summary(chat: models.Chat) -> dict:
+  settings = _coerce_agent_settings(chat.agent_settings_json)
   return {
     "id": chat.id,
     "title": chat.title,
@@ -2440,6 +2463,12 @@ def _app_chat_summary(chat: models.Chat) -> dict:
     "provider": chat.provider or "claude",
     "scope": _app_chat_scope(chat),
     "scope_label": _app_chat_scope_label(chat),
+    "owner_visible": settings.get("owner_visible") is True,
+    "title_locked": bool(chat.title_locked),
+    # App-owned conversational clients need only the opaque identity to retire
+    # stale external controls when the owner answers in the Möbius shell. The
+    # question text and answers remain on the owner-only transcript surface.
+    "pending_question_id": chat.pending_question_id,
   }
 
 
@@ -2528,6 +2557,7 @@ def create_app_chat(
     provider=provider,
     agent_settings_json=None,
     created_by_app_id=principal.app_id,
+    title_locked=bool(body.title),
   )
   _merge_app_chat_settings(
     chat,
@@ -2547,6 +2577,250 @@ def create_app_chat(
     "id": chat.id,
     "title": chat.title,
     "created_by_app_id": chat.created_by_app_id,
+  }
+
+
+@app_chat_router.post(
+  "/{chat_id}/output-media-token",
+  dependencies=[Depends(reject_cross_site)],
+)
+def issue_app_chat_output_media_token(
+  chat_id: str,
+  principal: Principal = Depends(get_principal),
+  db: Session = Depends(get_db),
+):
+  """Mint read-only output-media access for one chat owned by the app."""
+  if principal.app_id is None:
+    raise HTTPException(
+      status_code=403,
+      detail="App-chat output media tokens require an app token.",
+    )
+  chat = get_active_chat_for_principal(db, chat_id, principal)
+  app = db.query(models.App).filter(
+    models.App.id == principal.app_id,
+    models.App.deleted_at.is_(None),
+  ).first()
+  if app is None or not isinstance(app.token_nonce, str):
+    raise HTTPException(status_code=401, detail="App token is no longer valid.")
+  token = auth.create_app_chat_output_media_token(
+    owner_username=principal.owner.username,
+    token_epoch=principal.owner.token_epoch,
+    app_id=app.id,
+    app_nonce=app.token_nonce,
+    chat_id=chat.id,
+  )
+  return {"token": token, "expires_in": 900}
+
+
+_OWNER_SCREENSHOT_READY_SECS = 75
+_owner_screenshot_locks: dict[int, asyncio.Lock] = {}
+
+
+def _owner_screenshot_allowed(app: models.App) -> bool:
+  contract = app.capability_contract
+  if not isinstance(contract, dict):
+    return False
+  data = contract.get("data")
+  return isinstance(data, dict) and data.get("owner_screenshot") is True
+
+
+def _valid_screenshot_png(path: Path) -> bool:
+  try:
+    if path.stat().st_size <= 1024:
+      return False
+    with path.open("rb") as image:
+      return image.read(8) == b"\x89PNG\r\n\x1a\n"
+  except OSError:
+    return False
+
+
+def _run_screenshot_command(
+  command: list[str],
+  *,
+  env: dict[str, str],
+  timeout: float,
+) -> None:
+  completed = subprocess.run(
+    command,
+    env=env,
+    stdin=subprocess.DEVNULL,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE,
+    text=True,
+    timeout=timeout,
+    check=False,
+  )
+  if completed.returncode != 0:
+    detail = (completed.stderr or completed.stdout or "capture failed").strip()
+    raise RuntimeError(detail[-500:])
+
+
+def _capture_owner_shell(
+  *,
+  app_id: int,
+  target_chat_id: str,
+  output_chat_id: str,
+  owner_token: str,
+  warm_only: bool,
+) -> str | None:
+  """Capture one owner shell without exposing the owner token to the app.
+
+  The first request authenticates a dedicated, server-owned browser profile.
+  The scheduled bridge keeps that live page warm; later screenshot requests
+  take a direct raster capture without starting an agent or navigating again.
+  """
+  settings = get_settings()
+  data_dir = Path(settings.data_dir)
+  profile = data_dir / "agent-browser-profiles" / f"app-owner-{app_id}"
+  marker = Path(str(profile) + ".ready")
+  env = os.environ.copy()
+  env.update({
+    "AGENT_TOKEN": owner_token,
+    "API_BASE_URL": os.environ.get("API_BASE_URL", "http://localhost:8080"),
+    "CHAT_ID": target_chat_id,
+    "VIEWPORT_WIDTH": "1440",
+    "VIEWPORT_HEIGHT": "1000",
+    "VIEWPORT_PIXEL_RATIO": "1",
+    "AGENT_BROWSER_SESSION": f"app-owner-{app_id}",
+    "AGENT_BROWSER_PROFILE": str(profile),
+  })
+
+  marker_fresh = False
+  try:
+    marker_fresh = (
+      marker.read_text().strip() == target_chat_id
+      and time.time() - marker.stat().st_mtime < _OWNER_SCREENSHOT_READY_SECS
+    )
+  except OSError:
+    pass
+
+  if warm_only and marker_fresh:
+    return None
+
+  output_dir = data_dir / "chats" / output_chat_id / "media"
+  output_dir.mkdir(parents=True, exist_ok=True)
+  filename = f"owner-shell-{uuid.uuid4().hex}.png"
+  output = output_dir / filename
+
+  if marker_fresh:
+    try:
+      _run_screenshot_command(
+        ["agent-browser", "screenshot", str(output)],
+        env=env,
+        timeout=5,
+      )
+      if _valid_screenshot_png(output):
+        return None if warm_only else filename
+    except (OSError, RuntimeError, subprocess.TimeoutExpired):
+      pass
+    output.unlink(missing_ok=True)
+    marker.unlink(missing_ok=True)
+
+  script = Path(__file__).resolve().parents[2] / "scripts" / "agent-screenshot.sh"
+  cold_output = output
+  if warm_only:
+    cold_output = Path("/tmp") / f"app-owner-warm-{app_id}-{uuid.uuid4().hex}.png"
+  try:
+    _run_screenshot_command(
+      [
+        "bash", str(script), "--preserve-cache",
+        f"/chat/{target_chat_id}", str(cold_output),
+      ],
+      env=env,
+      timeout=35,
+    )
+    if not _valid_screenshot_png(cold_output):
+      raise RuntimeError("capture did not produce a valid PNG")
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.write_text(target_chat_id)
+    return None if warm_only else filename
+  except (OSError, RuntimeError, subprocess.TimeoutExpired):
+    if not warm_only:
+      cold_output.unlink(missing_ok=True)
+    raise
+  finally:
+    if warm_only:
+      cold_output.unlink(missing_ok=True)
+
+
+@app_chat_router.post(
+  "/{chat_id}/owner-screenshot",
+  dependencies=[Depends(reject_cross_site)],
+)
+async def capture_app_owner_screenshot(
+  chat_id: str,
+  body: AppOwnerScreenshotRequest,
+  principal: Principal = Depends(get_principal),
+  db: Session = Depends(get_db),
+):
+  """Capture the owner's canonical shell for one explicitly permitted app.
+
+  The app receives only the resulting filename in one of its own chats. The
+  short-lived owner bearer and persistent browser profile never cross the app
+  boundary. Permission is reviewed from the live capability contract on every
+  call, so omitting it on a later app apply revokes capture immediately.
+  """
+  if principal.app_id is None:
+    raise HTTPException(
+      status_code=403,
+      detail="Owner screenshots require an app-scoped token.",
+    )
+  output_chat = get_active_chat_for_principal(db, chat_id, principal)
+  app = db.query(models.App).filter(
+    models.App.id == principal.app_id,
+    models.App.deleted_at.is_(None),
+  ).first()
+  if app is None:
+    raise HTTPException(status_code=404, detail="App not found.")
+  if not _owner_screenshot_allowed(app):
+    raise HTTPException(
+      status_code=403,
+      detail=(
+        "This app needs permissions.owner_screenshot=true in its manifest."
+      ),
+    )
+  target_chat_id = str(app.chat_id or "")
+  target_chat = db.query(models.Chat.id).filter(
+    models.Chat.id == target_chat_id,
+    models.Chat.deleted_at.is_(None),
+  ).first()
+  if not target_chat_id or target_chat is None:
+    raise HTTPException(
+      status_code=409,
+      detail="The app has no active owner conversation to capture.",
+    )
+  if output_chat.created_by_app_id != app.id:
+    raise HTTPException(status_code=403, detail="Output chat is not owned by this app.")
+
+  owner_token = auth.create_access_token(
+    {"sub": principal.owner.username},
+    expires_delta=timedelta(minutes=2),
+    token_epoch=principal.owner.token_epoch,
+  )
+  lock = _owner_screenshot_locks.setdefault(app.id, asyncio.Lock())
+  try:
+    async with lock:
+      filename = await asyncio.to_thread(
+        _capture_owner_shell,
+        app_id=app.id,
+        target_chat_id=target_chat_id,
+        output_chat_id=output_chat.id,
+        owner_token=owner_token,
+        warm_only=body.warm_only,
+      )
+  except subprocess.TimeoutExpired as exc:
+    raise HTTPException(
+      status_code=504, detail="Möbius screenshot capture timed out.",
+    ) from exc
+  except (OSError, RuntimeError) as exc:
+    log.warning("owner screenshot failed for app %s: %s", app.id, exc)
+    raise HTTPException(
+      status_code=503, detail="Möbius screenshot capture is unavailable.",
+    ) from exc
+  return {
+    "ready": True,
+    "chat_id": output_chat.id,
+    "filename": filename,
   }
 
 
@@ -2620,12 +2894,16 @@ async def patch_app_chat(
           )
         chat.provider = body.provider
         chat.session_id = None
+    if body.title is not None:
+      chat.title = body.title
+      chat.title_locked = True
     _merge_app_chat_settings(
       chat,
       system_prompt=body.system_prompt,
       model=body.model,
       scope=body.scope,
       scope_label=body.scope_label,
+      owner_visible=body.owner_visible,
     )
     chat.updated_at = datetime.now(UTC)
     db.commit()

--- a/backend/app/routes/media.py
+++ b/backend/app/routes/media.py
@@ -28,11 +28,12 @@ _RASTER_MEDIA_TYPES = {
 _AGENT_TMP_ROOT = Path("/tmp")
 
 
-def _authorize_chat_media(chat_id, token_src, db):
+def _authorize_chat_media(chat_id, token_src, db, *, allow_app_output=False):
   """Validate the chat id and the owner-scoped media credential once."""
   validate_chat_id(chat_id)
   resolve_media_or_header_owner(
     token_src.token, db, chat_id=chat_id, from_query=token_src.from_query,
+    allow_app_output=allow_app_output,
   )
 
 
@@ -41,7 +42,9 @@ def _raster_media_type(file_path: Path) -> str | None:
   return guessed_type if guessed_type in _RASTER_MEDIA_TYPES else None
 
 
-def _serve_chat_image(chat_id, filename, token_src, db, *, preview=False):
+def _serve_chat_image(
+  chat_id, filename, token_src, db, *, preview=False, allow_app_output=False,
+):
   """Common auth + path-validation + FileResponse for a chat media file.
 
   The token can come from two sources:
@@ -52,7 +55,9 @@ def _serve_chat_image(chat_id, filename, token_src, db, *, preview=False):
 
   App tokens are rejected on both paths.
   """
-  _authorize_chat_media(chat_id, token_src, db)
+  _authorize_chat_media(
+    chat_id, token_src, db, allow_app_output=allow_app_output,
+  )
 
   settings = get_settings()
   base = Path(settings.data_dir) / "chats" / chat_id / "media"
@@ -83,7 +88,7 @@ def serve_chat_media(
 ):
   """Serves an agent-attached image or its bounded transcript preview."""
   return _serve_chat_image(
-    chat_id, filename, token_src, db, preview=preview,
+    chat_id, filename, token_src, db, preview=preview, allow_app_output=True,
   )
 
 

--- a/backend/app/routes/secrets.py
+++ b/backend/app/routes/secrets.py
@@ -6,7 +6,9 @@ import os
 import re
 import tempfile
 from pathlib import Path
+from urllib.parse import parse_qsl, quote, urlencode, urlparse, urlunparse
 
+import httpx
 from cryptography.fernet import Fernet, InvalidToken
 from fastapi import APIRouter, Depends, HTTPException, Response
 from pydantic import BaseModel, Field
@@ -16,11 +18,14 @@ from app import fs_locks, models
 from app.config import get_settings
 from app.database import get_db
 from app.deps import Principal, get_principal, reject_cross_site
+from app.net_utils import validate_url_safe
 
 router = APIRouter(prefix="/api/apps", tags=["app-secrets"])
 
 _SECRET_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,63}$")
 _MAX_SECRETS_PER_APP = 16
+_PROVIDER_NAME_RE = re.compile(r"^[a-z][a-z0-9-]{0,31}$")
+_CREDENTIAL_RESPONSE_LIMIT = 2 * 1024 * 1024
 
 
 class SecretWrite(BaseModel):
@@ -86,6 +91,54 @@ def _secret_count(directory: Path) -> int:
     1 for child in directory.iterdir()
     if child.is_file() and _SECRET_NAME_RE.fullmatch(child.name)
   )
+
+
+def _credentialed_fetch_config(app: models.App, provider: str) -> dict:
+  if not _PROVIDER_NAME_RE.fullmatch(provider):
+    raise HTTPException(status_code=404, detail="Credentialed provider not found.")
+  contract = app.capability_contract
+  data = contract.get("data") if isinstance(contract, dict) else None
+  providers = data.get("credentialed_fetch") if isinstance(data, dict) else None
+  config = providers.get(provider) if isinstance(providers, dict) else None
+  if not isinstance(config, dict):
+    raise HTTPException(status_code=404, detail="Credentialed provider not found.")
+  return config
+
+
+def _path_is_allowed(path: str, allowed: list[str]) -> bool:
+  for prefix in allowed:
+    if prefix.endswith("/") and path.startswith(prefix):
+      return True
+    if path == prefix or path.startswith(prefix + "/"):
+      return True
+  return False
+
+
+async def _credentialed_response(
+  client: httpx.AsyncClient, request: httpx.Request,
+) -> Response:
+  try:
+    upstream = await client.send(request, stream=True)
+  except Exception:
+    # Never include the upstream exception: httpx errors contain the complete
+    # URL, including the injected credential.
+    raise HTTPException(status_code=502, detail="Credentialed provider request failed.")
+  try:
+    body = bytearray()
+    async for chunk in upstream.aiter_bytes():
+      if len(body) + len(chunk) > _CREDENTIAL_RESPONSE_LIMIT:
+        raise HTTPException(
+          status_code=413, detail="Credentialed provider response is too large."
+        )
+      body.extend(chunk)
+    return Response(
+      content=bytes(body),
+      status_code=upstream.status_code,
+      media_type=upstream.headers.get("content-type", "application/octet-stream"),
+      headers={"Cache-Control": "no-store"},
+    )
+  finally:
+    await upstream.aclose()
 
 
 @router.put(
@@ -171,6 +224,90 @@ async def get_secret(
     media_type="text/plain",
     headers={"Cache-Control": "no-store"},
   )
+
+
+@router.get("/{app_id}/credentialed-fetch/{provider}")
+async def credentialed_fetch(
+  app_id: int,
+  provider: str,
+  url: str,
+  db: Session = Depends(get_db),
+  principal: Principal = Depends(get_principal),
+):
+  """Fetch a manifest-allowlisted provider URL with an encrypted app secret.
+
+  The caller supplies the provider URL without the credential. The server
+  requires an exact HTTPS origin and an allowlisted path from mobius.json,
+  injects the named secret into one declared query parameter or path prefix,
+  and never returns or logs the credential. App tokens remain self-scoped.
+  """
+  app = _authorize_app(db, principal, app_id)
+  config = _credentialed_fetch_config(app, provider)
+  try:
+    declared_origin = str(config["origin"])
+    allowed_paths = list(config["paths"])
+    secret_name = str(config["secret"])
+  except (KeyError, TypeError, ValueError):
+    raise HTTPException(status_code=404, detail="Credentialed provider not found.")
+
+  query_parameter = config.get("query_parameter")
+  path_prefix = config.get("path_prefix")
+  if (query_parameter is None) == (path_prefix is None):
+    raise HTTPException(status_code=404, detail="Credentialed provider not found.")
+  if query_parameter is not None:
+    query_parameter = str(query_parameter)
+  if path_prefix is not None:
+    path_prefix = str(path_prefix)
+
+  parsed = urlparse(url)
+  request_origin = f"{parsed.scheme}://{parsed.netloc}"
+  if (
+    parsed.scheme != "https"
+    or parsed.username is not None
+    or parsed.password is not None
+    or request_origin != declared_origin
+    or not _path_is_allowed(parsed.path, allowed_paths)
+  ):
+    raise HTTPException(status_code=403, detail="Provider URL is not allowlisted.")
+  query = parse_qsl(parsed.query, keep_blank_values=True)
+  if query_parameter is not None and any(
+    name == query_parameter for name, _ in query
+  ):
+    raise HTTPException(status_code=400, detail="Credential parameter must be omitted.")
+  if path_prefix is not None and not parsed.path.startswith(path_prefix + "/"):
+    raise HTTPException(status_code=400, detail="Credential path prefix is missing.")
+
+  expected_nonce = app.token_nonce
+  path = _secret_path(app_id, secret_name)
+  async with fs_locks.app_storage_lock(app_id):
+    db.expire_all()
+    current = _authorize_app(db, principal, app_id)
+    if current.token_nonce != expected_nonce:
+      raise HTTPException(status_code=404, detail="App not found.")
+    if not path.is_file():
+      raise HTTPException(status_code=409, detail="Provider credential is not configured.")
+    try:
+      secret = _fernet().decrypt(path.read_bytes()).decode()
+    except (InvalidToken, OSError, UnicodeDecodeError):
+      raise HTTPException(status_code=500, detail="Provider credential could not be read.")
+
+  if query_parameter is not None:
+    credentialed_url = urlunparse(parsed._replace(query=urlencode([
+      *query, (query_parameter, secret),
+    ])))
+  else:
+    # Treat the secret as exactly one path-segment suffix. Encoding slash and
+    # every other delimiter prevents a credential from changing the reviewed
+    # origin/path shape; colon remains literal for provider tokens that use it.
+    encoded_secret = quote(secret, safe="-._~:")
+    injected_path = path_prefix + encoded_secret + parsed.path[len(path_prefix):]
+    credentialed_url = urlunparse(parsed._replace(path=injected_path))
+  pinned_url, host_header, sni_host = validate_url_safe(credentialed_url)
+  async with httpx.AsyncClient(follow_redirects=False, timeout=15) as client:
+    request = client.build_request("GET", pinned_url)
+    request.headers["host"] = host_header
+    request.extensions["sni_hostname"] = sni_host
+    return await _credentialed_response(client, request)
 
 
 @router.delete(

--- a/backend/app/routes/secrets.py
+++ b/backend/app/routes/secrets.py
@@ -6,7 +6,7 @@ import os
 import re
 import tempfile
 from pathlib import Path
-from urllib.parse import parse_qsl, quote, urlencode, urlparse, urlunparse
+from urllib.parse import parse_qsl, quote, unquote, urlencode, urlparse, urlunparse
 
 import httpx
 from cryptography.fernet import Fernet, InvalidToken
@@ -112,6 +112,29 @@ def _path_is_allowed(path: str, allowed: list[str]) -> bool:
     if path == prefix or path.startswith(prefix + "/"):
       return True
   return False
+
+
+def _path_has_ambiguous_segments(path: str) -> bool:
+  """Reject path spellings an upstream service could normalize later.
+
+  The reviewed prefix check operates on URL text, while providers commonly
+  percent-decode and remove dot segments before routing. Inspect every bounded
+  decoding layer and reject any spelling that can become a dot segment or add
+  a new separator after Möbius has attached the credential.
+  """
+  decoded = path
+  for _ in range(len(path) + 1):
+    if "\\" in decoded or any(
+      segment in (".", "..") for segment in decoded.split("/")
+    ):
+      return True
+    next_decoded = unquote(decoded)
+    if next_decoded == decoded:
+      return False
+    if next_decoded.count("/") != decoded.count("/"):
+      return True
+    decoded = next_decoded
+  return True
 
 
 async def _credentialed_response(
@@ -266,6 +289,7 @@ async def credentialed_fetch(
     or parsed.username is not None
     or parsed.password is not None
     or request_origin != declared_origin
+    or _path_has_ambiguous_segments(parsed.path)
     or not _path_is_allowed(parsed.path, allowed_paths)
   ):
     raise HTTPException(status_code=403, detail="Provider URL is not allowlisted.")

--- a/backend/tests/test_app_chat_contract.py
+++ b/backend/tests/test_app_chat_contract.py
@@ -177,6 +177,7 @@ def test_owner_chat_list_includes_only_owner_visible_app_chats(
   row = db.query(models.Chat).filter(models.Chat.id == visible_id).first()
   assert row.created_by_app_id == app_id
   assert row.agent_settings_json["owner_visible"] is True
+  assert row.title_locked is True
 
   drawer = client.get("/api/chats", headers=auth)
   assert drawer.status_code == 200, drawer.text
@@ -189,6 +190,93 @@ def test_owner_chat_list_includes_only_owner_visible_app_chats(
   assert all_chats.status_code == 200, all_chats.text
   all_ids = {c["id"] for c in all_chats.json()}
   assert {owner.json()["id"], visible.json()["id"], hidden.json()["id"]} <= all_ids
+
+
+def test_app_can_promote_and_retitle_an_existing_chat(client, owner_token, db):
+  _, app_token = _make_app(client, owner_token, "promoted-chat")
+  app_auth = {"Authorization": f"Bearer {app_token}"}
+  owner_auth = {"Authorization": f"Bearer {owner_token}"}
+  created = client.post(
+    "/api/app-chats", json={"title": "Old bridge title"}, headers=app_auth,
+  )
+  chat_id = created.json()["id"]
+
+  patched = client.patch(
+    f"/api/app-chats/{chat_id}",
+    json={"title": "Bridge · Test user · Aug 24, 20:44", "owner_visible": True},
+    headers=app_auth,
+  )
+  assert patched.status_code == 200, patched.text
+  row = db.query(models.Chat).filter(models.Chat.id == chat_id).one()
+  assert row.title == "Bridge · Test user · Aug 24, 20:44"
+  assert row.title_locked is True
+  assert row.agent_settings_json["owner_visible"] is True
+  row.pending_question_id = "question-owned-by-this-chat"
+  db.commit()
+  assert chat_id in {
+    item["id"] for item in client.get("/api/chats", headers=owner_auth).json()
+  }
+
+  summary = client.get("/api/app-chats", headers=app_auth).json()[0]
+  assert summary["owner_visible"] is True
+  assert summary["title_locked"] is True
+  assert summary["pending_question_id"] == "question-owned-by-this-chat"
+
+
+def test_app_output_media_token_is_read_only_and_bound_to_own_chat(
+  client, owner_token, db,
+):
+  from pathlib import Path
+  from app.auth import decode_access_token
+  from app.config import get_settings
+
+  app_id, app_token = _make_app(client, owner_token, "output-media")
+  app_auth = {"Authorization": f"Bearer {app_token}"}
+  created = client.post(
+    "/api/app-chats", json={"title": "Build"}, headers=app_auth,
+  )
+  chat_id = created.json()["id"]
+  media_dir = Path(get_settings().data_dir) / "chats" / chat_id / "media"
+  media_dir.mkdir(parents=True, exist_ok=True)
+  (media_dir / "app-123.png").write_bytes(b"\x89PNG\r\n")
+
+  minted = client.post(
+    f"/api/app-chats/{chat_id}/output-media-token", headers=app_auth,
+  )
+  assert minted.status_code == 200, minted.text
+  assert minted.json()["expires_in"] == 900
+  token = minted.json()["token"]
+  claims = decode_access_token(token)
+  assert claims["scope"] == "app_chat_output_media"
+  assert claims["app_id"] == app_id
+  assert claims["media_chat"] == chat_id
+
+  assert client.get(
+    f"/api/chats/{chat_id}/media/app-123.png", params={"token": token},
+  ).status_code == 200
+  assert client.get(
+    f"/api/chats/{chat_id}/uploads/app-123.png", params={"token": token},
+  ).status_code == 403
+  assert client.get(
+    f"/api/chats/{chat_id}/tmp-images/app-123.png", params={"token": token},
+  ).status_code == 403
+  other = client.post(
+    "/api/app-chats", json={"title": "Other build"}, headers=app_auth,
+  ).json()["id"]
+  assert client.get(
+    f"/api/chats/{other}/media/app-123.png", params={"token": token},
+  ).status_code == 403
+  assert client.post(
+    f"/api/app-chats/{chat_id}/output-media-token",
+    headers={"Authorization": f"Bearer {owner_token}"},
+  ).status_code == 403
+
+  app = db.query(models.App).filter(models.App.id == app_id).one()
+  app.token_nonce = "rotated-output-media-nonce"
+  db.commit()
+  assert client.get(
+    f"/api/chats/{chat_id}/media/app-123.png", params={"token": token},
+  ).status_code == 401
 
 
 def test_app_chat_create_and_patch_store_custom_system_prompt(

--- a/backend/tests/test_app_jobs.py
+++ b/backend/tests/test_app_jobs.py
@@ -591,6 +591,7 @@ def test_job_context_is_nonsecret_and_self_scoped(client, owner_token, db):
   body = response.json()
   assert body["app_id"] == own.id
   assert body["source_dir"] == own.source_dir
+  assert body["public_origin"].startswith("http")
   serialized = json.dumps(body).lower()
   assert "token" not in serialized
   assert "credential" not in serialized

--- a/backend/tests/test_app_owner_screenshot.py
+++ b/backend/tests/test_app_owner_screenshot.py
@@ -1,0 +1,183 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from app.app_capabilities import contract_from_manifest
+from app.manifest_contract import ManifestContractError, validate_manifest_contract
+from test_app_fixtures import create_local_app
+
+
+def _manifest(permission=True):
+  return {
+    "id": "owner-shot",
+    "name": "Owner shot",
+    "version": "0.1.0",
+    "description": "Capture the owner's shell",
+    "entry": "index.jsx",
+    "permissions": {"owner_screenshot": permission},
+  }
+
+
+def _make_app(client, owner_token, db, *, allowed: bool):
+  owner_auth = {"Authorization": f"Bearer {owner_token}"}
+  target = client.post(
+    "/api/chats", json={"title": "Owning chat"}, headers=owner_auth,
+  )
+  assert target.status_code == 200, target.text
+  app = create_local_app(
+    client,
+    owner_auth,
+    name="Screenshot bridge" if allowed else "No screenshot bridge",
+    chat_id=target.json()["id"],
+    manifest_extra={
+      "permissions": {"owner_screenshot": True} if allowed else {},
+    },
+  )
+  app_token = client.post(
+    "/api/auth/app-token",
+    json={"app_id": app["id"]},
+    headers=owner_auth,
+  ).json()["token"]
+  app_auth = {"Authorization": f"Bearer {app_token}"}
+  output = client.post(
+    "/api/app-chats",
+    json={"title": "Telegram output"},
+    headers=app_auth,
+  )
+  assert output.status_code == 201, output.text
+  db.expire_all()
+  return app, app_auth, target.json()["id"], output.json()["id"]
+
+
+def test_owner_screenshot_permission_is_reviewed_in_contract():
+  manifest = _manifest()
+  validate_manifest_contract(manifest)
+  assert contract_from_manifest(manifest)["data"]["owner_screenshot"] is True
+
+
+def test_owner_screenshot_permission_must_be_boolean():
+  with pytest.raises(ManifestContractError, match="must be a boolean"):
+    validate_manifest_contract(_manifest("yes"))
+
+
+def test_permitted_app_captures_to_its_own_chat(
+  client, owner_token, db,
+):
+  app, app_auth, target_chat_id, output_chat_id = _make_app(
+    client, owner_token, db, allowed=True,
+  )
+  with patch(
+    "app.routes.chats._capture_owner_shell",
+    return_value="owner-shell.png",
+  ) as capture:
+    response = client.post(
+      f"/api/app-chats/{output_chat_id}/owner-screenshot",
+      json={"warm_only": False},
+      headers=app_auth,
+    )
+  assert response.status_code == 200, response.text
+  assert response.json() == {
+    "ready": True,
+    "chat_id": output_chat_id,
+    "filename": "owner-shell.png",
+  }
+  kwargs = capture.call_args.kwargs
+  assert kwargs["app_id"] == app["id"]
+  assert kwargs["target_chat_id"] == target_chat_id
+  assert kwargs["output_chat_id"] == output_chat_id
+  assert kwargs["warm_only"] is False
+  assert isinstance(kwargs["owner_token"], str) and kwargs["owner_token"]
+
+
+def test_warmup_returns_no_media_filename(client, owner_token, db):
+  _, app_auth, _, output_chat_id = _make_app(
+    client, owner_token, db, allowed=True,
+  )
+  with patch("app.routes.chats._capture_owner_shell", return_value=None):
+    response = client.post(
+      f"/api/app-chats/{output_chat_id}/owner-screenshot",
+      json={"warm_only": True},
+      headers=app_auth,
+    )
+  assert response.status_code == 200, response.text
+  assert response.json()["ready"] is True
+  assert response.json()["filename"] is None
+
+
+def test_unpermitted_app_cannot_capture_owner_shell(client, owner_token, db):
+  _, app_auth, _, output_chat_id = _make_app(
+    client, owner_token, db, allowed=False,
+  )
+  with patch("app.routes.chats._capture_owner_shell") as capture:
+    response = client.post(
+      f"/api/app-chats/{output_chat_id}/owner-screenshot",
+      json={"warm_only": False},
+      headers=app_auth,
+    )
+  assert response.status_code == 403
+  assert "permissions.owner_screenshot=true" in response.json()["detail"]
+  capture.assert_not_called()
+
+
+def test_owner_token_cannot_use_app_screenshot_route(client, owner_token, db):
+  _, _, _, output_chat_id = _make_app(client, owner_token, db, allowed=True)
+  response = client.post(
+    f"/api/app-chats/{output_chat_id}/owner-screenshot",
+    json={"warm_only": False},
+    headers={"Authorization": f"Bearer {owner_token}"},
+  )
+  assert response.status_code == 403
+
+
+def _write_test_png(path):
+  path.write_bytes(b"\x89PNG\r\n\x1a\n" + b"0" * 1024)
+
+
+def test_warm_owner_profile_skips_capture_while_fresh(tmp_path):
+  from app.routes import chats
+
+  profile = tmp_path / "agent-browser-profiles" / "app-owner-7"
+  marker = tmp_path / "agent-browser-profiles" / "app-owner-7.ready"
+  marker.parent.mkdir(parents=True)
+  marker.write_text("target-chat")
+  with (
+    patch.object(chats, "get_settings", return_value=SimpleNamespace(data_dir=tmp_path)),
+    patch.object(chats, "_run_screenshot_command") as run,
+  ):
+    result = chats._capture_owner_shell(
+      app_id=7,
+      target_chat_id="target-chat",
+      output_chat_id="output-chat",
+      owner_token="owner-token",
+      warm_only=True,
+    )
+  assert result is None
+  run.assert_not_called()
+  assert not profile.exists()
+
+
+def test_direct_owner_capture_uses_warm_browser_profile(tmp_path):
+  from app.routes import chats
+
+  marker = tmp_path / "agent-browser-profiles" / "app-owner-7.ready"
+  marker.parent.mkdir(parents=True)
+  marker.write_text("target-chat")
+
+  def capture(command, **_kwargs):
+    _write_test_png(tmp_path / "chats" / "output-chat" / "media" / command[-1].split("/")[-1])
+
+  with (
+    patch.object(chats, "get_settings", return_value=SimpleNamespace(data_dir=tmp_path)),
+    patch.object(chats, "_run_screenshot_command", side_effect=capture) as run,
+  ):
+    filename = chats._capture_owner_shell(
+      app_id=7,
+      target_chat_id="target-chat",
+      output_chat_id="output-chat",
+      owner_token="owner-token",
+      warm_only=False,
+    )
+  assert filename and filename.startswith("owner-shell-")
+  assert run.call_args.args[0][:2] == ["agent-browser", "screenshot"]
+  assert (tmp_path / "chats" / "output-chat" / "media" / filename).exists()

--- a/backend/tests/test_app_secrets.py
+++ b/backend/tests/test_app_secrets.py
@@ -1,8 +1,14 @@
+import json
 from pathlib import Path
 
+import httpx
+from fastapi import Response
+
 from app import models
-from app.auth import create_app_token
+from app.app_capabilities import contract_from_manifest
+from app.auth import create_app_token, hash_password
 from app.config import get_settings
+import app.routes.secrets as secrets_routes
 
 
 def _create_app(db, name: str) -> models.App:
@@ -23,6 +29,14 @@ def _create_app(db, name: str) -> models.App:
 
 def _app_auth(db, app: models.App) -> dict[str, str]:
   owner = db.query(models.Owner).first()
+  if owner is None:
+    owner = models.Owner(
+      username="test",
+      hashed_password=hash_password("testpassword123"),
+    )
+    db.add(owner)
+    db.commit()
+    db.refresh(owner)
   token = create_app_token(
     app.id, owner.username, owner.token_epoch, app.token_nonce,
   )
@@ -160,6 +174,218 @@ def test_media_token_cannot_access_app_secrets(client, auth, db, chat):
   assert client.head(path, headers=media_auth).status_code == 403
   assert client.get(path, headers=media_auth).status_code == 403
   assert client.delete(path, headers=media_auth).status_code == 403
+
+
+def _declare_credentialed_fetch(db, app: models.App, source: Path) -> None:
+  source.mkdir(parents=True, exist_ok=True)
+  manifest = {
+    "permissions": {
+      "credentialed_fetch": {
+        "amap": {
+          "secret": "amap-key",
+          "origin": "https://restapi.amap.com",
+          "paths": ["/v3/staticmap", "/v3/geocode/geo", "/v5/direction/"],
+          "query_parameter": "key",
+        },
+      },
+    },
+  }
+  (source / "mobius.json").write_text(json.dumps(manifest))
+  app.source_dir = str(source)
+  app.capability_contract = contract_from_manifest(manifest)
+  db.commit()
+  db.refresh(app)
+
+
+def test_credentialed_fetch_injects_secret_without_returning_it(
+  client, db, tmp_path, monkeypatch,
+):
+  app = _create_app(db, "Map Tool")
+  _declare_credentialed_fetch(db, app, tmp_path / "map-tool")
+  app_auth = _app_auth(db, app)
+  assert client.put(
+    f"/api/apps/{app.id}/secrets/amap-key",
+    headers={**app_auth, "Origin": "null", "Sec-Fetch-Site": "cross-site"},
+    json={"value": "private-map-key"},
+  ).status_code == 204
+
+  captured = {}
+  monkeypatch.setattr(
+    secrets_routes,
+    "validate_url_safe",
+    lambda url: (url, "restapi.amap.com", "restapi.amap.com"),
+  )
+
+  async def fake_response(_client, request):
+    captured["url"] = str(request.url)
+    return Response(content=b"map-bytes", media_type="image/png")
+
+  monkeypatch.setattr(secrets_routes, "_credentialed_response", fake_response)
+  response = client.get(
+    f"/api/apps/{app.id}/credentialed-fetch/amap",
+    headers=app_auth,
+    params={
+      "url": "https://restapi.amap.com/v3/staticmap?zoom=6&size=600*600",
+    },
+  )
+  assert response.status_code == 200
+  assert response.content == b"map-bytes"
+  assert "private-map-key" in captured["url"]
+  assert "private-map-key" not in response.text
+
+
+def test_credentialed_fetch_rejects_undeclared_origin_path_and_key(
+  client, db, tmp_path, monkeypatch,
+):
+  app = _create_app(db, "Strict Map")
+  _declare_credentialed_fetch(db, app, tmp_path / "strict-map")
+  headers = _app_auth(db, app)
+  assert client.put(
+    f"/api/apps/{app.id}/secrets/amap-key",
+    headers={**headers, "Origin": "null", "Sec-Fetch-Site": "cross-site"},
+    json={"value": "secret"},
+  ).status_code == 204
+  endpoint = f"/api/apps/{app.id}/credentialed-fetch/amap"
+
+  assert client.get(endpoint, headers=headers, params={
+    "url": "https://attacker.example/v3/staticmap",
+  }).status_code == 403
+  assert client.get(endpoint, headers=headers, params={
+    "url": "https://restapi.amap.com/v3/config/district",
+  }).status_code == 403
+  assert client.get(endpoint, headers=headers, params={
+    "url": "https://restapi.amap.com/v3/staticmap?key=override",
+  }).status_code == 400
+
+  (tmp_path / "strict-map" / "mobius.json").write_text(json.dumps({
+    "permissions": {"credentialed_fetch": {"amap": {
+      "secret": "amap-key",
+      "origin": "https://attacker.example",
+      "paths": ["/v3/staticmap"],
+      "query_parameter": "key",
+    }}},
+  }))
+  assert client.get(endpoint, headers=headers, params={
+    "url": "https://attacker.example/v3/staticmap",
+  }).status_code == 403
+
+
+def test_credentialed_fetch_rejects_oversized_response(
+  client, db, tmp_path, monkeypatch,
+):
+  app = _create_app(db, "Bounded Map")
+  _declare_credentialed_fetch(db, app, tmp_path / "bounded-map")
+  headers = _app_auth(db, app)
+  assert client.put(
+    f"/api/apps/{app.id}/secrets/amap-key",
+    headers={**headers, "Origin": "null", "Sec-Fetch-Site": "cross-site"},
+    json={"value": "secret"},
+  ).status_code == 204
+  monkeypatch.setattr(
+    secrets_routes,
+    "validate_url_safe",
+    lambda url: (url, "restapi.amap.com", "restapi.amap.com"),
+  )
+
+  async def oversized(_client, request, **_kwargs):
+    return httpx.Response(
+      200,
+      content=b"x" * (secrets_routes._CREDENTIAL_RESPONSE_LIMIT + 1),
+      request=request,
+    )
+
+  monkeypatch.setattr(httpx.AsyncClient, "send", oversized)
+  response = client.get(
+    f"/api/apps/{app.id}/credentialed-fetch/amap",
+    headers=headers,
+    params={"url": "https://restapi.amap.com/v3/staticmap"},
+  )
+  assert response.status_code == 413
+
+
+def test_credentialed_fetch_injects_secret_after_declared_path_prefix(
+  client, db, tmp_path, monkeypatch,
+):
+  app = _create_app(db, "Bot Bridge")
+  source = tmp_path / "bot-bridge"
+  source.mkdir()
+  (source / "mobius.json").write_text(json.dumps({
+    "permissions": {
+      "credentialed_fetch": {
+        "telegram": {
+          "secret": "bot-token",
+          "origin": "https://api.telegram.org",
+          "paths": ["/bot/"],
+          "path_prefix": "/bot",
+        },
+      },
+    },
+  }))
+  app.capability_contract = contract_from_manifest(json.loads(
+    (source / "mobius.json").read_text()
+  ))
+  app.source_dir = str(source)
+  db.commit()
+  db.refresh(app)
+  app_auth = _app_auth(db, app)
+  assert client.put(
+    f"/api/apps/{app.id}/secrets/bot-token",
+    headers={**app_auth, "Origin": "null", "Sec-Fetch-Site": "cross-site"},
+    json={"value": "123456:private/token"},
+  ).status_code == 204
+
+  captured = {}
+  monkeypatch.setattr(
+    secrets_routes,
+    "validate_url_safe",
+    lambda url: (url, "api.telegram.org", "api.telegram.org"),
+  )
+
+  async def fake_response(_client, request):
+    captured["url"] = str(request.url)
+    return Response(content=b'{"ok":true}', media_type="application/json")
+
+  monkeypatch.setattr(secrets_routes, "_credentialed_response", fake_response)
+  response = client.get(
+    f"/api/apps/{app.id}/credentialed-fetch/telegram",
+    headers=app_auth,
+    params={"url": "https://api.telegram.org/bot/getMe"},
+  )
+  assert response.status_code == 200
+  assert "/bot123456:private%2Ftoken/getMe" in captured["url"]
+  assert "private/token" not in response.text
+
+
+def test_credentialed_fetch_path_prefix_rejects_unreviewed_path(
+  client, db, tmp_path,
+):
+  app = _create_app(db, "Strict Bot")
+  source = tmp_path / "strict-bot"
+  source.mkdir()
+  (source / "mobius.json").write_text(json.dumps({
+    "permissions": {
+      "credentialed_fetch": {
+        "telegram": {
+          "secret": "bot-token",
+          "origin": "https://api.telegram.org",
+          "paths": ["/bot/"],
+          "path_prefix": "/bot",
+        },
+      },
+    },
+  }))
+  app.capability_contract = contract_from_manifest(json.loads(
+    (source / "mobius.json").read_text()
+  ))
+  app.source_dir = str(source)
+  db.commit()
+  db.refresh(app)
+  headers = _app_auth(db, app)
+
+  endpoint = f"/api/apps/{app.id}/credentialed-fetch/telegram"
+  assert client.get(endpoint, headers=headers, params={
+    "url": "https://api.telegram.org/file/getMe",
+  }).status_code == 403
 
 
 def test_entrypoint_secret_root_is_usable_when_volume_chown_fails():

--- a/backend/tests/test_app_secrets.py
+++ b/backend/tests/test_app_secrets.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 import httpx
+import pytest
 from fastapi import Response
 
 from app import models
@@ -268,6 +269,29 @@ def test_credentialed_fetch_rejects_undeclared_origin_path_and_key(
   assert client.get(endpoint, headers=headers, params={
     "url": "https://attacker.example/v3/staticmap",
   }).status_code == 403
+
+
+@pytest.mark.parametrize("path", [
+  "/v3/staticmap/../config/district",
+  "/v3/staticmap/%2e%2e/config/district",
+  "/v3/staticmap/%252e%252e/config/district",
+  "/v3/staticmap%2f..%2fconfig/district",
+  "/v3/staticmap%252f..%252fconfig/district",
+  "/v3/staticmap/%5c..%5cconfig/district",
+])
+def test_credentialed_fetch_rejects_ambiguous_path_segments(
+  client, db, tmp_path, path,
+):
+  app = _create_app(db, "Traversal-safe map")
+  _declare_credentialed_fetch(db, app, tmp_path / "traversal-safe-map")
+
+  response = client.get(
+    f"/api/apps/{app.id}/credentialed-fetch/amap",
+    headers=_app_auth(db, app),
+    params={"url": f"https://restapi.amap.com{path}"},
+  )
+
+  assert response.status_code == 403
 
 
 def test_credentialed_fetch_rejects_oversized_response(

--- a/backend/tests/test_opaque_origin_cors.py
+++ b/backend/tests/test_opaque_origin_cors.py
@@ -35,6 +35,24 @@ def test_sandboxed_frame_preflight_is_answered_with_a_wildcard(client):
   assert _origin(r) == "*"
 
 
+def test_sandboxed_frame_can_preflight_secret_existence_head(client):
+  """Encrypted app secrets deliberately expose existence through HEAD.
+  Authorization makes the otherwise-safelisted method preflight, so HEAD must
+  be present in Access-Control-Allow-Methods or the setup screen can save a key
+  but can never recognize it after remounting."""
+  r = client.options(
+    "/api/apps/1/secrets/provider-key",
+    headers={
+      "Origin": "null",
+      "Access-Control-Request-Method": "HEAD",
+      "Access-Control-Request-Headers": "authorization",
+    },
+  )
+  assert r.status_code == 200
+  allowed = r.headers.get("access-control-allow-methods", "").upper()
+  assert "HEAD" in {method.strip() for method in allowed.split(",")}
+
+
 def test_connector_mutation_preflight_allows_the_generation_header(client):
   """The Connections app's frame is opaque-origin: every toggle/re-check
   sends X-Mobius-Connector-Generation, which the browser preflights. If the

--- a/backend/tests/test_validate_app_cli.py
+++ b/backend/tests/test_validate_app_cli.py
@@ -203,7 +203,13 @@ def test_removed_job_authority_permissions_fail_clearly(
 def test_requires_accepts_recognized_capabilities(tmp_path):
   _write_app(tmp_path, "export default function App(){ return <div /> }")
   manifest = json.loads((tmp_path / "mobius.json").read_text())
-  manifest["requires"] = ["identity_manage", "railway_manage"]
+  manifest["requires"] = [
+    "identity_manage",
+    "railway_manage",
+    "credentialed_fetch",
+    "app_chat_output_media",
+    "owner_screenshot",
+  ]
   validate_manifest_contract(manifest)  # does not raise on a build that has them
 
 

--- a/backend/tests/test_validate_app_cli.py
+++ b/backend/tests/test_validate_app_cli.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 from fastapi import HTTPException
 
+from app.app_capabilities import contract_from_manifest
 from app.install import _validate_manifest
 from app.manifest_contract import ManifestContractError, validate_manifest_contract
 
@@ -41,6 +42,44 @@ def test_validator_accepts_an_installable_app(tmp_path):
   result = _run(tmp_path)
   assert result.returncode == 0, result.stderr
   assert "OK" in result.stdout
+
+
+def test_manifest_accepts_one_path_prefix_credential_placement(tmp_path):
+  _write_app(tmp_path, "export default function App(){ return <div /> }")
+  manifest = json.loads((tmp_path / "mobius.json").read_text())
+  manifest["permissions"] = {
+    "credentialed_fetch": {
+      "telegram": {
+        "secret": "bot-token",
+        "origin": "https://api.telegram.org",
+        "paths": ["/bot/"],
+        "path_prefix": "/bot",
+      },
+    },
+  }
+  validate_manifest_contract(manifest)
+  _validate_manifest(manifest)
+  assert contract_from_manifest(manifest)["data"]["credentialed_fetch"] == {
+    "telegram": manifest["permissions"]["credentialed_fetch"]["telegram"]
+  }
+
+
+def test_manifest_rejects_two_credential_placements(tmp_path):
+  _write_app(tmp_path, "export default function App(){ return <div /> }")
+  manifest = json.loads((tmp_path / "mobius.json").read_text())
+  manifest["permissions"] = {
+    "credentialed_fetch": {
+      "telegram": {
+        "secret": "bot-token",
+        "origin": "https://api.telegram.org",
+        "paths": ["/bot/"],
+        "path_prefix": "/bot",
+        "query_parameter": "token",
+      },
+    },
+  }
+  with pytest.raises(ManifestContractError, match="exactly one"):
+    validate_manifest_contract(manifest)
 
 
 def test_validator_stays_zero_configuration_outside_a_runtime(tmp_path):


### PR DESCRIPTION
## Summary
- add manifest-scoped credentialed fetches that inject encrypted app secrets into reviewed query or path positions without exposing them to app code
- let app-owned conversations opt into owner visibility and issue short-lived, read-only output-media links
- add an explicit owner-screenshot capability backed by an isolated warm browser profile for fast visual previews

## Security
- pin credentialed requests to reviewed HTTPS origins and path prefixes, reject caller-supplied credentials, cap responses, and keep injected URLs out of errors
- bind output-media tokens to the live app nonce and exact app-owned chat
- keep owner screenshot tokens and browser profiles server-side and re-check the reviewed permission on every request

## Testing
- `pytest -q tests/test_app_secrets.py tests/test_opaque_origin_cors.py tests/test_validate_app_cli.py tests/test_app_chat_contract.py tests/test_app_jobs.py tests/test_app_owner_screenshot.py` — 106 passed