### PR TITLE
Settle no-change Autopilot reviews without public noise

### DIFF
--- a/backend/app/contribution_autopilot.py
+++ b/backend/app/contribution_autopilot.py
@@ -56,9 +56,11 @@ FAILURE_ESCALATION_THRESHOLD = 2
 MAX_ROUND_LOG = 30
 MAX_IGNORED_EVENT_URLS = 20
 
-# Outcomes that mean the round did useful work (resets the failure counter and
-# advances the round count/cursor). Anything else is a non-productive round.
+# Outcomes that settle the claimed attention (reset the failure counter and
+# advance the round count/cursor). Public actions prove ``pushed``/``replied``;
+# the agent may explicitly settle an exact no-change review as ``handled``.
 PRODUCTIVE_OUTCOMES = frozenset({"pushed", "replied"})
+SETTLED_OUTCOMES = PRODUCTIVE_OUTCOMES | {"handled"}
 
 
 # ─────────────────────────── row access ────────────────────────────
@@ -433,20 +435,27 @@ def complete_round(
 
   ``event_at`` is accepted for compatibility but deliberately ignored: the
   cursor advances only to the canonical timestamp stored by the claim.
-  Requires the live claim's run_id. Productive outcomes reset the failure
-  counter, bump ``rounds_used``, and advance the handled-event cursor; a
-  non-productive ``failed`` counts toward escalation. Returns
+  Requires the live claim's run_id. Settled outcomes reset the failure counter,
+  bump ``rounds_used``, and advance the handled-event cursor; a failed round
+  counts toward escalation. Public action endpoints prove ``pushed`` and
+  ``replied``; ``handled`` is reserved for an exact no-change review. Returns
   ``{"status": "ok"|"stale", "escalate": bool}``.
   """
   row = get_row(db, app_id, record_id)
   if not verify_claim(row, run_id):
     return {"status": "stale", "escalate": False, "productive": False}
 
-  # Public action endpoints, not the caller, decide whether the round did work.
-  recorded_outcome = (
-    row.round_action if row.round_action in PRODUCTIVE_OUTCOMES else "failed"
-  )
-  productive = recorded_outcome in PRODUCTIVE_OUTCOMES
+  # Public action endpoints, not the caller, decide whether a push or reply
+  # happened. A no-change review is different: the claimed agent may settle
+  # the exact attention item as ``handled`` without manufacturing public noise.
+  # Any successful public action still wins over that caller-declared outcome.
+  if row.round_action in PRODUCTIVE_OUTCOMES:
+    recorded_outcome = row.round_action
+  elif outcome == "handled":
+    recorded_outcome = "handled"
+  else:
+    recorded_outcome = "failed"
+  productive = recorded_outcome in SETTLED_OUTCOMES
   entry = {
     "attention_key": row.attention_key,
     "run_id": run_id,

--- a/backend/tests/test_contribution_autopilot.py
+++ b/backend/tests/test_contribution_autopilot.py
@@ -179,6 +179,49 @@ def test_completion_cannot_claim_unrecorded_public_work(db):
   assert row.rounds_json[-1]["outcome"] == "failed"
 
 
+def test_no_change_round_can_settle_exact_attention_without_public_noise(db):
+  autopilot.stamp_grant(db, 1, "rec", head_sha="abc")
+  v = autopilot.claim_for_round(
+    db, 1, "rec", attention_key="review:all-clear",
+    event_at="2026-07-01T00:00:00Z",
+  )
+
+  result = autopilot.complete_round(
+    db, 1, "rec", run_id=v["run_id"], outcome="handled",
+    summary="The exact review was all clear; no reply was needed.",
+  )
+
+  assert result == {
+    "status": "ok", "escalate": False, "productive": True,
+  }
+  row = autopilot.get_row(db, 1, "rec")
+  assert row.rounds_used == 1
+  assert row.consecutive_failures == 0
+  assert row.last_handled_attention_key == "review:all-clear"
+  assert row.last_handled_event_at == "2026-07-01T00:00:00.000000Z"
+  assert row.rounds_json[-1]["outcome"] == "handled"
+
+
+def test_public_action_outcome_wins_over_handled_completion(db):
+  autopilot.stamp_grant(db, 1, "rec", head_sha="abc")
+  v = autopilot.claim_for_round(
+    db, 1, "rec", attention_key="review:fixed",
+    event_at="2026-07-01T00:00:00Z",
+  )
+  assert autopilot.record_action(
+    db, 1, "rec", run_id=v["run_id"], action="pushed", head_sha="def",
+  )
+
+  autopilot.complete_round(
+    db, 1, "rec", run_id=v["run_id"], outcome="handled",
+    summary="The review is settled.",
+  )
+
+  row = autopilot.get_row(db, 1, "rec")
+  assert row.granted_head_sha == "def"
+  assert row.rounds_json[-1]["outcome"] == "pushed"
+
+
 def test_reply_action_mirrors_exact_event_urls(db):
   autopilot.stamp_grant(db, 1, "rec", head_sha="abc")
   v = autopilot.claim_for_round(


### PR DESCRIPTION
## Problem

Autopilot only treated a round as successful after a push or public reply. A reviewer could leave an all-clear review, or repeat feedback already satisfied by the current head, and the correct no-change follow-up was recorded as a failure. The cursor stayed behind and Contribute raised attention unless the agent manufactured a pointless GitHub comment.

## Fix

- add a `handled` settled outcome for an exact claimed event that needs neither code nor a useful reply
- keep successful push/reply evidence authoritative when a public action did occur
- advance the exact event cursor and reset failure state without inventing public activity
- preserve the live run-id claim and existing bounded round accounting

## Prior work

This is a focused follow-up to [#166](https://github.com/mobius-os/mobius/pull/166), which introduced the platform-owned Autopilot grant and round lifecycle. That merged implementation deliberately proved pushes and replies server-side, but did not represent a legitimate no-change completion.

## Testing

- `python3 -m py_compile backend/app/contribution_autopilot.py backend/tests/test_contribution_autopilot.py`
- `scripts/wt-pytest.sh backend/tests/test_contribution_autopilot.py` (30 passed)
- `git diff --check`

Because this changes background review-state progression, run the hosted GitHub checks on the exact reviewed head before opening the PR.