### PR TITLE
Add reply-to-quote drafts to the chat composer

### DIFF
--- a/frontend/src/components/ChatView/ChatInputBar.jsx
+++ b/frontend/src/components/ChatView/ChatInputBar.jsx
@@ -97,6 +97,8 @@ import {
 } from './composerShortcuts.js'
 import { isTouchPrimary } from '../../lib/pointerPrimary.js'
 import SlashMenu from './SlashMenu.jsx'
+import ReplyChips from './ReplyChips.jsx'
+import ReplySelectionRow from './ReplySelectionRow.jsx'
 import {
   applySlashCommand,
   matchSlashCommands,
@@ -453,6 +455,14 @@ function FileChips({ files, onRemove, chatId }) {
  *   pendingFiles       — file upload chips state
  *   onAddFiles         — receives FileList from file picker
  *   onRemoveFile       — receives chip id
+ *   pendingReplies     — stacked reply-to-quote drafts (see ReplyChips /
+ *                        replyQuotes.js). Rendered above the input row;
+ *                        bundled into the next send by ChatView, not here.
+ *   onRemoveReply      — receives a reply id
+ *   selectedAssistantText — live selection text from an assistant message
+ *                        (see assistantSelection.js), or null. Renders the
+ *                        "Reply to selection" row above the input row.
+ *   onReplyToSelection — tapped on that row; opens ReplyNoteEditor
  *   leftButtons        — buttons rendered to the LEFT of the pill
  *                        (e.g., <ComposerPopover /> — owns its own
  *                        "+" trigger; the bar no longer ships a
@@ -508,6 +518,10 @@ export default function ChatInputBar({
   pendingFiles,
   onAddFiles,
   onRemoveFile,
+  pendingReplies = [],
+  onRemoveReply,
+  selectedAssistantText,
+  onReplyToSelection,
   leftButtons,
   rightButtons,
   attachTriggerRef,
@@ -630,8 +644,10 @@ export default function ChatInputBar({
 
   // A completed attachment is a complete message in its own right. Feed that
   // through the same primary-action and keyboard-shortcut gate as typed text
-  // so an image/file-only draft exposes Send instead of Mic.
-  const hasInput = hasSendablePayload(input, pendingFiles)
+  // so an image/file-only draft exposes Send instead of Mic. A stacked reply
+  // is the same: it becomes real message text on send, so its presence alone
+  // must expose Send even with an otherwise-empty textarea.
+  const hasInput = hasSendablePayload(input, pendingFiles) || pendingReplies.length > 0
   const hasUploading = pendingFiles?.some(c => c.status === 'uploading') ?? false
 
   function restoreFocusAfterFilePicker() {
@@ -860,6 +876,8 @@ export default function ChatInputBar({
         listId={slashListId}
         optionId={slashOptionId}
       />
+      <ReplySelectionRow selectedText={selectedAssistantText} onReply={onReplyToSelection} />
+      <ReplyChips replies={pendingReplies} onRemove={onRemoveReply} />
       <div className="chat__input-row">
         {leftButtons}
         <div className={`chat__pill${hasFiles ? ' chat__pill--with-attach' : ''}`}>

--- a/frontend/src/components/ChatView/ChatView.css
+++ b/frontend/src/components/ChatView/ChatView.css
@@ -2116,7 +2116,9 @@
 .chat__foot .slash-menu,
 .chat__foot .chat__pill,
 .chat__foot .composer-plus,
-.chat__foot .chat__usage-strip { pointer-events: auto; }
+.chat__foot .chat__usage-strip,
+.chat__foot .chat__reply-select-row,
+.chat__foot .chat__reply-tray { pointer-events: auto; }
 
 /* One geometry-neutral stack for every control that floats above the measured
    footer. The safe default keeps transient-only controls clear of the composer.
@@ -4091,4 +4093,214 @@
   position: absolute;
   /* chat__attach-card-remove is 20×20; expand to 40px on each axis */
   inset: -10px;
+}
+
+/* ── Reply-to-quote: selection row, stacked chip tray, note editor ─────────
+   See assistantSelection.js / ReplySelectionRow.jsx / ReplyChips.jsx /
+   ReplyNoteEditor.jsx. Deliberately kept OUT of .chat__pill (the file-attach
+   tray's growth-cap geometry above is load-bearing for keyboard-viewport
+   math); both render as their own rows above .chat__input-row instead, so
+   neither participates in --composer-reserve/--composer-room at all.
+
+   The selection row lives in the COMPOSER, not floating over the transcript
+   or pinned elsewhere on screen: earlier attempts at a toolbar positioned
+   near (or fixed away from) the selection either collided with the OS's own
+   copy/paste callout or just read as a stray floating pill with no clear
+   home. The composer is already the expected landing spot for "things about
+   to join my next message" (file chips, reply chips) — this is the same
+   idea one step earlier, for the selection that hasn't become a chip yet. */
+.chat__reply-select-row {
+  /* Same opaque material as the pill/+ button pair (CONTRACT #4 above) —
+     this sits in the transparent gutter beside them, not inside the pill
+     itself, so it needs its own backdrop or scrolling transcript text
+     shows straight through it. */
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  max-width: fit-content;
+  box-sizing: border-box;
+  background: color-mix(in srgb, var(--surface) 92%, transparent);
+  backdrop-filter: blur(16px) saturate(140%);
+  color: var(--accent);
+  border: 1px solid var(--border-light);
+  border-radius: 999px;
+  padding: 7px 14px 7px 10px;
+  margin: 0 0 6px;
+  font-size: 13px;
+  font-weight: 500;
+  text-align: left;
+  cursor: pointer;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.18);
+}
+.chat__reply-select-row:hover,
+.chat__reply-select-row:focus-visible {
+  background: var(--surface2);
+}
+.chat__reply-select-row-icon { flex-shrink: 0; opacity: 0.9; }
+.chat__reply-select-row-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chat__reply-tray {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  padding: 0 2px 6px;
+}
+
+.chat__reply-chip {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  max-width: 220px;
+  background: var(--surface2);
+  border: 1px solid var(--border-light);
+  border-radius: 999px;
+  padding: 5px 22px 5px 10px;
+  font-size: 12px;
+  color: var(--text);
+}
+.chat__reply-chip-icon {
+  flex-shrink: 0;
+  color: var(--accent);
+  opacity: 0.9;
+}
+.chat__reply-chip-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.chat__reply-chip-remove {
+  position: absolute;
+  top: 50%;
+  right: 4px;
+  transform: translateY(-50%);
+  width: 16px;
+  height: 16px;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.6);
+  color: #fff;
+  font-size: 12px;
+  border: none;
+  cursor: pointer;
+}
+[data-theme="light"] .chat__reply-chip-remove {
+  background: rgba(0, 0, 0, 0.35);
+}
+.chat__reply-chip-remove::after {
+  content: '';
+  position: absolute;
+  /* 16×16 visual control, expanded to a real 36px tap target */
+  inset: -10px;
+}
+
+.chat__reply-editor-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.50);
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  z-index: 1000;
+  padding: 16px;
+  padding-bottom: max(16px, env(safe-area-inset-bottom, 0px));
+  box-sizing: border-box;
+}
+[data-theme="light"] .chat__reply-editor-overlay {
+  background: rgba(15, 18, 25, 0.32);
+}
+@media (min-width: 640px) {
+  .chat__reply-editor-overlay { align-items: center; }
+}
+
+.chat__reply-editor {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  width: min(420px, 100%);
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.35);
+}
+.chat__reply-editor-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.chat__reply-editor-title {
+  font-size: 15px;
+  font-weight: 600;
+  margin: 0;
+}
+.chat__reply-editor-close {
+  background: transparent;
+  border: none;
+  color: var(--muted);
+  font-size: 20px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 4px;
+}
+.chat__reply-editor-quote {
+  margin: 0;
+  padding: 8px 10px;
+  border-left: 3px solid var(--accent);
+  background: var(--surface2);
+  border-radius: 8px;
+  font-size: 13px;
+  color: var(--muted);
+  font-style: italic;
+  max-height: 5.6em;
+  overflow-y: auto;
+}
+.chat__reply-editor-input {
+  width: 100%;
+  box-sizing: border-box;
+  resize: vertical;
+  min-height: 64px;
+  background: var(--surface2);
+  color: var(--text);
+  border: 1px solid var(--border-light);
+  border-radius: 10px;
+  padding: 10px 12px;
+  font-size: 14px;
+  font-family: var(--font);
+}
+.chat__reply-editor-input:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+.chat__reply-editor-foot {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+.chat__reply-editor-btn {
+  background: var(--accent);
+  color: var(--accent-fg, #ffffff);
+  border: 1px solid var(--accent);
+  border-radius: 999px;
+  padding: 8px 16px;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+}
+.chat__reply-editor-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.chat__reply-editor-btn--ghost {
+  background: var(--surface);
+  color: var(--text);
+  border-color: var(--border);
 }

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -40,6 +40,9 @@ import useComposerDraftState from './hooks/useComposerDraftState.js'
 import useChatRuntimePolicy from './hooks/useChatRuntimePolicy.js'
 import useOffscreenNudge, { useNudgeTargetRef } from './hooks/useOffscreenNudge.js'
 import ChatInputBar from './ChatInputBar.jsx'
+import ReplyNoteEditor from './ReplyNoteEditor.jsx'
+import { useAssistantSelection } from './assistantSelection.js'
+import { makeReplyId, formatPendingRepliesForSend } from './replyQuotes.js'
 import { hasSendablePayload } from './composerSubmission.js'
 import AgentContextInspector from './AgentContextInspector.jsx'
 import ChatSummaryViewer from './ChatSummaryViewer.jsx'
@@ -629,6 +632,33 @@ export default function ChatView({
     setArmedWaits(Array.isArray(runtime?.waits) ? runtime.waits : [])
   }, [chatId, queryClient])
 
+  // Stacked "reply to a quote" drafts (ReplySelectionRow → ReplyNoteEditor
+  // → ReplyChips) — session-only state, mirroring pendingFiles' shape but
+  // deliberately NOT routed through useComposerDraftState: nothing here
+  // survives a reload, only a chat switch. replyDraftQuote holds the quote
+  // text between "Reply" tapped and the note actually saved (or cancelled).
+  const [pendingReplies, setPendingReplies] = useState([])
+  const [replyDraftQuote, setReplyDraftQuote] = useState(null)
+  useEffect(() => {
+    setPendingReplies([])
+    setReplyDraftQuote(null)
+  }, [chatId])
+  const handleReplySelected = useCallback((quoteText) => {
+    setReplyDraftQuote(quoteText)
+    // Release the live selection now that its text is captured — leaving it
+    // highlighted while the note editor sits on top just invites the owner
+    // to re-trigger the OS's own copy/paste callout on top of our dialog.
+    window.getSelection?.()?.removeAllRanges()
+  }, [])
+  const handleReplyNoteSave = useCallback((note) => {
+    setPendingReplies(prev => [...prev, { id: makeReplyId(), quote: replyDraftQuote, note }])
+    setReplyDraftQuote(null)
+  }, [replyDraftQuote])
+  const handleReplyNoteCancel = useCallback(() => setReplyDraftQuote(null), [])
+  const handleReplyRemove = useCallback((id) => {
+    setPendingReplies(prev => prev.filter(r => r.id !== id))
+  }, [])
+
   useEffect(() => {
     let cancelled = false
     if (!activeGoalObjective) {
@@ -663,6 +693,10 @@ export default function ChatView({
 
   // DOM refs
   const scrollRef = useRef(null)
+  // Live text selection inside an assistant message, or null. Drives
+  // ReplySelectionRow (rendered by ChatInputBar, not floated over the
+  // transcript — see assistantSelection.js for why).
+  const selectedAssistantText = useAssistantSelection(scrollRef)
   const spacerRef = useRef(null)
   const lastUserMsgRef = useRef(null)
   // Stable callback ref attached to the last user message <div>. An
@@ -3315,6 +3349,16 @@ export default function ChatView({
     }
   }, [streamSend, commitMessages, fetchMessages, freezeQuestionSubmission])
 
+  // Stacked replies become plain visible message text, prepended ahead of
+  // whatever the owner typed — never a hidden augmentation. Cleared
+  // optimistically at submit time, same spirit as doSend's own
+  // clearComposerFilesForSend: a failed send still restores the FULL
+  // combined text into the plain textarea (doSend's restoreComposerText),
+  // so nothing is silently lost, it just loses its chip identity on retry.
+  function composerTextWithReplies() {
+    return formatPendingRepliesForSend(pendingReplies) + input.trim()
+  }
+
   function handleSubmit(e) {
     e.preventDefault()
     if (isProviderSwitchBlocking(chatId)) return
@@ -3322,7 +3366,9 @@ export default function ChatView({
       setModelSelectionRequest(request => request + 1)
       return
     }
-    doSend(input.trim())
+    const text = composerTextWithReplies()
+    setPendingReplies([])
+    doSend(text)
   }
 
   function handleSubmitSteer(e) {
@@ -3334,7 +3380,9 @@ export default function ChatView({
     }
     if (submitSteerInFlightRef.current) return
     submitSteerInFlightRef.current = true
-    void doSend(input.trim(), { directSteer: true })
+    const text = composerTextWithReplies()
+    setPendingReplies([])
+    void doSend(text, { directSteer: true })
       .finally(() => { submitSteerInFlightRef.current = false })
   }
 
@@ -4778,6 +4826,14 @@ export default function ChatView({
       </div>
       )}
 
+      {replyDraftQuote != null && (
+        <ReplyNoteEditor
+          quote={replyDraftQuote}
+          onSave={handleReplyNoteSave}
+          onClose={handleReplyNoteCancel}
+        />
+      )}
+
       <div ref={footRef} className="chat__foot">
         {/* Foot order, top to bottom:
             floating actions overlay the transcript without joining the measured
@@ -4922,6 +4978,10 @@ export default function ChatView({
           pendingFiles={pendingFiles}
           onAddFiles={handleComposerAddFiles}
           onRemoveFile={handleComposerRemoveFile}
+          pendingReplies={pendingReplies}
+          onRemoveReply={handleReplyRemove}
+          selectedAssistantText={embedded ? null : selectedAssistantText}
+          onReplyToSelection={handleReplySelected}
           attachTriggerRef={attachTriggerRef}
           messageHistory={messageHistory}
           provider={chatInfo?.provider}

--- a/frontend/src/components/ChatView/MsgContent.jsx
+++ b/frontend/src/components/ChatView/MsgContent.jsx
@@ -61,6 +61,7 @@ function AssistantCopySurface({ msg, markdownByIndex, children }) {
   return (
     <div
       className="chat__assistant-copy-surface"
+      data-reply-source="assistant"
       onCopy={(event) => copyAssistantSelection(event, markdownForBlock)}
     >
       {children}

--- a/frontend/src/components/ChatView/ReplyChips.jsx
+++ b/frontend/src/components/ChatView/ReplyChips.jsx
@@ -1,0 +1,31 @@
+/**
+ * ReplyChips — the stacked row of pending "reply to a quote" drafts, shown
+ * above the composer's input row. Each chip is one ReplySelectionRow +
+ * ReplyNoteEditor round trip; all of them get bundled into the next real
+ * send (see replyQuotes.formatPendingRepliesForSend) and cleared together.
+ */
+import { Quote } from '@openai/apps-sdk-ui/components/Icon'
+import { truncateForChip } from './replyQuotes.js'
+
+export default function ReplyChips({ replies, onRemove }) {
+  if (!replies?.length) return null
+  return (
+    <div className="chat__reply-tray">
+      {replies.map(reply => (
+        <div key={reply.id} className="chat__reply-chip" title={reply.quote}>
+          <Quote className="chat__reply-chip-icon" width={13} height={13} />
+          <span className="chat__reply-chip-text">
+            {truncateForChip(reply.note, 60)}
+          </span>
+          <button
+            type="button"
+            className="chat__reply-chip-remove"
+            onPointerDown={(e) => e.preventDefault()}
+            onClick={() => onRemove(reply.id)}
+            aria-label="Remove this reply"
+          >×</button>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/components/ChatView/ReplyNoteEditor.jsx
+++ b/frontend/src/components/ChatView/ReplyNoteEditor.jsx
@@ -1,0 +1,87 @@
+/**
+ * ReplyNoteEditor — the small text window opened by ReplySelectionRow's
+ * "Reply to selection" button. Shows the quoted excerpt and lets the owner
+ * type what they want to address about it. Saving (button or Enter) stacks it as a
+ * pending reply chip above the composer — it never sends anything itself.
+ */
+import { useRef, useState } from 'react'
+import useDialogFocus from '../../hooks/useDialogFocus.js'
+import { truncateForChip } from './replyQuotes.js'
+
+export default function ReplyNoteEditor({ quote, onSave, onClose }) {
+  const [note, setNote] = useState('')
+  const dialogRef = useRef(null)
+  const textareaRef = useRef(null)
+
+  useDialogFocus({
+    containerRef: dialogRef,
+    initialFocusRef: textareaRef,
+    onClose,
+  })
+
+  function commit() {
+    const trimmed = note.trim()
+    if (!trimmed) return
+    onSave(trimmed)
+  }
+
+  function handleKeyDown(e) {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      commit()
+    }
+  }
+
+  return (
+    <div className="chat__reply-editor-overlay" role="presentation" onClick={onClose}>
+      <div
+        ref={dialogRef}
+        className="chat__reply-editor"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="reply-editor-title"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="chat__reply-editor-head">
+          <h2 id="reply-editor-title" className="chat__reply-editor-title">Reply to this</h2>
+          <button
+            type="button"
+            className="chat__reply-editor-close"
+            onClick={onClose}
+            aria-label="Cancel"
+          >×</button>
+        </div>
+        <blockquote className="chat__reply-editor-quote">
+          {truncateForChip(quote, 220)}
+        </blockquote>
+        <textarea
+          ref={textareaRef}
+          className="chat__reply-editor-input"
+          value={note}
+          onChange={(e) => setNote(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="What do you want to address?"
+          aria-label="Your note about this excerpt"
+          rows={3}
+        />
+        <div className="chat__reply-editor-foot">
+          <button
+            type="button"
+            className="chat__reply-editor-btn chat__reply-editor-btn--ghost"
+            onClick={onClose}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="chat__reply-editor-btn"
+            onClick={commit}
+            disabled={!note.trim()}
+          >
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/ChatView/ReplySelectionRow.jsx
+++ b/frontend/src/components/ChatView/ReplySelectionRow.jsx
@@ -1,0 +1,27 @@
+/**
+ * ReplySelectionRow — the "Reply to selection" affordance shown above the
+ * composer's input row while an assistant-message selection is live (see
+ * assistantSelection.js). Tapping it opens ReplyNoteEditor with the selected
+ * text; the composer is the stable, expected home for this rather than a
+ * control floating over the transcript (see assistantSelection.js for why).
+ */
+import { Quote } from '@openai/apps-sdk-ui/components/Icon'
+import { truncateForChip } from './replyQuotes.js'
+
+export default function ReplySelectionRow({ selectedText, onReply }) {
+  if (!selectedText) return null
+  return (
+    <button
+      type="button"
+      className="chat__reply-select-row"
+      // Keep the selection alive through the tap — a focus shift before
+      // click fires would collapse it on most browsers, the same trick the
+      // composer already uses for its remove/× controls.
+      onPointerDown={(e) => e.preventDefault()}
+      onClick={() => onReply(selectedText)}
+    >
+      <Quote className="chat__reply-select-row-icon" width={14} height={14} />
+      <span className="chat__reply-select-row-label">Reply to “{truncateForChip(selectedText, 40)}”</span>
+    </button>
+  )
+}

--- a/frontend/src/components/ChatView/__tests__/optimisticSteerQueue.test.js
+++ b/frontend/src/components/ChatView/__tests__/optimisticSteerQueue.test.js
@@ -100,7 +100,7 @@ test('the modified-Enter submit uses one direct request and reveals only queue f
   )
   assert.match(
     source,
-    /function handleSubmitSteer\(e\) \{[\s\S]*?if \(submitSteerInFlightRef\.current\) return[\s\S]*?submitSteerInFlightRef\.current = true[\s\S]*?doSend\(input\.trim\(\), \{ directSteer: true \}\)[\s\S]*?\.finally\(\(\) => \{ submitSteerInFlightRef\.current = false \}\)/,
+    /function handleSubmitSteer\(e\) \{[\s\S]*?if \(submitSteerInFlightRef\.current\) return[\s\S]*?submitSteerInFlightRef\.current = true[\s\S]*?doSend\(text, \{ directSteer: true \}\)[\s\S]*?\.finally\(\(\) => \{ submitSteerInFlightRef\.current = false \}\)/,
     'the keyboard handler must synchronously guard the one direct request',
   )
 })

--- a/frontend/src/components/ChatView/assistantSelection.js
+++ b/frontend/src/components/ChatView/assistantSelection.js
@@ -1,0 +1,56 @@
+/**
+ * useAssistantSelection — tracks whether the live text selection sits inside
+ * an assistant message (long-press-drag on touch, click-drag on desktop) and
+ * returns its normalized text, or null.
+ *
+ * Deliberately does NOT render anything near the selection. iOS/Android both
+ * draw their own copy/paste callout directly over a fresh selection; a
+ * "Reply" control positioned next to that rect (or pinned anywhere over the
+ * transcript) either hides under it or sits somewhere that reads as a random
+ * floating button. The composer already owns a stable, expected spot for
+ * "things about to become part of my next message" (file chips, stacked
+ * reply chips) — ReplyChips-adjacent UI in ChatInputBar renders the actual
+ * "Reply to selection" affordance there instead of floating one over the
+ * transcript. This hook only answers "is there one, and what does it say".
+ *
+ * Scoped to `[data-reply-source="assistant"]` (set by MsgContent only on
+ * assistant bubbles) so selecting the owner's own sent messages never offers
+ * a reply-to-quote — that surface already has copy/edit affordances.
+ */
+import { useEffect, useState } from 'react'
+import { normalizeSelectedText } from './replyQuotes.js'
+
+function selectedAssistantText(containerEl) {
+  const selection = window.getSelection?.()
+  if (!selection || selection.rangeCount === 0 || selection.isCollapsed) return null
+  const text = normalizeSelectedText(selection.toString())
+  if (!text) return null
+  const anchor = selection.anchorNode
+  const focus = selection.focusNode
+  const anchorEl = anchor?.nodeType === 1 ? anchor : anchor?.parentElement
+  const focusEl = focus?.nodeType === 1 ? focus : focus?.parentElement
+  const source = anchorEl?.closest?.('[data-reply-source="assistant"]')
+  if (!source) return null
+  // Both ends of the selection must live in the same assistant bubble — a
+  // drag that escapes into surrounding chrome (or another message) is not a
+  // clean quote.
+  if (!focusEl?.closest?.('[data-reply-source="assistant"]')) return null
+  if (containerEl && !containerEl.contains(source)) return null
+  return text
+}
+
+export function useAssistantSelection(containerRef) {
+  const [selectedText, setSelectedText] = useState(null)
+
+  useEffect(() => {
+    function refresh() {
+      setSelectedText(selectedAssistantText(containerRef?.current))
+    }
+    // selectionchange fires for both mouse drag-select and touch
+    // long-press-drag-select — one listener covers both trigger paths.
+    document.addEventListener('selectionchange', refresh)
+    return () => document.removeEventListener('selectionchange', refresh)
+  }, [containerRef])
+
+  return selectedText
+}

--- a/frontend/src/components/ChatView/replyQuotes.js
+++ b/frontend/src/components/ChatView/replyQuotes.js
@@ -1,0 +1,63 @@
+/**
+ * Pure helpers for stacked "reply to a quote" drafts — selected assistant
+ * text + a short owner note, held in the composer until the next real send.
+ */
+
+const MAX_CHIP_QUOTE_CHARS = 80
+const MAX_TOOLBAR_QUOTE_CHARS = 600
+
+let replyIdSeq = 0
+
+/** Stable per-draft id. Not persisted — only needs to be unique within one
+ *  mounted composer's lifetime (chip keys + removal lookups). */
+export function makeReplyId() {
+  replyIdSeq += 1
+  return `reply-${Date.now()}-${replyIdSeq}`
+}
+
+/** Collapse the whitespace a DOM selection carries across block boundaries
+ *  (headings, list items, code lines) into a single readable snippet. */
+export function normalizeSelectedText(raw) {
+  return String(raw || '')
+    .replace(/\r\n/g, '\n')
+    .replace(/[ \t]+/g, ' ')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim()
+}
+
+/** Truncate for the compact stacked chip — quotes can run to paragraphs,
+ *  the chip only needs enough to remind the owner which excerpt this is. */
+export function truncateForChip(text, max = MAX_CHIP_QUOTE_CHARS) {
+  const clean = normalizeSelectedText(text).replace(/\n+/g, ' ')
+  if (clean.length <= max) return clean
+  return `${clean.slice(0, max - 1).trimEnd()}…`
+}
+
+/** Selections can span an entire streamed answer. Cap what actually gets
+ *  quoted back into the sent message — long past this, it stops reading like
+ *  a quote and starts re-sending the whole reply as if the owner typed it. */
+export function truncateForSend(text, max = MAX_TOOLBAR_QUOTE_CHARS) {
+  const clean = normalizeSelectedText(text)
+  if (clean.length <= max) return clean
+  return `${clean.slice(0, max).trimEnd()}…`
+}
+
+/** One stacked reply rendered as a markdown blockquote + the owner's note,
+ *  in the shape the agent should read it — not a hidden augmentation, this
+ *  is plain visible message text. */
+export function formatReplyForSend({ quote, note }) {
+  const quotedLines = truncateForSend(quote)
+    .split('\n')
+    .map(line => `> ${line}`)
+    .join('\n')
+  const trimmedNote = String(note || '').trim()
+  return `${quotedLines}\n${trimmedNote}`
+}
+
+/** All stacked replies, oldest first, ready to prepend to whatever the owner
+ *  typed in the composer. Returns '' for an empty list so callers can
+ *  concatenate unconditionally. */
+export function formatPendingRepliesForSend(replies) {
+  if (!replies?.length) return ''
+  return replies.map(formatReplyForSend).join('\n\n') + '\n\n'
+}


### PR DESCRIPTION
## What this adds

Select text in one of the assistant's replies and a **"Reply to selection"** row appears above the message box. Tap it, type a short note in the small editor that opens, and it stacks as a quote + note chip above the composer — multiple chips can stack. Nothing is sent to the agent until the owner actually submits a real message: stacked replies are prepended as plain, visible quoted text ahead of it, then cleared together.

## Why not a floating toolbar

The first iteration positioned a "Reply" control right next to the text selection (or, in a second pass, pinned it to a fixed spot on screen). Both approaches collided with the OS's own native copy/paste callout, which draws directly over a fresh selection on iOS/Android — the control was either hidden underneath it or read as a disconnected floating pill with no obvious home.

The composer already owns the expected landing spot for "things about to join my next message" (existing file-attachment chips). This change puts the reply-to-quote affordance there instead: a `ReplySelectionRow` above the input box, using the same opaque backdrop-blur material as the send pill, added to the composer's existing `pointer-events` allow-list (`.chat__foot` intentionally passes clicks through everywhere except the pill and a short allow-listed set of controls — this addition needed to join that list, plus its own opaque background, or scrolled transcript text shows/clicks through it).

## New files

- `assistantSelection.js` — hook that tracks whether the live selection sits inside an assistant message (`[data-reply-source="assistant"]`, set only on assistant bubbles so the owner's own sent messages don't offer this).
- `ReplySelectionRow.jsx` — the composer-docked "Reply to selection" affordance.
- `ReplyNoteEditor.jsx` — the small modal for typing the note.
- `ReplyChips.jsx` — the stacked-chip tray.
- `replyQuotes.js` — pure formatting/truncation helpers, plus the code that prepends stacked replies as markdown blockquotes ahead of the composer text at send time.

## Manual verification

Exercised end to end in the running shell: select → "Reply to selection" row appears in the composer → note editor opens with the quoted excerpt → Save stacks a removable chip → multiple stack → the send button activates from stacked replies alone even with an empty textarea.