### PR TITLE
Converge local app schedules on source apply

### DIFF
--- a/backend/app/app_apply.py
+++ b/backend/app/app_apply.py
@@ -447,8 +447,12 @@ async def apply_source_revision(
       )
       if not changed:
         db.rollback()
+        # An unchanged revision re-declares the SAME manifest, so no prior
+        # declaration can be obsolete and re-registration is idempotent. A
+        # pre-drop here would only widen the window in which a failed
+        # registration leaves a previously healthy schedule retired.
         warnings = await _sync_accepted_app_side_effects(
-          db, app, manifest, drop_prior_cron=not created,
+          db, app, manifest, drop_prior_cron=False,
         )
         return ApplyResult(app=app, mode="unchanged", warnings=warnings)
 

--- a/backend/app/app_apply.py
+++ b/backend/app/app_apply.py
@@ -83,6 +83,38 @@ async def _sync_accepted_app_skills(
   return tuple(warnings)
 
 
+async def _sync_accepted_app_side_effects(
+  db: Session,
+  app: models.App,
+  manifest: dict | None,
+  *,
+  drop_prior_cron: bool,
+) -> tuple[str, ...]:
+  """Converge post-commit declarations for one accepted local revision.
+
+  The caller holds the app source lock. Store-managed worktrees have no local
+  manifest authority, so their reviewed schedule remains installer-owned.
+  """
+  warnings: list[str] = []
+  if manifest is not None:
+    from app import install
+
+    schedule = manifest.get("schedule")
+    try:
+      await install._sync_manifest_cron_unlocked(
+        app=app,
+        manifest=manifest,
+        drop_prior_cron=drop_prior_cron,
+        bundled_job=bool(schedule and schedule.get("job")),
+        warnings=warnings,
+      )
+    except Exception as exc:
+      log.exception("app apply: cron sync failed post-commit")
+      warnings.append(f"cron: registration failed — {exc!r}")
+  warnings.extend(await _sync_accepted_app_skills(db, app, manifest))
+  return tuple(warnings)
+
+
 async def _git_operation(label: str, fn, *args):
   """Run one app-repository operation with a stable client-facing failure.
 
@@ -415,7 +447,9 @@ async def apply_source_revision(
       )
       if not changed:
         db.rollback()
-        warnings = await _sync_accepted_app_skills(db, app, manifest)
+        warnings = await _sync_accepted_app_side_effects(
+          db, app, manifest, drop_prior_cron=not created,
+        )
         return ApplyResult(app=app, mode="unchanged", warnings=warnings)
 
       app.jsx_source = source
@@ -431,7 +465,9 @@ async def apply_source_revision(
       if previous_bundle != published:
         unlink_app_bundle(app.id, previous_bundle)
       db.refresh(app)
-      warnings = await _sync_accepted_app_skills(db, app, manifest)
+      warnings = await _sync_accepted_app_side_effects(
+        db, app, manifest, drop_prior_cron=not created,
+      )
       return ApplyResult(
         app=app,
         mode="created" if created else "updated",

--- a/backend/app/install.py
+++ b/backend/app/install.py
@@ -2201,6 +2201,63 @@ def _select_install_target(
   )
 
 
+async def _sync_manifest_cron_unlocked(
+  *,
+  app: models.App,
+  manifest: dict,
+  drop_prior_cron: bool,
+  bundled_job: bool,
+  warnings: list[str],
+) -> None:
+  """Converge one accepted manifest's cron while its source lock is held.
+
+  Store installs and explicit local-source applies are two acceptance paths for
+  the same manifest contract. Keeping cron convergence here prevents either
+  path from becoming add-only: an accepted update that drops its schedule must
+  retire both the live entry and its replayable declaration.
+  """
+  schedule = manifest.get("schedule")
+  job_name = schedule.get("job") if schedule else None
+  cron_job_name = job_name or "job.sh"
+  has_cron = bool(schedule and schedule.get("default"))
+  if not (bundled_job or has_cron or drop_prior_cron):
+    return
+
+  app_data_dir = Path(app.source_dir)
+  app_data_dir.mkdir(parents=True, exist_ok=True)
+  if drop_prior_cron:
+    await asyncio.to_thread(_drop_app_cron, app_data_dir)
+  job_path = app_data_dir / cron_job_name
+  if job_name and job_path.exists() and not os.access(job_path, os.X_OK):
+    warnings.append(
+      f"schedule.job {cron_job_name} is not executable — cron/run-job "
+      "will fail until the app repo commits the executable bit"
+    )
+  active_cron_scaffold = app_cron.cron_scaffold(CRON_SCAFFOLD)
+  if has_cron and active_cron_scaffold.exists():
+    await asyncio.to_thread(
+      app_cron.register_cron,
+      app.slug,
+      schedule["default"],
+      job_path,
+      app.id,
+      scaffold=active_cron_scaffold,
+    )
+  elif has_cron:
+    sentinel = app_data_dir / ".cron-pending.json"
+    sentinel.write_text(
+      json.dumps({
+        "expr": schedule["default"],
+        "job": cron_job_name,
+        "status": "pending — init-cron-scaffold.sh not on PATH",
+      }),
+      encoding="utf-8",
+    )
+    warnings.append(
+      "cron: scaffold script not available — registration pending"
+    )
+
+
 async def _run_post_commit_effects(
   db: Session,
   *,
@@ -2217,53 +2274,21 @@ async def _run_post_commit_effects(
   manifest = candidate.manifest
   schedule = manifest.get("schedule")
   job_name = schedule.get("job") if schedule else None
-  cron_job_name = job_name or "job.sh"
   has_cron = bool(schedule and schedule.get("default"))
   drop_prior_cron = mode == "update"
   if candidate.bundled_job or has_cron or drop_prior_cron:
-    slug = app.slug
-    data_dir = Path(get_settings().data_dir)
     app_data_dir = Path(app.source_dir)
     try:
       async with fs_locks.source_dir_lock(str(app_data_dir)):
         if not db.query(models.App.id).filter(models.App.id == app.id).first():
           raise HTTPException(404, "App removed before cron registration.")
-        app_data_dir.mkdir(parents=True, exist_ok=True)
-        if drop_prior_cron:
-          await asyncio.to_thread(_drop_app_cron, app_data_dir)
-        job_path = app_data_dir / cron_job_name
-        if (
-          job_name
-          and job_path.exists()
-          and not os.access(job_path, os.X_OK)
-        ):
-          warnings.append(
-            f"schedule.job {cron_job_name} is not executable — cron/run-job "
-            "will fail until the app repo commits the executable bit"
-          )
-        active_cron_scaffold = app_cron.cron_scaffold(CRON_SCAFFOLD)
-        if has_cron and active_cron_scaffold.exists():
-          await asyncio.to_thread(
-            app_cron.register_cron,
-            slug,
-            schedule["default"],
-            job_path,
-            app.id,
-            scaffold=active_cron_scaffold,
-          )
-        elif has_cron:
-          sentinel = app_data_dir / ".cron-pending.json"
-          sentinel.write_text(
-            json.dumps({
-              "expr": schedule["default"],
-              "job": cron_job_name,
-              "status": "pending — init-cron-scaffold.sh not on PATH",
-            }),
-            encoding="utf-8",
-          )
-          warnings.append(
-            "cron: scaffold script not available — registration pending"
-          )
+        await _sync_manifest_cron_unlocked(
+          app=app,
+          manifest=manifest,
+          drop_prior_cron=drop_prior_cron,
+          bundled_job=bool(candidate.bundled_job),
+          warnings=warnings,
+        )
     except HTTPException as exc:
       log.warning(
         "install: job-script/cron step failed post-commit — %s",

--- a/backend/app/install.py
+++ b/backend/app/install.py
@@ -1308,6 +1308,10 @@ def _drop_app_cron(source_dir: Path) -> None:
     (source_dir / "init-cron.sh").unlink()
   except OSError:
     pass
+  try:
+    (source_dir / ".cron-pending.json").unlink()
+  except OSError:
+    pass
 
 
 def _storage_path(app_id: int, sub: str) -> Path:

--- a/backend/app/install.py
+++ b/backend/app/install.py
@@ -2219,6 +2219,12 @@ async def _sync_manifest_cron_unlocked(
   the same manifest contract. Keeping cron convergence here prevents either
   path from becoming add-only: an accepted update that drops its schedule must
   retire both the live entry and its replayable declaration.
+
+  ``drop_prior_cron`` means the previously accepted declaration may be obsolete
+  — a changed manifest can rename its job or drop the schedule outright, and
+  re-registering fixes neither. A caller re-accepting an IDENTICAL manifest
+  passes ``False`` instead: the scaffold already replaces its own entry, so
+  dropping first would only expose a healthy schedule to a failed re-register.
   """
   schedule = manifest.get("schedule")
   job_name = schedule.get("job") if schedule else None

--- a/backend/tests/test_app_apply.py
+++ b/backend/tests/test_app_apply.py
@@ -184,6 +184,34 @@ def test_unchanged_local_reapply_retries_failed_schedule_sync(client, auth):
   register.assert_called_once()
 
 
+def test_unchanged_local_reapply_keeps_a_live_schedule_when_cron_fails(
+  client, auth,
+):
+  source = _source()
+  _declare_schedule(source)
+  with patch("app.app_cron.register_cron"):
+    created = _apply(client, auth, source)
+
+  assert created.status_code == 200, created.text
+  # Stand in for the durable declaration written by the real scaffold.
+  init_cron = source / "init-cron.sh"
+  init_cron.write_text("#!/bin/sh\nexit 0\n")
+
+  with patch("app.install._unregister_cron") as unregister, patch(
+    "app.app_cron.register_cron", side_effect=RuntimeError("cron unavailable"),
+  ):
+    repeated = _apply(client, auth, source)
+
+  assert repeated.status_code == 200, repeated.text
+  assert repeated.json()["mode"] == "unchanged"
+  # Re-accepting the same schedule must never retire the working one first.
+  unregister.assert_not_called()
+  assert init_cron.exists()
+  assert repeated.json()["warnings"] == [
+    "cron: registration failed — RuntimeError('cron unavailable')"
+  ]
+
+
 def test_apply_refreshes_manifest_declared_skill_on_create_and_update(
   client, auth,
 ):

--- a/backend/tests/test_app_apply.py
+++ b/backend/tests/test_app_apply.py
@@ -143,6 +143,8 @@ def test_local_apply_converges_schedule_creation_and_removal(client, auth):
   # Stand in for the durable declaration written by the real scaffold.
   init_cron = source / "init-cron.sh"
   init_cron.write_text("#!/bin/sh\nexit 0\n")
+  pending_cron = source / ".cron-pending.json"
+  pending_cron.write_text('{"status":"pending"}\n')
   manifest = json.loads((source / "mobius.json").read_text())
   manifest.pop("schedule")
   (source / "mobius.json").write_text(json.dumps(manifest))
@@ -155,6 +157,7 @@ def test_local_apply_converges_schedule_creation_and_removal(client, auth):
   assert updated.json()["mode"] == "updated"
   unregister.assert_called_once_with(source)
   assert not init_cron.exists()
+  assert not pending_cron.exists()
   assert updated.json()["warnings"] == []
 
 

--- a/backend/tests/test_app_apply.py
+++ b/backend/tests/test_app_apply.py
@@ -51,6 +51,19 @@ def _declare_icon(source: Path, raw: bytes, name: str = "icon.png") -> None:
   (source / name).write_bytes(raw)
 
 
+def _declare_schedule(source: Path) -> None:
+  manifest = json.loads((source / "mobius.json").read_text())
+  manifest["schedule"] = {
+    "default": "*/10 * * * *",
+    "user_configurable": False,
+    "job": "job.sh",
+  }
+  (source / "mobius.json").write_text(json.dumps(manifest))
+  job = source / "job.sh"
+  job.write_text("#!/bin/sh\nexit 0\n")
+  job.chmod(0o755)
+
+
 def test_apply_creates_from_manifest_and_commits_exact_source(
   client, auth, db, chat,
 ):
@@ -112,6 +125,60 @@ def test_apply_updates_multifile_revision_once(client, auth, db):
       "chatId": "editing-chat",
     }),
   ]
