### PR TITLE
Keep app icons visible while updates load

### DIFF
--- a/frontend/src/components/AppIcon.css
+++ b/frontend/src/components/AppIcon.css
@@ -16,7 +16,10 @@
   width: 100%;
   height: 100%;
   object-fit: contain;
+  visibility: hidden;
 }
+
+.app-icon img.app-icon__image--displayed { visibility: visible; }
 
 .app-icon.is-image {
   overflow: visible;

--- a/frontend/src/components/AppIcon.jsx
+++ b/frontend/src/components/AppIcon.jsx
@@ -1,5 +1,5 @@
 /* AppIcon renders one installed app's artwork with a stable initials fallback. */
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import {
   appIconIsReady,
   appIconUrl,
@@ -11,38 +11,55 @@ import './AppIcon.css'
 
 export default function AppIcon({ item, label, className = '' }) {
   const iconUrl = appIconUrl(item)
-  const [loadedUrl, setLoadedUrl] = useState(
-    () => (appIconIsReady(iconUrl) ? iconUrl : null),
-  )
-  const hasImage = Boolean(
-    iconUrl && (loadedUrl === iconUrl || appIconIsReady(iconUrl)),
-  )
+  const iconOwner = item?.id ?? item?.slug ?? label
+  const currentIconRef = useRef(null)
+  currentIconRef.current = { owner: iconOwner, url: iconUrl }
+  const [displayedIcon, setDisplayedIcon] = useState(() => ({
+    owner: iconOwner,
+    url: appIconIsReady(iconUrl) ? iconUrl : null,
+  }))
+  const displayedUrl = iconUrl && displayedIcon.owner === iconOwner
+    ? displayedIcon.url
+    : null
+  // Keep the painted node mounted while the next version loads. URL keys let
+  // React promote that same decoded <img> on load instead of remounting it.
+  const candidateUrl = iconUrl && iconUrl !== displayedUrl ? iconUrl : null
+  const imageUrls = [displayedUrl, candidateUrl].filter(Boolean)
 
   return (
     <span
-      className={`app-icon${className ? ` ${className}` : ''}${hasImage ? ' is-image' : ''}`}
+      className={`app-icon${className ? ` ${className}` : ''}${displayedUrl ? ' is-image' : ''}`}
       style={{ '--app-color': item?.background_color || item?.theme_color || 'var(--accent)' }}
       aria-hidden="true"
     >
       <span>{appInitials(label)}</span>
-      {iconUrl && (
+      {imageUrls.map(url => (
         <img
-          src={iconUrl}
+          key={url}
+          src={url}
           alt=""
+          className={url === displayedUrl ? 'app-icon__image--displayed' : ''}
           loading="eager"
           decoding="async"
-          onLoad={event => {
-            event.currentTarget.hidden = false
-            rememberAppIconReady(iconUrl)
-            setLoadedUrl(iconUrl)
+          onLoad={() => {
+            rememberAppIconReady(url)
+            const current = currentIconRef.current
+            if (current.owner === iconOwner && current.url === url) {
+              setDisplayedIcon(current)
+            }
           }}
-          onError={event => {
-            event.currentTarget.hidden = true
-            forgetAppIconReady(iconUrl)
-            setLoadedUrl(null)
+          onError={() => {
+            forgetAppIconReady(url)
+            if (url === displayedUrl) {
+              setDisplayedIcon(current => (
+                current.owner === iconOwner && current.url === url
+                  ? { owner: iconOwner, url: null }
+                  : current
+              ))
+            }
           }}
         />
-      )}
+      ))}
     </span>
   )
 }

--- a/frontend/src/components/Shell/__tests__/appIcon.test.js
+++ b/frontend/src/components/Shell/__tests__/appIcon.test.js
@@ -1,11 +1,25 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
+import { renderHook } from '../../ChatView/hooks/__tests__/react-hook-shim.mjs'
+import AppIcon from '../../AppIcon.jsx'
 import {
   appIconIsReady,
   appIconUrl,
   appInitials,
   preloadAppIcons,
 } from '../../appIcon.js'
+
+function iconImages(element) {
+  return element.props.children
+    .flat(Infinity)
+    .filter(child => child?.type === 'img')
+}
+
+function displayedIconUrl(element) {
+  return iconImages(element)
+    .find(image => image.props.className === 'app-icon__image--displayed')
+    ?.props.src || null
+}
 
 test('app initials remain useful when custom artwork is missing', () => {
   assert.equal(appInitials('Beat Machine'), 'BM')
@@ -78,4 +92,78 @@ test('preloaded artwork is decoded and ready for the launcher first render', asy
   assert.deepEqual(result, [true])
   assert.equal(decodeCount, 1)
   assert.equal(appIconIsReady(url), true)
+})
+
+test('an app update keeps painted artwork until its replacement loads', () => {
+  const oldApp = { id: 42, icon_url: '/api/apps/42/icon?v=old' }
+  const nextApp = { id: 42, icon_url: '/api/apps/42/icon?v=next' }
+  const retryApp = { id: 42, icon_url: '/api/apps/42/icon?v=retry' }
+  const { result, rerender } = renderHook(AppIcon, {
+    item: oldApp,
+    label: 'Example',
+  })
+
+  assert.equal(displayedIconUrl(result.current), null)
+  iconImages(result.current)[0].props.onLoad()
+  assert.equal(displayedIconUrl(result.current), `${oldApp.icon_url}&size=128`)
+
+  rerender({ item: nextApp, label: 'Example' })
+  assert.equal(
+    displayedIconUrl(result.current),
+    `${oldApp.icon_url}&size=128`,
+    'the already-painted node remains visible while the new URL loads',
+  )
+  assert.deepEqual(
+    iconImages(result.current).map(image => image.props.src),
+    [`${oldApp.icon_url}&size=128`, `${nextApp.icon_url}&size=128`],
+  )
+
+  const candidate = iconImages(result.current)[1]
+  candidate.props.onError()
+  assert.equal(
+    displayedIconUrl(result.current),
+    `${oldApp.icon_url}&size=128`,
+    'a failed replacement cannot blank known-good artwork',
+  )
+
+  rerender({ item: retryApp, label: 'Example' })
+  iconImages(result.current)[1].props.onLoad()
+  assert.equal(displayedIconUrl(result.current), `${retryApp.icon_url}&size=128`)
+  assert.equal(iconImages(result.current).length, 1)
+})
+
+test('a superseded icon load cannot replace the current candidate', () => {
+  const oldApp = { id: 42, icon_url: '/api/apps/42/icon?v=old-race' }
+  const supersededApp = { id: 42, icon_url: '/api/apps/42/icon?v=superseded' }
+  const currentApp = { id: 42, icon_url: '/api/apps/42/icon?v=current' }
+  const { result, rerender } = renderHook(AppIcon, {
+    item: oldApp,
+    label: 'Example',
+  })
+
+  iconImages(result.current)[0].props.onLoad()
+  rerender({ item: supersededApp, label: 'Example' })
+  const staleLoad = iconImages(result.current)[1].props.onLoad
+  rerender({ item: currentApp, label: 'Example' })
+
+  staleLoad()
+  assert.equal(displayedIconUrl(result.current), `${oldApp.icon_url}&size=128`)
+  iconImages(result.current)[1].props.onLoad()
+  assert.equal(displayedIconUrl(result.current), `${currentApp.icon_url}&size=128`)
+})
+
+test('artwork from a different app is never retained as an update fallback', () => {
+  const first = { id: 1, icon_url: '/api/apps/1/icon?v=ready' }
+  const second = { id: 2, icon_url: '/api/apps/2/icon?v=pending' }
+  const { result, rerender } = renderHook(AppIcon, { item: first, label: 'First' })
+
+  iconImages(result.current)[0].props.onLoad()
+  assert.equal(displayedIconUrl(result.current), `${first.icon_url}&size=128`)
+
+  rerender({ item: second, label: 'Second' })
+  assert.equal(displayedIconUrl(result.current), null)
+  assert.deepEqual(
+    iconImages(result.current).map(image => image.props.src),
+    [`${second.icon_url}&size=128`],
+  )
 })

--- a/frontend/src/lib/__tests__/vite-env-loader.mjs
+++ b/frontend/src/lib/__tests__/vite-env-loader.mjs
@@ -24,6 +24,7 @@ const REACT_SHIM = new URL(
 // blanket: most files here are read as source text, and a global alias would
 // silently swap React out from under anything that later imports for real.
 const REACT_SHIMMED_MODULES = [
+  '/components/AppIcon.jsx',
   '/components/Shell/useAppIntentNavigation.js',
   '/components/Shell/useShellReloadController.js',
   '/hooks/useSystemEventStream.js',


### PR DESCRIPTION
## Summary
- keep the last successfully painted app icon visible while a new version loads
- promote replacement artwork only after its own image load event
- preserve known-good artwork when replacements fail and ignore superseded loads

## Why
App updates version their icon URLs. Replacing the visible image immediately could leave the launcher blank while the new asset loaded or failed. The shared icon component now owns an atomic artwork handoff for every launcher surface.

## Testing
- `npm test` (2,664 library tests and 94 hook tests passed)
- authenticated rendered shell check