### PR TITLE
Restore composer focus after browser history navigation

### DIFF
--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -727,12 +727,14 @@ export default function Shell({ onInitialVisualReady }) {
     return true
   }
 
-  // Browser traversal bypasses the drawer and tab selection handlers. Reserve
-  // the touch keyboard at useNavigation's validated restore boundary, before
-  // the outgoing chat or app can become inert.
+  // Browser traversal bypasses the drawer and tab selection handlers. Use the
+  // same destination-composer handoff as direct chat selection at
+  // useNavigation's validated restore boundary, before the outgoing chat or
+  // app can become inert. On touch this still reserves the software keyboard
+  // only for a saved draft; on desktop it restores keyboard focus.
   beforeRestoreRouteRef.current = (route) => {
     if (route?.view !== 'chat' || route.chatId == null) return
-    reserveTouchDraftComposer(route.chatId)
+    focusSelectedChatComposer(route.chatId)
   }
 
   // A restored single-screen chat has no click handler to request focus. Keep

--- a/frontend/src/components/Shell/__tests__/chatHandoff.test.js
+++ b/frontend/src/components/Shell/__tests__/chatHandoff.test.js
@@ -325,8 +325,8 @@ test('direct chat actions hand focus to the destination composer', () => {
   assert.match(shell, /className="shell__composer-focus-lease"[\s\S]*aria-label="Restoring message draft"/,
     'the hidden lease must not impersonate the visible Message Möbius composer in the accessibility tree')
   assert.match(shell,
-    /beforeRestoreRouteRef\.current = \(route\) => \{[\s\S]*route\?\.view !== 'chat'[\s\S]*reserveTouchDraftComposer\(route\.chatId\)/,
-    'Back and Forward must use the same draft-only touch focus handoff')
+    /beforeRestoreRouteRef\.current = \(route\) => \{[\s\S]*route\?\.view !== 'chat'[\s\S]*focusSelectedChatComposer\(route\.chatId\)/,
+    'Back and Forward must use the same destination-composer focus handoff')
   assert.match(shell, /const beforeRestoreRouteRef = useRef\(null\)/)
   assert.match(shell, /beforeRestoreRouteRef,\s*\}\)/)
   assert.match(

--- a/tests/navigation.spec.mjs
+++ b/tests/navigation.spec.mjs
@@ -1764,6 +1764,25 @@ test.describe('Drawer state machine — extended invariants', () => {
     expect(await page.evaluate(() => !!document.querySelector('.settings'))).toBe(true)
   })
 
+  test('20a. returning to a chat through browser history restores composer focus', async ({ page }) => {
+    await setup(page, { width: 1280, height: 800 })
+
+    const paintedComposer = page.locator(
+      '[data-chat-surface="painted"] textarea[aria-label="Message Möbius…"]',
+    )
+    await paintedComposer.focus()
+    await expect(paintedComposer).toBeFocused()
+
+    // Cmd+,/. invokes this same browser traversal outside the app. The route
+    // restore must carry the outgoing chat's keyboard-forward intent back to
+    // its real composer, rather than leaving focus on the document body.
+    await page.getByRole('button', { name: 'Apps', exact: true }).click()
+    await expect(page.getByRole('region', { name: 'Installed apps' })).toBeVisible()
+
+    await goBack(page)
+    await expect(paintedComposer).toBeFocused()
+  })
+
   test('20b. Forward to an unconsumed drawer sentinel reopens the drawer', async ({ page }) => {
     await setup(page)
     await openDrawer(page)


### PR DESCRIPTION
## Summary
- route browser-history chat restoration through the same destination-composer focus handoff as direct chat selection
- preserve the existing draft-only software-keyboard lease on touch devices
- add focused unit and browser coverage for returning from Apps to a chat

## Why
Browser traversal bypasses the drawer and tab selection handlers. Its restore boundary only invoked the draft-based touch handoff, so desktop history navigation returned to the right chat but left focus on the document instead of the composer.

This is the existing-chat history counterpart to #559 and reuses the shared focus handoff established in #731 rather than adding a second focus mechanism.

## Testing
- focused Shell handoff suite (9 passed)
- changed frontend surfaces linted (0 errors; existing hook warnings only)
- authenticated rendered smoke with a desktop pointer: Back restored the visible composer, accepted typing, and the probe draft was cleared
- isolated Playwright regression added for the hosted suite; the Docker-backed local wrapper was unavailable in the app container