### PR TITLE
Restore Apps directory after shell handoff

### DIFF
--- a/frontend/src/hooks/__tests__/claimedReloadDestination.test.js
+++ b/frontend/src/hooks/__tests__/claimedReloadDestination.test.js
@@ -1,0 +1,72 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { renderHook } from '../../components/ChatView/hooks/__tests__/react-hook-shim.mjs'
+
+function memoryStorage(initial = {}) {
+  const values = new Map(Object.entries(initial))
+  return {
+    getItem: key => (values.has(key) ? values.get(key) : null),
+    setItem: (key, value) => values.set(key, String(value)),
+    removeItem: key => values.delete(key),
+  }
+}
+
+test('a claimed Apps navigation survives the shell reload before the old page paints it', async () => {
+  const listeners = new Map()
+  globalThis.window = {
+    location: { pathname: '/shell/', search: '', href: 'http://localhost/shell/' },
+    innerWidth: 390,
+    innerHeight: 844,
+    addEventListener(type, handler) {
+      if (!listeners.has(type)) listeners.set(type, new Set())
+      listeners.get(type).add(handler)
+    },
+    removeEventListener(type, handler) { listeners.get(type)?.delete(handler) },
+  }
+  globalThis.location = window.location
+  globalThis.document = { body: { style: {} } }
+  globalThis.localStorage = memoryStorage()
+  globalThis.sessionStorage = memoryStorage({
+    'shell-reload': JSON.stringify({
+      destinationClaimed: true,
+      activeView: 'apps',
+      activeAppId: null,
+      activeChatId: null,
+      drawerOpen: false,
+    }),
+  })
+  globalThis.history = {
+    state: null,
+    pushState(state) { this.state = state },
+    replaceState(state) { this.state = state },
+    back() {},
+  }
+  delete globalThis.navigation
+
+  const [{ default: useNavigation }, paneModel] = await Promise.all([
+    import('../useNavigation.js'),
+    import('../../components/Shell/paneModel.js'),
+  ])
+  const ws = paneModel.seedFromFlatTabs([{ kind: 'chat', id: 'current-chat' }])
+  const workspaceStateRef = { current: { ws, undo: null } }
+  const actions = []
+  const dispatchWorkspace = action => {
+    actions.push(action)
+    workspaceStateRef.current = paneModel.workspaceReducer(workspaceStateRef.current, action)
+  }
+
+  renderHook(useNavigation, {
+    workspace: ws,
+    workspaceStateRef,
+    dispatchWorkspace,
+    visiblePaneIds: new Set(Object.keys(ws.panes)),
+    blobValid: true,
+    replaceImplicitBootTab: false,
+    dragActiveRef: { current: false },
+  })
+
+  assert.deepEqual(
+    actions.find(action => action.type === 'SET_SINGLE_SCREEN'),
+    { type: 'SET_SINGLE_SCREEN', item: { kind: 'apps', id: 'apps' } },
+  )
+})

--- a/frontend/src/hooks/useNavigation.js
+++ b/frontend/src/hooks/useNavigation.js
@@ -1219,6 +1219,16 @@ export default function useNavigation({
             },
             tabModel.makeTab('chat', claimedReloadDestination.chatId),
           )
+        } else if (claimedReloadDestination.view === 'apps') {
+          bootDeepLink(
+            {
+              view: 'apps',
+              appId: null,
+              chatId: null,
+              paneId: bootPaneId,
+            },
+            tabModel.appsTab(),
+          )
         } else if (
           claimedReloadDestination.view === 'settings'
           && workspaceStateRef.current.ws.viewMode === 'panes'


### PR DESCRIPTION
## Summary
- restore a claimed Apps-directory destination after a queued shell generation reloads the page
- route the destination through the same world-aware boot path already used for claimed chats and apps
- cover the exact handoff behavior through the real navigation hook

## Why
Follow-up to #893. That pull request correctly preserves claimed chat, app, and Settings destinations, but it merged while review was still checking a newly moved head. The review found that `view: apps` could also be claimed before the outgoing page painted it, yet the incoming shell had no Apps-directory restore branch and would reopen the prior surface.

## Testing
- `npm test` — 2,674 library tests and 93 hook tests passed
- production frontend build passed, including offline and push-worker checks
- `npm run lint` — 0 errors (46 existing warnings, below the 47-warning ceiling)
- exact diff integrity, contributor trailer, and secret-pattern scans passed