### PR TITLE
Use Starlette’s supported httpx2 test transport

### DIFF
--- a/backend/app/connect_runner.py
+++ b/backend/app/connect_runner.py
@@ -297,6 +297,11 @@ def _run_command(cmd, cwd, timeout):
         if proc is not None:
             _terminate_process_tree(proc)
         return "", "runner error: %s" % exc, 1, False
+    finally:
+        if proc is not None:
+            for stream in (proc.stdout, proc.stderr):
+                if stream is not None:
+                    stream.close()
 
 
 def _serve(cfg):

--- a/backend/requirements.lock
+++ b/backend/requirements.lock
@@ -147,6 +147,7 @@ anyio==4.14.2 \
     # via
     #   claude-agent-sdk
     #   httpx
+    #   httpx2
     #   mcp
     #   sse-starlette
     #   starlette
@@ -728,6 +729,7 @@ h11==0.16.0 \
     --hash=sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86
     # via
     #   httpcore
+    #   httpcore2
     #   uvicorn
 http-ece==1.2.1 \
     --hash=sha256:8c6ab23116bbf6affda894acfd5f2ca0fb8facbcbb72121c11c75c33e7ce8cff
@@ -736,6 +738,10 @@ httpcore==1.0.9 \
     --hash=sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55 \
     --hash=sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8
     # via httpx
+httpcore2==2.12.0 \
+    --hash=sha256:7e04258ce01013d7d615e5b910a3b27fac937d7a95038227e79652b4ba3b4ceb \
+    --hash=sha256:9293522bba0aa7c4c8e9e3f040c16575bd8868e155a77fa30c7a9085a5eae648
+    # via httpx2
 httptools==0.8.0 \
     --hash=sha256:0770728beb05094c809b98e814edff5fef69d26ad7d21185f2f6d5884a0ba683 \
     --hash=sha256:0ea897f0c729581ebf72131a438a7932d9b14efef72d75ada966700cac3caaeb \
@@ -798,6 +804,10 @@ httpx-sse==0.4.3 \
     --hash=sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc \
     --hash=sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d
     # via mcp
+httpx2==2.12.0 \
+    --hash=sha256:7631fe9887a8a2275f4a2540e053aa670fcc50742864a9ae7c66e609fdcf12cf \
+    --hash=sha256:cc8b6eecb8661c146b8f89a60e97456ee086e91a784ed31ac450c3a9e613dd36
+    # via -r requirements.txt
 idna==3.18 \
     --hash=sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2 \
     --hash=sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848
@@ -805,6 +815,7 @@ idna==3.18 \
     #   anyio
     #   email-validator
     #   httpx
+    #   httpx2
     #   requests
     #   yarl
 iniconfig==2.3.0 \
@@ -1666,6 +1677,12 @@ starlette==1.3.1 \
     #   fastapi
     #   mcp
     #   sse-starlette
+truststore==0.10.4 \
+    --hash=sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301 \
+    --hash=sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981
+    # via
+    #   httpcore2
+    #   httpx2
 typing-extensions==4.16.0 \
     --hash=sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8 \
     --hash=sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5
@@ -1674,6 +1691,7 @@ typing-extensions==4.16.0 \
     #   aiosignal
     #   anyio
     #   fastapi
+    #   httpx2
     #   limits
     #   mcp
     #   pydantic

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,6 +9,7 @@ pydantic[email]>=2.7.0
 pydantic-settings>=2.5.0
 slowapi>=0.1.10
 httpx>=0.28.0
+httpx2>=2.12.0
 Pillow>=11.0.0
 pywebpush>=2.0.0
 pytest>=8.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,6 +8,8 @@ python-multipart>=0.0.18
 pydantic[email]>=2.7.0
 pydantic-settings>=2.5.0
 slowapi>=0.1.10
+# Runtime integrations use httpx; the self-testing runtime's Starlette
+# TestClient imports httpx2 instead of its deprecated httpx fallback.
 httpx>=0.28.0
 httpx2>=2.12.0
 Pillow>=11.0.0

--- a/backend/tests/test_connect.py
+++ b/backend/tests/test_connect.py
@@ -400,6 +400,7 @@ async def test_exec_timeout_clears_its_pending_request(client, auth, monkeypatch
   assert channel.pending == {}
 
 
+@pytest.mark.filterwarnings("error")
 @pytest.mark.skipif(sys.platform == "win32", reason="POSIX process-group contract")
 def test_runner_timeout_terminates_the_entire_command_tree(tmp_path: Path):
   """A timed-out command must not leave descendants running on the machine."""

--- a/backend/tests/test_verify_test_runtime.py
+++ b/backend/tests/test_verify_test_runtime.py
@@ -14,6 +14,13 @@ SHA = "a" * 40
 ROOT = Path(__file__).resolve().parents[2]
 
 
+def test_starlette_test_client_uses_supported_httpx2_transport():
+  import httpx2
+  from starlette.testclient import TestClient
+
+  assert issubclass(TestClient, httpx2.Client)
+
+
 def _version(**overrides):
   value = {
     "test_runtime": True,


### PR DESCRIPTION
## Summary

- Use the exact `httpx2` distribution imported first by Starlette 1.3.1's `TestClient`, while retaining `httpx` for runtime integrations and locking both reproducibly.
- Keep test tooling in the existing single backend environment and make the supported `TestClient` inheritance an executable dependency contract, rather than adding a parallel requirements path.
- Close the Connect runner's timeout pipes so warning-strict tests do not leak resources.

## Verification

- Confirmed Starlette 1.3.1 imports `httpx2` before its deprecated `httpx` fallback, and verified the locked PyPI artifacts belong to the Pydantic Services/Tom Christie distribution.
- `pip check` — no broken requirements.
- Warning-strict focused suite — 48 passed.
- Broader backend contract and Connect suite — 104 passed.
- Python compilation and `git diff --check` passed.