+
+
+def test_local_apply_converges_schedule_creation_and_removal(client, auth):
+  source = _source()
+  _declare_schedule(source)
+
+  with patch("app.app_cron.register_cron") as register:
+    created = _apply(client, auth, source)
+
+  assert created.status_code == 200, created.text
+  app_id = created.json()["app"]["id"]
+  assert register.call_args.args[:4] == (
+    "demo", "*/10 * * * *", source / "job.sh", app_id,
+  )
+
+  # Stand in for the durable declaration written by the real scaffold.
+  init_cron = source / "init-cron.sh"
+  init_cron.write_text("#!/bin/sh\nexit 0\n")
+  manifest = json.loads((source / "mobius.json").read_text())
+  manifest.pop("schedule")
+  (source / "mobius.json").write_text(json.dumps(manifest))
+  (source / "job.sh").unlink()
+
+  with patch("app.install._unregister_cron") as unregister:
+    updated = _apply(client, auth, source)
+
+  assert updated.status_code == 200, updated.text
+  assert updated.json()["mode"] == "updated"
+  unregister.assert_called_once_with(source)
+  assert not init_cron.exists()
+  assert updated.json()["warnings"] == []
+
+
+def test_unchanged_local_reapply_retries_failed_schedule_sync(client, auth):
+  source = _source()
+  _declare_schedule(source)
+  with patch(
+    "app.app_cron.register_cron", side_effect=RuntimeError("cron unavailable"),
+  ):
+    created = _apply(client, auth, source)
+
+  assert created.status_code == 200, created.text
+  assert created.json()["mode"] == "created"
+  assert created.json()["warnings"] == [
+    "cron: registration failed — RuntimeError('cron unavailable')"
+  ]
+
+  with patch("app.app_cron.register_cron") as register:
+    repeated = _apply(client, auth, source)
+
+  assert repeated.status_code == 200, repeated.text
+  assert repeated.json()["mode"] == "unchanged"
+  assert repeated.json()["warnings"] == []
+  register.assert_called_once()
 
 
 def test_apply_refreshes_manifest_declared_skill_on_create_and_update(


### PR DESCRIPTION
## Summary

- Give local source applies the same schedule-convergence path as Store installs.
- Remove obsolete live and restart declarations when an accepted manifest drops its schedule.
- Retry failed schedule registration when the same unchanged source revision is reapplied.
- Return non-fatal schedule synchronization problems as apply warnings while keeping the accepted app revision available.

## Testing

- `scripts/wt-pytest.sh backend/tests/test_app_apply.py backend/tests/test_apps_install.py -q` — 179 passed
- `git diff --check`