### PR TITLE
Synchronize workspace E2E pointer ownership

### DIFF
--- a/tests/workspace-panes.spec.mjs
+++ b/tests/workspace-panes.spec.mjs
@@ -91,13 +91,23 @@ async function ensureNavigationOpen(page) {
  *  suppresses the trailing click, so it never also toggles the drawer. */
 async function holdLogo(page, brand) {
   await brand.scrollIntoViewIfNeeded()
+  const startedInBuilder = await brand.evaluate(element => (
+    element.classList.contains('shell__brand--builder')
+  ))
   const box = await brand.boundingBox()
   await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2)
   await page.mouse.down()
-  await expect(brand).toHaveClass(/is-holding/)
-  // Completion clears the hold class while the pointer is still down. Observe
-  // that owned boundary instead of sleeping past an assumed animation frame.
-  await expect(brand).not.toHaveClass(/is-holding/, { timeout: 3000 })
+  // Under a loaded CI runner the 450ms hold can complete between pointerdown
+  // returning and the first assertion. Accept either owned boundary: the live
+  // hold class or the mode flip it commits, then require the completed flip.
+  await expect.poll(() => brand.evaluate((element, wasBuilder) => (
+    element.classList.contains('is-holding')
+      || element.classList.contains('shell__brand--builder') !== wasBuilder
+  ), startedInBuilder), { timeout: 3000 }).toBe(true)
+  await expect.poll(() => brand.evaluate((element, wasBuilder) => (
+    !element.classList.contains('is-holding')
+      && element.classList.contains('shell__brand--builder') !== wasBuilder
+  ), startedInBuilder), { timeout: 3000 }).toBe(true)
   await page.mouse.up()
 }
 
