### PR TITLE
Keep assistant question ownership stable across restarts

### DIFF
--- a/backend/app/chat_event_sink.py
+++ b/backend/app/chat_event_sink.py
@@ -106,6 +106,18 @@ def get_active_sink(chat_id: str) -> "ChatEventSink | None":
   return _active_sinks.get(chat_id)
 
 
+def active_sink_assistant_message_id(chat_id: str) -> str | None:
+  """Return the assistant segment currently owned by the live reducer.
+
+  The sink rotates this identity synchronously at a steer cut, before the
+  replacement snapshot can reach persistence. Read APIs use this narrow view
+  to avoid briefly reporting the sealed segment as current.
+  """
+  sink = get_active_sink(chat_id)
+  message_id = getattr(sink, "assistant_message_id", None)
+  return str(message_id) if message_id else None
+
+
 def active_sink_stream_snapshot(chat_id: str, broadcast) -> dict | None:
   """Freeze the current assistant segment for one snapshot-capable subscriber.
 

--- a/backend/app/chat_writer.py
+++ b/backend/app/chat_writer.py
@@ -358,6 +358,22 @@ class MigrateChat(_Command):
 
 
 @dataclass
+class BackfillAssistantIdentity(_Command):
+  """Repair one legacy chat's scalar assistant owner during boot.
+
+  The schema migration can add and backfill the scalar for rows that already
+  carry an assistant message id, but it must not rewrite ``Chat.messages``.
+  This actor-owned command handles the one legacy exception: a parked,
+  unanswered question whose assistant row predates message identities. It
+  gives that exact row a deterministic id and stores the same id in the scalar
+  in one transaction. New writes already establish both values together, so
+  this is idempotent upgrade work rather than a second live-write path.
+  """
+
+  chat_id: str = ""
+
+
+@dataclass
 class RewriteChatMediaPaths(_Command):
   """Atomically rewrite one chat's legacy media URLs during boot."""
 
@@ -1535,6 +1551,8 @@ class ChatWriterActor:
       return self._stash_thinking_trace(db, cmd)
     if isinstance(cmd, MigrateChat):
       return self._migrate_chat(db, cmd)
+    if isinstance(cmd, BackfillAssistantIdentity):
+      return self._backfill_assistant_identity(db, cmd)
     if isinstance(cmd, RewriteChatMediaPaths):
       return self._rewrite_chat_media_paths(db, cmd)
     if isinstance(cmd, ReconcileStartupChat):
@@ -1897,6 +1915,71 @@ class ChatWriterActor:
     if not _commit_or_rollback(db):
       raise _PersistFailed("RewriteChatMediaPaths did not persist")
     return len(values)
+
+  def _backfill_assistant_identity(
+    self, db, cmd: "BackfillAssistantIdentity",
+  ) -> int:
+    """Backfill one pre-identity assistant owner through the writer actor."""
+    from app.models import Chat
+
+    chat = _active_chat(db, cmd.chat_id)
+    if chat is None or chat.active_assistant_message_id is not None:
+      return 0
+
+    owner_id = None
+    repaired_messages = None
+    question_id = chat.pending_question_id
+    if isinstance(question_id, str) and 0 < len(question_id) <= 64:
+      messages = list(chat.messages or [])
+      for index in range(len(messages) - 1, -1, -1):
+        message = messages[index]
+        if not isinstance(message, dict) or message.get("hidden"):
+          continue
+        if message.get("role") != "assistant":
+          continue
+        matches_question = any(
+          isinstance(block, dict)
+          and block.get("type") == "question"
+          and block.get("question_id") == question_id
+          and not block.get("answers")
+          for block in (message.get("blocks") or [])
+        )
+        if not matches_question:
+          continue
+        owner_id = _assistant_message_id(message)
+        if owner_id is None:
+          generated = f"assistant-question-{question_id}"
+          if len(generated) <= 128:
+            owner_id = generated
+            repaired_messages = list(messages)
+            repaired = dict(message)
+            repaired["id"] = owner_id
+            repaired_messages[index] = repaired
+        break
+
+    if owner_id is None:
+      owner_id = _assistant_message_id(chat.live_assistant)
+    if owner_id is None:
+      return 0
+
+    values = {"active_assistant_message_id": owner_id}
+    if repaired_messages is not None:
+      values["messages"] = repaired_messages
+    result = db.execute(
+      update(Chat)
+      .where(
+        Chat.id == cmd.chat_id,
+        Chat.deleted_at.is_(None),
+        Chat.active_assistant_message_id.is_(None),
+      )
+      .values(**values)
+    )
+    if result.rowcount != 1:
+      db.rollback()
+      return 0
+    if not _commit_or_rollback(db):
+      raise _PersistFailed("BackfillAssistantIdentity did not persist")
+    return 1
 
   def _reconcile_startup_chat(
     self, db, cmd: "ReconcileStartupChat",

--- a/backend/app/chat_writer.py
+++ b/backend/app/chat_writer.py
@@ -1906,6 +1906,9 @@ class ChatWriterActor:
 
     if not cmd.chat_id or cmd.recovered_at is None:
       return False
+    pending_question_id, active_assistant_message_id = (
+      _tail_open_question_state(cmd.messages)
+    )
     chat_update = db.execute(
       update(Chat)
       .where(Chat.id == cmd.chat_id, Chat.deleted_at.is_(None))
@@ -1917,7 +1920,8 @@ class ChatWriterActor:
         # Rebuild the protocol barrier from that repaired source instead of
         # preserving a marker that Finalize may have cleared just before the
         # process died (or that an older write may have left stale).
-        pending_question_id=_tail_open_question_id(cmd.messages),
+        pending_question_id=pending_question_id,
+        active_assistant_message_id=active_assistant_message_id,
       )
     )
     if chat_update.rowcount != 1:
@@ -2226,6 +2230,7 @@ class ChatWriterActor:
       "blocks": [],
       "ts": next_message_ts(existing + pending),
     }
+    chat.active_assistant_message_id = cmd.run_token
     if len(existing) == 1:
       _name_chat_from_first_message(chat, cmd.title_source)
     started_at = datetime.now(UTC)
@@ -2358,12 +2363,12 @@ class ChatWriterActor:
     if applied:
       # The recovered-answer path (an answer submitted after a restart, when no
       # in-memory pending question survives) reaches AppendPending instead of
-      # AnswerQuestion, so clear the durable marker here too — mirroring
-      # _answer_question. Otherwise it stays set for the whole recovered turn and
-      # every read surface, the composer's queue/steer lock included, keeps
-      # treating the chat as awaiting an answer. Gated on `applied` so an
+      # AnswerQuestion. No physical runner remains to continue the old assistant
+      # row, so retire both its question marker and browser owner; the admitted
+      # continuation atomically installs its own owner. Gated on `applied` so an
       # ordinary queue-behind send never disturbs a genuinely open question.
       chat.pending_question_id = None
+      chat.active_assistant_message_id = None
     chat.updated_at = datetime.now(UTC)
     chat.activity_at = datetime.now(UTC)
     if not _commit_or_rollback(db):
@@ -2709,6 +2714,7 @@ class ChatWriterActor:
         chat.messages + list(chat.pending_messages or [])
       ),
     }
+    chat.active_assistant_message_id = cmd.run_token
     started_at = datetime.now(UTC)
     chat.updated_at = datetime.now(UTC)
     # Restart recovery can route the first send through PromotePending instead
@@ -2867,6 +2873,10 @@ class ChatWriterActor:
     if cmd.messages is not None:
       chat.messages = cmd.messages
       chat.live_assistant = None
+      (
+        chat.pending_question_id,
+        chat.active_assistant_message_id,
+      ) = _tail_open_question_state(cmd.messages)
     chat.updated_at = datetime.now(UTC)
     if not _commit_or_rollback(db):
       raise _PersistFailed("ReplaceTranscript did not persist")
@@ -2942,19 +2952,27 @@ class ChatWriterActor:
         db, cmd.chat_id, cmd.terminal_status
       )
     changed = run_changed
-    # A tokened terminal may clear the marker only when it actually closed that
-    # exact running row. Otherwise a delayed FinishRun from predecessor A could
-    # erase the open question written by successor B. The tokenless lifecycle
-    # path intentionally retires all work and may always clear it.
-    should_clear_question = (
-      cmd.terminal_status != "interrupted"
-      and (not cmd.run_token or run_changed)
-    )
-    if should_clear_question:
-      chat = _active_chat(db, cmd.chat_id)
-      if chat is not None and chat.pending_question_id is not None:
-        chat.pending_question_id = None
-        changed = True
+    # A tokened terminal may retire browser ownership only when it actually
+    # closed that exact run. Otherwise a delayed FinishRun from predecessor A
+    # could erase successor B's question/assistant owner. Tokenless lifecycle
+    # cleanup intentionally retires all work, including on a soft-deleted row.
+    should_retire_surface = not cmd.run_token or run_changed
+    if should_retire_surface:
+      from app.models import Chat
+
+      chat = db.query(Chat).filter(Chat.id == cmd.chat_id).first()
+      preserve_parked_question = bool(
+        chat is not None
+        and cmd.terminal_status == "interrupted"
+        and chat.pending_question_id is not None
+      )
+      if chat is not None and not preserve_parked_question:
+        if chat.pending_question_id is not None:
+          chat.pending_question_id = None
+          changed = True
+        if chat.active_assistant_message_id is not None:
+          chat.active_assistant_message_id = None
+          changed = True
     if changed and not _commit_or_rollback(db):
       raise _PersistFailed("FinishRun did not persist")
     if not cmd.run_token or owner == cmd.run_token:
@@ -3076,6 +3094,9 @@ class ChatWriterActor:
 
       chat.messages = messages
       chat.live_assistant = None
+      pending_question_id, question_owner_id = _tail_open_question_state(messages)
+      chat.pending_question_id = pending_question_id
+      chat.active_assistant_message_id = question_owner_id
       changed = True
 
     if changed and not _commit_or_rollback(db):
@@ -3141,7 +3162,10 @@ class ChatWriterActor:
     # the park so the run status and the marker land together.
     chat = _active_chat(db, cmd.chat_id)
     if chat is not None:
-      chat.pending_question_id = _tail_open_question_id(chat.messages)
+      (
+        chat.pending_question_id,
+        chat.active_assistant_message_id,
+      ) = _tail_open_question_state(chat.messages)
     if changed and not _commit_or_rollback(db):
       raise _PersistFailed("ParkRun did not persist")
     if owner is None or owner == cmd.run_token:
