### PR TITLE
Add a shell command palette and global shortcuts

### DIFF
--- a/frontend/public/app-frame.html
+++ b/frontend/public/app-frame.html
@@ -570,6 +570,7 @@
     let initialized = false;
     let currentToken = null;
     let currentCapabilityContract = null;
+    let shellShortcuts = [];
     let tokenRefreshPromise = null;
     let tokenRefreshResolve = null;
     let mountedRoot = null;
@@ -587,6 +588,39 @@
     // well as the document scroller, without walking every node when the drawer
     // opens. Nested third-party frames stay covered by the outer iframe guard.
     const gestureScrollers = new Set();
+
+    function setShellShortcuts(value) {
+      shellShortcuts = (Array.isArray(value) ? value : []).slice(0, 64).filter(function (item) {
+        return item && typeof item.actionId === 'string'
+          && item.binding && typeof item.binding.key === 'string';
+      });
+    }
+
+    function frameShortcutMatches(event, binding) {
+      if (!event || !binding || event.isComposing || event.repeat) return false;
+      const eventKey = typeof event.key === 'string' ? event.key.toLocaleLowerCase() : '';
+      const bindingKey = String(binding.key || '').toLocaleLowerCase();
+      if (!bindingKey || eventKey !== bindingKey) return false;
+      if (Boolean(event.metaKey || event.ctrlKey) !== Boolean(binding.mod)) return false;
+      if (Boolean(event.shiftKey) !== Boolean(binding.shift)) return false;
+      if (Boolean(event.altKey) !== Boolean(binding.alt)) return false;
+      return true;
+    }
+
+    // App code retains every ordinary/editor shortcut. Only the exact global
+    // chords advertised by the shell are captured and forwarded as named
+    // actions; raw keystrokes never cross the iframe boundary.
+    document.addEventListener('keydown', function (event) {
+      const shortcut = shellShortcuts.find(function (item) {
+        return frameShortcutMatches(event, item.binding);
+      });
+      if (!shortcut) return;
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      window.parent.postMessage({
+        type: 'moebius:shell-shortcut', actionId: shortcut.actionId
+      }, window.location.origin);
+    }, true);
 
     // App intent listeners live in app code, alongside this runtime listener.
     // The parent keeps an opaque cover over the frame until we acknowledge.
@@ -1164,6 +1198,10 @@
         setFrameInteractivity(msg.interactive === true, msg.suspendScrolling === true);
         return;
       }