@@ -821,7 +831,13 @@ async function expectCaretAligned(page, caret, target, label) {
 
 /** Press on a source element, arm past slop, glide to a target point, release —
  *  the mouse-path drag Chromium delivers as real pointer events. */
-async function mouseDrag(page, sourceLocator, toX, toY, { release = true } = {}) {
+async function mouseDrag(
+  page,
+  sourceLocator,
+  toX,
+  toY,
+  { release = true, resolveTarget = null } = {},
+) {
   await sourceLocator.scrollIntoViewIfNeeded()
   const box = await sourceLocator.boundingBox()
   const sx = box.x + box.width / 2
@@ -830,6 +846,7 @@ async function mouseDrag(page, sourceLocator, toX, toY, { release = true } = {})
   await page.mouse.down()
   await page.mouse.move(sx + 10, sy, { steps: 3 }) // clear the 5px slop → arm
   await expect(page.locator('.workspace__drag-chip')).toBeVisible({ timeout: 3000 })
+  if (resolveTarget) ({ x: toX, y: toY } = await resolveTarget())
   await page.mouse.move(toX, toY, { steps: 14 })
   await expect(page.locator('.workspace__drop-preview.is-visible'))
     .toBeVisible({ timeout: 3000 })
@@ -888,6 +905,15 @@ async function touchDrag(
       await cdp.detach()
     },
   }
+}
+
+async function resolveBuilderContentCenter(page) {
+  // Arming a drag from Standard unfolds Builder as a render-only preview.
+  // Target geometry therefore belongs to that newly mounted world, not the
+  // Standard content box measured before pointerdown.
+  await expect(page.locator('.workspace__chrome')).toHaveCount(1, { timeout: 3000 })
+  const content = await page.locator('.shell__content').boundingBox()
+  return { x: content.x + content.width / 2, y: content.y + content.height / 2 }
 }
 
 async function bootThreeTab(page, tag, workspaceFixture = twoPanesThreeTabs, expectTiled = true) {
@@ -1637,11 +1663,13 @@ test.describe('Workspace view-mode toggle', () => {
     const baseline = await readWs(page)
 
     await ensureNavigationOpen(page)
-    const content = await page.locator('.shell__content').boundingBox()
     const row = page.locator(`.drawer__item[data-drag-key="chat:${c.id}"]`)
     await expect(row).toBeVisible()
     // Arm + move the drag (builder unfolds), then Escape to cancel before dropping.
-    await mouseDrag(page, row, content.x + content.width / 2, content.y + content.height / 2, { release: false })
+    await mouseDrag(page, row, 0, 0, {
+      release: false,
+      resolveTarget: () => resolveBuilderContentCenter(page),
+    })
     await page.keyboard.press('Escape')
     await page.mouse.up()
 
@@ -1672,12 +1700,14 @@ test.describe('Workspace view-mode toggle', () => {
     expect((await readWs(page)).viewMode).toBe('single')
 
     await ensureNavigationOpen(page)
-    const content = await page.locator('.shell__content').boundingBox()
     const row = page.locator(`.drawer__item[data-drag-key="chat:${c.id}"]`)
     await expect(row).toBeVisible()
     // Arm the single-mode drag → the builder preview unfolds (render-only, tiled).
     // Leave the pointer DOWN (no drop): the dragPreviewBuilder override is live.
-    await mouseDrag(page, row, content.x + content.width / 2, content.y + content.height / 2, { release: false })
+    await mouseDrag(page, row, 0, 0, {
+      release: false,
+      resolveTarget: () => resolveBuilderContentCenter(page),
+    })
     await expect(page.locator('.workspace__chrome')).toHaveCount(1, { timeout: 3000 })
 
     // Negative: with NO foreground event, the live-drag preview persists (the

--- a/tests/workspace-panes.spec.mjs
+++ b/tests/workspace-panes.spec.mjs
@@ -910,10 +910,19 @@ async function touchDrag(
 async function resolveBuilderContentCenter(page) {
   // Arming a drag from Standard unfolds Builder as a render-only preview.
   // Target geometry therefore belongs to that newly mounted world, not the
-  // Standard content box measured before pointerdown.
+  // Standard content box measured before pointerdown. The shell content's
+  // geometric center can be the divider between two panes, so use the focused
+  // pane strip for the x-axis and the content box for the y-axis.
   await expect(page.locator('.workspace__chrome')).toHaveCount(1, { timeout: 3000 })
-  const content = await page.locator('.shell__content').boundingBox()
-  return { x: content.x + content.width / 2, y: content.y + content.height / 2 }
+  const focusedPaneId = await page.evaluate(
+    key => JSON.parse(localStorage.getItem(key)).focusedPaneId,
+    paneModel.STORAGE_KEY,
+  )
+  const [strip, content] = await Promise.all([
+    page.locator(`[data-pane-strip="${focusedPaneId}"]`).boundingBox(),
+    page.locator('.shell__content').boundingBox(),
+  ])
+  return { x: strip.x + strip.width / 2, y: content.y + content.height / 2 }
 }
 
 async function bootThreeTab(page, tag, workspaceFixture = twoPanesThreeTabs, expectTiled = true) {

--- a/tests/workspace-panes.spec.mjs
+++ b/tests/workspace-panes.spec.mjs
@@ -90,10 +90,14 @@ async function ensureNavigationOpen(page) {
  *  real pointer path (not the deterministic Shift+Enter). The completed hold
  *  suppresses the trailing click, so it never also toggles the drawer. */
 async function holdLogo(page, brand) {
+  await brand.scrollIntoViewIfNeeded()
   const box = await brand.boundingBox()
   await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2)
   await page.mouse.down()
-  await page.waitForTimeout(650) // comfortably past the 450ms hold threshold
+  await expect(brand).toHaveClass(/is-holding/)
+  // Completion clears the hold class while the pointer is still down. Observe
+  // that owned boundary instead of sleeping past an assumed animation frame.
+  await expect(brand).not.toHaveClass(/is-holding/, { timeout: 3000 })
   await page.mouse.up()
 }
 
@@ -818,13 +822,17 @@ async function expectCaretAligned(page, caret, target, label) {
 /** Press on a source element, arm past slop, glide to a target point, release —
  *  the mouse-path drag Chromium delivers as real pointer events. */
 async function mouseDrag(page, sourceLocator, toX, toY, { release = true } = {}) {
+  await sourceLocator.scrollIntoViewIfNeeded()
   const box = await sourceLocator.boundingBox()
   const sx = box.x + box.width / 2
   const sy = box.y + box.height / 2
   await page.mouse.move(sx, sy)
   await page.mouse.down()
   await page.mouse.move(sx + 10, sy, { steps: 3 }) // clear the 5px slop → arm
+  await expect(page.locator('.workspace__drag-chip')).toBeVisible({ timeout: 3000 })
   await page.mouse.move(toX, toY, { steps: 14 })
+  await expect(page.locator('.workspace__drop-preview.is-visible'))
+    .toBeVisible({ timeout: 3000 })
   if (release) await page.mouse.up()
 }
 
@@ -1948,11 +1956,7 @@ test.describe('Logo activation + middle-click', () => {
 
     const brand = page.getByRole('button', { name: 'Toggle navigation' })
     const navBefore = await brand.getAttribute('aria-expanded')
-    const box = await page.locator('.shell__brand').boundingBox()
-    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2)
-    await page.mouse.down()
-    await page.waitForTimeout(650) // hold past the ~450ms threshold (rAF completes it)
-    await page.mouse.up()
+    await holdLogo(page, brand)
 
     await expect.poll(async () => (await readWs(page)).viewMode, {
       timeout: 3000, message: 'a completed hold flips to builder mode',


### PR DESCRIPTION
## Summary

- drive logo holds through the button that owns the pointer gesture
- observe hold completion instead of sleeping for an assumed animation frame
- require the drag controller to arm and expose a live drop zone before release

## Why

The recurring workspace flakes failed before the product assertions: one logo case pressed the wrapper instead of the button used by the shared helper, and the mouse-drag helper could release before it had observed either pointer ownership or a resolved drop target.

The revised tests synchronize on the product's own gesture states. They keep the same real Chromium pointer path and strict behavior assertions without adding retries or longer blanket waits.

Addresses #908.

## Testing

- `node --check tests/workspace-panes.spec.mjs`
- ESLint on `tests/workspace-panes.spec.mjs`

The exact revision still needs repeated focused and complete hosted E2E runs.