@@ -3910,15 +3934,24 @@ class _WriteOutcome(enum.Enum):
   DROPPED = "dropped"  # write attempted but the commit dropped (lock)
 
 
-def _tail_open_question_id(messages) -> str | None:
-  """question_id of the last assistant message's open AskUserQuestion, else None.
+def _assistant_message_id(message: object) -> str | None:
+  """Return a message id that fits the durable assistant-owner column."""
+  if not isinstance(message, dict):
+    return None
+  value = message.get("id")
+  return value if isinstance(value, str) and 0 < len(value) <= 128 else None
+
+
+def _tail_open_question_state(
+  messages,
+) -> tuple[str | None, str | None]:
+  """Open question id and its assistant row id at the transcript tail.
 
   The durable `pending_question_id` marker is, by definition, "the transcript
   tail is an unanswered question." Deriving it from the messages is the single
   rule every writer that needs to (re)establish the marker can share, so the
-  marker cannot drift from the transcript. This mirrors the one-time boot
-  backfill in schema_migrations._add_chat_pending_question_id and applies the same
-  1..64-char id validation the column accepts.
+  marker and assistant owner cannot drift from each other. This mirrors the
+  schema backfills and applies both columns' length constraints.
   """
   for message in reversed(messages or []):
     if not isinstance(message, dict) or message.get("hidden"):
@@ -3935,9 +3968,14 @@ def _tail_open_question_id(messages) -> str | None:
         and isinstance(candidate, str)
         and 0 < len(candidate) <= 64
       ):
-        return candidate
+        return candidate, _assistant_message_id(message)
     break
-  return None
+  return None, None
+
+
+def _tail_open_question_id(messages) -> str | None:
+  """Return only the open question id for callers that do not own its row."""
+  return _tail_open_question_state(messages)[0]
 
 
 def _active_chat(db, chat_id: str):
@@ -4043,6 +4081,9 @@ def _apply_last_assistant_message(db, chat_id: str, message: dict):
     msgs.append(message)
   chat.messages = msgs
   chat.live_assistant = None
+  message_owner_id = _assistant_message_id(message)
+  if message_owner_id is not None:
+    chat.active_assistant_message_id = message_owner_id
   return (
     _WriteOutcome.APPLIED
     if _commit_or_rollback(db)
@@ -4073,7 +4114,7 @@ def update_live_assistant(
   from app.models import Chat
 
   row = db.execute(
-    select(Chat.live_assistant).where(
+    select(Chat.live_assistant, Chat.active_assistant_message_id).where(
       Chat.id == chat_id,
       Chat.deleted_at.is_(None),
     )
@@ -4081,6 +4122,7 @@ def update_live_assistant(
   if row is None:
     return None if require_row else True
   existing = row[0] if isinstance(row[0], dict) else None
+  existing_owner_id = row[1] if isinstance(row[1], str) else None
   snapshot = json_safe(copy.deepcopy(message))
   if not isinstance(snapshot, dict):
     return True
@@ -4137,7 +4179,13 @@ def update_live_assistant(
     .where(Chat.id == chat_id, Chat.deleted_at.is_(None))
     # The stream is authoritative while this value changes. Bypass
     # updated_at's onupdate default so retained history remains reusable.
-    .values(live_assistant=snapshot, updated_at=Chat.updated_at)
+    .values(
+      live_assistant=snapshot,
+      active_assistant_message_id=(
+        _assistant_message_id(snapshot) or existing_owner_id
+      ),
+      updated_at=Chat.updated_at,
+    )
   )
   return _commit_or_rollback(db)
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -154,6 +154,14 @@ class Chat(Base):
   # streaming update never rewrites every prior message. Finalize and startup
   # recovery merge this bounded value into `messages`.
   live_assistant = Column(JSON, nullable=True, default=None)
+  # The one assistant transcript row allowed to own regenerable browser state.
+  # Unlike `live_assistant`, this identity deliberately survives QuestionCommit:
+  # a parked unanswered card is durable history but can still be preceded by a
+  # stale browser replay after reconnect/restart. Start/steer snapshot writes
+  # rotate it, terminal run closure clears it, and startup recovery rebuilds it
+  # from the repaired open-question row. Keeping the scalar beside the JSON
+  # blobs lets /runtime enforce that ownership without hydrating either blob.
+  active_assistant_message_id = Column(String(128), nullable=True, default=None)
   # The AskUserQuestion this chat is currently parked on, or NULL. The single
   # durable source of truth for "a question is open": set when the card is
   # committed, cleared when it is answered or the turn ends, and KEPT across a

--- a/backend/app/routes/chats.py
+++ b/backend/app/routes/chats.py
@@ -18,6 +18,7 @@ from app import (
   activity, auth, chat_search, models, providers, questions, secure_inputs,
 )
 from app.chat_visibility import coerce_agent_settings, visible_in_owner_drawer
+from app.chat_event_sink import active_sink_assistant_message_id
 from app.chat_waits import (
   armed_wait_chat_ids,
   armed_waits_for_chat,
@@ -79,6 +80,24 @@ def _open_question_id_for(chat: models.Chat) -> str | None:
     return chat.pending_question_id
   pending = questions.get(chat.id)
   return pending.question_id if pending is not None else None
+
+
+def _active_assistant_message_id(
+  chat: models.Chat,
+) -> str | None:
+  """Return the one assistant row allowed to own a live browser surface.
+
+  The in-process sink wins during a steer because it rotates before its next
+  snapshot commits. Otherwise the actor-owned durable scalar covers both the
+  bounded live snapshot and a question already merged into history. The latter
+  is why this cannot be inferred from `live_assistant`: QuestionCommit clears
+  that JSON value by design while the parked card still owns the browser row.
+  """
+  sink_id = active_sink_assistant_message_id(chat.id)
+  if sink_id:
+    return sink_id
+  value = chat.active_assistant_message_id
+  return str(value) if value else None
 
 # Separate router for the app-attributed chat contract (design §1). It
 # lives under its own /api/app-chats prefix so the owner-only /api/chats
@@ -550,6 +569,7 @@ def _chat_detail_response(
     "total": total,
     "offset": start,
     "running": running,
+    "active_assistant_message_id": _active_assistant_message_id(chat),
     "active_goal_objective": active_goal_objective,
     "pending_question_id": _open_question_id_for(chat),
     "session_id": chat.session_id if expose_session else None,
@@ -1375,11 +1395,13 @@ def get_chat_runtime(
     load_fields=(
       models.Chat.pending_messages,
       models.Chat.pending_question_id,
+      models.Chat.active_assistant_message_id,
       models.Chat.updated_at,
     ),
   )
   return {
     "running": is_chat_running(chat.id),
+    "active_assistant_message_id": _active_assistant_message_id(chat),
     "active_goal_objective": running_goal_objective(db, chat.id),
     "pending_messages": list(chat.pending_messages or []),
     "pending_question_id": _open_question_id_for(chat),

--- a/backend/app/schema_migrations.py
+++ b/backend/app/schema_migrations.py
@@ -1685,6 +1685,113 @@ def _retire_restart_resume_toggle(eng) -> None:
     ))
 
 
+def _add_chat_active_assistant_identity(eng) -> None:
+  """Add the scalar owner of regenerable assistant browser state.
+
+  A pending question is the stronger protocol boundary, so locate the exact
+  unanswered card it names first. Otherwise backfill from the bounded live
+  snapshot. This also repairs a stale pre-upgrade live value instead of letting
+  it outrank a committed owner decision. Everything is self-contained because
+  migration history is immutable after publication.
+  """
+  from sqlalchemy import JSON as SAJSON, bindparam, inspect as sa_inspect, text
+
+  inspector = sa_inspect(eng)
+  if "chats" not in inspector.get_table_names():
+    return
+  columns = {column["name"] for column in inspector.get_columns("chats")}
+  with eng.begin() as conn:
+    if "active_assistant_message_id" not in columns:
+      conn.execute(text(
+        "ALTER TABLE chats ADD COLUMN "
+        "active_assistant_message_id VARCHAR(128) NULL"
+      ))
+      columns.add("active_assistant_message_id")
+    if not {"id", "messages"}.issubset(columns):
+      return
+    # Keep the common upgrade path scalar-only. Historical transcripts can be
+    # large; hydrate one only for the small set of chats actually parked on a
+    # question instead of pulling every chat blob through the migration.
+    selected = ["id"]
+    if "live_assistant" in columns:
+      selected.append("live_assistant")
+    if "pending_question_id" in columns:
+      selected.append("pending_question_id")
+    filters = ["active_assistant_message_id IS NULL"]
+    if "deleted_at" in columns:
+      filters.append("deleted_at IS NULL")
+    rows = conn.execute(text(
+      "SELECT " + ", ".join(selected) + " FROM chats WHERE "
+      + " AND ".join(filters)
+    )).mappings().all()
+
+    def decoded(value):
+      if not isinstance(value, str):
+        return value
+      try:
+        return json.loads(value)
+      except (TypeError, ValueError, json.JSONDecodeError):
+        return None
+
+    def bounded_id(value):
+      return value if isinstance(value, str) and 0 < len(value) <= 128 else None
+
+    update_messages = text(
+      "UPDATE chats SET messages = :messages WHERE id = :chat_id"
+    ).bindparams(bindparam("messages", type_=SAJSON))
+
+    for row in rows:
+      owner_id = None
+      pending_question_id = row.get("pending_question_id")
+      if isinstance(pending_question_id, str):
+        raw_messages = conn.execute(text(
+          "SELECT messages FROM chats WHERE id = :chat_id"
+        ), {"chat_id": row["id"]}).scalar_one_or_none()
+        messages = decoded(raw_messages)
+        if isinstance(messages, list):
+          for index in range(len(messages) - 1, -1, -1):
+            message = messages[index]
+            if not isinstance(message, dict) or message.get("hidden"):
+              continue
+            if message.get("role") != "assistant":
+              continue
+            matching_question = any(
+              isinstance(block, dict)
+              and block.get("type") == "question"
+              and block.get("question_id") == pending_question_id
+              and not block.get("answers")
+              for block in (message.get("blocks") or [])
+            )
+            if matching_question:
+              owner_id = bounded_id(message.get("id"))
+              if owner_id is None:
+                # Pre-identity assistant rows still have one unambiguous owner:
+                # the exact unanswered card named by the durable marker. Give
+                # only that row a deterministic id and persist the same value in
+                # the scalar; inventing an id without updating the transcript
+                # would point the browser at a row that does not exist.
+                generated = f"assistant-question-{pending_question_id}"
+                owner_id = bounded_id(generated)
+                if owner_id is not None:
+                  repaired = dict(message)
+                  repaired["id"] = owner_id
+                  messages[index] = repaired
+                  conn.execute(update_messages, {
+                    "chat_id": row["id"],
+                    "messages": messages,
+                  })
+              break
+      if owner_id is None:
+        live = decoded(row.get("live_assistant"))
+        if isinstance(live, dict):
+          owner_id = bounded_id(live.get("id"))
+      if owner_id is not None:
+        conn.execute(text(
+          "UPDATE chats SET active_assistant_message_id = :owner_id "
+          "WHERE id = :chat_id AND active_assistant_message_id IS NULL"
+        ), {"chat_id": row["id"], "owner_id": owner_id})
+
+
 def _pin_established_legacy_chat_models(eng) -> None:
   """Replace the retired interactive SDK default with explicit chat choices.
 
