### PR TITLE
Match notification Clear all color to title

### DIFF
--- a/frontend/src/components/NotificationsView/NotificationsView.css
+++ b/frontend/src/components/NotificationsView/NotificationsView.css
@@ -41,7 +41,7 @@
   border: 0;
   border-radius: 999px;
   background: transparent;
-  color: var(--accent);
+  color: var(--text);
   font: inherit;
   font-size: 13px;
   font-weight: 650;

--- a/frontend/src/components/NotificationsView/__tests__/notificationsActions.test.js
+++ b/frontend/src/components/NotificationsView/__tests__/notificationsActions.test.js
@@ -16,4 +16,6 @@ test('notification header clears immediately and closes through the bell boundar
     css,
     /@media \(hover: hover\) and \(pointer: fine\)[\s\S]*?\.notifications__clear:hover/,
   )
+  const clearRule = css.match(/\.notifications__clear\s*\{([^}]*)\}/)?.[1] ?? ''
+  assert.match(clearRule, /color:\s*var\(--text\)/)
 })


### PR DESCRIPTION
## Summary

- match the notification header's **Clear all** action to the title's theme-aware text color
- keep the action's existing hover, focus, and disabled states unchanged
- add a focused regression check for the shared color token

## Testing

- `node --loader=./src/lib/__tests__/vite-env-loader.mjs --test src/components/NotificationsView/__tests__/notificationsActions.test.js`