+      if (msg.type === 'moebius:frame-shortcuts') {
+        setShellShortcuts(msg.shortcuts);
+        return;
+      }
       if (msg.type === 'moebius:frame-font-check') {
         const requestId = typeof msg.requestId === 'string' ? msg.requestId : '';
         if (!requestId || requestId.length > 160) return;
@@ -1206,6 +1244,7 @@
         currentCapabilityContract = msg.capabilityContract || null;
         acceptToken(msg.token);
         if (initialized) return;
+        setShellShortcuts(msg.shellShortcuts);
         initialized = true;
         if (typeof window.__mobiusHydrateLocalStorage === 'function') {
           window.__mobiusHydrateLocalStorage(msg.storage);

--- a/frontend/src/components/AppCanvas/AppCanvas.jsx
+++ b/frontend/src/components/AppCanvas/AppCanvas.jsx
@@ -31,6 +31,7 @@ import {
   appMediaSessionEvent,
   applyVirtualStorageMutation,
   attributedFrameVersion,
+  attributedShellShortcutAction,
   serveClipboardWrite,
   serveModuleRequest,
   serveStorageRpc,
@@ -164,7 +165,13 @@ function appFrameRequestUrl(appId, version, frameRev) {
 //      shell wrapper. The live frame signals the parent so its pane becomes the
 //      focused owner of keyboard and immersive state.
 //
-//   9. moebius:account-link-*                               three-party broker
+//   9. {type:'moebius:frame-shortcuts', shortcuts}         parent → frame
+//      and {type:'moebius:shell-shortcut', actionId}       frame → parent
+//      The shell advertises only its reserved named actions to the live,
+//      interactive frame. Exact source + focus gating prevents arbitrary
+//      keylogging or a hidden frame dispatching workspace behavior.
+//
+//  10. moebius:account-link-*                              three-party broker
 //      The CSP-sandboxed app frame has an opaque origin, so an external OAuth
 //      completion page cannot safely target it by the shell's concrete origin.
 //      A live, visible frame with the reviewed identity_manage grant registers
@@ -294,9 +301,10 @@ const AppCanvas = forwardRef(function AppCanvas({
   // background content cannot keep coasting beneath the drawer.
   interactive = visible,
   pendingIntent = null,
+  shellShortcuts = null,
   onNavPush, onNavPop, onNavReset, onNavForwardResult,
   onAppFocus, onImmersive, onIntentDelivered, onAppError, onHostRequest,
-  onMediaSession,
+  onMediaSession, onShellShortcut,
 }, hostRef) {
   const queryClient = useQueryClient()
   const [serviceSurface, setServiceSurface] = useState(null)
@@ -516,6 +524,10 @@ const AppCanvas = forwardRef(function AppCanvas({
   frameVisibleRef.current = frameVisible
   const capabilityContractRef = useRef(capabilityContract)
   capabilityContractRef.current = capabilityContract
+  const shellShortcutsRef = useRef(Array.isArray(shellShortcuts) ? shellShortcuts : [])
+  shellShortcutsRef.current = Array.isArray(shellShortcuts) ? shellShortcuts : []
+  const onShellShortcutRef = useRef(onShellShortcut)
+  onShellShortcutRef.current = onShellShortcut
   const capabilityHostRef = useRef(null)
   if (!capabilityHostRef.current) {
     capabilityHostRef.current = createCapabilityHost({
@@ -615,6 +627,10 @@ const AppCanvas = forwardRef(function AppCanvas({
         bg: eff?.bg ?? theme?.bg,
         storage: readAppFrameStorage(appId, undefined, appSlug),
         capabilityContract,
+        shellShortcuts: v === liveVersionRef.current && activeRef.current
+          && visibleRef.current && interactiveRef.current
+          ? shellShortcutsRef.current
+          : [],
       },
       '*',
     )
@@ -899,6 +915,14 @@ const AppCanvas = forwardRef(function AppCanvas({
 
       if (msg.type === 'moebius:frame-focus') {
         onAppFocus?.(appId)
+        return
+      }
+
+      if (msg.type === 'moebius:shell-shortcut') {
+        if (srcVersion !== liveVersionRef.current
+            || !activeRef.current || !visibleRef.current || !interactiveRef.current) return
+        const actionId = attributedShellShortcutAction(msg, shellShortcutsRef.current)
+        if (actionId) onShellShortcutRef.current?.(actionId)
         return
       }
 
@@ -1275,6 +1299,15 @@ const AppCanvas = forwardRef(function AppCanvas({
     })
   }
 
+  function sendShellShortcuts(v) {
+    const enabled = v === liveVersionRef.current
+      && activeRef.current && visibleRef.current && interactiveRef.current
+    postToFrame(v, {
+      type: 'moebius:frame-shortcuts',
+      shortcuts: enabled ? shellShortcutsRef.current : [],
+    })
+  }
+
   useEffect(() => {
     if (loadedDocsRef.current.has(swap.liveVersion)) {
       sendVisibility(swap.liveVersion, frameVisible)
@@ -1293,6 +1326,13 @@ const AppCanvas = forwardRef(function AppCanvas({
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [interactive, frameVisible, swap.liveVersion])
+
+  useLayoutEffect(() => {
+    for (const v of framesRef.current.keys()) {
+      if (loadedDocsRef.current.has(v)) sendShellShortcuts(v)
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [active, visible, interactive, shellShortcuts, swap.liveVersion])
 
   useEffect(() => {
     for (const v of framesRef.current.keys()) {
@@ -1485,6 +1525,7 @@ const AppCanvas = forwardRef(function AppCanvas({
     sendOnlineStatus(v)
     sendInsets(v)
     sendImmersiveState(v)
+    sendShellShortcuts(v)
     // A booting incoming frame is invisible by construction and must not
     // start audio/rAF work before promotion, so it learns `visible:false`
     // here; the live frame gets the real visible verdict. Promotion re-sends

--- a/frontend/src/components/AppCanvas/appFrameProtocol.js
+++ b/frontend/src/components/AppCanvas/appFrameProtocol.js
@@ -13,6 +13,16 @@ export function attributedFrameVersion(frames, source) {
   return null
 }
 
+export function attributedShellShortcutAction(message, advertisedShortcuts) {
+  if (!message || message.type !== 'moebius:shell-shortcut') return null
+  const actionId = typeof message.actionId === 'string' ? message.actionId : ''
+  if (!actionId) return null
+  return (Array.isArray(advertisedShortcuts) ? advertisedShortcuts : [])
+    .some(shortcut => shortcut?.actionId === actionId)
+    ? actionId
+    : null
+}
+
 const MEDIA_EVENTS = new Set(['open', 'update', 'close'])
 const MEDIA_STATES = new Set(['loading', 'playing', 'paused'])
 

--- a/frontend/src/components/GlobalSearch/GlobalSearch.css
+++ b/frontend/src/components/GlobalSearch/GlobalSearch.css
@@ -287,6 +287,12 @@
   box-shadow: inset 3px 0 0 var(--accent);
 }
 
+.global-search__result[aria-disabled="true"] {
+  color: var(--muted);
+  cursor: default;
+  opacity: 0.62;
+}
+
 @media (hover: hover) and (pointer: fine) {
   .global-search__result:hover { background: var(--surface2); }
   .global-search__close:hover { background: var(--surface2); }
@@ -305,6 +311,29 @@
   place-items: center;
   background: var(--surface2);
   color: var(--muted);
+}
+
+.global-search__command-icon {
+  font: 700 14px/1 var(--font, system-ui);
+}
+
+.global-search__command-bindings {
+  flex: none;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 5px;
+}
+
+.global-search__command-bindings kbd {
+  min-width: 24px;
+  padding: 3px 6px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg);
+  color: var(--muted);
+  font: 600 10px/1.35 var(--font, system-ui);
+  text-align: center;
 }
 
 .global-search__result-main {
@@ -403,5 +432,6 @@
   .global-search__input-wrap kbd { display: none; }
   .global-search__result { padding-inline: 10px; }
   .global-search__match-kind { display: none; }
+  .global-search__command-bindings kbd:nth-child(n + 2) { display: none; }
   .global-search__empty { min-height: 40dvh; padding: 20px; }
 }

--- a/frontend/src/components/GlobalSearch/GlobalSearch.jsx
+++ b/frontend/src/components/GlobalSearch/GlobalSearch.jsx
@@ -1,4 +1,4 @@
-/* GlobalSearch is the keyboard-openable search dialog for chats and installed apps. */
+/* GlobalSearch is the shell command palette and cross-workspace search dialog. */
 import { createPortal } from 'react-dom'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
@@ -27,6 +27,7 @@ import {
   rememberRecentSelection,
   resolveRecentSelections,
   resolvedSearchSelection,
+  searchCommands,
   searchInstalledApps,
   visibleChatSearchState,
 } from './globalSearchModel.js'
@@ -60,6 +61,34 @@ function GlobalSearchResult({
     onPointerMove: event => onPointerActivity(index, event),
     onFocus: () => onSelect(index),
     onClick: () => onOpen(row),
+  }
+
+  if (row.kind === 'command') {
+    const command = row.value
+    const unavailable = command.enabled === false
+    return (
+      <button
+        {...sharedProps}
+        className={`${resultClass} global-search__result--command`}
+        aria-disabled={unavailable || undefined}
+        title={unavailable ? command.unavailableReason : undefined}
+      >
+        <span className="global-search__result-icon global-search__command-icon" aria-hidden="true">
+          ⌘
+        </span>
+        <span className="global-search__result-main">
+          <span className="global-search__result-title">{command.title}</span>
+          <span className="global-search__result-detail">
+            {unavailable && command.unavailableReason
+              ? command.unavailableReason
+              : command.description}
+          </span>
+        </span>
+        <span className="global-search__command-bindings" aria-label={command.shortcutLabels.join(' or ')}>
+          {command.shortcutLabels.map(label => <kbd key={label}>{label}</kbd>)}
+        </span>
+      </button>
+    )
   }
 
   if (row.kind === 'app') {
@@ -127,7 +156,7 @@ function GlobalSearchResult({
 
 export function GlobalSearchButton({ active = false, buttonRef, onClick }) {
   const shortcut = shortcutLabel(SHELL_SHORTCUTS.openSearch)
-  const label = active ? 'Close search' : 'Search chats and apps'
+  const label = active ? 'Close search' : 'Search and commands'
   return (
     <button
       ref={buttonRef}
@@ -144,7 +173,7 @@ export function GlobalSearchButton({ active = false, buttonRef, onClick }) {
   )
 }
 
-export default function GlobalSearch({ onClose, onOpenTarget }) {
+export default function GlobalSearch({ commands = [], onClose, onOpenTarget, onRunCommand }) {
   const dialogRef = useRef(null)
   const inputRef = useRef(null)
   const contentRef = useRef(null)
@@ -225,6 +254,10 @@ export default function GlobalSearch({ onClose, onOpenTarget }) {
     () => searchInstalledApps(appsQuery.data, normalizedQuery),
     [appsQuery.data, normalizedQuery],
   )
+  const commandResults = useMemo(
+    () => searchCommands(commands, normalizedQuery).filter(command => command.id !== 'search.open'),
+    [commands, normalizedQuery],
+  )
   const recentSelectionRows = useMemo(
     () => resolveRecentSelections(
       recentSelectionRefs,
@@ -260,9 +293,23 @@ export default function GlobalSearch({ onClose, onOpenTarget }) {
     onOpenTarget?.(chatSearchOpenTarget(chat))
   }, [onClose, onOpenTarget])
 
+  const openCommand = useCallback((command) => {
+    if (!command?.id || command.enabled === false) return
+    onClose()
+    onRunCommand?.(command.id)
+  }, [onClose, onRunCommand])
+
   const resultGroups = useMemo(() => {
     const groups = normalizedQuery
       ? [
+          ...(commandResults.length ? [{
+            headingId: 'global-search-commands',
+            listId: 'global-search-command-results',
+            label: 'Commands',
+            rows: commandResults.map(command => ({
+              kind: 'command', value: command,
+            })),
+          }] : []),
           ...(appResults.length ? [{
             headingId: 'global-search-apps',
             listId: 'global-search-app-results',
@@ -282,6 +329,14 @@ export default function GlobalSearch({ onClose, onOpenTarget }) {
           },
         ]
       : [
+          ...(commandResults.length ? [{
+            headingId: 'global-search-commands',
+            listId: 'global-search-command-results',
+            label: 'Commands',
+            rows: commandResults.map(command => ({
+              kind: 'command', value: command,
+            })),
+          }] : []),
           ...(recentSelectionRows.length ? [{
             headingId: 'global-search-recent-selections',
             listId: 'global-search-recent-selection-results',
@@ -301,7 +356,7 @@ export default function GlobalSearch({ onClose, onOpenTarget }) {
       ...group,
       rows: group.rows.map(row => ({ ...row, index: nextIndex++ })),
     }))
-  }, [appResults, normalizedQuery, recentSelectionRows, visibleChats])
+  }, [appResults, commandResults, normalizedQuery, recentSelectionRows, visibleChats])
 
   const selectableResults = useMemo(
     () => resultGroups.flatMap(group => group.rows),
@@ -317,10 +372,11 @@ export default function GlobalSearch({ onClose, onOpenTarget }) {
     .join(' ')
 
   const openResult = useCallback((row) => {
+    if (row?.kind === 'command') openCommand(row.value)
     if (row?.kind === 'app') openApp(row.value)
     if (row?.kind === 'chat' && row.recent) openRecentChat(row.value)
     if (row?.kind === 'chat' && !row.recent) openChat(row.value)
-  }, [openApp, openChat, openRecentChat])
+  }, [openApp, openChat, openCommand, openRecentChat])
 
   const openSelectedResult = useCallback(() => {
     openResult(selectableResults[activeResultIndex])
@@ -369,6 +425,7 @@ export default function GlobalSearch({ onClose, onOpenTarget }) {
     && visibleChats.status === 'ready'
     && visibleChats.results.length === 0
     && appResults.length === 0
+    && commandResults.length === 0
   const loadingRecentSelections = !normalizedQuery
     && resultGroups.length === 0
     && recentSelectionRefs.some(selection => (
@@ -393,8 +450,8 @@ export default function GlobalSearch({ onClose, onOpenTarget }) {
       >
         <header className="global-search__header">
           <div>
-            <h2 id="global-search-title" className="global-search__title">Search</h2>
-            <p className="global-search__subtitle">Chats and installed apps</p>
+            <h2 id="global-search-title" className="global-search__title">Search &amp; commands</h2>
+            <p className="global-search__subtitle">Workspace actions, chats, and installed apps</p>
           </div>
           <button
             type="button"
@@ -418,8 +475,8 @@ export default function GlobalSearch({ onClose, onOpenTarget }) {
               if (contentRef.current) contentRef.current.scrollTop = 0
             }}
             onKeyDown={handleSearchKeyDown}
-            placeholder="Search chats, apps, and app details"
-            aria-label="Search chats, apps, and app details"
+            placeholder="Search commands, chats, apps, and app details"
+            aria-label="Search commands, chats, apps, and app details"
             role="combobox"
             aria-autocomplete="list"
             aria-controls={resultListIds || undefined}
@@ -445,11 +502,11 @@ export default function GlobalSearch({ onClose, onOpenTarget }) {
               <span className="global-search__empty-icon" aria-hidden="true">
                 <MagnifyingGlassSearch width={30} height={30} />
               </span>
-              <h3>{loadingRecentSelections ? 'Loading recent selections…' : 'No recent selections yet'}</h3>
+              <h3>{loadingRecentSelections ? 'Loading workspace actions…' : 'No commands are available'}</h3>
               <p>
                 {loadingRecentSelections
-                  ? 'The chats and apps you opened through search will appear here.'
-                  : 'Search for a chat or app and open it. It will appear here the next time you use ⌘K.'}
+                  ? 'Commands and the chats and apps you opened through search will appear here.'
+                  : 'Search for a command, chat, or app.'}
               </p>
             </div>
           )}

--- a/frontend/src/components/GlobalSearch/__tests__/globalSearchModel.test.js
+++ b/frontend/src/components/GlobalSearch/__tests__/globalSearchModel.test.js
@@ -11,6 +11,7 @@ import {
   rememberRecentSelection,
   resolveRecentSelections,
   resolvedSearchSelection,
+  searchCommands,
   searchInstalledApps,
   visibleChatSearchState,
 } from '../globalSearchModel.js'
@@ -103,6 +104,23 @@ test('all query terms must match and result limits are stable', () => {
   }])
   assert.deepEqual(searchInstalledApps(apps, 'news missing'), [])
   assert.equal(searchInstalledApps(apps, 'news', 1).length, 1)
+})
+
+test('command search covers action copy, keywords, and shortcut labels', () => {
+  const commands = [
+    {
+      id: 'pane.newChat', title: 'New chat pane',
+      description: 'Open a new chat beside the focused pane.',
+      category: 'Tabs and panes', keywords: ['split'], shortcutLabels: ['⌘\\'],
+    },
+    {
+      id: 'history.back', title: 'Go back', description: 'Previous destination.',
+      category: 'Navigation', keywords: ['history'], shortcutLabels: ['⌘,'],
+    },
+  ]
+  assert.deepEqual(searchCommands(commands, 'split pane'), [commands[0]])
+  assert.deepEqual(searchCommands(commands, 'history'), [commands[1]])
+  assert.deepEqual(searchCommands(commands, ''), commands)
 })
 
 test('recent selections persist as a deduplicated most-recent-first list', () => {

--- a/frontend/src/components/GlobalSearch/globalSearchModel.js
+++ b/frontend/src/components/GlobalSearch/globalSearchModel.js
@@ -52,6 +52,21 @@ function includesEvery(text, tokens) {
   return tokens.every(token => text.includes(token))
 }
 
+export function searchCommands(commands, query, limit = 12) {
+  const tokens = queryTokens(query)
+  const rows = Array.isArray(commands) ? commands : []
+  if (!tokens.length) return rows.slice(0, Math.max(0, limit))
+  return rows
+    .filter(command => includesEvery(normalize([
+      command?.title,
+      command?.description,
+      command?.category,
+      ...(Array.isArray(command?.keywords) ? command.keywords : []),
+      ...(Array.isArray(command?.shortcutLabels) ? command.shortcutLabels : []),
+    ].filter(Boolean).join(' ')), tokens))
+    .slice(0, Math.max(0, limit))
+}
+
 export function searchInstalledApps(apps, query, limit = 8) {
   const tokens = queryTokens(query)
   if (!tokens.length) return []

--- a/frontend/src/components/NotificationBell/NotificationCenter.jsx
+++ b/frontend/src/components/NotificationBell/NotificationCenter.jsx
@@ -3,7 +3,6 @@
 import {
   forwardRef,
   useCallback,
-  useEffect,
   useImperativeHandle,
   useRef,
   useState,
@@ -11,15 +10,11 @@ import {
 import { useQueryClient } from '@tanstack/react-query'
 import GlobalSearch, { GlobalSearchButton } from '../GlobalSearch/GlobalSearch.jsx'
 import NotificationsView from '../NotificationsView/NotificationsView.jsx'
-import {
-  SHELL_SHORTCUTS,
-  shortcutMatches,
-} from '../../lib/keyboardShortcuts.js'
 import NotificationBell from './NotificationBell.jsx'
 import useNotificationCenter from './useNotificationCenter.js'
 
 const NotificationCenter = forwardRef(function NotificationCenter(
-  { onOpenTarget },
+  { commands, onOpenTarget, onRunCommand },
   eventActionsRef,
 ) {
   const queryClient = useQueryClient()
@@ -30,13 +25,6 @@ const NotificationCenter = forwardRef(function NotificationCenter(
     actions: { toggle, close, clearAll, reconcile, onCreated },
     meta: { rootRef, bellRef },
   } = useNotificationCenter(queryClient)
-
-  // System events stay a narrow nudge from Shell while all interactive state
-  // remains local to this component.
-  useImperativeHandle(eventActionsRef, () => ({
-    reconcile,
-    onCreated,
-  }), [onCreated, reconcile])
 
   const openTarget = useCallback((target) => {
     close()
@@ -49,6 +37,14 @@ const NotificationCenter = forwardRef(function NotificationCenter(
     setSearchOpen(true)
   }, [close])
 
+  // System events and the shell command dispatcher stay narrow nudges while
+  // all interactive overlay state remains local to this component.
+  useImperativeHandle(eventActionsRef, () => ({
+    reconcile,
+    onCreated,
+    openSearch,
+  }), [onCreated, openSearch, reconcile])
+
   const toggleSearch = useCallback(() => {
     close()
     setSearchOpen(value => !value)
@@ -58,16 +54,6 @@ const NotificationCenter = forwardRef(function NotificationCenter(
     setSearchOpen(false)
     toggle()
   }, [toggle])
-
-  useEffect(() => {
-    const onKeyDown = (event) => {
-      if (!shortcutMatches(event, SHELL_SHORTCUTS.openSearch)) return
-      event.preventDefault()
-      openSearch()
-    }
-    document.addEventListener('keydown', onKeyDown)
-    return () => document.removeEventListener('keydown', onKeyDown)
-  }, [openSearch])
 
   return (
     <div ref={rootRef} className="notification-center">
@@ -91,8 +77,10 @@ const NotificationCenter = forwardRef(function NotificationCenter(
       )}
       {searchOpen && (
         <GlobalSearch
+          commands={commands}
           onClose={() => setSearchOpen(false)}
           onOpenTarget={openTarget}
+          onRunCommand={onRunCommand}
         />
       )}
     </div>

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -158,6 +158,7 @@ import useWorkspaceSession from './useWorkspaceSession.js'
 import useShellReloadController from './useShellReloadController.js'
 import useAppFrameCache from './useAppFrameCache.js'
 import useShellVisualViewport from './useShellVisualViewport.js'
+import useShellShortcuts from '../../hooks/useShellShortcuts.js'
 import ShellBrand from './ShellBrand.jsx'
 import { createMediaSessionOwner } from './mediaSessionOwner.js'
 import { HistoryDismissProvider } from '../../hooks/useHistoryDismiss.jsx'
@@ -222,7 +223,8 @@ export default function Shell({ onInitialVisualReady }) {
     activeChatId,
     drawerOpen, settingsOverlayOpen, settingsOpenRaw, openDrawer, closeDrawer,
     drawerNavigationCover, finishDrawerNavigationPresentation,
-    navTo, tabRevealRevision, applyModeDestination, dismissSettings,
+    navTo, navigateBackward, navigateForward,
+    tabRevealRevision, applyModeDestination, dismissSettings,
     backFiredRef, drawerPushedRef, navStackRef, navigationEpochRef,
     activeViewRef, activeChatIdRef, activeAppIdRef,
     drawerOpenRef,
@@ -1553,50 +1555,117 @@ export default function Shell({ onInitialVisualReady }) {
   // the chord is inert while a cross-origin app iframe holds focus — in that
   // case click into the shell chrome (a strip tab or the divider) first, then
   // press the chord.
+  const applyWorkspaceUndo = useCallback(({ reopenOnly = false } = {}) => {
+    const wsState = workspaceStateRef.current
+    const undoSlot = wsState.undo
+    if (!undoSlot || (reopenOnly && !undoSlot.reopenable)) return false
+    // A mode-restoring undo (single-leaf drop, empty-builder auto-return) routes
+    // through the controller FIRST (INV 2/3) so its re-entry/exit deal fires as
+    // one gesture, not a passive sync a render later.
+    const restoredMode = undoSlot.restoreViewMode
+      ? undoSlot.ws.viewMode : wsState.ws.viewMode
+    if (restoredMode !== wsState.ws.viewMode) {
+      const scene = sceneInputsRef.current
+      const paneWorld = restoredMode === 'panes' ? undoSlot.ws : wsState.ws
+      const paneProjection = restoredMode === 'panes'
+        ? paneModel.projectLayout(paneWorld, scene.mode, scene.contentRect)
+        : scene.projection
+      const plan = deriveModeSnapshotPlan({
+        workspace: paneWorld,
+        projection: paneProjection,
+        contentRect: scene.contentRect,
+      })
+      modeView.run({
+        direction: restoredMode === 'panes' ? 'enter' : 'exit',
+        to: restoredMode,
+        cause: 'undo',
+        plan,
+        update: () => {
+          dispatchWorkspace({ type: 'UNDO_LAST' })
+        },
+      })
+      return true
+    }
+    dispatchWorkspace({ type: 'UNDO_LAST' })
+    return true
+  }, [dispatchWorkspace, modeView])
+
   useEffect(() => {
     const onKey = (e) => {
       if (!undoKeyPressed(e) || isEditableTarget(document.activeElement)) return
       e.preventDefault()
-      // A mode-restoring undo (single-leaf drop, empty-builder auto-return) routes
-      // through the controller FIRST (INV 2/3) so its re-entry/exit deal fires as one
-      // gesture, not a passive sync a render later. undo.restoreViewMode reverts the
-      // snapshot's mode; every other undo carries the current mode forward
-      // (restoredMode === current), so no mode presentation change is needed there. The presentation
-      // plan is built from the tree the beat animates: re-entering builder deals in
-      // the RESTORED tree; exiting to single deals the CURRENT tiled tree out.
-      const wsState = workspaceStateRef.current
-      const undoSlot = wsState.undo
-      if (undoSlot) {
-        const restoredMode = undoSlot.restoreViewMode
-          ? undoSlot.ws.viewMode : wsState.ws.viewMode
-        if (restoredMode !== wsState.ws.viewMode) {
-          const scene = sceneInputsRef.current
-          const paneWorld = restoredMode === 'panes' ? undoSlot.ws : wsState.ws
-          const paneProjection = restoredMode === 'panes'
-            ? paneModel.projectLayout(paneWorld, scene.mode, scene.contentRect)
-            : scene.projection
-          const plan = deriveModeSnapshotPlan({
-            workspace: paneWorld,
-            projection: paneProjection,
-            contentRect: scene.contentRect,
-          })
-          modeView.run({
-            direction: restoredMode === 'panes' ? 'enter' : 'exit',
-            to: restoredMode,
-            cause: 'undo',
-            plan,
-            update: () => {
-              dispatchWorkspace({ type: 'UNDO_LAST' })
-            },
-          })
-          return
-        }
-      }
-      dispatchWorkspace({ type: 'UNDO_LAST' })
+      applyWorkspaceUndo()
     }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
-  }, [dispatchWorkspace, modeView])
+  }, [applyWorkspaceUndo])
+
+  const shortcutFocusedPane = workspace.panes[workspace.focusedPaneId] || null
+  const shortcutBuilderActive = workspace.viewMode === 'panes'
+  const shortcutActions = {
+    'search.open': {
+      run: () => {
+        notificationCenterActionsRef.current?.openSearch()
+        return true
+      },
+    },
+    'chat.new': {
+      run: () => {
+        startUserChat()
+        return true
+      },
+    },
+    'tab.newChat': {
+      run: () => {
+        const ws = workspaceStateRef.current.ws
+        if (ws.viewMode === 'single') {
+          const transition = handleToggleViewMode('shortcut')
+          if (!transition.changed) return false
+        }
+        startUserNewChatPresentation({ forceNew: true })
+        return true
+      },
+    },
+    'tab.close': {
+      enabled: shortcutBuilderActive && !!shortcutFocusedPane?.activeTabKey,
+      unavailableReason: 'Open Builder to close an active tab.',
+      run: () => {
+        const ws = workspaceStateRef.current.ws
+        const pane = ws.panes[ws.focusedPaneId]
+        if (ws.viewMode !== 'panes' || !pane?.activeTabKey) return false
+        dispatchWorkspace({ type: 'CLOSE_TAB', tabKey: pane.activeTabKey })
+        return true
+      },
+    },
+    'workspace.reopenClosed': {
+      enabled: workspaceStateRef.current.undo?.reopenable === true,
+      unavailableReason: 'Close a tab or pane first.',
+      run: () => applyWorkspaceUndo({ reopenOnly: true }),
+    },
+    'pane.newChat': {
+      run: () => {
+        void openNewChatPane()
+        return true
+      },
+    },
+    'pane.close': {
+      enabled: shortcutBuilderActive && !!shortcutFocusedPane,
+      unavailableReason: 'Open Builder to close a pane.',
+      run: () => {
+        const ws = workspaceStateRef.current.ws
+        if (ws.viewMode !== 'panes' || !ws.panes[ws.focusedPaneId]) return false
+        dispatchWorkspace({ type: 'CLOSE_PANE', paneId: ws.focusedPaneId })
+        return true
+      },
+    },
+    'history.back': { run: navigateBackward },
+    'history.forward': { run: navigateForward },
+  }
+  const {
+    commands: shellCommands,
+    frameBindings: shellFrameShortcuts,
+    runAction: runShellShortcut,
+  } = useShellShortcuts(shortcutActions)
 
   // No per-mutation undo toast: the reducer still mints a fresh undo slot on
   // every workspace mutation (its `toast` label included, for the reducer's own
@@ -3298,6 +3367,47 @@ export default function Shell({ onInitialVisualReady }) {
     return startUserNewChatPresentation({ forceNew })
   }
 
+  async function openNewChatPane() {
+    let resolution
+    try {
+      resolution = await resolveNewChatId()
+    } catch (error) {
+      recordClientError({ where: 'new-chat-pane-resolution', error })
+      resolution = { chatId: null, reason: 'error' }
+    }
+    const { chatId, reason } = resolution
+    if (chatId == null) {
+      if (reason === 'offline') showToast("You're offline.")
+      else if (reason === 'error') {
+        showToast("Couldn't open a new chat pane — please try again.", { variant: 'error' })
+      }
+      return false
+    }
+
+    const wsState = workspaceStateRef.current
+    const ws = wsState.ws
+    const action = {
+      type: 'OPEN_TAB_AT',
+      tab: tabModel.makeTab('chat', chatId),
+      target: { paneId: ws.focusedPaneId, edge: 'right' },
+      flipViewMode: ws.viewMode === 'single' ? 'panes' : null,
+      label: 'Opened chat pane',
+    }
+    // Probe the owning pure reducer before dispatch. A max-depth/max-pane
+    // refusal falls back to an ordinary focused tab, so a successfully created
+    // chat is never stranded off-screen.
+    if (paneModel.workspaceReducer(wsState, action) === wsState) {
+      applyModeDestination({
+        view: 'chat', chatId, appId: null, paneId: ws.focusedPaneId,
+      })
+      showToast('No room for another pane — opened the chat in the focused pane.')
+    } else {
+      dispatchWorkspace(action)
+    }
+    requestComposer(chatId, { focus: true, restoreExistingDraft: true })
+    return true
+  }
+
   // Keep the latest-newChat ref current so handleAppError's crash-report
   // fallback starts a chat with this render's live closure.
   newChatRef.current = newChat
@@ -3737,7 +3847,9 @@ export default function Shell({ onInitialVisualReady }) {
           )}
           <NotificationCenter
             ref={notificationCenterActionsRef}
+            commands={shellCommands}
             onOpenTarget={handleNotificationOpen}
+            onRunCommand={runShellShortcut}
           />
         </div>
       </header>
@@ -3975,6 +4087,8 @@ export default function Shell({ onInitialVisualReady }) {
               onAppError={handleAppError}
               onHostRequest={handleAppHostRequest}
               onMediaSession={handleMediaSession}
+              shellShortcuts={shellFrameShortcuts}
+              onShellShortcut={runShellShortcut}
             />
             </ErrorBoundary>
           </div>

--- a/frontend/src/components/Shell/__tests__/notificationCenterOwnership.test.js
+++ b/frontend/src/components/Shell/__tests__/notificationCenterOwnership.test.js
@@ -21,6 +21,9 @@ test('notification toggles are owned below the workspace shell', () => {
   )
   assert.match(center, /useNotificationCenter\(queryClient\)/)
   assert.match(center, /useImperativeHandle\(eventActionsRef/)
+  assert.match(center, /openSearch/)
+  assert.doesNotMatch(center, /document\.addEventListener\('keydown'/)
+  assert.match(shell, /useShellShortcuts\(shortcutActions\)/)
 })
 
 test('closed bell hover styling only applies to precise pointing devices', () => {

--- a/frontend/src/components/Shell/__tests__/paneModel.test.js
+++ b/frontend/src/components/Shell/__tests__/paneModel.test.js
@@ -1091,6 +1091,7 @@ test('CLOSE_PANE closes a whole pane, is undoable, and names itself', () => {
   const closed = paneModel.workspaceReducer(start, { type: 'CLOSE_PANE', paneId })
   assert.equal(Object.keys(closed.ws.panes).length, 1, 'the pane collapsed away')
   assert.equal(closed.undo.toast, 'Closed pane')
+  assert.equal(closed.undo.reopenable, true)
   const undone = paneModel.workspaceReducer(closed, { type: 'UNDO_LAST' })
   assert.equal(undone.ws, ws, 'Undo restores the closed pane and its tabs')
 })
@@ -1256,6 +1257,7 @@ test('reducer CLOSE_TAB reason:deleted clears the slot; a user close snapshots',
     { type: 'CLOSE_TAB', tabKey: 'chat:b' },
   )
   assert.ok(userClose.undo, 'a user close is undoable')
+  assert.equal(userClose.undo.reopenable, true, 'and can power Reopen closed')
   assert.equal(
     paneModel.workspaceReducer(userClose, { type: 'UNDO_LAST' }).ws, seed,
     'and UNDO brings the tab back',

--- a/frontend/src/components/Shell/paneModel.js
+++ b/frontend/src/components/Shell/paneModel.js
@@ -1740,7 +1740,13 @@ export function workspaceReducer(state, action) {
       if (next === ws) return state
       const closeLabel = action.label || 'Closed tab'
       const { ws: closed, autoReturned } = completeCloseTransition(ws, next)
-      return { ws: closed, undo: { ws, label: closeLabel, toast: closeLabel, restoreViewMode: autoReturned } }
+      return {
+        ws: closed,
+        undo: {
+          ws, label: closeLabel, toast: closeLabel,
+          restoreViewMode: autoReturned, reopenable: true,
+        },
+      }
     }
     case 'CLOSE_PANE': {
       // Closing a pane closes all its tabs at once (a keyboard/menu affordance —
@@ -1750,7 +1756,13 @@ export function workspaceReducer(state, action) {
       if (next === ws) return state
       const paneLabel = action.label || 'Closed pane'
       const { ws: closed, autoReturned } = completeCloseTransition(ws, next)
-      return { ws: closed, undo: { ws, label: paneLabel, toast: paneLabel, restoreViewMode: autoReturned } }
+      return {
+        ws: closed,
+        undo: {
+          ws, label: paneLabel, toast: paneLabel,
+          restoreViewMode: autoReturned, reopenable: true,
+        },
+      }
     }
     case 'CLOSE_OTHER_TABS': {
       // Keep only the named tab in its pane. The kept tab survives, so the pane
@@ -1759,19 +1771,19 @@ export function workspaceReducer(state, action) {
       const next = closeOtherTabs(ws, action.tabKey)
       if (next === ws) return state
       const label = action.label || 'Closed other tabs'
-      return { ws: next, undo: { ws, label, toast: label } }
+      return { ws: next, undo: { ws, label, toast: label, reopenable: true } }
     }
     case 'CLOSE_TABS_TO_RIGHT': {
       const next = closeTabsToRight(ws, action.tabKey)
       if (next === ws) return state
       const label = action.label || 'Closed tabs to the right'
-      return { ws: next, undo: { ws, label, toast: label } }
+      return { ws: next, undo: { ws, label, toast: label, reopenable: true } }
     }
     case 'CLOSE_TABS_TO_LEFT': {
       const next = closeTabsToLeft(ws, action.tabKey)
       if (next === ws) return state
       const label = action.label || 'Closed tabs to the left'
-      return { ws: next, undo: { ws, label, toast: label } }
+      return { ws: next, undo: { ws, label, toast: label, reopenable: true } }
     }
     case 'MOVE_TAB': {
       const next = moveTab(ws, action.tabKey, action.target)

--- a/frontend/src/hooks/useNavigation.js
+++ b/frontend/src/hooks/useNavigation.js
@@ -4,6 +4,7 @@ import {
   isMobiusNavState,
   isTopmostAppEntry,
   navEntryId,
+  navEntryIndex,
   navTraversalDirection,
   ownerKeyOf,
   pushNavEntry,
@@ -106,8 +107,9 @@ export const coldRestoredCanvasAppId =
  * Navigation: an ADAPTER above the workspace reducer (design §1 ownership
  * boundary) + drawer-as-virtual-route + custom navStack.
  *
- * **READ ARCHITECTURE.md "Navigation back-stack + drawer model"** and
- * docs/design/split-pane-workspace.md §1/§5 before editing this file.
+ * **READ ARCHITECTURE.md "Workspace model" and "Navigation back-stack +
+ * drawer model"**, plus the focused navigation/workspace tests, before
+ * editing this file.
  *
  * The workspace reducer (paneModel.js) is the single live authority for what is
  * on screen: pane contents, per-pane active tabs, and `focusedPaneId`. This hook
@@ -318,6 +320,11 @@ export default function useNavigation({
   // stays put while traversing iframe-created phantom entries; the next tagged
   // destination can then still be compared with the last shell position.
   const currentNavStateRef = useRef(null)
+  // Highest shell-relative position on the CURRENT forward branch. Every
+  // pushState prunes the browser's former forward branch, so pushShellEntry
+  // replaces (rather than maxes) this value. This gives shortcut-triggered
+  // Forward a shell-owned boundary even where the Navigation API is absent.
+  const furthestNavIndexRef = useRef(navEntryIndex(history.state) ?? 0)
   // Transient shell surfaces (currently the chat image viewer) own real Back
   // sentinels but no route. The callback registry lets handleBack dismiss the
   // exact mounted surface without teaching it about that surface's React state.
@@ -501,6 +508,7 @@ export default function useNavigation({
       appNav,
     })
     currentNavStateRef.current = state
+    furthestNavIndexRef.current = navEntryIndex(state) ?? furthestNavIndexRef.current
     return state
   }, [])
 
@@ -1229,6 +1237,7 @@ export default function useNavigation({
         ? navRoute('chat', lastChatIdRef.current, null, bootPaneId)
         : initialRoute
       currentNavStateRef.current = replaceNavEntry('base', '/shell/', baseRoute)
+      furthestNavIndexRef.current = navEntryIndex(currentNavStateRef.current) ?? 0
 
       // Seed HOME as the back-stack root when this load booted into a deep
       // destination (canvas/settings) so Back always reaches the chat surface.
@@ -1422,6 +1431,8 @@ export default function useNavigation({
               currentState: committed || registration.returnState,
               entryId: sourceEntryId,
             })
+            furthestNavIndexRef.current = navEntryIndex(rearmed)
+              ?? furthestNavIndexRef.current
           }
           if (rearmed) {
             currentNavStateRef.current = rearmed
@@ -1828,6 +1839,37 @@ export default function useNavigation({
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
+  const navigateBackward = useCallback(() => {
+    const current = currentNavStateRef.current
+    const hasShellTarget = navStackRef.current.length > 0
+      || drawerOpenRef.current
+      || current?.kind === 'drawer'
+      || current?.kind === 'dismissible'
+      || current?.kind === 'app'
+      || _anyAppHasSentinels(appSentinelCountsRef.current)
+      || appLocalPopsRef.current.length > 0
+    if (!hasShellTarget) return false
+    if (typeof navigation !== 'undefined' && navigation.canGoBack === false) return false
+    try {
+      history.back()
+      return true
+    } catch {
+      return false
+    }
+  }, [])
+
+  const navigateForward = useCallback(() => {
+    const currentIndex = navEntryIndex(currentNavStateRef.current)
+    if (currentIndex == null || currentIndex >= furthestNavIndexRef.current) return false
+    if (typeof navigation !== 'undefined' && navigation.canGoForward === false) return false
+    try {
+      history.forward()
+      return true
+    } catch {
+      return false
+    }
+  }, [])
+
   // Keep the current physical entry self-contained. snapshotRoute() re-stamps
   // the current focused pane + content ids; a derived projection cannot be
   // repaired by a scalar setter, so this only refreshes the entry's route.
@@ -1886,6 +1928,8 @@ export default function useNavigation({
     closeDrawer,
     finishDrawerNavigationPresentation,
     navTo,
+    navigateBackward,
+    navigateForward,
     tabRevealRevision,
     applyModeDestination,
     dismissSettings,

--- a/frontend/src/hooks/useShellShortcuts.js
+++ b/frontend/src/hooks/useShellShortcuts.js
@@ -3,6 +3,7 @@ import {
   findShellShortcut,
   frameShortcutBindings,
   resolveShellCommands,
+  shouldReserveShellShortcut,
   shortcutLabel,
   shortcutLockCodes,
 } from '../lib/keyboardShortcuts.js'
@@ -13,6 +14,7 @@ export default function useShellShortcuts(actions) {
   actionsRef.current = actions
 
   const catalog = useMemo(() => resolveShellCommands(), [])
+  const standalone = isStandaloneDisplay()
   const runAction = useCallback((actionId) => {
     const action = actionsRef.current?.[actionId]
     if (!action || action.enabled === false || typeof action.run !== 'function') return false
@@ -23,16 +25,17 @@ export default function useShellShortcuts(actions) {
     const onKeyDown = (event) => {
       const command = findShellShortcut(event, catalog)
       if (!command) return
-      // A reserved chord belongs to the shell even when its action is currently
-      // unavailable. Preventing the native default keeps Cmd+W from closing the
-      // installed app just because Standard mode has no closable Builder tab.
+      const handled = runAction(command.id)
+      // An unavailable chord is reserved only in an installed display, where
+      // allowing Cmd/Ctrl+W through would close the whole app. In an ordinary
+      // browser tab, preserve the browser/app default when Möbius did nothing.
+      if (!shouldReserveShellShortcut(handled, standalone)) return
       event.preventDefault()
       event.stopImmediatePropagation?.()
-      runAction(command.id)
     }
     document.addEventListener('keydown', onKeyDown, true)
     return () => document.removeEventListener('keydown', onKeyDown, true)
-  }, [catalog, runAction])
+  }, [catalog, runAction, standalone])
 
   // Browser-reserved chords are not uniformly overridable by web content. In an
   // installed display, make one best-effort Keyboard Lock request from the first
@@ -69,6 +72,16 @@ export default function useShellShortcuts(actions) {
     }
   }), [actions, catalog])
 
-  const frameBindings = useMemo(() => frameShortcutBindings(catalog), [catalog])
+  const disabledFrameActionIds = commands
+    .filter(command => command.enabled === false)
+    .map(command => command.id)
+    .join('\u0000')
+  const frameBindings = useMemo(() => {
+    const disabled = new Set(disabledFrameActionIds.split('\u0000').filter(Boolean))
+    return frameShortcutBindings(catalog.map(command => ({
+      ...command,
+      enabled: !disabled.has(command.id),
+    })), { reserveUnavailable: standalone })
+  }, [catalog, disabledFrameActionIds, standalone])
   return { commands, frameBindings, runAction }
 }

--- a/frontend/src/hooks/useShellShortcuts.js
+++ b/frontend/src/hooks/useShellShortcuts.js
@@ -1,0 +1,74 @@
+import { useCallback, useEffect, useMemo, useRef } from 'react'
+import {
+  findShellShortcut,
+  frameShortcutBindings,
+  resolveShellCommands,
+  shortcutLabel,
+  shortcutLockCodes,
+} from '../lib/keyboardShortcuts.js'
+import { isStandaloneDisplay } from '../utils/installPlatform.js'
+
+export default function useShellShortcuts(actions) {
+  const actionsRef = useRef(actions)
+  actionsRef.current = actions
+
+  const catalog = useMemo(() => resolveShellCommands(), [])
+  const runAction = useCallback((actionId) => {
+    const action = actionsRef.current?.[actionId]
+    if (!action || action.enabled === false || typeof action.run !== 'function') return false
+    return action.run() !== false
+  }, [])
+
+  useEffect(() => {
+    const onKeyDown = (event) => {
+      const command = findShellShortcut(event, catalog)
+      if (!command) return
+      // A reserved chord belongs to the shell even when its action is currently
+      // unavailable. Preventing the native default keeps Cmd+W from closing the
+      // installed app just because Standard mode has no closable Builder tab.
+      event.preventDefault()
+      event.stopImmediatePropagation?.()
+      runAction(command.id)
+    }
+    document.addEventListener('keydown', onKeyDown, true)
+    return () => document.removeEventListener('keydown', onKeyDown, true)
+  }, [catalog, runAction])
+
+  // Browser-reserved chords are not uniformly overridable by web content. In an
+  // installed display, make one best-effort Keyboard Lock request from the first
+  // trusted pointer gesture. Unsupported/denied engines simply retain the
+  // command-palette fallback and every chord the document does receive.
+  useEffect(() => {
+    const keyboard = navigator.keyboard
+    const codes = shortcutLockCodes(catalog)
+    if (!isStandaloneDisplay() || !keyboard?.lock || !codes.length) return undefined
+    let live = true
+    let locked = false
+    const tryLock = () => {
+      window.removeEventListener('pointerdown', tryLock, true)
+      Promise.resolve(keyboard.lock(codes)).then(() => {
+        if (!live) keyboard.unlock?.()
+        else locked = true
+      }).catch(() => {})
+    }
+    window.addEventListener('pointerdown', tryLock, { capture: true, once: true })
+    return () => {
+      live = false
+      window.removeEventListener('pointerdown', tryLock, true)
+      if (locked) keyboard.unlock?.()
+    }
+  }, [catalog])
+
+  const commands = useMemo(() => catalog.map(command => {
+    const action = actions?.[command.id]
+    return {
+      ...command,
+      enabled: action?.enabled !== false && typeof action?.run === 'function',
+      unavailableReason: action?.unavailableReason || '',
+      shortcutLabels: command.bindings.map(binding => shortcutLabel(binding)),
+    }
+  }), [actions, catalog])
+
+  const frameBindings = useMemo(() => frameShortcutBindings(catalog), [catalog])
+  return { commands, frameBindings, runAction }
+}

--- a/frontend/src/lib/__tests__/keyboardShortcuts.test.js
+++ b/frontend/src/lib/__tests__/keyboardShortcuts.test.js
@@ -6,6 +6,7 @@ import {
   frameShortcutBindings,
   resolveShellCommands,
   shortcutLabel,
+  shouldReserveShellShortcut,
   shortcutLockCodes,
   shortcutMatches,
 } from '../keyboardShortcuts.js'
@@ -38,6 +39,26 @@ test('only advertised global commands cross the mini-app boundary', () => {
   assert.deepEqual(shortcutLockCodes(commands), [
     'KeyK', 'KeyN', 'KeyT', 'KeyW', 'Backslash', 'Comma', 'Period',
   ])
+})
+
+test('disabled chords keep native browser behavior but stay reserved in an installed app', () => {
+  const commands = resolveShellCommands().map(command => ({
+    ...command,
+    enabled: command.id !== 'tab.close',
+  }))
+
+  assert.equal(
+    frameShortcutBindings(commands).some(item => item.actionId === 'tab.close'),
+    false,
+  )
+  assert.equal(
+    frameShortcutBindings(commands, { reserveUnavailable: true })
+      .some(item => item.actionId === 'tab.close'),
+    true,
+  )
+  assert.equal(shouldReserveShellShortcut(false, false), false)
+  assert.equal(shouldReserveShellShortcut(true, false), true)
+  assert.equal(shouldReserveShellShortcut(false, true), true)
 })
 
 test('shortcut labels adapt to the owner platform', () => {

--- a/frontend/src/lib/__tests__/keyboardShortcuts.test.js
+++ b/frontend/src/lib/__tests__/keyboardShortcuts.test.js
@@ -2,7 +2,11 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 import {
   SHELL_SHORTCUTS,
+  findShellShortcut,
+  frameShortcutBindings,
+  resolveShellCommands,
   shortcutLabel,
+  shortcutLockCodes,
   shortcutMatches,
 } from '../keyboardShortcuts.js'
 
@@ -16,9 +20,30 @@ test('search uses the conventional Cmd/Ctrl+K chord without stealing variants', 
   assert.equal(shortcutMatches({ metaKey: true, key: 'k', repeat: true }, shortcut), false)
 })
 
+test('the command catalog distinguishes new chat from a new Builder tab', () => {
+  const commands = resolveShellCommands()
+  assert.equal(findShellShortcut({ metaKey: true, key: 'n' }, commands)?.id, 'chat.new')
+  assert.equal(findShellShortcut({ metaKey: true, key: 't' }, commands)?.id, 'tab.newChat')
+  assert.equal(findShellShortcut({ metaKey: true, shiftKey: true, key: 't' }, commands)?.id, 'workspace.reopenClosed')
+  assert.equal(findShellShortcut({ metaKey: true, altKey: true, key: 't' }, commands), null)
+})
+
+test('only advertised global commands cross the mini-app boundary', () => {
+  const commands = resolveShellCommands()
+  const frameBindings = frameShortcutBindings(commands)
+  assert.ok(frameBindings.some(item => item.actionId === 'search.open'))
+  assert.ok(frameBindings.some(item => item.actionId === 'history.forward'))
+  assert.equal(frameBindings.some(item => item.actionId === 'workspace.undo'), false)
+  assert.equal(frameBindings.some(item => item.binding.key === 'z'), false)
+  assert.deepEqual(shortcutLockCodes(commands), [
+    'KeyK', 'KeyN', 'KeyT', 'KeyW', 'Backslash', 'Comma', 'Period',
+  ])
+})
+
 test('shortcut labels adapt to the owner platform', () => {
   assert.equal(shortcutLabel(SHELL_SHORTCUTS.openSearch, 'MacIntel'), '⌘K')
   assert.equal(shortcutLabel(SHELL_SHORTCUTS.openSearch, 'Win32'), 'Ctrl+K')
   assert.equal(shortcutLabel(SHELL_SHORTCUTS.toggleBuilder, 'MacIntel'), '⇧↵')
   assert.equal(shortcutLabel(SHELL_SHORTCUTS.toggleBuilder, 'Linux x86_64'), 'Shift+Enter')
+  assert.equal(shortcutLabel({ key: ',', mod: true }, 'MacIntel'), '⌘,')
 })

--- a/frontend/src/lib/__tests__/shellShortcutBridge.test.js
+++ b/frontend/src/lib/__tests__/shellShortcutBridge.test.js
@@ -1,0 +1,14 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { attributedShellShortcutAction } from '../../components/AppCanvas/appFrameProtocol.js'
+
+test('the frame bridge accepts only action ids advertised by its shell host', () => {
+  const advertised = [{ actionId: 'search.open', binding: { key: 'k', mod: true } }]
+  assert.equal(attributedShellShortcutAction({
+    type: 'moebius:shell-shortcut', actionId: 'search.open',
+  }, advertised), 'search.open')
+  assert.equal(attributedShellShortcutAction({
+    type: 'moebius:shell-shortcut', actionId: 'chat.new',
+  }, advertised), null)
+  assert.equal(attributedShellShortcutAction({ type: 'other' }, advertised), null)
+})

--- a/frontend/src/lib/keyboardShortcuts.js
+++ b/frontend/src/lib/keyboardShortcuts.js
@@ -1,15 +1,142 @@
-/* Shell shortcut bindings stay centralized so matching and labels cannot drift. */
+/*
+ * Shell keyboard commands have one declarative catalog. The shell dispatcher,
+ * command palette, app-frame bridge, and labels all consume this same data
+ * rather than growing parallel key listeners.
+ */
 
-export const SHELL_SHORTCUTS = {
-  openSearch: { key: 'k', mod: true },
-  undoWorkspace: { key: 'z', mod: true },
-  toggleBuilder: { key: 'Enter', shift: true },
+const DEFAULT_BINDINGS = Object.freeze({
+  openSearch: Object.freeze({ key: 'k', code: 'KeyK', mod: true }),
+  newChat: Object.freeze({ key: 'n', code: 'KeyN', mod: true }),
+  newTab: Object.freeze({ key: 't', code: 'KeyT', mod: true }),
+  closeTab: Object.freeze({ key: 'w', code: 'KeyW', mod: true }),
+  reopenClosed: Object.freeze({ key: 't', code: 'KeyT', mod: true, shift: true }),
+  newPane: Object.freeze({ key: '\\', code: 'Backslash', mod: true }),
+  closePane: Object.freeze({ key: 'w', code: 'KeyW', mod: true, shift: true }),
+  historyBack: Object.freeze({ key: ',', code: 'Comma', mod: true }),
+  historyForward: Object.freeze({ key: '.', code: 'Period', mod: true }),
+  undoWorkspace: Object.freeze({ key: 'z', code: 'KeyZ', mod: true }),
+  toggleBuilder: Object.freeze({ key: 'Enter', code: 'Enter', shift: true }),
+})
+
+// Compatibility names for focused, non-general gestures that still have their
+// own interaction owner (workspace undo and the logo's Builder toggle).
+export const SHELL_SHORTCUTS = Object.freeze({
+  openSearch: DEFAULT_BINDINGS.openSearch,
+  undoWorkspace: DEFAULT_BINDINGS.undoWorkspace,
+  toggleBuilder: DEFAULT_BINDINGS.toggleBuilder,
+})
+
+export const SHELL_COMMAND_DEFINITIONS = Object.freeze([
+  {
+    id: 'search.open',
+    title: 'Search and commands',
+    description: 'Find chats, apps, and workspace actions.',
+    category: 'Workspace',
+    keywords: ['command palette', 'find', 'open'],
+    bindings: [DEFAULT_BINDINGS.openSearch],
+    captureInMiniApps: true,
+  },
+  {
+    id: 'chat.new',
+    title: 'New chat',
+    description: 'Start a new chat in the current workspace.',
+    category: 'Chats',
+    keywords: ['compose'],
+    bindings: [DEFAULT_BINDINGS.newChat],
+    captureInMiniApps: true,
+  },
+  {
+    id: 'tab.newChat',
+    title: 'New chat tab',
+    description: 'Open a new chat as a Builder tab.',
+    category: 'Tabs and panes',
+    keywords: ['new tab', 'open tab'],
+    bindings: [DEFAULT_BINDINGS.newTab],
+    captureInMiniApps: true,
+  },
+  {
+    id: 'tab.close',
+    title: 'Close active tab',
+    description: 'Close the active Builder tab.',
+    category: 'Tabs and panes',
+    keywords: ['remove tab'],
+    bindings: [DEFAULT_BINDINGS.closeTab],
+    captureInMiniApps: true,
+  },
+  {
+    id: 'workspace.reopenClosed',
+    title: 'Reopen last closed',
+    description: 'Restore the most recently closed tab or pane.',
+    category: 'Tabs and panes',
+    keywords: ['undo close', 'restore tab', 'restore pane'],
+    bindings: [DEFAULT_BINDINGS.reopenClosed],
+    captureInMiniApps: true,
+  },
+  {
+    id: 'pane.newChat',
+    title: 'New chat pane',
+    description: 'Open a new chat beside the focused pane.',
+    category: 'Tabs and panes',
+    keywords: ['split pane', 'open pane'],
+    bindings: [DEFAULT_BINDINGS.newPane],
+    captureInMiniApps: true,
+  },
+  {
+    id: 'pane.close',
+    title: 'Close focused pane',
+    description: 'Close the focused pane and all of its tabs.',
+    category: 'Tabs and panes',
+    keywords: ['remove pane'],
+    bindings: [DEFAULT_BINDINGS.closePane],
+    captureInMiniApps: true,
+  },
+  {
+    id: 'history.back',
+    title: 'Go back',
+    description: 'Return to the previous workspace destination.',
+    category: 'Navigation',
+    keywords: ['history previous'],
+    bindings: [DEFAULT_BINDINGS.historyBack],
+    captureInMiniApps: true,
+  },
+  {
+    id: 'history.forward',
+    title: 'Go forward',
+    description: 'Move forward through workspace history.',
+    category: 'Navigation',
+    keywords: ['history next'],
+    bindings: [DEFAULT_BINDINGS.historyForward],
+    captureInMiniApps: true,
+  },
+])
+
+export function normalizeShortcutBinding(binding) {
+  if (!binding || typeof binding !== 'object') return null
+  const key = typeof binding.key === 'string' ? binding.key.trim() : ''
+  if (!key || key.length > 32) return null
+  const code = typeof binding.code === 'string' && binding.code.length <= 32
+    ? binding.code.trim()
+    : ''
+  return {
+    key,
+    ...(code ? { code } : {}),
+    mod: binding.mod === true,
+    shift: binding.shift === true,
+    alt: binding.alt === true,
+  }
+}
+
+export function resolveShellCommands() {
+  return SHELL_COMMAND_DEFINITIONS.map(definition => ({
+    ...definition,
+    bindings: definition.bindings.map(normalizeShortcutBinding).filter(Boolean),
+  }))
 }
 
 export function shortcutMatches(event, binding) {
   if (!event || !binding || event.isComposing || event.repeat) return false
-  const eventKey = typeof event.key === 'string' ? event.key.toLowerCase() : ''
-  const bindingKey = String(binding.key || '').toLowerCase()
+  const eventKey = typeof event.key === 'string' ? event.key.toLocaleLowerCase() : ''
+  const bindingKey = String(binding.key || '').toLocaleLowerCase()
   if (!bindingKey || eventKey !== bindingKey) return false
 
   const hasMod = Boolean(event.metaKey || event.ctrlKey)
@@ -19,6 +146,35 @@ export function shortcutMatches(event, binding) {
   return true
 }
 
+export function findShellShortcut(event, commands) {
+  for (const command of Array.isArray(commands) ? commands : []) {
+    if (command.bindings?.some(binding => shortcutMatches(event, binding))) return command
+  }
+  return null
+}
+
+export function frameShortcutBindings(commands) {
+  return (Array.isArray(commands) ? commands : []).flatMap(command => (
+    command.captureInMiniApps
+      ? command.bindings.map(binding => ({ actionId: command.id, binding }))
+      : []
+  ))
+}
+
+export function shortcutLockCodes(commands) {
+  return [...new Set(frameShortcutBindings(commands).map(({ binding }) => (
+    binding.code || null
+  )).filter(Boolean))]
+}
+
+function displayKey(key, apple) {
+  if (key === 'Enter') return apple ? '↵' : 'Enter'
+  if (key === '\\') return '\\'
+  if (key === ',') return ','
+  if (key === '.') return '.'
+  return String(key || '').toLocaleUpperCase()
+}
+
 export function shortcutLabel(binding, platform = globalThis.navigator?.platform || '') {
   if (!binding) return ''
   const apple = /Mac|iPhone|iPad|iPod/i.test(platform)
@@ -26,9 +182,7 @@ export function shortcutLabel(binding, platform = globalThis.navigator?.platform
   if (binding.mod) parts.push(apple ? '⌘' : 'Ctrl')
   if (binding.alt) parts.push(apple ? '⌥' : 'Alt')
   if (binding.shift) parts.push(apple ? '⇧' : 'Shift')
-  const key = binding.key === 'Enter'
-    ? (apple ? '↵' : 'Enter')
-    : String(binding.key || '').toUpperCase()
+  const key = displayKey(binding.key, apple)
   if (key) parts.push(key)
   return apple ? parts.join('') : parts.join('+')
 }

--- a/frontend/src/lib/keyboardShortcuts.js
+++ b/frontend/src/lib/keyboardShortcuts.js
@@ -153,12 +153,16 @@ export function findShellShortcut(event, commands) {
   return null
 }
 
-export function frameShortcutBindings(commands) {
+export function frameShortcutBindings(commands, { reserveUnavailable = false } = {}) {
   return (Array.isArray(commands) ? commands : []).flatMap(command => (
-    command.captureInMiniApps
+    command.captureInMiniApps && (reserveUnavailable || command.enabled !== false)
       ? command.bindings.map(binding => ({ actionId: command.id, binding }))
       : []
   ))
+}
+
+export function shouldReserveShellShortcut(handled, standalone) {
+  return handled === true || standalone === true
 }
 
 export function shortcutLockCodes(commands) {


### PR DESCRIPTION
## Summary

- Turn the existing search surface into a command palette for common chat, tab, pane, and history actions.
- Keep one declarative shortcut catalog shared by shell dispatch, displayed labels, and focused mini-app frames.
- Preserve editor shortcuts and accept mini-app shortcut messages only from the live, visible, interactive frame for actions the shell advertised.
- Add safe reopen-closed behavior and best-effort keyboard locking for installed app displays, with palette fallbacks where browsers reserve a chord.

## Testing

- `npm test` — passed (2,658 frontend library tests and 87 hook tests, plus structural prechecks)
- `npm run build` — production and offline/PWA builds passed
- `git diff --check`