@@ -1868,6 +1975,7 @@ _SCHEMA_MIGRATIONS = (
   ("0016_app_connect_manage", _add_app_connect_manage),
   ("0017_retire_restart_resume_toggle", _retire_restart_resume_toggle),
   ("0018_explicit_legacy_chat_models", _pin_established_legacy_chat_models),
+  ("0019_chat_active_assistant_identity", _add_chat_active_assistant_identity),
 )
 
 

--- a/backend/app/schema_migrations.py
+++ b/backend/app/schema_migrations.py
@@ -1690,11 +1690,12 @@ def _add_chat_active_assistant_identity(eng) -> None:
 
   A pending question is the stronger protocol boundary, so locate the exact
   unanswered card it names first. Otherwise backfill from the bounded live
-  snapshot. This also repairs a stale pre-upgrade live value instead of letting
-  it outrank a committed owner decision. Everything is self-contained because
-  migration history is immutable after publication.
+  snapshot. Rows whose exact parked-question owner predates assistant message
+  ids stay null here: startup repairs that transcript through the chat-writer
+  actor, then stores both identities in one serialized transaction. Schema
+  migrations never rewrite ``Chat.messages``.
   """
-  from sqlalchemy import JSON as SAJSON, bindparam, inspect as sa_inspect, text
+  from sqlalchemy import inspect as sa_inspect, text
 
   inspector = sa_inspect(eng)
   if "chats" not in inspector.get_table_names():
@@ -1736,10 +1737,6 @@ def _add_chat_active_assistant_identity(eng) -> None:
     def bounded_id(value):
       return value if isinstance(value, str) and 0 < len(value) <= 128 else None
 
-    update_messages = text(
-      "UPDATE chats SET messages = :messages WHERE id = :chat_id"
-    ).bindparams(bindparam("messages", type_=SAJSON))
-
     for row in rows:
       owner_id = None
       pending_question_id = row.get("pending_question_id")
@@ -1764,22 +1761,6 @@ def _add_chat_active_assistant_identity(eng) -> None:
             )
             if matching_question:
               owner_id = bounded_id(message.get("id"))
-              if owner_id is None:
-                # Pre-identity assistant rows still have one unambiguous owner:
-                # the exact unanswered card named by the durable marker. Give
-                # only that row a deterministic id and persist the same value in
-                # the scalar; inventing an id without updating the transcript
-                # would point the browser at a row that does not exist.
-                generated = f"assistant-question-{pending_question_id}"
-                owner_id = bounded_id(generated)
-                if owner_id is not None:
-                  repaired = dict(message)
-                  repaired["id"] = owner_id
-                  messages[index] = repaired
-                  conn.execute(update_messages, {
-                    "chat_id": row["id"],
-                    "messages": messages,
-                  })
               break
       if owner_id is None:
         live = decoded(row.get("live_assistant"))

--- a/backend/app/startup.py
+++ b/backend/app/startup.py
@@ -252,6 +252,41 @@ def _start_chat_writer(_context: StartupContext) -> None:
   start_writer()
 
 
+def _backfill_active_assistant_identities(context: StartupContext) -> None:
+  """Route the legacy parked-question identity repair through chat_writer."""
+  from app import models
+  from app.chat_writer import (
+    BackfillAssistantIdentity,
+    get_writer,
+    wait_ack,
+  )
+
+  with SessionLocal() as db:
+    candidate_ids = [
+      row[0] for row in (
+        db.query(models.Chat.id)
+        .filter(
+          models.Chat.deleted_at.is_(None),
+          models.Chat.active_assistant_message_id.is_(None),
+          # The schema migration already backfills ordinary live snapshots.
+          # Only id-less parked-question rows need a transcript rewrite, so
+          # keep boot work proportional to that narrow legacy population.
+          models.Chat.pending_question_id.isnot(None),
+        )
+        .all()
+      )
+    ]
+  changed = 0
+  for chat_id in candidate_ids:
+    changed += int(wait_ack(get_writer().submit(
+      BackfillAssistantIdentity(chat_id=chat_id),
+    )) or 0)
+  if changed:
+    context.logger.info(
+      "backfilled active assistant identity for %d legacy chat(s)", changed,
+    )
+
+
 def _initialize_push(_context: StartupContext) -> None:
   from app.push import init_vapid
 
@@ -348,6 +383,10 @@ DATABASE_STARTUP_TASKS = (
   # soon as the schema exists; later startup failures still fail open exactly
   # as they did when the writer started near the end of the plan.
   StartupTask("start chat writer", _start_chat_writer),
+  StartupTask(
+    "backfill active assistant identities",
+    _backfill_active_assistant_identities,
+  ),
   StartupTask("purge expired chat tombstones", _purge_expired_chats),
   StartupTask("backfill session links", _backfill_session_links),
   StartupTask("backfill prompt snapshots", _backfill_prompt_snapshots),

--- a/backend/tests/test_chat_live_assistant.py
+++ b/backend/tests/test_chat_live_assistant.py
@@ -46,6 +46,7 @@ def test_stream_snapshot_updates_only_live_value(db):
   history_version = chat.updated_at
 
   assert update_live_assistant(db, chat.id, {
+    "id": "assistant-streaming",
     "role": "assistant",
     "blocks": [{"type": "text", "text": "streaming"}],
   }) is True
@@ -54,6 +55,7 @@ def test_stream_snapshot_updates_only_live_value(db):
   assert chat.messages == history
   assert chat.live_assistant["ts"] == 4
   assert chat.live_assistant["blocks"][0]["text"] == "streaming"
+  assert chat.active_assistant_message_id == "assistant-streaming"
   assert chat.updated_at == history_version
   assert materialized_messages(chat)[-1] == chat.live_assistant
 
@@ -83,6 +85,7 @@ def test_finalize_merges_live_turn_once_and_clears_snapshot(db):
   assert chat.messages[-1]["id"] == "assistant-current"
   assert chat.messages[-1]["ts"] == 4
   assert chat.messages[-1]["blocks"][0]["text"] == "complete"
+  assert chat.active_assistant_message_id == "assistant-current"
   assert chat.updated_at != history_version
 
 

--- a/backend/tests/test_chat_transcript_compact.py
+++ b/backend/tests/test_chat_transcript_compact.py
@@ -610,6 +610,7 @@ def test_runtime_route_does_not_select_transcript_json(
   assert runtime.status_code == 200
   assert runtime.json() == {
     "running": True,
+    "active_assistant_message_id": None,
     "active_goal_objective": None,
     "pending_messages": [],
     "pending_question_id": None,
@@ -623,4 +624,99 @@ def test_runtime_route_does_not_select_transcript_json(
   )
   assert "chats.pending_messages" in chat_select
   assert "chats.updated_at" in chat_select
+  assert "chats.active_assistant_message_id" in chat_select
   assert "chats.messages as" not in chat_select
+  assert not any(
+    "json_extract(chats.live_assistant" in statement
+    for statement in statements
+  )
+
+
+def test_detail_and_runtime_expose_the_durable_assistant_owner(
+  client,
+  auth,
+  db,
+  monkeypatch,
+):
+  created = client.post(
+    "/api/chats",
+    headers=auth,
+    json={"title": "Assistant owner"},
+  )
+  chat_id = created.json()["id"]
+  chat = db.query(models.Chat).filter(models.Chat.id == chat_id).one()
+  chat.active_assistant_message_id = "assistant-current"
+  db.commit()
+  monkeypatch.setattr("app.routes.chats.is_chat_running", lambda _: True)
+
+  detail = client.get(f"/api/chats/{chat_id}", headers=auth)
+  runtime = client.get(f"/api/chats/{chat_id}/runtime", headers=auth)
+
+  assert detail.status_code == 200
+  assert runtime.status_code == 200
+  assert detail.json()["active_assistant_message_id"] == "assistant-current"
+  assert runtime.json()["active_assistant_message_id"] == "assistant-current"
+
+
+def test_parked_question_exposes_its_tail_owner_without_live_json(
+  client,
+  auth,
+  db,
+):
+  """A restart-safe parked card still owns one assistant row after commit.
+
+  This is the real failure topology: an older answered card, a hidden
+  continuation boundary, then the current unanswered card. The lightweight
+  runtime must name the final row without reading transcript/live JSON.
+  """
+  created = client.post(
+    "/api/chats",
+    headers=auth,
+    json={"title": "Parked assistant owner"},
+  )
+  chat_id = created.json()["id"]
+  chat = db.query(models.Chat).filter(models.Chat.id == chat_id).one()
+  chat.messages = [
+    {"role": "user", "content": "earlier", "ts": 1},
+    {
+      "id": "assistant-older",
+      "role": "assistant",
+      "ts": 2,
+      "blocks": [{
+        "type": "question",
+        "question_id": "question-older",
+        "questions": [{"id": "old", "question": "Old choice?"}],
+        "answers": {"old": "Done"},
+      }],
+    },
+    {
+      "role": "user",
+      "kind": "wait_result",
+      "hidden": True,
+      "content": "checks finished",
+      "ts": 3,
+    },
+    {
+      "id": "assistant-current",
+      "role": "assistant",
+      "ts": 4,
+      "blocks": [{
+        "type": "question",
+        "question_id": "question-current",
+        "questions": [{"id": "current", "question": "Current choice?"}],
+      }],
+    },
+  ]
+  chat.pending_question_id = "question-current"
+  chat.live_assistant = None
+  chat.active_assistant_message_id = "assistant-current"
+  db.commit()
+
+  detail = client.get(f"/api/chats/{chat_id}", headers=auth)
+  runtime = client.get(f"/api/chats/{chat_id}/runtime", headers=auth)
+
+  assert detail.status_code == 200
+  assert runtime.status_code == 200
+  assert detail.json()["active_assistant_message_id"] == "assistant-current"
+  assert runtime.json()["active_assistant_message_id"] == "assistant-current"
+  assert runtime.json()["pending_question_id"] == "question-current"

--- a/backend/tests/test_chat_writer_contention.py
+++ b/backend/tests/test_chat_writer_contention.py
@@ -26,6 +26,7 @@ from app.chat_writer import (
   AnswerQuestion,
   AppendPending,
   AppendSteeredUserMessage,
+  BackfillAssistantIdentity,
   Barrier,
   CancelPending,
   ChatWriterActor,
@@ -243,6 +244,34 @@ def test_question_commit_commits_before_ack(actor):
   assert chat["messages"][-1]["blocks"][0]["question_id"] == "q1"
   assert chat["pending_question_id"] == "q1"
   assert chat["active_assistant_message_id"] == "assistant-question"
+
+
+def test_legacy_parked_question_identity_is_repaired_by_writer(actor):
+  """Upgrade repair mutates the transcript only through a domain command."""
+  _seed_chat(
+    messages=[
+      {"role": "user", "content": "pick", "ts": 1},
+      _question_msg("q-legacy"),
+    ],
+    pending_question_id="q-legacy",
+  )
+
+  assert _await(actor.submit(
+    BackfillAssistantIdentity(chat_id="c1"),
+  )) == 1
+  chat = _load_chat()
+  assert chat["messages"][-1]["id"] == "assistant-question-q-legacy"
+  assert (
+    chat["active_assistant_message_id"]
+    == "assistant-question-q-legacy"
+  )
+
+  # The startup task may run again after an interrupted boot; the exact same
+  # row and scalar remain untouched.
+  assert _await(actor.submit(
+    BackfillAssistantIdentity(chat_id="c1"),
+  )) == 0
+  assert _load_chat() == chat
 
 
 # -- 3. question not broadcast on QuestionCommit fail ----------------------

--- a/backend/tests/test_chat_writer_contention.py
+++ b/backend/tests/test_chat_writer_contention.py
@@ -54,6 +54,7 @@ def _seed_chat(
   pending=None,
   session_id="sess-1",
   pending_question_id=None,
+  active_assistant_message_id=None,
   title="Test chat",
   title_locked=False,
 ):
@@ -69,6 +70,7 @@ def _seed_chat(
       session_id=session_id,
       provider="claude",
       pending_question_id=pending_question_id,
+      active_assistant_message_id=active_assistant_message_id,
     )
     db.add(chat)
     db.commit()
@@ -116,6 +118,7 @@ def _load_chat(chat_id="c1"):
       "live_assistant": chat.live_assistant,
       "pending_messages": list(chat.pending_messages or []),
       "pending_question_id": chat.pending_question_id,
+      "active_assistant_message_id": chat.active_assistant_message_id,
       "session_id": chat.session_id,
       "provider": chat.provider,
       "title": chat.title,
@@ -143,12 +146,15 @@ def _load_run(run_token):
     db.close()
 
 
-def _assistant_msg(blocks, content=""):
+def _assistant_msg(blocks, content="", message_id=None):
   """Build an assistant-message snapshot the persist helpers accept."""
-  return {"role": "assistant", "content": content, "blocks": list(blocks)}
+  message = {"role": "assistant", "content": content, "blocks": list(blocks)}
+  if message_id is not None:
+    message["id"] = message_id
+  return message
 
 
-def _question_msg(question_id, content=""):
+def _question_msg(question_id, content="", message_id=None):
   """An assistant message carrying a single AskUserQuestion block."""
   return _assistant_msg(
     [
@@ -159,6 +165,7 @@ def _question_msg(question_id, content=""):
       }
     ],
     content=content,
+    message_id=message_id,
   )
 
 
@@ -224,13 +231,18 @@ def test_question_commit_commits_before_ack(actor):
   question."""
   _seed_chat(messages=[{"role": "user", "content": "hi", "ts": 1}])
   fut = actor.submit(
-    QuestionCommit(chat_id="c1", run_token="rt1", snapshot=_question_msg("q1"))
+    QuestionCommit(
+      chat_id="c1",
+      run_token="rt1",
+      snapshot=_question_msg("q1", message_id="assistant-question"),
+    )
   )
   assert _await(fut) is True
   # The ack has resolved; the row MUST already carry the question block.
   chat = _load_chat()
   assert chat["messages"][-1]["blocks"][0]["question_id"] == "q1"
   assert chat["pending_question_id"] == "q1"
