### PR TITLE
Keep app switches warm and performance samples passive

### DIFF
--- a/frontend/src/components/Shell/__tests__/appFrameCache.test.js
+++ b/frontend/src/components/Shell/__tests__/appFrameCache.test.js
@@ -1,7 +1,23 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
-import { deriveRenderedAppIds } from '../appFrameCache.js'
+import {
+  BASE_APP_CACHE_MAX,
+  HIGH_MEMORY_APP_CACHE_MAX,
+  appFrameCacheMaxForDeviceMemory,
+  deriveRenderedAppIds,
+} from '../appFrameCache.js'
+
+test('unknown and lower-memory devices keep the established six-frame budget', () => {
+  assert.equal(appFrameCacheMaxForDeviceMemory(undefined), BASE_APP_CACHE_MAX)
+  assert.equal(appFrameCacheMaxForDeviceMemory(4), BASE_APP_CACHE_MAX)
+  assert.equal(BASE_APP_CACHE_MAX, 6)
+})
+
+test('the highest reported memory tier retains a larger warm working set', () => {
+  assert.equal(appFrameCacheMaxForDeviceMemory(8), HIGH_MEMORY_APP_CACHE_MAX)
+  assert.equal(HIGH_MEMORY_APP_CACHE_MAX, 10)
+})
 
 test('visible app frames remain mounted even when they exceed the warm limit', () => {
   assert.deepEqual(

--- a/frontend/src/components/Shell/appFrameCache.js
+++ b/frontend/src/components/Shell/appFrameCache.js
@@ -1,10 +1,22 @@
-export const APP_CACHE_MAX = 6
+export const BASE_APP_CACHE_MAX = 6
+export const HIGH_MEMORY_APP_CACHE_MAX = 10
+
+/**
+ * Keep the established six-frame budget unless the browser positively reports
+ * at least 8 GB through the Device Memory API. Unknown devices (including
+ * browsers that omit the API) must not take on additional iframe pressure.
+ */
+export function appFrameCacheMaxForDeviceMemory(deviceMemoryGb) {
+  return Number.isFinite(deviceMemoryGb) && deviceMemoryGb >= 8
+    ? HIGH_MEMORY_APP_CACHE_MAX
+    : BASE_APP_CACHE_MAX
+}
 
 export function deriveRenderedAppIds({
   visibleAppIds,
   singleScreen,
   warmIds,
-  max = APP_CACHE_MAX,
+  max = BASE_APP_CACHE_MAX,
 }) {
   const result = new Set()
   for (const id of visibleAppIds) result.add(String(id))

--- a/frontend/src/components/Shell/useAppFrameCache.js
+++ b/frontend/src/components/Shell/useAppFrameCache.js
@@ -11,7 +11,10 @@ import {
 } from '../../lib/appPrecache.js'
 import { coldRestoredCanvasAppId } from '../../hooks/useNavigation.js'
 import * as tabModel from './tabModel.js'
-import { APP_CACHE_MAX, deriveRenderedAppIds } from './appFrameCache.js'
+import {
+  appFrameCacheMaxForDeviceMemory,
+  deriveRenderedAppIds,
+} from './appFrameCache.js'
 
 /** Own mounted app-frame identity, bounded recency, warming, and eviction. */
 export default function useAppFrameCache({
@@ -27,6 +30,9 @@ export default function useAppFrameCache({
   tombstoneRoute,
   dispatchWorkspace,
 }) {
+  const [appCacheMax] = useState(() => appFrameCacheMaxForDeviceMemory(
+    typeof navigator === 'undefined' ? undefined : navigator.deviceMemory,
+  ))
   const warmLruRef = useRef(
     coldRestoredCanvasAppId != null ? [String(coldRestoredCanvasAppId)] : [],
   )
@@ -55,8 +61,9 @@ export default function useAppFrameCache({
       visibleAppIds,
       singleScreen: workspace.singleScreen,
       warmIds: warmLruRef.current,
+      max: appCacheMax,
     })
-  }, [visibleAppIds, warmVersion, workspace.singleScreen])
+  }, [appCacheMax, visibleAppIds, warmVersion, workspace.singleScreen])
 
   // Visible apps must enter the mounted set synchronously; this effect only
   // rotates the bounded hidden remainder for later renders.
@@ -66,14 +73,14 @@ export default function useAppFrameCache({
     const merged = [
       ...visible,
       ...previous.filter(id => !visible.includes(id)),
-    ].slice(0, APP_CACHE_MAX)
+    ].slice(0, appCacheMax)
     const changed = merged.length !== previous.length
       || merged.some((id, index) => id !== previous[index])
     if (changed) {
       warmLruRef.current = merged
       setWarmVersion(version => version + 1)
     }
-  }, [visibleAppIds])
+  }, [appCacheMax, visibleAppIds])
 
   const appsLiveFetched = appsQuery.isSuccess && appsQuery.isFetchedAfterMount
 

