### PR TITLE
Update Nano ID to its patched release

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9578,9 +9578,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary

- update the transitive Nano ID resolution from 3.3.17 to 3.3.18
- remove GHSA-2v37-7h3g-55p8 from the locked frontend dependency graph
- keep direct dependencies and application code unchanged

## Testing

- `npm audit` — 0 vulnerabilities
- `npm ci --ignore-scripts`
- `npm run build` — production and offline/PWA builds passed