### PR TITLE
Refresh Android notification worker before subscribing

### DIFF
--- a/frontend/src/lib/__tests__/pushSubscription.test.js
+++ b/frontend/src/lib/__tests__/pushSubscription.test.js
@@ -201,6 +201,41 @@ test('a failed install settles instead of hanging forever', async () => {
   await assert.rejects(done)
 })
 
+test('worker activation cannot miss a state change during listener setup', async () => {
+  const container = fakeContainer({ installing: true })
+  const worker = container.pushWorker.installing
+  const addEventListener = worker.addEventListener
+  worker.addEventListener = (type, listener) => {
+    addEventListener.call(worker, type, listener)
+    worker.state = 'activated'
+  }
+  container.pushWorker.active = worker
+  const push = fakePush()
+
+  await subscribeToPush({ container, push })
+
+  assert.equal(push.sent.length, 1)
+  assert.deepEqual(worker.listeners, [], 'the activation listener is released')
+})
+
+test('a wedged worker activation rejects after the bounded wait', async () => {
+  const container = fakeContainer({ installing: true })
+  const worker = container.pushWorker.installing
+  const push = fakePush()
+
+  await assert.rejects(
+    subscribeToPush({
+      container,
+      push,
+      workerActivationTimeoutMs: 0,
+    }),
+    /activation timed out/,
+  )
+
+  assert.deepEqual(worker.listeners, [], 'the timed-out listener is released')
+  assert.deepEqual(push.sent, [], 'subscription never uses the wedged worker')
+})
+
 test('an existing worker refresh waits for its replacement before subscribing',
   async () => {
     const container = fakeContainer({ updating: true })

--- a/frontend/src/lib/__tests__/pushSubscription.test.js
+++ b/frontend/src/lib/__tests__/pushSubscription.test.js
@@ -34,12 +34,46 @@ function fakeSubscription(endpoint) {
  *   retire, `null` for a caching worker that never held one, `'throws'` for a
  *   registration whose pushManager is unusable, or `'missing'` for none at all.
  */
-function fakeContainer({ legacy = null, installing = false } = {}) {
+function fakeContainer({
+  legacy = null,
+  installing = false,
+  updating = false,
+  delayedUpdate = false,
+} = {}) {
   const registered = []
+  const refreshedWorker = (updating || delayedUpdate) ? fakeInstallingWorker() : null
+  const updateListeners = []
+  let resolveUpdatePublished = null
+  const updatePublished = delayedUpdate
+    ? new Promise((resolve) => { resolveUpdatePublished = resolve })
+    : null
   const pushWorker = {
     scope: `${ORIGIN}${PUSH_SW_SCOPE}`,
     active: installing ? null : {},
     installing: installing ? fakeInstallingWorker() : null,
+    waiting: null,
+    updateCalls: 0,
+    addEventListener(type, listener) {
+      if (type === 'updatefound') updateListeners.push(listener)
+    },
+    removeEventListener(type, listener) {
+      if (type !== 'updatefound') return
+      const index = updateListeners.indexOf(listener)
+      if (index !== -1) updateListeners.splice(index, 1)
+    },
+    async update() {
+      this.updateCalls += 1
+      if (refreshedWorker) {
+        const publish = () => {
+          this.installing = refreshedWorker
+          updateListeners.slice().forEach((listener) => listener())
+          resolveUpdatePublished?.()
+        }
+        if (delayedUpdate) setTimeout(publish, 0)
+        else publish()
+      }
+      return this
+    },
     pushManager: {
       subscribe: async (options) => {
         // The browser rejects with InvalidStateError when the registration has
@@ -54,6 +88,9 @@ function fakeContainer({ legacy = null, installing = false } = {}) {
   return {
     registered,
     pushWorker,
+    refreshedWorker,
+    updateListeners,
+    updatePublished,
     register: async (url, options) => {
       registered.push({ url, ...options })
       return pushWorker
@@ -104,8 +141,9 @@ test('the push worker is registered inside the shell PWA scope', async () => {
   // The URL is a three-way contract with vite.config.js globIgnores and the
   // backend's worker delivery contract, so pin the literals, not the constants.
   assert.deepEqual(container.registered, [
-    { url: '/sw-push.js', scope: '/shell/push/' },
+    { url: '/sw-push.js', scope: '/shell/push/', updateViaCache: 'none' },
   ])
+  assert.equal(container.pushWorker.updateCalls, 1, 'an active worker is checked for updates')
   assert.ok(
     PUSH_SW_SCOPE.startsWith(SHELL_MANIFEST_SCOPE),
     `${PUSH_SW_SCOPE} must sit inside the shell scope ${SHELL_MANIFEST_SCOPE}`,
@@ -161,6 +199,50 @@ test('a failed install settles instead of hanging forever', async () => {
   // No active worker, so subscribe() rejects — the caller's catch surfaces it.
   // The point is that this resolves at all rather than stranding the promise.
   await assert.rejects(done)
+})
+
+test('an existing worker refresh waits for its replacement before subscribing',
+  async () => {
+    const container = fakeContainer({ updating: true })
+    const worker = container.refreshedWorker
+    const push = fakePush()
+
+    const done = subscribeToPush({ container, push })
+    await new Promise((resolve) => setImmediate(resolve))
+
+    assert.equal(container.pushWorker.updateCalls, 1)
+    assert.deepEqual(push.sent, [], 'does not subscribe through the stale active worker')
+    assert.equal(worker.listeners.length, 1, 'waits for the refreshed worker')
+
+    container.pushWorker.active = worker
+    container.pushWorker.installing = null
+    worker.settle('activated')
+    await done
+
+    assert.equal(push.sent.length, 1)
+    assert.deepEqual(worker.listeners, [], 'the refresh listener is released')
+    assert.deepEqual(container.updateListeners, [], 'the update listener is released')
+  })
+
+test('a replacement published after update resolves is still awaited', async () => {
+  const container = fakeContainer({ delayedUpdate: true })
+  const worker = container.refreshedWorker
+  const push = fakePush()
+
+  const done = subscribeToPush({ container, push })
+  await container.updatePublished
+  await new Promise((resolve) => setImmediate(resolve))
+
+  assert.deepEqual(push.sent, [], 'does not miss the queued worker announcement')
+  assert.equal(worker.listeners.length, 1, 'waits for the late-published worker')
+
+  container.pushWorker.active = worker
+  container.pushWorker.installing = null
+  worker.settle('activated')
+  await done
+
+  assert.equal(push.sent.length, 1)
+  assert.deepEqual(container.updateListeners, [], 'the update listener is released')
 })
 
 test('a subscription left on the caching worker is retired', async () => {
@@ -319,6 +401,14 @@ test('the retry drives the real subscribe from a redundant first install to succ
       scope: `${ORIGIN}${PUSH_SW_SCOPE}`,
       active: null,
       installing: redundantWorker,
+      waiting: null,
+      updateCalls: 0,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      async update() {
+        this.updateCalls += 1
+        return this
+      },
       pushManager: {
         subscribe: async (options) => {
           if (!pushWorker.active) throw new Error('InvalidStateError')
@@ -346,6 +436,7 @@ test('the retry drives the real subscribe from a redundant first install to succ
 
     assert.equal(ok, true)
     assert.equal(registrations, 2, 're-registered on the retry')
+    assert.equal(pushWorker.updateCalls, 1, 'the retry checks the active worker')
     assert.equal(push.sent.length, 1, 'the subscription finally landed')
   })
 

--- a/frontend/src/lib/pushSubscription.js
+++ b/frontend/src/lib/pushSubscription.js
@@ -7,6 +7,7 @@ import { api } from '../api/client.js'
  */
 export const PUSH_SW_SCOPE = '/shell/push/'
 const PUSH_SW_URL = '/sw-push.js'
+const PUSH_WORKER_ACTIVATION_TIMEOUT_MS = 5000
 
 // Scopes an earlier release subscribed on. This is an ALLOWLIST on purpose:
 // "retire every registration that isn't ours" would silently unsubscribe a
@@ -15,18 +16,37 @@ const PUSH_SW_URL = '/sw-push.js'
 // Removable once no install can still be running the pre-/shell/push/ shell.
 const LEGACY_PUSH_SCOPES = ['/']
 
-function waitForWorkerActivation(worker) {
+function waitForWorkerActivation(worker, {
+  timeoutMs = PUSH_WORKER_ACTIVATION_TIMEOUT_MS,
+  setTimeoutFn = (typeof setTimeout !== 'undefined' ? setTimeout : null),
+  clearTimeoutFn = (typeof clearTimeout !== 'undefined' ? clearTimeout : null),
+} = {}) {
   if (worker.state === 'activated' || worker.state === 'redundant') {
     return Promise.resolve(worker.state)
   }
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
+    let settled = false
+    let timer = null
+    const finish = (state) => {
+      if (settled) return
+      settled = true
+      worker.removeEventListener('statechange', onChange)
+      if (timer != null && clearTimeoutFn) clearTimeoutFn(timer)
+      if (state === 'timeout') {
+        reject(new Error('Push worker activation timed out.'))
+      } else {
+        resolve(state)
+      }
+    }
     const onChange = () => {
       if (worker.state === 'activated' || worker.state === 'redundant') {
-        worker.removeEventListener('statechange', onChange)
-        resolve(worker.state)
+        finish(worker.state)
       }
     }
     worker.addEventListener('statechange', onChange)
+    if (setTimeoutFn) timer = setTimeoutFn(() => finish('timeout'), timeoutMs)
+    // The worker can settle between the state read above and listener setup.
+    onChange()
   })
 }
 
@@ -52,7 +72,7 @@ async function checkForUpdatedWorker(registration) {
 }
 
 /** Register the push worker and resolve once the newest worker is active. */
-async function activatePushWorker(container) {
+async function activatePushWorker(container, { activationTimeoutMs } = {}) {
   const registration = await container.register(PUSH_SW_URL, {
     scope: PUSH_SW_SCOPE,
     updateViaCache: 'none',
@@ -71,7 +91,9 @@ async function activatePushWorker(container) {
   // active worker while its replacement installs leaves the very next push on
   // stale display code. Wait for the candidate; a failed update is retried by
   // subscribeToPushWithRetry instead of silently reusing the stale worker.
-  const state = await waitForWorkerActivation(worker)
+  const state = await waitForWorkerActivation(worker, {
+    timeoutMs: activationTimeoutMs,
+  })
   if (state === 'redundant') throw new Error('Push worker activation failed.')
   return registration
 }
@@ -118,11 +140,12 @@ function applicationServerKey(publicKey) {
 export async function subscribeToPush({
   container = navigator.serviceWorker,
   push = api.push,
+  workerActivationTimeoutMs,
 } = {}) {
   // Independent: the worker's first install is a real fetch, and holding the
   // key request behind it costs a round trip on every fresh install.
   const [registration, res] = await Promise.all([
-    activatePushWorker(container),
+    activatePushWorker(container, { activationTimeoutMs: workerActivationTimeoutMs }),
     push.vapidKey(),
   ])
   // Throw (don't silently return) on a cold-backend failure so a first-boot

--- a/frontend/src/lib/pushSubscription.js
+++ b/frontend/src/lib/pushSubscription.js
@@ -15,27 +15,64 @@ const PUSH_SW_URL = '/sw-push.js'
 // Removable once no install can still be running the pre-/shell/push/ shell.
 const LEGACY_PUSH_SCOPES = ['/']
 
-/** Register the push worker and resolve once it has an active worker. */
-async function activatePushWorker(container) {
-  const registration = await container.register(
-    PUSH_SW_URL, { scope: PUSH_SW_SCOPE },
-  )
-  if (registration.active) return registration
-  const worker = registration.installing
-  if (!worker) return registration
-  // register() resolves while the worker is still installing, and
-  // pushManager.subscribe() needs an active one. `redundant` resolves too, so
-  // a failed install surfaces as a subscribe error instead of hanging here
-  // forever on a promise nobody can settle.
-  await new Promise((resolve) => {
+function waitForWorkerActivation(worker) {
+  if (worker.state === 'activated' || worker.state === 'redundant') {
+    return Promise.resolve(worker.state)
+  }
+  return new Promise((resolve) => {
     const onChange = () => {
       if (worker.state === 'activated' || worker.state === 'redundant') {
         worker.removeEventListener('statechange', onChange)
-        resolve()
+        resolve(worker.state)
       }
     }
     worker.addEventListener('statechange', onChange)
   })
+}
+
+async function checkForUpdatedWorker(registration) {
+  let worker = null
+  const onUpdateFound = () => {
+    worker = registration.installing || registration.waiting || worker
+  }
+  registration.addEventListener('updatefound', onUpdateFound)
+  try {
+    await registration.update()
+    worker = registration.installing || registration.waiting || worker
+    if (!worker) {
+      // The registration publishes `installing` in a queued task on some
+      // browsers, after update() itself has resolved.
+      await new Promise((resolve) => setTimeout(resolve, 0))
+      worker = registration.installing || registration.waiting || worker
+    }
+  } finally {
+    registration.removeEventListener('updatefound', onUpdateFound)
+  }
+  return worker
+}
+
+/** Register the push worker and resolve once the newest worker is active. */
+async function activatePushWorker(container) {
+  const registration = await container.register(PUSH_SW_URL, {
+    scope: PUSH_SW_SCOPE,
+    updateViaCache: 'none',
+  })
+
+  let worker = registration.installing || registration.waiting
+  if (!worker && registration.active) {
+    // register() may legitimately reuse an active worker without checking its
+    // script yet. Force that check so a phone cannot keep the pre-badge worker
+    // and render Chrome's generic bell after Möbius has shipped a new glyph.
+    worker = await checkForUpdatedWorker(registration)
+  }
+  if (!worker) return registration
+
+  // pushManager.subscribe() only needs SOME active worker, but using the old
+  // active worker while its replacement installs leaves the very next push on
+  // stale display code. Wait for the candidate; a failed update is retried by
+  // subscribeToPushWithRetry instead of silently reusing the stale worker.
+  const state = await waitForWorkerActivation(worker)
+  if (state === 'redundant') throw new Error('Push worker activation failed.')
   return registration
 }
 


### PR DESCRIPTION
## Problem

Android can keep an older Möbius push worker active after updated notification display code ships. Notification setup returned as soon as any worker was active, so an existing subscription could continue through stale display code and render Chrome's generic bell instead of Möbius's badge.

## Fix

- bypass the HTTP cache when registering the dedicated push worker
- explicitly ask an existing registration to check for updates, including the browser's queued worker announcement
- wait for an installing or waiting replacement to activate before reusing the subscription
- route failed replacement activation through the existing bounded retry path instead of silently falling back to stale code

The existing subscription remains intact while the refreshed worker activates.

## Prior work

This builds on the dedicated Android status badge from [#797](https://github.com/mobius-os/mobius/pull/797) and the first-install retry from [#876](https://github.com/mobius-os/mobius/pull/876). Unlike those merged fixes, this closes the update path where an already-active worker could mask a newer worker generation.

## Testing

- `node --loader=./src/lib/__tests__/vite-env-loader.mjs --test src/lib/__tests__/pushSubscription.test.js src/lib/__tests__/swNotificationTarget.test.js`
- `npm run runtime:check`
- `npm run test:lib` (2,667 tests)