+  assert chat["active_assistant_message_id"] == "assistant-question"
 
 
 # -- 3. question not broadcast on QuestionCommit fail ----------------------
@@ -472,6 +484,42 @@ def test_replace_transcript_broad_fences_other_token_snapshot(actor):
   assert chat["messages"][-1]["blocks"][0]["content"] == "replaced"
 
 
+def test_replace_transcript_rebuilds_question_and_owner_as_one_state(actor):
+  """A full transcript replacement cannot leave either derived scalar stale."""
+  _seed_chat(
+    messages=[{"role": "user", "content": "old", "ts": 1}],
+    pending_question_id="old-question",
+    active_assistant_message_id="assistant-old",
+  )
+  replacement = [
+    {"role": "user", "content": "new", "ts": 2},
+    {
+      "id": "assistant-current",
+      "role": "assistant",
+      "ts": 3,
+      "blocks": [{
+        "type": "question",
+        "question_id": "current-question",
+        "questions": [{"id": "pick", "question": "Choose?"}],
+      }],
+    },
+  ]
+
+  assert _await(actor.submit(ReplaceTranscript(
+    chat_id="c1", messages=replacement,
+  ))) is True
+  chat = _load_chat()
+  assert chat["pending_question_id"] == "current-question"
+  assert chat["active_assistant_message_id"] == "assistant-current"
+
+  assert _await(actor.submit(ReplaceTranscript(
+    chat_id="c1", messages=[{"role": "user", "content": "settled", "ts": 4}],
+  ))) is True
+  chat = _load_chat()
+  assert chat["pending_question_id"] is None
+  assert chat["active_assistant_message_id"] is None
+
+
 # -- 6. concurrent append/cancel/promote preserve order -------------------
 def test_concurrent_append_cancel_promote_preserve_order(actor):
   """Concurrent AppendPending / CancelPending / PromotePending never lose a
@@ -668,6 +716,7 @@ def test_start_turn_is_atomic(actor):
   assert chat["provider"] == "codex"
   assert chat["running_status"] == "running"
   assert chat["running_started_at"] is not None
+  assert chat["active_assistant_message_id"] == "rt1"
 
 
 def test_start_turn_keeps_a_useful_first_message_title_preview(actor):
@@ -828,6 +877,7 @@ def test_answering_owner_question_releases_pending_promotion(actor):
     messages=[question],
     pending=queued,
     pending_question_id="owner-decision",
+    active_assistant_message_id="assistant-owner-decision",
   )
 
   assert _await(actor.submit(AnswerQuestion(
@@ -836,6 +886,12 @@ def test_answering_owner_question_releases_pending_promotion(actor):
     question_id="owner-decision",
     answers={"Choose a direction.": "Continue"},
   ))) is True
+  answered = _load_chat()
+  assert answered["pending_question_id"] is None
+  assert (
+    answered["active_assistant_message_id"]
+    == "assistant-owner-decision"
+  )
   promoted = _await(actor.submit(PromotePending(
     chat_id="c1",
     run_token="released-promotion",
@@ -849,6 +905,7 @@ def test_answering_owner_question_releases_pending_promotion(actor):
   assert chat["pending_question_id"] is None
   assert chat["pending_messages"] == []
   assert chat["running_status"] == "running"
+  assert chat["active_assistant_message_id"] == "released-promotion"
   assert _load_run("released-promotion")["status"] == "running"
 
 
@@ -886,6 +943,7 @@ def test_promote_pending_collapses_all_followups(actor):
   assert [m["content"] for m in chat["messages"][-2:]] == ["first", "second"]
   assert chat["pending_messages"] == []
   assert chat["running_status"] == "running"
+  assert chat["active_assistant_message_id"] == "rt1"
 
 
 def test_promote_pending_names_a_new_chat_recovered_from_the_queue(actor):
@@ -1304,6 +1362,35 @@ def test_answer_question_no_block_raises(actor):
     _await(fut)
 
 
+def test_recovered_answer_retires_old_assistant_before_continuation(actor):
+  question = _question_msg(
+    "q-recovered", message_id="assistant-before-recovery",
+  )
+  _seed_chat(
+    messages=[{"role": "user", "content": "go", "ts": 1}, question],
+    pending_question_id="q-recovered",
+    active_assistant_message_id="assistant-before-recovery",
+  )
+
+  result = _await(actor.submit(AppendPending(
+    chat_id="c1",
+    user_msg={"role": "user", "content": "answer", "hidden": True, "ts": 3},
+    answers={"q-recovered": "Blue"},
+    question_id="q-recovered",
+    front=True,
+    require_answer_match=True,
+  )))
+
+  chat = _load_chat()
+  assert result["stored"]["content"] == "answer"
+  assert chat["messages"][-1]["blocks"][0]["answers"] == {
+    "q-recovered": "Blue",
+  }
+  assert chat["pending_question_id"] is None
+  assert chat["active_assistant_message_id"] is None
+  assert chat["pending_messages"][0]["content"] == "answer"
+
+
 # -- 12. stop-races-answer never resolves a cancelled future --------------
 def test_stop_races_answer_never_resolves_cancelled_future(actor):
   """If the caller's ack future is cancelled before the answer commits (the
@@ -1456,10 +1543,13 @@ def test_clear_pending_empty_queue_is_noop(actor):
   assert chat["pending_messages"] == []
 
 
-def test_finish_run_closes_durable_run(actor):
+def test_finish_run_closes_durable_run_and_retires_assistant_owner(actor):
   from datetime import UTC, datetime
 
-  cid = _seed_chat(messages=[{"role": "user", "content": "hi", "ts": 1}])
+  cid = _seed_chat(
+    messages=[{"role": "user", "content": "hi", "ts": 1}],
+    active_assistant_message_id="rt1",
+  )
   # Seed the run via a throwaway session.
   db = SessionLocal()
   try:
@@ -1478,6 +1568,43 @@ def test_finish_run_closes_durable_run(actor):
   chat = _load_chat()
   assert chat["running_status"] is None
   assert chat["running_started_at"] is None
