### PR TITLE
Activate shell reload transitions before replacement

### DIFF
--- a/frontend/src/components/Shell/__tests__/shellReloadController.test.js
+++ b/frontend/src/components/Shell/__tests__/shellReloadController.test.js
@@ -254,3 +254,36 @@ test('an expired non-navigation interaction cannot starve an old pending apply',
     globalThis.history = previousHistory
   }
 })
+
+test('a prepared cross-document transition activates before replacement', async () => {
+  const previousHistory = globalThis.history
+  globalThis.history = { state: null, replaceState() {} }
+  try {
+    const harness = controllerHarness()
+    const frames = []
+    let prepared = 0
+    harness.win.__mobiusPrepareShellReloadTransition = () => {
+      prepared += 1
+      return true
+    }
+    harness.win.requestAnimationFrame = callback => {
+      frames.push(callback)
+      return frames.length
+    }
+    const { result } = renderHook(useShellReloadController, harness.inputs)
+
+    result.current.requestShellReload()
+    await tick()
+    await tick()
+
+    assert.equal(prepared, 1)
+    assert.equal(harness.replacements.length, 0,
+      'replacement must not race the dynamically inserted navigation rule')
+    assert.equal(frames.length, 1)
+
+    frames.shift()()
+    assert.deepEqual(harness.replacements, ['/shell/'])
+  } finally {
+    globalThis.history = previousHistory
+  }
+})

--- a/frontend/src/components/Shell/useShellReloadController.js
+++ b/frontend/src/components/Shell/useShellReloadController.js
@@ -212,8 +212,20 @@ export default function useShellReloadController(inputs) {
       // supporting browsers to retain the outgoing pixels until the incoming
       // shell reports its destination ready. Reload is excluded from
       // cross-document view transitions.
-      win.__mobiusPrepareShellReloadTransition?.()
-      win.location.replace('/shell/')
+      const transitionPrepared = (
+        win.__mobiusPrepareShellReloadTransition?.() === true
+      )
+      const navigate = () => win.location.replace('/shell/')
+      if (transitionPrepared && typeof win.requestAnimationFrame === 'function') {
+        // The cross-document opt-in is injected dynamically so unrelated
+        // navigations keep ordinary browser semantics. Give the browser one
+        // rendering boundary to activate that rule before replacement;
+        // navigating in the insertion task makes `pageswap.viewTransition`
+        // nondeterministically null in Chromium.
+        win.requestAnimationFrame(navigate)
+      } else {
+        navigate()
+      }
     }
     // Release the worker, but never wait for its activation to make the
     // navigation fresh. Online shell navigation owns freshness; activation


### PR DESCRIPTION
## Summary

- activate the dynamically scoped cross-document view-transition rule for one rendering boundary before replacing the shell document
- keep unrelated navigations outside the cross-document transition contract
- preserve the existing atomic destination handoff while making `pageswap.viewTransition` deterministic

## Root cause

PR #893 intentionally installs `@view-transition { navigation: auto; }` only for controlled shell rebuilds. Chromium can begin a same-task `location.replace()` before that newly inserted opt-in participates in navigation, leaving `pageswap.viewTransition` null and exposing a loading flash. The isolated #920 merge group reproduced this on both browser-test attempts even though #920 changes only a lockfile.

## Verification

- 15 focused shell reload/navigation transition tests pass
- complete frontend library and hook suites pass
- lint passes with zero errors on the changed files
- structural ratchet passes
- production and offline/PWA builds pass

## Prior work

This is a focused follow-up to merged PR #893; no separate open issue or PR already owns the activation race.