--- a/frontend/src/lib/__tests__/appPrecache.test.js
+++ b/frontend/src/lib/__tests__/appPrecache.test.js
@@ -77,9 +77,10 @@ test('warm selection skips recents no longer installed', () => {
   assert.deepEqual(picked.map(a => a.id), [2])
 })
 
-test('warm selection caps at the limit', () => {
+test('speculative app-code warming stays capped at six apps', () => {
   const apps = Array.from({ length: 10 }, (_, i) => app(i + 1, `2026-06-0${(i % 9) + 1}`))
   const picked = selectAppsToWarm(apps, [10, 9, 8, 7, 6, 5, 4, 3])
+  assert.equal(WARM_APP_LIMIT, 6)
   assert.equal(picked.length, WARM_APP_LIMIT)
 })
 

--- a/frontend/src/lib/__tests__/frameInteractivityContract.test.js
+++ b/frontend/src/lib/__tests__/frameInteractivityContract.test.js
@@ -22,8 +22,9 @@ test('frame suspension reaches the live app before paint', () => {
   assert.match(canvas, /moebius:frame-interactivity/)
 })
 
-test('hidden app-frame history is bounded to six without limiting open tabs', () => {
-  assert.match(frameCacheModel, /const APP_CACHE_MAX = 6/)
+test('hidden app-frame history stays device-bounded without limiting open tabs', () => {
+  assert.match(frameCacheModel, /const BASE_APP_CACHE_MAX = 6/)
+  assert.match(frameCacheModel, /const HIGH_MEMORY_APP_CACHE_MAX = 10/)
   assert.doesNotMatch(shell, /openTabs\.slice\(/)
 })
 

--- a/frontend/src/lib/__tests__/perfProbePassive.test.js
+++ b/frontend/src/lib/__tests__/perfProbePassive.test.js
@@ -1,6 +1,41 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { collectDom } from '../perfProbe.js'
+import { collectAnimationsForSample, collectDom } from '../perfProbe.js'
+
+test('automatic performance samples never enumerate live animations', () => {
+  const previousDocument = globalThis.document
+  globalThis.document = {
+    getAnimations() {
+      assert.fail('an automatic sample must not force an animation census')
+    },
+  }
+  try {
+    for (const reason of ['initial', 'interval', 'hidden']) {
+      assert.equal(collectAnimationsForSample(reason), null)
+    }
+  } finally {
+    globalThis.document = previousDocument
+  }
+})
+
+test('an explicit manual sample can request the live animation census', () => {
+  const previousDocument = globalThis.document
+  globalThis.document = {
+    getAnimations() {
+      return [
+        { playState: 'running', animationName: 'pulse' },
+        { playState: 'paused', animationName: 'idle' },
+      ]
+    },
+  }
+  try {
+    const census = collectAnimationsForSample('manual')
+    assert.equal(census.runningCount, 1)
+    assert.deepEqual({ ...census.byName }, { pulse: 1 })
+  } finally {
+    globalThis.document = previousDocument
+  }
+})
 
 test('the interval performance probe never walks computed styles', () => {
   const previousDocument = globalThis.document

--- a/frontend/src/lib/appPrecache.js
+++ b/frontend/src/lib/appPrecache.js
@@ -4,8 +4,8 @@
  *
  * Two signals feed the warm set:
  *   - the drawer pin (`app.pinned_at`) — deliberate, long-term intent;
- *   - the iframe LRU in Shell.jsx — actual recent use. The in-memory
- *     LRU starts empty on every load, so its rotations are merged into
+ *   - the shell's app-frame LRU — actual recent use. The in-memory LRU
+ *     starts empty on every load, so its rotations are merged into
  *     localStorage (mergeAppLru) and read back on the next shell load
  *     (parseStoredAppLru). That persisted list is the cross-session
  *     "most-recent apps" signal.
@@ -18,8 +18,9 @@ export const APP_LRU_STORAGE_KEY = 'mobius-app-lru'
 
 // Upper bound on apps warmed per shell load AND on the persisted LRU
 // depth. Each warmed app costs one token fetch + two bounded SW fetches
-// (frame + module), all idle-scheduled — six keeps the whole pass cheap
-// on a phone while covering pins + everything the user touched lately.
+// (frame + module), all idle-scheduled. Keep this network budget independent
+// from the live iframe budget: a high-memory device may retain more mounted
+// frames without multiplying speculative requests on its next shell load.
 export const WARM_APP_LIMIT = 6
 
 // Resolve the worker that owns the app-code cache. A first-load page may not
@@ -65,9 +66,8 @@ export function parseStoredAppLru(raw) {
 // Folds the live in-memory LRU into the previously stored one: current
 // entries first (they are the freshest recency), then stored entries
 // that haven't reappeared, deduped, capped. The merge — rather than a
-// plain overwrite — is what gives the list cross-session depth: the
-// in-memory LRU holds only 4 ids, so overwriting would forget last
-// session's apps the moment one app is opened today.
+// plain overwrite — preserves older recency whenever the current mounted set
+// is shallower than the persisted warming budget.
 export function mergeAppLru(current, stored, cap = WARM_APP_LIMIT) {
   const merged = []
   const seen = new Set()

--- a/frontend/src/lib/perfProbe.js
+++ b/frontend/src/lib/perfProbe.js
@@ -234,6 +234,15 @@ function collectAnimations() {
   }
 }
 
+export function collectAnimationsForSample(reason) {
+  // Android may synchronously recalculate style/layout to answer
+  // document.getAnimations(). Recurring and lifecycle-triggered samples must
+  // only read browser entries already recorded for them; the animation census
+  // remains available for an explicit one-shot console sample.
+  if (reason !== 'manual') return null
+  return collectAnimations()
+}
+
 export function collectDom() {
   return {
     // Keep the interval sample O(1) with respect to style/layout. The former
@@ -348,7 +357,7 @@ function buildSample(reason) {
       p75DurationMs: sorted.length ? sorted[Math.floor(sorted.length * 0.25)].durationMs : 0,
     },
     cls: Math.round(cls * 1000) / 1000,
-    animations: collectAnimations(),
+    animations: collectAnimationsForSample(reason),
     dom: collectDom(),
     hotPaths: counters,
   }


### PR DESCRIPTION
## Summary
- retain ten live app frames on devices that positively report at least 8 GB of memory
- preserve the six-frame budget for lower-memory and unknown devices
- keep speculative app-code warming capped at six apps, independent of the live iframe budget
- keep automatic performance samples layout-passive by reserving the live animation census for explicit manual diagnostics

## Why
Field traces from the affected 8 GB Android separated fast shell acknowledgement from 2.8–3.9 second app readiness delays after the six-frame cache evicted a recently used app. The same opted-in recorder also called `document.getAnimations()` every 15 seconds, which could synchronously force layout. This addresses both measured causes while preserving the established memory budget on unknown devices and the established speculative network budget everywhere.

## Testing
- 2,678 frontend library tests and 93 hook tests pass at the exact prepared head
- production build, offline worker, and push-worker checks pass
- full lint reports 0 errors (46 pre-existing warnings)
- an authenticated 426×860 Chromium run on the high-memory path retained ten frames in one document; reopening a retained app reused the same iframe in 17.2 ms with zero app resource requests