+  assert chat["active_assistant_message_id"] is None
+
+
+def test_interrupted_finish_preserves_parked_question_owner(actor):
+  from datetime import UTC, datetime
+
+  question = _question_msg(
+    "owner-decision", message_id="assistant-owner-decision",
+  )
+  cid = _seed_chat(
+    messages=[question],
+    pending_question_id="owner-decision",
+    active_assistant_message_id="assistant-owner-decision",
+  )
+  db = SessionLocal()
+  try:
+    db.add(models.ChatRun(
+      id="rt-question",
+      chat_id=cid,
+      status="running",
+      provider="claude",
+      started_at=datetime.now(UTC),
+    ))
+    db.commit()
+  finally:
+    db.close()
+
+  _await(actor.submit(FinishRun(
+    chat_id=cid,
+    run_token="rt-question",
+    terminal_status="interrupted",
+  )))
+
+  chat = _load_chat(cid)
+  assert chat["running_status"] is None
+  assert chat["pending_question_id"] == "owner-decision"
+  assert chat["active_assistant_message_id"] == "assistant-owner-decision"
 
 
 def test_stale_finish_run_cannot_clear_successor_question(actor):
@@ -1498,7 +1625,7 @@ def test_stale_finish_run_cannot_clear_successor_question(actor):
   _await(actor.submit(QuestionCommit(
     chat_id="c1",
     run_token="new-run",
-    snapshot=_question_msg("new-question"),
+    snapshot=_question_msg("new-question", message_id="new-run"),
   )))
 
   _await(actor.submit(FinishRun(
@@ -1507,6 +1634,7 @@ def test_stale_finish_run_cannot_clear_successor_question(actor):
 
   chat = _load_chat()
   assert chat["pending_question_id"] == "new-question"
+  assert chat["active_assistant_message_id"] == "new-run"
   assert chat["running_status"] == "running"
   assert _load_run("old-run")["status"] == "interrupted"
   assert _load_run("new-run")["status"] == "running"
@@ -1514,7 +1642,9 @@ def test_stale_finish_run_cannot_clear_successor_question(actor):
   _await(actor.submit(FinishRun(
     chat_id="c1", run_token="new-run", terminal_status="completed",
   )))
-  assert _load_chat()["pending_question_id"] is None
+  chat = _load_chat()
+  assert chat["pending_question_id"] is None
+  assert chat["active_assistant_message_id"] is None
 
 
 def test_stale_wedged_recovery_cannot_clobber_new_run(actor):
@@ -1544,6 +1674,7 @@ def test_stale_wedged_recovery_cannot_clobber_new_run(actor):
   assert result is False
   chat = _load_chat()
   assert chat["running_status"] == "running"
+  assert chat["active_assistant_message_id"] == "new-run"
   assert [message["content"] for message in chat["messages"]] == ["old", "new"]
   assert _load_run("old-run")["status"] == "interrupted"
   assert _load_run("new-run")["status"] == "running"

--- a/backend/tests/test_chats_stream_answer_race.py
+++ b/backend/tests/test_chats_stream_answer_race.py
@@ -350,6 +350,7 @@ def test_recovered_answer_clears_pending_question_marker(
     try:
       row = db.query(models.Chat).filter(models.Chat.id == chat.id).first()
       row.pending_question_id = qid
+      row.active_assistant_message_id = "assistant-before-recovered-answer"
       db.commit()
     finally:
       db.close()
@@ -384,6 +385,7 @@ def test_recovered_answer_clears_pending_question_marker(
       # The marker MUST be cleared so the composer unblocks with the answer,
       # not only when the recovered turn eventually ends.
       assert row.pending_question_id is None
+      assert row.active_assistant_message_id == scheduled[0]["run_token"]
     finally:
       db.close()
 

--- a/backend/tests/test_crash_recovery.py
+++ b/backend/tests/test_crash_recovery.py
@@ -190,6 +190,7 @@ def test_reconcile_rebuilds_open_question_barrier_from_repaired_tail(db):
     messages=[
       {"role": "user", "content": "Review PR #787", "ts": 1},
       {
+        "id": "assistant-question-recovery",
         "role": "assistant",
         "ts": 2,
         "blocks": [{
@@ -221,6 +222,7 @@ def test_reconcile_rebuilds_open_question_barrier_from_repaired_tail(db):
   assert blocks[-1]["question_id"] == "owner-decision"
   assert blocks[-1].get("answers") is None
   assert row.pending_question_id == "owner-decision"
+  assert row.active_assistant_message_id == "assistant-question-recovery"
   assert [item["cid"] for item in row.pending_messages] == ["wait-result-787"]
 
 

--- a/backend/tests/test_db_migrations.py
+++ b/backend/tests/test_db_migrations.py
@@ -1535,7 +1535,7 @@ def test_active_assistant_identity_migration_backfills_live_and_parked_rows(
   assert owners == {
     "deleted": None,
     "historical-only": None,
-    "idless": "assistant-question-q-idless",
+    "idless": None,
     "live": "assistant-live",
     "missing-question": None,
     "parked": "assistant-current",
@@ -1547,7 +1547,7 @@ def test_active_assistant_identity_migration_backfills_live_and_parked_rows(
     if isinstance(idless["messages"], str)
     else idless["messages"]
   )
-  assert idless_messages[-1]["id"] == "assistant-question-q-idless"
+  assert "id" not in idless_messages[-1]
 
 
 def test_connections_manage_reaches_a_ledgered_database(tmp_path):

--- a/backend/tests/test_db_migrations.py
+++ b/backend/tests/test_db_migrations.py
@@ -1164,6 +1164,7 @@ def test_run_migrations_records_an_inspectable_append_only_history(tmp_path):
     "0016_app_connect_manage",
     "0017_retire_restart_resume_toggle",
     "0018_explicit_legacy_chat_models",
+    "0019_chat_active_assistant_identity",
   ]
   assert second == first
 
@@ -1434,6 +1435,119 @@ def test_pending_question_migration_backfills_only_active_latest_question(
     "completed": None,
     "superseded": None,
   }
+
+
+def test_active_assistant_identity_migration_backfills_live_and_parked_rows(
+  tmp_path,
+):
+  eng = create_engine(f"sqlite:///{tmp_path / 'assistant-identity.db'}")
+  parked_messages = [
+    {
+      "id": "assistant-older",
+      "role": "assistant",
+      "blocks": [{
+        "type": "question",
+        "question_id": "q-older",
+        "answers": {"pick": "done"},
+      }],
+    },
+    {"role": "user", "hidden": True, "kind": "wait_result"},
+    {
+      "id": "assistant-current",
+      "role": "assistant",
+      "blocks": [{
+        "type": "question",
+        "question_id": "q-current",
+      }],
+    },
+  ]
+  with eng.begin() as conn:
+    conn.execute(text(
+      "CREATE TABLE chats ("
+      "id VARCHAR(64) PRIMARY KEY, messages JSON, live_assistant JSON, "
+      "pending_question_id VARCHAR(64), deleted_at DATETIME NULL)"
+    ))
+    rows = (
+      (
+        "live",
+        [],
+        {"id": "assistant-live", "role": "assistant", "blocks": []},
+        None,
+        None,
+      ),
+      ("parked", parked_messages, None, "q-current", None),
+      (
+        "parked-with-stale-live",
+        parked_messages,
+        {"id": "assistant-stale", "role": "assistant", "blocks": []},
+        "q-current",
+        None,
+      ),
+      ("missing-question", parked_messages, None, "q-missing", None),
+      ("historical-only", parked_messages, None, None, None),
+      ("idless", [{
+        "role": "assistant",
+        "blocks": [{"type": "question", "question_id": "q-idless"}],
+      }], None, "q-idless", None),
+      (
+        "deleted",
+        [],
+        {"id": "assistant-deleted", "role": "assistant", "blocks": []},
+        None,
+        "2026-08-25 12:00:00",
+      ),
+    )
+    for chat_id, messages, live, pending_question_id, deleted_at in rows:
+      conn.execute(text(
+        "INSERT INTO chats "
+        "(id, messages, live_assistant, pending_question_id, deleted_at) "
+        "VALUES (:id, :messages, :live, :pending, :deleted_at)"
+      ), {
+        "id": chat_id,
+        "messages": json.dumps(messages),
+        "live": json.dumps(live) if live is not None else None,
+        "pending": pending_question_id,
+        "deleted_at": deleted_at,
+      })
+
+  migrations._add_chat_active_assistant_identity(eng)
+  # Simulate a process death after SQLite committed the ALTER/backfill but
+  # before the ledger marker: a retry sees the column and must still repair any
+  # row whose scalar did not land.
+  with eng.begin() as conn:
+    conn.execute(text(
+      "UPDATE chats SET active_assistant_message_id = NULL "
+      "WHERE id IN ('parked', 'idless')"
+    ))
+  migrations._add_chat_active_assistant_identity(eng)
+
+  assert "active_assistant_message_id" in {
+    column["name"] for column in inspect(eng).get_columns("chats")
+  }
+  with eng.connect() as conn:
+    migrated = conn.execute(text(
+      "SELECT id, active_assistant_message_id, messages "
+      "FROM chats ORDER BY id"
+    )).mappings().all()
+  owners = {
+    row["id"]: row["active_assistant_message_id"] for row in migrated
+  }
+  assert owners == {
+    "deleted": None,
+    "historical-only": None,
+    "idless": "assistant-question-q-idless",
+    "live": "assistant-live",
+    "missing-question": None,
+    "parked": "assistant-current",
+    "parked-with-stale-live": "assistant-current",
+  }
+  idless = next(row for row in migrated if row["id"] == "idless")
+  idless_messages = (
+    json.loads(idless["messages"])
+    if isinstance(idless["messages"], str)
+    else idless["messages"]
+  )
+  assert idless_messages[-1]["id"] == "assistant-question-q-idless"
 
 
 def test_connections_manage_reaches_a_ledgered_database(tmp_path):

--- a/backend/tests/test_drain_for_restart.py
+++ b/backend/tests/test_drain_for_restart.py
@@ -78,6 +78,8 @@ def _chat(chat_id: str):
     return {
       "messages": materialized_messages(row),
       "pending": list(row.pending_messages or []),
+      "pending_question_id": row.pending_question_id,
+      "active_assistant_message_id": row.active_assistant_message_id,
       "running_status": "running" if has_running_run(db, chat_id) else None,
     }
   finally:
@@ -620,9 +622,15 @@ def test_authenticated_restart_question_stays_waiting_not_manual():
   nonce = "restart-nonce-question"
   _seed(cid, messages=[
     {"role": "user", "content": "hi", "ts": 1},
-    {"role": "assistant", "ts": 2, "content": "", "blocks": [
+    {
+      "id": f"rt-{cid}",
+      "role": "assistant", "ts": 2, "content": "", "blocks": [
       {"type": "text", "content": "I need your approval."},
-      {"type": "question", "id": "q1", "text": "Restart now?"},
+      {
+        "type": "question",
+        "question_id": "q1",
+        "questions": [{"id": "q1", "question": "Restart now?"}],
+      },
     ]},
   ])
   db = SessionLocal()
@@ -646,11 +654,14 @@ def test_authenticated_restart_question_stays_waiting_not_manual():
   run = _run(cid)
   assert run["status"] == "interrupted"
   assert run["restart_nonce"] is None
-  blocks = _chat(cid)["messages"][-1]["blocks"]
+  chat = _chat(cid)
+  blocks = chat["messages"][-1]["blocks"]
   assert blocks[-1]["type"] == "question"
   note = next(block for block in blocks if block["type"] == "error")
   assert "answer is still needed" in note["message"]
   assert not note.get("resumable")
+  assert chat["pending_question_id"] == "q1"
+  assert chat["active_assistant_message_id"] == f"rt-{cid}"
 
 
 def test_reconcile_restart_note_normalizes_before_open_question():

--- a/backend/tests/test_startup_tasks.py
+++ b/backend/tests/test_startup_tasks.py
@@ -98,6 +98,12 @@ def test_production_startup_plan_has_explicit_unique_order_and_criticality():
   assert startup.PROCESS_STARTUP_TASKS[-1].name == "initialize database"
   assert startup.DATABASE_STARTUP_TASKS[0].name == "start chat writer"
   assert names.index("initialize database") < names.index("start chat writer")
+  assert names.index("start chat writer") < names.index(
+    "backfill active assistant identities"
+  )
+  assert names.index("backfill active assistant identities") < names.index(
+    "reconcile startup chats"
+  )
   assert names.index("start chat writer") < names.index("fix forward chat media")
   assert names.index("start chat writer") < names.index("reconcile startup chats")
   assert names.index("initialize push") < names.index("notify reconciled chats")

--- a/backend/tests/test_system_broadcast.py
+++ b/backend/tests/test_system_broadcast.py
@@ -41,6 +41,7 @@ from app.chat_writer import Barrier, StartTurn, get_writer
 from app.chat_transcript import materialized_messages
 from app.chat_event_sink import (
   ChatEventSink,
+  active_sink_assistant_message_id,
   active_sink_stream_snapshot,
   get_active_sink,
   register_active_sink,
@@ -120,6 +121,9 @@ def test_active_sink_snapshot_is_frozen_and_broadcast_identity_keyed():
   sink.assistant_blocks = [{"type": "text", "content": "hello"}]
   register_active_sink(bc.chat_id, sink)
   try:
+    assert active_sink_assistant_message_id(
+      bc.chat_id,
+    ) == sink.assistant_message_id
     snapshot = active_sink_stream_snapshot(bc.chat_id, bc)
     assert snapshot == {
       "items": sink.assistant_blocks,
@@ -249,6 +253,7 @@ def test_question_event_is_saved_before_broadcast(db, chat):
       assert any(b.get("type") == "question" for b in blocks), (
         "question block must be persisted before the broadcast"
       )
+      assert row.active_assistant_message_id == "rt-q"
     finally:
       s.close()
 
@@ -343,6 +348,7 @@ def test_non_question_save_routes_to_actor_off_loop(db, chat):
   messages = materialized_messages(row)
   assert messages and messages[-1].get("role") == "assistant"
   assert any(b.get("type") == "tool" for b in messages[-1]["blocks"])
+  assert row.active_assistant_message_id == "rt-t"
 
 
 def test_streaming_commit_runs_off_the_event_loop_thread(db, chat):

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -118,7 +118,13 @@ import {
   isPendingQuestionSendFailure,
   sendFailureMessage,
 } from './sendFailure.js'
-import { assistantStreamCoversMessage, chooseActiveAssistantDataKey, findTrailingAssistantPartialIndex, streamItemsHaveRenderableContent } from './streamPromotion.js'
+import {
+  assistantStreamBelongsToActiveMessage,
+  assistantStreamCoversMessage,
+  chooseActiveAssistantDataKey,
+  findTrailingAssistantPartialIndex,
+  streamItemsHaveRenderableContent,
+} from './streamPromotion.js'
 import {
   commitAssistantPromotion,
   deriveActiveAssistantSelection,
@@ -140,6 +146,7 @@ import {
   runtimeStreamAttachAction,
   shouldRetireRestoredQuestionSnapshot,
   shouldAttachRunningStream,
+  shouldAdoptRuntimeAssistantOwner,
   shouldRecoverSettledRuntime,
   shouldRetryStopAfterConfirm,
   stopConfirmedIdle,
@@ -483,6 +490,20 @@ export default function ChatView({
       { running },
     )
   }
+  // The server names the only assistant row allowed to own regenerable live
+  // stream state. Keep a synchronous ref for terminal/promotion callbacks;
+  // React state drives source selection for ordinary renders.
+  const [activeAssistantMessageId, setActiveAssistantMessageIdState] = useState(
+    () => cached?.activeAssistantMessageId ?? null,
+  )
+  const activeAssistantMessageIdRef = useRef(
+    cached?.activeAssistantMessageId ?? null,
+  )
+  const setActiveAssistantMessageId = useCallback((value) => {
+    const next = typeof value === 'string' && value ? value : null
+    activeAssistantMessageIdRef.current = next
+    setActiveAssistantMessageIdState(next)
+  }, [])
   const {
     input,
     inputValueRef,
@@ -1107,6 +1128,14 @@ export default function ChatView({
         data, latestGoalObjective(msgs),
       )
       setActiveGoalObjective(runtimeGoalObjective)
+      const adoptAssistantOwner = shouldAdoptRuntimeAssistantOwner({
+        runtimeRunning: !!data.running,
+        localAuthoritative: preserveLocalTurn,
+        authoritativeRefresh: authoritative,
+      })
+      if (adoptAssistantOwner) {
+        setActiveAssistantMessageId(data.active_assistant_message_id || null)
+      }
       setLiveQuestionId(data.pending_question_id || null)
       if (Array.isArray(data.waits)) setArmedWaits(data.waits)
       updateChatRuntimeCache(queryClient, chatMessagesQueryKey(chatId), {
@@ -1114,6 +1143,9 @@ export default function ChatView({
         activeGoalObjective: runtimeGoalObjective,
         pending_messages: data.pending_messages || [],
         pending_question_id: data.pending_question_id || null,
+        ...(adoptAssistantOwner ? {
+          activeAssistantMessageId: data.active_assistant_message_id || null,
+        } : {}),
         waits: data.waits || [],
       })
       // Reconcile pending queue against authoritative server state.
@@ -1127,6 +1159,7 @@ export default function ChatView({
       }
       return {
         running: !!data.running,
+        activeAssistantMessageId: data.active_assistant_message_id || null,
         pendingQuestionId: data.pending_question_id || null,
         pendingLimitResume: !!tailResumableBlock(msgs)?.pause?.resets_at,
       }
@@ -1141,6 +1174,7 @@ export default function ChatView({
     commitMessages,
     pendingQueue.hydrate,
     queryClient,
+    setActiveAssistantMessageId,
   ])
 
   // Active-turn runtime reconciliation. The SSE stream is authoritative for
@@ -1165,6 +1199,7 @@ export default function ChatView({
       const serverPending = data.pending_messages || []
       const runtime = {
         running: !!data.running,
+        activeAssistantMessageId: data.active_assistant_message_id || null,
         pendingQuestionId: data.pending_question_id || null,
       }
       // The SSE stream is the source of truth for "a turn is live" — this poll
@@ -1179,6 +1214,13 @@ export default function ChatView({
         localStartRequestRef.current?.chatId === String(chatId)
       const localAuthoritative =
         handlingStopRef.current || localStartInFlight || isStreamingRef.current
+      const adoptAssistantOwner = shouldAdoptRuntimeAssistantOwner({
+        runtimeRunning: runtime.running,
+        localAuthoritative,
+      })
+      if (adoptAssistantOwner) {
+        setActiveAssistantMessageId(runtime.activeAssistantMessageId)
+      }
       if (shouldRecoverSettledRuntime({
         runtimeWasObservedRunning: serverRunningRef.current,
         runtimeRunning: !!data.running,
@@ -1244,6 +1286,9 @@ export default function ChatView({
         activeGoalObjective: runtimeGoalObjective,
         pending_messages: serverPending,
         pending_question_id: pendingQuestionId,
+        ...(adoptAssistantOwner ? {
+          activeAssistantMessageId: runtime.activeAssistantMessageId,
+        } : {}),
         waits: data.waits || [],
       })
       // Don't let the fallback poll add/clobber the queue while a turn is live
@@ -1280,6 +1325,7 @@ export default function ChatView({
     messagesRef,
     pendingQueue.hydrate,
     queryClient,
+    setActiveAssistantMessageId,
   ])
 
   const handleCompactionStored = useCallback(
@@ -1355,8 +1401,15 @@ export default function ChatView({
       // one transcript boundary. A restored assistant may be bridged in place
       // above a newer local row, so committing the following rows separately
       // at the list tail makes a restart marker flash below that newer row.
-      promoteStreamToMessages({ followingMessages: promotedRows })
+      promoteStreamToMessages({
+        followingMessages: promotedRows,
+        authoritativeCut: true,
+      })
       if (continues) {
+        // The next physical run has been created but its assistant identity is
+        // established by the successor stream/runtime snapshot. Do not let the
+        // completed run's owner reject that fresh surface in the handoff gap.
+        setActiveAssistantMessageId(null)
         // Backend auto-promoted queued follow-ups into the next turn. Newer
         // backend code persists the visible rows separately while sending
         // combined text to the provider; older code returned one combined row.
@@ -1386,6 +1439,7 @@ export default function ChatView({
         setSending(true)
         setServerRunningState(true)
       } else {
+        setActiveAssistantMessageId(null)
         setSending(false)
         sendingRef.current = false
         setServerRunningState(false)
@@ -1431,6 +1485,7 @@ export default function ChatView({
     },
     onNeedsRefresh: fetchMessages,
     onQueuedTurnStarting: ({ ts, message } = {}) => {
+      setActiveAssistantMessageId(null)
       // A queued message is being promoted into its OWN run — the rail's
       // run-start boundary for queue drains. useStreamConnection fires this
       // callback during catch-up replay too, in event order, so a reconnect
@@ -1470,6 +1525,7 @@ export default function ChatView({
       content,
       messages: steeredBatch,
       assistantMessageId,
+      nextAssistantMessageId,
       sealedItems,
     }) => {
       // The steer's transcript split has COMMITTED (fired for both providers,
@@ -1516,7 +1572,12 @@ export default function ChatView({
         keepTurnOpen: true,
         items: sealedItems,
         assistantMessageId,
+        authoritativeCut: true,
       })
+      // The sealed segment was promoted under the previous owner above. The
+      // sink rotates synchronously at this cut, so adopt its successor before
+      // the hook re-bases streamItems onto the new segment after this callback.
+      setActiveAssistantMessageId(nextAssistantMessageId)
       const steeredIsFirstUser = isFirstVisibleUserMessage()
       // Arm the scroll mode BEFORE rendering the steered row. EventSource
       // callbacks are outside React's synthetic event layer, and query-cache
@@ -1793,6 +1854,7 @@ export default function ChatView({
     followingMessages = [],
     items: explicitItems = null,
     assistantMessageId: explicitAssistantMessageId = undefined,
+    authoritativeCut = false,
   } = {}) {
     const following = Array.isArray(followingMessages)
       ? followingMessages.filter(Boolean)
@@ -1805,6 +1867,21 @@ export default function ChatView({
       ? latestAssistantMessageIdRef.current
       : explicitAssistantMessageId
     if (items.length === 0 && following.length === 0) return
+    if (!authoritativeCut && !assistantStreamBelongsToActiveMessage(
+      assistantMessageId,
+      activeAssistantMessageIdRef.current,
+    )) {
+      // A restart can leave an old sessionStorage snapshot alive after the
+      // server has moved to another assistant. Regenerable stream state may be
+      // discarded, but continuation rows delivered with this boundary are
+      // durable and still belong at their timestamp-defined positions.
+      if (following.length > 0) {
+        commitMessages(prev => insertMessageBatchByTs(prev, following))
+      }
+      clearStreamItems?.()
+      promotedRef.current = !keepTurnOpen
+      return
+    }
     // A steer can cut over before the assistant emitted any real output — the
     // only buffered item is an empty/whitespace token. Sealing it would leave a
     // stray empty assistant bubble before the steered user row (the card-166
@@ -2044,6 +2121,9 @@ export default function ChatView({
         pendingQuestionId: runtime.pending_question_id,
       })
       setServerRunningLocalState(running)
+      setActiveAssistantMessageId(
+        runtime.active_assistant_message_id || null,
+      )
       setActiveGoalObjective(goalObjectiveFromRuntime(
         runtime, latestGoalObjective(visibleMessages),
       ))
@@ -2168,6 +2248,8 @@ export default function ChatView({
         )
         updateChatRuntimeCache(queryClient, queryKey, {
           running: !!runtime.running,
+          activeAssistantMessageId:
+            runtime.active_assistant_message_id || null,
           activeGoalObjective: runtimeGoalObjective,
           pending_messages: runtime.pending_messages || [],
           pending_question_id: runtime.pending_question_id || null,
@@ -2324,7 +2406,14 @@ export default function ChatView({
       loadingOlder.current = false
       disconnect()
     }
-  }, [chatId, loadNonce, hidden, searchReveal?.id, searchReveal?.anchorKey])
+  }, [
+    chatId,
+    hidden,
+    loadNonce,
+    searchReveal?.anchorKey,
+    searchReveal?.id,
+    setActiveAssistantMessageId,
+  ])
 
 
   // Paginate older messages. Captures a pre-prepend anchor so we can
@@ -4189,10 +4278,12 @@ export default function ChatView({
     messages,
     streamItems,
     streamAssistantMessageId,
+    activeAssistantMessageId,
     liveItemsRetired: retiredAssistantItemsRef.current === streamItems,
     findBridgeIndex: bridgeHook.findBridgeIndex,
   }), [
     bridgeMountInputs,
+    activeAssistantMessageId,
     messages,
     streamAssistantMessageId,
     streamItems,

--- a/frontend/src/components/ChatView/__tests__/activeAssistantSelection.test.js
+++ b/frontend/src/components/ChatView/__tests__/activeAssistantSelection.test.js
@@ -105,6 +105,44 @@ test('a cached assistant identity followed by a newer turn is not current', () =
   assert.equal(result.activeMirrorMsgIdx, 3)
 })
 
+test('the server owner rejects an old cached question across a hidden restart run', () => {
+  const stale = {
+    id: 'assistant-before-restart',
+    role: 'assistant',
+    ts: 2,
+    blocks: [{ type: 'question', question_id: 'old-question', questions: [] }],
+  }
+  const current = {
+    id: 'assistant-current',
+    role: 'assistant',
+    ts: 4,
+    blocks: [{ type: 'text', content: 'current work' }],
+  }
+  const messages = [
+    { role: 'user', ts: 1, content: 'request' },
+    stale,
+    { role: 'user', ts: 3, kind: 'wait_result', hidden: true },
+    current,
+  ]
+
+  const result = deriveActiveAssistantSelection({
+    turnActive: true,
+    messages,
+    streamItems: [{
+      type: 'question', question_id: 'old-question', questions: [],
+    }],
+    streamAssistantMessageId: 'assistant-before-restart',
+    activeAssistantMessageId: 'assistant-current',
+    findBridgeIndex: () => -1,
+  })
+
+  assert.equal(result.hasLiveAssistantPayload, false,
+    'the cached question cannot compete with the current run')
+  assert.equal(result.activeMirrorMsg, current)
+  assert.equal(result.activeMirrorMsgIdx, 3)
+  assert.equal(result.useDbActivePayload, true)
+})
+
 
 test('same-turn hidden answer does not release the identified assistant row', () => {
   const active = {
@@ -116,7 +154,10 @@ test('same-turn hidden answer does not release the identified assistant row', ()
   const messages = [
     { role: 'user', ts: 1, content: 'request' },
     active,
-    { role: 'user', ts: 3, hidden: true, content: 'answer' },
+    {
+      role: 'user', ts: 3, kind: 'continuation', hidden: true,
+      content: 'answer',
+    },
   ]
 
   const result = deriveActiveAssistantSelection({
@@ -124,6 +165,7 @@ test('same-turn hidden answer does not release the identified assistant row', ()
     messages,
     streamItems: [{ type: 'question', question_id: 'q1', questions: [] }],
     streamAssistantMessageId: 'assistant-live',
+    activeAssistantMessageId: 'assistant-live',
     findBridgeIndex: () => -1,
   })
 

--- a/frontend/src/components/ChatView/__tests__/chatDetailCache.test.js
+++ b/frontend/src/components/ChatView/__tests__/chatDetailCache.test.js
@@ -95,6 +95,7 @@ test('prefetched chat detail matches the synchronous ChatView cache contract', (
     offset: 12,
     total: 13,
     running: false,
+    active_assistant_message_id: 'assistant-current',
     active_goal_objective: 'Finish the migration',
     pending_messages: [{ id: 'queued' }],
     pending_question_id: 'question-1',
@@ -111,6 +112,7 @@ test('prefetched chat detail matches the synchronous ChatView cache contract', (
   assert.equal(cached.restorationWindowComplete, true)
   assert.equal(cached.messages[0].blocks[0].status, 'done')
   assert.equal(cached.updated_at, source.updated_at)
+  assert.equal(cached.activeAssistantMessageId, 'assistant-current')
   assert.equal(source.messages[0].blocks[0].status, 'running', 'projection does not mutate the response')
   assert.equal(cached.offset, 12)
   assert.equal(cached.activeGoalObjective, 'Finish the migration')
@@ -222,6 +224,27 @@ test('idle foreground reconciliation refetches only a disproven unowned snapshot
   }), false, 'an active runtime remains owned by the stream path')
   assert.equal(shouldRefetchTranscriptForRuntime(cached, moved, true), false,
     'an optimistic local turn cannot be overwritten by a foreground poll')
+})
+
+test('a retained running snapshot requires the current assistant owner', () => {
+  const updated_at = '2026-07-30T12:00:00Z'
+  const cached = {
+    updated_at,
+    activeAssistantMessageId: 'assistant-before-restart',
+    messages: [],
+  }
+  assert.equal(chatSnapshotMatchesRuntime(cached, {
+    updated_at,
+    active_assistant_message_id: 'assistant-before-restart',
+  }), true)
+  assert.equal(chatSnapshotMatchesRuntime(cached, {
+    updated_at,
+    active_assistant_message_id: 'assistant-current',
+  }), false)
+  assert.equal(chatSnapshotMatchesRuntime({ updated_at, messages: [] }, {
+    updated_at,
+    active_assistant_message_id: 'assistant-current',
+  }), false, 'a legacy cache cannot claim a newly identified live owner')
 })
 
 test('pending question lookup requires the exact unanswered owner row', () => {

--- a/frontend/src/components/ChatView/__tests__/chatRuntimeState.test.js
+++ b/frontend/src/components/ChatView/__tests__/chatRuntimeState.test.js
@@ -19,6 +19,7 @@ import {
   runtimeStreamAttachAction,
   serverSnapshotBehindLocal,
   shouldAttachRunningStream,
+  shouldAdoptRuntimeAssistantOwner,
   shouldRetireRestoredQuestionSnapshot,
   shouldRecoverSettledRuntime,
   shouldRetryStopAfterConfirm,
@@ -211,6 +212,26 @@ test('a fresh running verdict repairs only an exhausted visible stream', () => {
     running: false,
     connectionError: 'disconnected',
   }), 'none', 'an idle server verdict must not resurrect a stream')
+})
+
+test('assistant ownership ignores only idle responses captured behind a local transition', () => {
+  assert.equal(shouldAdoptRuntimeAssistantOwner({
+    runtimeRunning: false,
+    localAuthoritative: true,
+  }), false, 'a pre-StartTurn idle response cannot retire the new local owner')
+  assert.equal(shouldAdoptRuntimeAssistantOwner({
+    runtimeRunning: true,
+    localAuthoritative: true,
+  }), true, 'a running response has crossed the atomic start boundary')
+  assert.equal(shouldAdoptRuntimeAssistantOwner({
+    runtimeRunning: false,
+    localAuthoritative: false,
+  }), true, 'an ordinary idle response retires the settled owner')
+  assert.equal(shouldAdoptRuntimeAssistantOwner({
+    runtimeRunning: false,
+    localAuthoritative: true,
+    authoritativeRefresh: true,
+  }), true, 'a canonical transcript refresh may settle a missed terminal event')
 })
 
 test('only a cold stream prefix missing the durable question is retired', () => {

--- a/frontend/src/components/ChatView/__tests__/streamPromotion.test.js
+++ b/frontend/src/components/ChatView/__tests__/streamPromotion.test.js
@@ -6,6 +6,7 @@ import assert from 'node:assert/strict'
 import { assistantAnchorKey, messageKey } from '../../../lib/chatDetailCache.js'
 
 import {
+  assistantStreamBelongsToActiveMessage,
   streamItemsToAssistantPayload,
   carryQuestionAnswers,
   promoteAssistantStream,
@@ -21,6 +22,21 @@ import {
   chooseActiveAssistantMirrorIndex,
   chooseActiveAssistantDataKey,
 } from '../streamPromotion.js'
+
+test('only the server-owned assistant stream may promote into history', () => {
+  assert.equal(assistantStreamBelongsToActiveMessage(
+    'assistant-current', 'assistant-current',
+  ), true)
+  assert.equal(assistantStreamBelongsToActiveMessage(
+    'assistant-before-restart', 'assistant-current',
+  ), false)
+  assert.equal(assistantStreamBelongsToActiveMessage(
+    null, 'assistant-current',
+  ), false, 'unidentified regenerable state fails closed once an owner exists')
+  assert.equal(assistantStreamBelongsToActiveMessage(
+    'legacy-stream', null,
+  ), true, 'rolling servers retain the legacy transcript-boundary fallback')
+})
 
 // Lever 2a: the live tool item carries tool_use_id, and streamItemToBlock
 // spreads ...item, so the identity flows onto the promoted DB-shaped block for

--- a/frontend/src/components/ChatView/activeAssistantSelection.js
+++ b/frontend/src/components/ChatView/activeAssistantSelection.js
@@ -2,6 +2,7 @@
 
 import { startsFollowingTurn } from './chatRuntimeState.js'
 import {
+  assistantStreamBelongsToActiveMessage,
   chooseActiveAssistantMirrorIndex,
   chooseActiveAssistantSurface,
   findTrailingAssistantPartialIndex,
@@ -19,24 +20,41 @@ export function deriveActiveAssistantSelection({
   messages,
   streamItems,
   streamAssistantMessageId = null,
+  activeAssistantMessageId = null,
   liveItemsRetired = false,
   findBridgeIndex,
 }) {
-  const identityMsgIdx = turnActive && streamAssistantMessageId
+  const streamIdentityMsgIdx = turnActive && streamAssistantMessageId
     ? messages.findIndex(message => (
         message?.role === 'assistant'
         && message.id != null
         && String(message.id) === String(streamAssistantMessageId)
       ))
     : -1
+  const activeIdentityMsgIdx = turnActive && activeAssistantMessageId
+    ? messages.findIndex(message => (
+        message?.role === 'assistant'
+        && message.id != null
+        && String(message.id) === String(activeAssistantMessageId)
+      ))
+    : -1
+  const identifiedStreamIsCurrent = assistantStreamBelongsToActiveMessage(
+    streamAssistantMessageId,
+    activeAssistantMessageId,
+  )
+  const identityMsgIdx = activeAssistantMessageId
+    ? activeIdentityMsgIdx
+    : streamIdentityMsgIdx
   const legacyBridgeMsgIdx = turnActive ? findBridgeIndex(messages) : -1
   const legacyBridgeFollowedByNewTurn = legacyBridgeMsgIdx >= 0 && messages
     .slice(legacyBridgeMsgIdx + 1)
     .some(startsFollowingTurn)
-  const legacyBridgeAllowed = !streamAssistantMessageId || (
-    legacyBridgeMsgIdx >= 0
-    && messages[legacyBridgeMsgIdx]?.id == null
-    && !legacyBridgeFollowedByNewTurn
+  const legacyBridgeAllowed = !activeAssistantMessageId && (
+    !streamAssistantMessageId || (
+      legacyBridgeMsgIdx >= 0
+      && messages[legacyBridgeMsgIdx]?.id == null
+      && !legacyBridgeFollowedByNewTurn
+    )
   )
   const bridgeMsgIdx = identityMsgIdx >= 0
     ? identityMsgIdx
@@ -45,24 +63,33 @@ export function deriveActiveAssistantSelection({
     ? findTrailingAssistantPartialIndex(messages)
     : -1
   if (
-    streamAssistantMessageId
+    (activeAssistantMessageId || streamAssistantMessageId)
     && identityMsgIdx < 0
     && trailingAssistantPartialIdx >= 0
     && messages[trailingAssistantPartialIdx]?.id != null
+    && (
+      !activeAssistantMessageId
+      || String(messages[trailingAssistantPartialIdx].id)
+        !== String(activeAssistantMessageId)
+    )
   ) {
     trailingAssistantPartialIdx = -1
   }
   const bridgeMsg = bridgeMsgIdx >= 0 ? messages[bridgeMsgIdx] : null
-  const bridgeFollowedByNewTurn = bridgeMsgIdx >= 0 && messages
+  const bridgeFollowedByNewTurn = !activeAssistantMessageId
+    && bridgeMsgIdx >= 0 && messages
     .slice(bridgeMsgIdx + 1)
     .some(startsFollowingTurn)
   // A sessionStorage snapshot can survive the restart that begins a successor
-  // turn. Its id is real but no longer current; a successor turn boundary
-  // proves the cached payload must not compete with the successor's DB row.
-  const staleIdentifiedPayload = !!(
-    streamAssistantMessageId
-    && identityMsgIdx >= 0
-    && bridgeFollowedByNewTurn
+  // turn. The server-owned assistant id is authoritative when available;
+  // transcript boundaries remain only a rolling-data fallback.
+  const staleIdentifiedPayload = !!streamAssistantMessageId && (
+    !identifiedStreamIsCurrent
+    || (
+      !activeAssistantMessageId
+      && streamIdentityMsgIdx >= 0
+      && bridgeFollowedByNewTurn
+    )
   )
   const hasLiveAssistantPayload = !!(
     turnActive && streamItems.length > 0 && !staleIdentifiedPayload

--- a/frontend/src/components/ChatView/chatRuntimeState.js
+++ b/frontend/src/components/ChatView/chatRuntimeState.js
@@ -205,6 +205,20 @@ export function shouldRecoverSettledRuntime({
     && !localStartInFlight
 }
 
+/**
+ * Do not let an idle response captured before a local start/stop/stream
+ * transition retire that transition's assistant owner. A running response has
+ * crossed StartTurn's atomic boundary and is safe to adopt; an explicit
+ * authoritative transcript refresh is safe for the same reason.
+ */
+export function shouldAdoptRuntimeAssistantOwner({
+  runtimeRunning = false,
+  localAuthoritative = false,
+  authoritativeRefresh = false,
+} = {}) {
+  return !!authoritativeRefresh || !!runtimeRunning || !localAuthoritative
+}
+
 function coldBlockRenderCost(block) {
   if (block?.type !== 'text') return 1
   // Markdown reports create work roughly in proportion to their source size,

--- a/frontend/src/components/ChatView/streamPromotion.js
+++ b/frontend/src/components/ChatView/streamPromotion.js
@@ -8,6 +8,20 @@ import { assistantAnchorKey } from '../../lib/chatDetailCache.js'
 import { startsFollowingTurn } from './chatRuntimeState.js'
 import { questionKey } from './questionKey.js'
 
+
+/** Whether a regenerable stream snapshot is owned by the server's current
+ * assistant row. An absent server owner keeps the rolling-data fallback; once
+ * an owner is known, an unidentified or differently identified snapshot must
+ * never rewrite history. */
+export function assistantStreamBelongsToActiveMessage(
+  streamAssistantMessageId,
+  activeAssistantMessageId,
+) {
+  if (!activeAssistantMessageId) return true
+  if (!streamAssistantMessageId) return false
+  return String(streamAssistantMessageId) === String(activeAssistantMessageId)
+}
+
 export function streamItemToBlock(item, { finalize = true } = {}) {
   if (item.type === 'text') return { type: 'text', content: item.content }
   if (item.type === 'thinking') {

--- a/frontend/src/lib/chatDetailCache.js
+++ b/frontend/src/lib/chatDetailCache.js
@@ -121,6 +121,20 @@ export function chatSnapshotMatchesRuntime(cached, runtime) {
     && typeof runtime?.updated_at === 'string'
     && cached.updated_at === runtime.updated_at
   if (!sameVersion) return false
+  // A live snapshot can rotate assistant segments without advancing the
+  // transcript version (notably at a steer cut). Once the server exposes the
+  // owner, a legacy cache with no owner—or a cache for the sealed segment—is
+  // not authoritative even when its transcript timestamp still matches.
+  if (Object.prototype.hasOwnProperty.call(
+    runtime || {}, 'active_assistant_message_id',
+  )) {
+    if (!Object.prototype.hasOwnProperty.call(
+      cached || {}, 'activeAssistantMessageId',
+    )) return false
+    const cachedId = cached.activeAssistantMessageId || null
+    const runtimeId = runtime.active_assistant_message_id || null
+    if (cachedId !== runtimeId) return false
+  }
   return !runtime.pending_question_id
     || hasPendingQuestionMessage(
       cached.messages,
@@ -163,6 +177,7 @@ export function chatDetailCacheValue(data = {}) {
     restorationWindowComplete: sourceWindowValid
       && data.offset + messages.length === data.total,
     updated_at: typeof data.updated_at === 'string' ? data.updated_at : null,
+    activeAssistantMessageId: data.active_assistant_message_id || null,
     messages,
     total,
     offset,


### PR DESCRIPTION
## Summary
- give regenerable assistant browser state one server-owned message identity
- preserve that identity when an unanswered question is parked in transcript history
- reject stale browser replay across restart, steer, and successor-run boundaries
- repair legacy id-less parked question rows during writer-owned startup migration

## Testing
- `scripts/wt-pytest.sh backend/tests/test_chat_transcript_compact.py backend/tests/test_chat_writer_contention.py backend/tests/test_chat_live_assistant.py backend/tests/test_crash_recovery.py backend/tests/test_drain_for_restart.py backend/tests/test_system_broadcast.py backend/tests/test_chats_stream_answer_race.py backend/tests/test_db_migrations.py backend/tests/test_startup_tasks.py -q` (225 passed)
- `npm test` (2,669 library tests and 93 hook tests passed)
- `npm run lint` (passes with 46 existing warnings)
- `python3 backend/scripts/check-schema-migrations.py --against 0dd7ac4885ce09684b918d929160500660bda0b7` (19 append-only migrations verified)
- authenticated browser replay against both parked and resumed post-restart states