### PR TITLE
Expose chat changes and artifacts in the Brain menu

### DIFF
--- a/backend/app/chat_event_sink.py
+++ b/backend/app/chat_event_sink.py
@@ -46,6 +46,7 @@ from app.memory_recall import (
 )
 from app.runtime_types import ChatEvent
 from app.secure_inputs import redact_reveal_markers
+from app.tool_edit_preview import edit_diff_sidecar_id
 
 
 _active_sinks: dict[str, "ChatEventSink"] = {}
@@ -539,6 +540,38 @@ class ChatEventSink:
     )
     return True
 
+  def _stash_full_edit_diff(self, event: ChatEvent) -> None:
+    """Move a truncated edit preview's complete diff off-wire.
+
+    Provider adapters attach ``_full_diff`` only as an in-process handoff.
+    This funnel removes it before reduction, persistence, catch-up replay, or
+    SSE can observe the event, then records a stable sidecar id on the bounded
+    preview. Repeated patch updates for the same tool overwrite that sidecar,
+    so the final complete patch wins without growing Chat.messages.
+    """
+    preview = event.get("edit_preview")
+    if not isinstance(preview, dict):
+      return
+    clean_preview = dict(preview)
+    full_diff = clean_preview.pop("_full_diff", None)
+    event["edit_preview"] = clean_preview
+    if not isinstance(full_diff, str) or not full_diff:
+      return
+    tool_use_id = event.get("tool_use_id")
+    if not self.chat_id or not isinstance(tool_use_id, str) or not tool_use_id:
+      _get_logger().warning(
+        "full edit diff arrived without a stable owner chat_id=%s tool_use_id=%s",
+        self.chat_id, tool_use_id,
+      )
+      return
+    sidecar_id = edit_diff_sidecar_id(self.chat_id, tool_use_id)
+    clean_preview["full_id"] = sidecar_id
+    self._submit_fire_and_forget(
+      StashToolOutput(
+        chat_id=self.chat_id, tool_use_id=sidecar_id, output=full_diff,
+      )
+    )
+
   def record_lifecycle(self, event: dict) -> None:
     """Queue private lifecycle metadata without broadcasting it.
 
@@ -595,6 +628,13 @@ class ChatEventSink:
     assert event_type != "question", (
       "question events must go through publish_question(), not publish()"
     )
+
+    # Edit diffs have the same inline-vs-full split as large tool output, but
+    # their bounded preview is nested on tool_start/tool_input. Strip and stash
+    # its private complete-text handoff before the event reaches any durable or
+    # live transcript surface.
+    if event_type in ("tool_start", "tool_input"):
+      self._stash_full_edit_diff(event)
 
     # Contract rule 6: reduce a large tool_output to a bounded excerpt and stash
     # its full text BEFORE process_event (which copies content onto the block)

--- a/backend/app/routes/chats.py
+++ b/backend/app/routes/chats.py
@@ -1569,6 +1569,82 @@ def get_tool_output_by_id(
   )
 
 
+@router.get("/{chat_id}/edit-diffs")
+def get_chat_edit_diffs(
+  chat_id: str,
+  _: models.Owner = Depends(get_current_owner),
+  db: Session = Depends(get_db),
+) -> dict:
+  """Return only the file changes recorded by one chat, with full sidecars.
+
+  The ordinary chat payload keeps edit previews bounded. This explicit owner
+  action is the lazy expansion boundary: it scans the transcript for edit
+  blocks, fences already-queued sidecar writes, and substitutes complete diff
+  text wherever the block names one. Orphaned sidecars are never enumerable.
+  """
+  from app.chat_transcript import materialized_messages
+
+  chat = get_active_chat_or_404(db, chat_id)
+  _drain_writer_before_sidecar_read(db, chat_id, "chat changes")
+  chat = get_active_chat_or_404(db, chat_id)
+  messages = materialized_messages(chat)
+
+  entries: list[dict] = []
+  full_ids: set[str] = set()
+  for message_index, message in enumerate(messages):
+    blocks = message.get("blocks") if isinstance(message, dict) else None
+    if not isinstance(blocks, list):
+      continue
+    for block_index, block in enumerate(blocks):
+      if not isinstance(block, dict) or block.get("type") != "tool":
+        continue
+      preview = block.get("edit_preview")
+      if not (
+        isinstance(preview, dict)
+        and isinstance(preview.get("diff"), str)
+        and preview["diff"]
+      ):
+        continue
+      projected_preview = {
+        "diff": preview["diff"],
+        "truncated": preview.get("truncated") is True,
+        **({"relative": True} if preview.get("relative") is True else {}),
+      }
+      full_id = preview.get("full_id")
+      if isinstance(full_id, str) and full_id:
+        projected_preview["full_id"] = full_id
+        full_ids.add(full_id)
+      entries.append({
+        "id": block.get("tool_use_id") or f"message-{message_index}-block-{block_index}",
+        "tool": block.get("tool") or "Edit",
+        "ts": message.get("ts"),
+        "preview": projected_preview,
+      })
+
+  full_by_id: dict[str, str] = {}
+  if full_ids:
+    rows = db.query(
+      models.ToolOutput.tool_use_id,
+      cast(models.ToolOutput.output, Text),
+    ).filter(
+      models.ToolOutput.chat_id == chat_id,
+      models.ToolOutput.tool_use_id.in_(full_ids),
+    ).all()
+    full_by_id = {
+      full_id: decode_tool_output(stored)
+      for full_id, stored in rows
+    }
+
+  for entry in entries:
+    preview = entry["preview"]
+    full = full_by_id.get(preview.get("full_id"))
+    if full is not None:
+      preview["diff"] = full
+      preview["truncated"] = False
+
+  return {"entries": entries}
+
+
 @router.get(
   "/{chat_id}/thinking-trace/{thinking_id}",
   response_class=PlainTextResponse,

--- a/backend/app/tool_edit_preview.py
+++ b/backend/app/tool_edit_preview.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import difflib
+import hashlib
 import json
 from typing import Any
 
@@ -18,11 +19,26 @@ def _bounded_preview(diff: str, *, relative: bool = False) -> dict | None:
   if not diff:
     return None
   truncated = len(diff) > MAX_EDIT_PREVIEW_CHARS
-  return {
+  preview = {
     "diff": diff[:MAX_EDIT_PREVIEW_CHARS],
     "truncated": truncated,
     **({"relative": True} if relative else {}),
   }
+  # The transcript and live event keep the bounded preview above. The sink
+  # removes this private handoff before either surface sees it and stores the
+  # complete text in the existing compressed sidecar table. Only truncated
+  # previews need a sidecar; ordinary edits remain one inline value.
+  if truncated:
+    preview["_full_diff"] = diff
+  return preview
+
+
+def edit_diff_sidecar_id(chat_id: str, tool_use_id: str) -> str:
+  """Stable bounded key for one tool's complete edit diff sidecar."""
+  digest = hashlib.sha256(
+    f"{chat_id}\0{tool_use_id}".encode("utf-8", errors="surrogatepass")
+  ).hexdigest()
+  return f"edit-diff-{digest}"
 
 
 def _quoted_path(path: str) -> str:

--- a/backend/tests/test_tool_edit_preview.py
+++ b/backend/tests/test_tool_edit_preview.py
@@ -64,6 +64,7 @@ def test_codex_patch_preview_keeps_multiple_file_kinds_and_bounds_payload():
   }])
   assert large["truncated"] is True
   assert len(large["diff"]) == MAX_EDIT_PREVIEW_CHARS
+  assert len(large["_full_diff"]) > len(large["diff"])
 
 
 def test_preview_quoting_preserves_unicode_paths():

--- a/backend/tests/test_tool_output_stash.py
+++ b/backend/tests/test_tool_output_stash.py
@@ -17,6 +17,7 @@ from app.chat_writer import (
     StashToolOutput,
     get_writer,
 )
+from app.chat_event_sink import ChatEventSink
 from app.events import (
     TOOL_OUTPUT_INLINE_THRESHOLD,
     process_event,
@@ -111,7 +112,89 @@ def test_stash_ignores_empty_key(db):
     assert fut.result(timeout=5) is False
 
 
+def test_sink_stashes_full_edit_diff_and_keeps_private_text_off_wire(db):
+    class Bus:
+        def __init__(self):
+            self.events = []
+
+        def publish(self, event):
+            self.events.append(json.loads(json.dumps(event)))
+
+    bus = Bus()
+    sink = ChatEventSink(
+        bus,
+        "chat-edit",
+        recall_binding=EMPTY_RECALL_BINDING,
+    )
+    full = "diff --git a/a b/a\n" + ("+large line\n" * 2500)
+    event = {
+        "type": "tool_start",
+        "tool": "Edit",
+        "tool_use_id": "edit-1",
+        "edit_preview": {
+            "diff": full[:20000],
+            "truncated": True,
+            "_full_diff": full,
+        },
+    }
+
+    sink.publish(event)
+    _flush_writer()
+
+    preview = bus.events[0]["edit_preview"]
+    assert "_full_diff" not in preview
+    assert preview["full_id"].startswith("edit-diff-")
+    assert sink.assistant_blocks[0]["edit_preview"] == preview
+    assert decode_tool_output(_raw_tool_output(
+        db, "chat-edit", preview["full_id"],
+    )) == full
+
+
 # -- endpoint -------------------------------------------------------------
+def test_chat_edit_diffs_endpoint_expands_only_linked_sidecars(client, auth, db):
+    chat_id = str(uuid.uuid4())
+    full_id = "edit-diff-" + ("a" * 64)
+    orphan_id = "edit-diff-" + ("b" * 64)
+    preview = "diff --git a/a b/a\n@@ -1 +1 @@\n-old\n+partial"
+    full = preview + " complete"
+    db.add(models.Chat(
+        id=chat_id,
+        title="t",
+        messages=[{
+            "role": "assistant",
+            "ts": 123,
+            "blocks": [{
+                "type": "tool",
+                "tool": "Edit",
+                "tool_use_id": "edit-1",
+                "edit_preview": {
+                    "diff": preview,
+                    "truncated": True,
+                    "full_id": full_id,
+                },
+            }],
+        }],
+    ))
+    db.add(models.ToolOutput(chat_id=chat_id, tool_use_id=full_id, output=full))
+    db.add(models.ToolOutput(chat_id=chat_id, tool_use_id=orphan_id, output="secret orphan"))
+    db.commit()
+
+    response = client.get(f"/api/chats/{chat_id}/edit-diffs", headers=auth)
+
+    assert response.status_code == 200
+    assert response.json() == {"entries": [{
+        "id": "edit-1",
+        "tool": "Edit",
+        "ts": 123,
+        "preview": {
+            "diff": full,
+            "truncated": False,
+            "full_id": full_id,
+        },
+    }]}
+    assert "secret orphan" not in response.text
+
+
 def test_tool_output_by_id_endpoint_serves_full_text(client, auth, db):
     chat_id = str(uuid.uuid4())
     db.add(models.Chat(id=chat_id, title="t", messages=[]))

--- a/frontend/src/components/ChatView/ChatDiffViewer.jsx
+++ b/frontend/src/components/ChatView/ChatDiffViewer.jsx
@@ -1,0 +1,187 @@
+/* Full chat-scoped diff viewer opened from the composer's Brain menu. */
+
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { X } from '@openai/apps-sdk-ui/components/Icon'
+import { apiFetch } from '../../api/client.js'
+import useDialogFocus from '../../hooks/useDialogFocus.js'
+import { formatRelativeTime } from '../../lib/relativeTime.js'
+import FileDiffList from '../DiffView/FileDiffList.jsx'
+import {
+  mergeChatDiffEntries,
+  normalizeChatDiffEntries,
+  summarizeChatDiffs,
+} from './chatDiffs.js'
+import './ChatWork.css'
+
+function updateLabel(entry) {
+  const count = entry?.preview?.files?.length || 0
+  return count === 1 ? '1 file' : `${count} files`
+}
+
+function updateTime(value) {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return formatRelativeTime(new Date(value).toISOString())
+  }
+  return formatRelativeTime(value)
+}
+
+export default function ChatDiffViewer({ chatId, initialEntries, onClose }) {
+  const [state, setState] = useState({
+    status: 'loading',
+    entries: initialEntries || [],
+    error: '',
+  })
+  const dialogRef = useRef(null)
+  const closeRef = useRef(null)
+  const expansionSequenceRef = useRef(0)
+  const initialEntriesRef = useRef(initialEntries || [])
+  const [expansionCommand, setExpansionCommand] = useState(null)
+  initialEntriesRef.current = initialEntries || []
+
+  useDialogFocus({
+    containerRef: dialogRef,
+    initialFocusRef: closeRef,
+    onClose,
+  })
+
+  useEffect(() => {
+    setState(current => ({
+      ...current,
+      entries: mergeChatDiffEntries(current.entries, initialEntries),
+    }))
+  }, [initialEntries])
+
+  useEffect(() => {
+    const controller = new AbortController()
+    async function load() {
+      try {
+        const response = await apiFetch(
+          `/chats/${encodeURIComponent(chatId)}/edit-diffs`,
+          { signal: controller.signal },
+        )
+        if (!response.ok) throw new Error(`Request failed (${response.status})`)
+        const data = await response.json()
+        const authoritative = normalizeChatDiffEntries(data?.entries)
+        setState({
+          status: 'ready',
+          entries: mergeChatDiffEntries(authoritative, initialEntriesRef.current),
+          error: '',
+        })
+      } catch (error) {
+        if (error?.name === 'AbortError') return
+        setState(current => ({
+          ...current,
+          status: 'error',
+          error: 'Could not refresh the complete change history.',
+        }))
+      }
+    }
+    load()
+    return () => controller.abort()
+  }, [chatId])
+
+  const summary = useMemo(() => summarizeChatDiffs(state.entries), [state.entries])
+  const shortenedCount = state.entries.filter(entry => entry.preview?.truncated).length
+
+  function setEveryDiffExpanded(expanded) {
+    expansionSequenceRef.current += 1
+    setExpansionCommand({
+      id: expansionSequenceRef.current,
+      expanded,
+    })
+  }
+
+  return (
+    <div className="chat-work__overlay" role="presentation" onClick={onClose}>
+      <div
+        ref={dialogRef}
+        className="chat-work chat-work--diffs"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="chat-work-diff-title"
+        onClick={event => event.stopPropagation()}
+      >
+        <header className="chat-work__head">
+          <div>
+            <h2 id="chat-work-diff-title">Changes from this chat</h2>
+            <p>
+              {summary.updateCount > 0
+                ? `${summary.updateCount} ${summary.updateCount === 1 ? 'update' : 'updates'} · ${summary.fileCount} ${summary.fileCount === 1 ? 'file' : 'files'}`
+                : 'Every recorded file edit will appear here.'}
+            </p>
+          </div>
+          <button
+            ref={closeRef}
+            type="button"
+            className="chat-work__close"
+            onClick={onClose}
+            aria-label="Close changes"
+          >
+            <X width={19} height={19} />
+          </button>
+        </header>
+        {state.entries.length > 0 && (
+          <div className="chat-work__toolbar">
+            <div role="group" aria-label="Diff display controls">
+              <button type="button" onClick={() => setEveryDiffExpanded(true)}>
+                Expand all
+              </button>
+              <button type="button" onClick={() => setEveryDiffExpanded(false)}>
+                Collapse all
+              </button>
+            </div>
+          </div>
+        )}
+        <div className="chat-work__body">
+          {state.status === 'loading' && state.entries.length === 0 && (
+            <p className="chat-work__state" role="status">Loading changes…</p>
+          )}
+          {state.status === 'error' && state.entries.length === 0 && (
+            <p className="chat-work__state chat-work__state--error" role="alert">
+              {state.error}
+            </p>
+          )}
+          {state.entries.length === 0 && state.status === 'ready' && (
+            <div className="chat-work__empty">
+              <strong>No file changes recorded yet</strong>
+              <span>Edits made through this chat will collect here automatically.</span>
+            </div>
+          )}
+          {state.entries.length > 0 && (
+            <div className="chat-work__updates">
+              {state.status === 'error' && (
+                <p className="chat-work__notice">{state.error} Showing the changes already loaded in this chat.</p>
+              )}
+              {shortenedCount > 0 && (
+                <p className="chat-work__notice">
+                  {shortenedCount === 1
+                    ? '1 older update is excerpt-only because its full diff was never saved.'
+                    : `${shortenedCount} older updates are excerpt-only because their full diffs were never saved.`}
+                </p>
+              )}
+              {state.entries.map((entry, index) => (
+                <section className="chat-work__update" key={entry.id}>
+                  <div className="chat-work__update-head">
+                    <div>
+                      <span className="chat-work__update-number">Update {index + 1}</span>
+                      <strong>{updateLabel(entry)}</strong>
+                    </div>
+                    {entry.ts ? <span>{updateTime(entry.ts)}</span> : null}
+                  </div>
+                  <FileDiffList
+                    files={entry.preview.files}
+                    diffTruncated={entry.preview.truncated}
+                    expansionCommand={expansionCommand}
+                  />
+                  {entry.preview.relative && (
+                    <p className="chat-work__update-note">Line numbers are relative to the edited selection.</p>
+                  )}
+                </section>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -43,6 +43,7 @@ import ChatInputBar from './ChatInputBar.jsx'
 import { hasSendablePayload } from './composerSubmission.js'
 import AgentContextInspector from './AgentContextInspector.jsx'
 import ChatSummaryViewer from './ChatSummaryViewer.jsx'
+import ChatDiffViewer from './ChatDiffViewer.jsx'
 import ChatUsageInspector from './ChatUsageInspector.jsx'
 import ChatUsageStrip from './ChatUsageStrip.jsx'
 import { formatUsageAriaSummary } from './chatUsageFormat.js'
@@ -169,6 +170,7 @@ import {
   resetComposerTextarea,
 } from './composerTextareaSizing.js'
 import { needsModelSelection } from './modelSelectionPolicy.js'
+import { collectChatDiffs } from './chatDiffs.js'
 import {
   EMPTY_BUILD_PHASE_RAIL,
   accumulateBuildPhase,
@@ -332,6 +334,8 @@ export default function ChatView({
   // chat has a stable frame to paint. Empty/error chats are already stable;
   // transcript chats wait for useScrollMode's existing hide-then-reveal gate.
   onDisplayReady = null,
+  artifactsAppId = null,
+  onOpenArtifact = null,
 }) {
   const queryClient = useQueryClient()
   // Cheap per-chat token/cost summary for the always-visible composer badge
@@ -546,6 +550,7 @@ export default function ChatView({
   // cards themselves use to publish the node being observed.
   const [showInspector, setShowInspector] = useState(false)
   const [showSummary, setShowSummary] = useState(false)
+  const [showChanges, setShowChanges] = useState(false)
   const [showUsage, setShowUsage] = useState(false)
   const [visibleMessageMetaKey, setVisibleMessageMetaKey] = useState(null)
   const messageMetaTimerRef = useRef(null)
@@ -4227,6 +4232,10 @@ export default function ChatView({
   const pendingStreamQuestion = activeAssistantIsStreaming
     ? streamItems.find(it => it.type === 'question' && !it.answers)
     : null
+  const chatDiffEntries = useMemo(() => collectChatDiffs([
+    ...messages,
+    { role: 'assistant', blocks: streamItems },
+  ]), [messages, streamItems])
   const hasPendingQuestion = !!pendingStreamQuestion || !!liveQuestionId
 
   // Answerability id: prefer the durable pending_question_id marker; during the
@@ -4531,6 +4540,13 @@ export default function ChatView({
         <ChatSummaryViewer
           chatId={chatId}
           onClose={() => setShowSummary(false)}
+        />
+      )}
+      {!embedded && showChanges && (
+        <ChatDiffViewer
+          chatId={chatId}
+          initialEntries={chatDiffEntries}
+          onClose={() => setShowChanges(false)}
         />
       )}
       {!embedded && showUsage && (
@@ -4969,6 +4985,9 @@ export default function ChatView({
                 modelSelectionRequest={modelSelectionRequest}
                 onOpenInspector={() => setShowInspector(true)}
                 onOpenSummary={() => setShowSummary(true)}
+                onOpenChanges={() => setShowChanges(true)}
+                artifactsAppId={artifactsAppId}
+                onOpenArtifact={onOpenArtifact}
                 onOpenUsage={() => setShowUsage(true)}
                 embedded={embedded}
               />

--- a/frontend/src/components/ChatView/ChatWork.css
+++ b/frontend/src/components/ChatView/ChatWork.css
@@ -1,0 +1,299 @@
+/* Chat-owned work surfaces: Brain-menu artifacts and the full diff overlay. */
+
+.composer-popover__section--artifacts {
+  margin-top: 6px;
+  padding-top: 7px;
+  border-top: 1px solid var(--border-light);
+}
+
+.composer-popover__eyebrow {
+  padding: 3px 10px 5px;
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1.3;
+  letter-spacing: 0.02em;
+}
+
+.composer-popover__artifact-latest {
+  background: color-mix(in srgb, var(--accent) 7%, transparent);
+}
+
+.composer-popover__artifact-latest .composer-popover__row-icon {
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 11%, var(--surface2));
+}
+
+.composer-popover__artifact-more {
+  margin-top: 2px;
+}
+
+.composer-popover__artifact-summary {
+  min-height: 36px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 10px;
+  border-radius: 8px;
+  color: var(--muted);
+  cursor: pointer;
+  list-style: none;
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+.composer-popover__artifact-summary::-webkit-details-marker { display: none; }
+
+.composer-popover__artifact-summary span:first-child { flex: 1; }
+
+.composer-popover__artifact-summary svg {
+  transition: transform 0.16s ease;
+}
+
+.composer-popover__artifact-more[open] .composer-popover__artifact-summary svg {
+  transform: rotate(180deg);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .composer-popover__artifact-summary:hover { background: var(--surface2); }
+}
+
+.composer-popover__artifact-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  padding-top: 1px;
+}
+
+.composer-popover__artifact-list .composer-popover__row {
+  padding-left: 14px;
+}
+
+.chat-work__overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 220;
+  display: grid;
+  place-items: center;
+  padding: 16px;
+  background: rgba(0, 0, 0, 0.48);
+}
+
+[data-theme="light"] .chat-work__overlay {
+  background: rgba(15, 18, 25, 0.34);
+}
+
+.chat-work {
+  width: min(980px, 100%);
+  max-height: calc(100% - 8px);
+  min-height: 0;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  background: var(--surface);
+  color: var(--text);
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.34);
+}
+
+[data-theme="light"] .chat-work {
+  box-shadow: 0 16px 50px rgba(15, 18, 25, 0.18);
+}
+
+.chat-work__head {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 17px 18px 15px;
+  border-bottom: 1px solid var(--border-light);
+}
+
+.chat-work__head h2 {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+.chat-work__head p {
+  margin: 3px 0 0;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.chat-work__close {
+  flex: 0 0 auto;
+  width: 40px;
+  height: 40px;
+  margin: -6px -6px 0 0;
+  display: grid;
+  place-items: center;
+  border: 0;
+  border-radius: 10px;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .chat-work__close:hover { background: var(--surface2); color: var(--text); }
+}
+
+.chat-work__close:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
+.chat-work__toolbar {
+  flex: 0 0 auto;
+  min-height: 42px;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding: 5px 12px;
+  border-bottom: 1px solid var(--border-light);
+  color: var(--muted);
+  font-size: 11px;
+  line-height: 1.4;
+}
+
+.chat-work__toolbar > div {
+  flex: 0 0 auto;
+  display: flex;
+  gap: 4px;
+}
+
+.chat-work__toolbar button {
+  min-height: 32px;
+  padding: 5px 10px;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  font: inherit;
+  font-weight: 600;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .chat-work__toolbar button:hover { background: var(--surface2); color: var(--text); }
+}
+
+.chat-work__toolbar button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
+.chat-work__body {
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding: 14px;
+}
+
+.chat-work__state,
+.chat-work__notice {
+  margin: 0;
+  padding: 12px 14px;
+  border: 1px solid var(--border-light);
+  border-radius: 11px;
+  background: var(--bg);
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.chat-work__state--error { color: var(--danger); }
+
+.chat-work__empty {
+  min-height: 220px;
+  display: grid;
+  place-content: center;
+  justify-items: center;
+  gap: 5px;
+  padding: 24px;
+  color: var(--muted);
+  text-align: center;
+}
+
+.chat-work__empty strong { color: var(--text); font-size: 14px; }
+.chat-work__empty span { font-size: 12px; line-height: 1.45; }
+
+.chat-work__updates {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.chat-work__update {
+  overflow: hidden;
+  border: 1px solid var(--border-light);
+  border-radius: 13px;
+  background: var(--bg);
+}
+
+.chat-work__update-head {
+  min-height: 46px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 12px;
+  color: var(--muted);
+  font-size: 11px;
+}
+
+.chat-work__update-head > div {
+  min-width: 0;
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.chat-work__update-head strong {
+  color: var(--text);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.chat-work__update-number {
+  color: var(--muted);
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.chat-work__update .file-diff-list {
+  border: 0;
+  border-top: 1px solid var(--border-light);
+  border-radius: 0;
+}
+
+.chat-work__update-note {
+  margin: 0;
+  padding: 8px 12px;
+  border-top: 1px solid var(--border-light);
+  color: var(--muted);
+  font-size: 11px;
+  line-height: 1.4;
+}
+
+@media (max-width: 640px) {
+  .chat-work__overlay {
+    align-items: end;
+    padding: 8px;
+  }
+
+  .chat-work {
+    width: 100%;
+    max-height: calc(100% - 8px);
+    border-radius: 18px;
+  }
+
+  .chat-work__head { padding: 16px; }
+  .chat-work__body { padding: 9px; }
+  .chat-work__updates { gap: 9px; }
+}

--- a/frontend/src/components/ChatView/ComposerPopover.jsx
+++ b/frontend/src/components/ChatView/ComposerPopover.jsx
@@ -1,13 +1,14 @@
 /**
  * ComposerPopover — the brain button in the chat composer and the popover
- * it opens. Three sections in one popover:
+ * it opens. Four sections in one popover:
  *
- *   1. Attach files  — calls `onAttachClick` (parent owns the hidden
+ *   1. Attach files + chat changes — calls `onAttachClick` (parent owns the hidden
  *      <input type="file"> so it can clear .value after each pick).
- *   2. Model / effort / summary / automation — renders
+ *   2. Artifacts touched by this chat, with the latest always exposed.
+ *   3. Model / effort / summary / automation — renders
  *      <ChatSettingsPanel> when a chatInfo is available; omitted on a fresh
  *      empty chat where chatInfo hasn't loaded yet.
- *   3. Chat summary / agent context — opens the two owner-facing continuity
+ *   4. Chat summary / agent context — opens the two owner-facing continuity
  *      viewers after the picker.
  *
  * Open/close state, outside-click, and Escape live here. The trigger
@@ -36,9 +37,20 @@
  */
 
 import { useEffect, useLayoutEffect, useRef, useState } from 'react'
-import { DollarCircle, FileDocument, InfoCircle, Paperclip } from '@openai/apps-sdk-ui/components/Icon'
+import { useQuery } from '@tanstack/react-query'
+import {
+  ChevronDown,
+  Code,
+  DollarCircle,
+  FileDocument,
+  InfoCircle,
+  Paperclip,
+} from '@openai/apps-sdk-ui/components/Icon'
 import BrainUsageIcon from './BrainUsageIcon.jsx'
 import ChatSettingsPanel from './ChatSettingsPanel.jsx'
+import { loadChatArtifacts } from './chatArtifacts.js'
+import { apiFetch } from '../../api/client.js'
+import { formatRelativeTime } from '../../lib/relativeTime.js'
 import { popoverMaxHeight, nearestClipTop } from './composerPopoverHeight.js'
 import { focusComposerElement } from './composerFocusPolicy.js'
 import {
@@ -48,6 +60,7 @@ import {
 } from '../../lib/layoutSpace.js'
 import useModelSelectionPopover from './hooks/useModelSelectionPopover.js'
 import useDiscardUnconfirmedSwitchOnPickerClose from './hooks/useDiscardUnconfirmedSwitchOnPickerClose.js'
+import './ChatWork.css'
 
 export default function ComposerPopover({
   chatInfo,
@@ -72,6 +85,9 @@ export default function ComposerPopover({
   modelSelectionRequest = 0,
   onOpenInspector,
   onOpenSummary,
+  onOpenChanges,
+  artifactsAppId = null,
+  onOpenArtifact,
   onOpenUsage,
   embedded = false,
   pending = false,
@@ -97,6 +113,22 @@ export default function ComposerPopover({
     modelSelectionRequest,
     composerInputRef,
   )
+  const artifactsQuery = useQuery({
+    queryKey: ['chat-work-artifacts', String(artifactsAppId || ''), String(chatId || '')],
+    queryFn: ({ signal }) => loadChatArtifacts(
+      artifactsAppId,
+      chatId,
+      { signal, request: apiFetch },
+    ),
+    enabled: Boolean(open && !embedded && artifactsAppId && chatId),
+    staleTime: 0,
+  })
+  const chatArtifacts = artifactsQuery.data || []
+  const latestArtifact = chatArtifacts[0] || null
+  const latestArtifactRelativeTime = latestArtifact
+    ? formatRelativeTime(latestArtifact.touchedAt)
+    : ''
+  const otherArtifacts = chatArtifacts.slice(1)
   useDiscardUnconfirmedSwitchOnPickerClose(
     open,
     providerSwitchState?.status,
@@ -221,6 +253,16 @@ export default function ComposerPopover({
     onOpenSummary?.()
   }
 
+  function handleOpenChanges() {
+    setOpen(false)
+    onOpenChanges?.()
+  }
+
+  function handleOpenArtifact(artifactId) {
+    setOpen(false)
+    onOpenArtifact?.(artifactId)
+  }
+
   function handleOpenUsage() {
     setOpen(false)
     onOpenUsage?.()
@@ -283,7 +325,100 @@ export default function ComposerPopover({
                 </span>
               </span>
             </button>
+            {!embedded && (
+              <button
+                type="button"
+                className="composer-popover__row"
+                onClick={handleOpenChanges}
+              >
+                <span className="composer-popover__row-icon" aria-hidden="true">
+                  <Code width={19} height={19} />
+                </span>
+                <span className="composer-popover__row-main">
+                  <span className="composer-popover__row-title">Changes</span>
+                  <span className="composer-popover__row-sub">View this chat’s file changes</span>
+                </span>
+              </button>
+            )}
           </div>
+          {!embedded && artifactsAppId && artifactsQuery.isLoading && (
+            <div className="composer-popover__section composer-popover__section--artifacts">
+              <span className="composer-popover__eyebrow">Latest artifact</span>
+              <div className="composer-popover__row" role="status">
+                <span className="composer-popover__row-icon" aria-hidden="true">
+                  <FileDocument width={18} height={18} />
+                </span>
+                <span className="composer-popover__row-main">
+                  <span className="composer-popover__row-title">Looking in this chat…</span>
+                </span>
+              </div>
+            </div>
+          )}
+          {!embedded && artifactsAppId && artifactsQuery.isError && (
+            <div className="composer-popover__section composer-popover__section--artifacts">
+              <button
+                type="button"
+                className="composer-popover__row"
+                onClick={() => artifactsQuery.refetch()}
+              >
+                <span className="composer-popover__row-icon" aria-hidden="true">
+                  <FileDocument width={18} height={18} />
+                </span>
+                <span className="composer-popover__row-main">
+                  <span className="composer-popover__row-title">Artifacts unavailable</span>
+                  <span className="composer-popover__row-sub">Tap to try again</span>
+                </span>
+              </button>
+            </div>
+          )}
+          {!embedded && latestArtifact && (
+            <div className="composer-popover__section composer-popover__section--artifacts">
+              <span className="composer-popover__eyebrow">Latest artifact</span>
+              <button
+                type="button"
+                className="composer-popover__row composer-popover__artifact-latest"
+                onClick={() => handleOpenArtifact(latestArtifact.id)}
+              >
+                <span className="composer-popover__row-icon" aria-hidden="true">
+                  <FileDocument width={18} height={18} />
+                </span>
+                <span className="composer-popover__row-main">
+                  <span className="composer-popover__row-title">{latestArtifact.title}</span>
+                  <span className="composer-popover__row-sub">
+                    {latestArtifactRelativeTime
+                      ? `Edited here ${latestArtifactRelativeTime} · v${latestArtifact.version}`
+                      : `Edited in this chat · v${latestArtifact.version}`}
+                  </span>
+                </span>
+              </button>
+              {otherArtifacts.length > 0 && (
+                <details className="composer-popover__artifact-more">
+                  <summary className="composer-popover__artifact-summary">
+                    <span>Other artifacts</span>
+                    <span>{otherArtifacts.length}</span>
+                    <ChevronDown width={15} height={15} aria-hidden="true" />
+                  </summary>
+                  <div className="composer-popover__artifact-list">
+                    {otherArtifacts.map(artifact => (
+                      <button
+                        key={artifact.id}
+                        type="button"
+                        className="composer-popover__row"
+                        onClick={() => handleOpenArtifact(artifact.id)}
+                      >
+                        <span className="composer-popover__row-main">
+                          <span className="composer-popover__row-title">{artifact.title}</span>
+                          <span className="composer-popover__row-sub">
+                            {formatRelativeTime(artifact.touchedAt) || `Version ${artifact.version}`}
+                          </span>
+                        </span>
+                      </button>
+                    ))}
+                  </div>
+                </details>
+              )}
+            </div>
+          )}
           {chatInfo && chatId && (
             <div className="composer-popover__section composer-popover__section--picker">
               <ChatSettingsPanel

--- a/frontend/src/components/ChatView/__tests__/chatArtifacts.test.js
+++ b/frontend/src/components/ChatView/__tests__/chatArtifacts.test.js
@@ -1,0 +1,55 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  artifactTouchForChat,
+  artifactsTouchedByChat,
+} from '../chatArtifacts.js'
+
+test('chat artifacts are attributed by version touch, not global record recency', () => {
+  const records = [
+    {
+      id: 'launch-brief-a1b2',
+      title: 'Launch brief',
+      chat_id: 'chat-a',
+      created_at: '2026-08-20T10:00:00Z',
+      updated_at: '2026-08-25T10:00:00Z',
+      current_version: 3,
+      versions: [
+        { v: 1, chat_id: 'chat-a', created_at: '2026-08-20T10:00:00Z' },
+        { v: 2, chat_id: 'chat-a', created_at: '2026-08-22T10:00:00Z' },
+        { v: 3, chat_id: 'chat-b', created_at: '2026-08-25T10:00:00Z' },
+      ],
+    },
+    {
+      id: 'flow-map-c3d4',
+      title: 'Flow map',
+      chat_id: 'chat-b',
+      created_at: '2026-08-21T10:00:00Z',
+      updated_at: '2026-08-24T10:00:00Z',
+      current_version: 2,
+      versions: [
+        { v: 1, chat_id: 'chat-b', created_at: '2026-08-21T10:00:00Z' },
+        { v: 2, chat_id: 'chat-a', created_at: '2026-08-24T10:00:00Z' },
+      ],
+    },
+  ]
+
+  const touched = artifactsTouchedByChat(records, 'chat-a')
+  assert.deepEqual(touched.map(item => item.id), ['flow-map-c3d4', 'launch-brief-a1b2'])
+  assert.equal(touched[1].touchedAt, '2026-08-22T10:00:00Z')
+  assert.equal(touched[1].version, 2)
+  assert.equal(touched[0].version, 2)
+})
+
+test('legacy provenance is retained and malformed ids are ignored', () => {
+  assert.equal(artifactTouchForChat({
+    id: 'legacy-artifact',
+    title: 'Legacy',
+    chat_id: 'chat-a',
+    created_at: '2026-08-20T10:00:00Z',
+  }, 'chat-a')?.title, 'Legacy')
+  assert.equal(artifactTouchForChat({
+    id: '../escape', chat_id: 'chat-a',
+  }, 'chat-a'), null)
+})

--- a/frontend/src/components/ChatView/__tests__/chatDiffs.test.js
+++ b/frontend/src/components/ChatView/__tests__/chatDiffs.test.js
@@ -1,0 +1,36 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  collectChatDiffs,
+  mergeChatDiffEntries,
+  normalizeChatDiffEntries,
+  summarizeChatDiffs,
+} from '../chatDiffs.js'
+
+const small = {
+  diff: 'diff --git a/src/a.js b/src/a.js\n--- a/src/a.js\n+++ b/src/a.js\n@@ -1 +1 @@\n-old\n+new',
+  truncated: false,
+}
+
+test('chat changes dedupe a live replay by stable tool id', () => {
+  const entries = collectChatDiffs([
+    { ts: 1, blocks: [{ type: 'tool', tool: 'Edit', tool_use_id: 'edit-1', edit_preview: small }] },
+    { ts: 2, blocks: [{ type: 'tool', tool: 'Edit', tool_use_id: 'edit-1', edit_preview: small }] },
+  ])
+  assert.equal(entries.length, 1)
+  assert.equal(entries[0].ts, 2)
+  assert.deepEqual(summarizeChatDiffs(entries), {
+    updateCount: 1,
+    fileCount: 1,
+  })
+})
+
+test('complete route data wins over a bounded live twin', () => {
+  const full = normalizeChatDiffEntries([{ id: 'edit-1', preview: small }])
+  const bounded = normalizeChatDiffEntries([{
+    id: 'edit-1',
+    preview: { ...small, truncated: true },
+  }])
+  assert.equal(mergeChatDiffEntries(full, bounded)[0].preview.truncated, false)
+})

--- a/frontend/src/components/ChatView/chatArtifacts.js
+++ b/frontend/src/components/ChatView/chatArtifacts.js
@@ -1,0 +1,82 @@
+/* Chat-scoped projection of records owned by the installed Artifacts app. */
+
+const ARTIFACT_ID_RE = /^[A-Za-z0-9_-]{1,64}$/
+
+function recordFromEntry(entry) {
+  const content = entry?.content
+  if (content && typeof content === 'object') return content
+  if (typeof content !== 'string') return null
+  try {
+    const parsed = JSON.parse(content)
+    return parsed && typeof parsed === 'object' ? parsed : null
+  } catch {
+    return null
+  }
+}
+
+function timestamp(value) {
+  const parsed = Date.parse(value)
+  return Number.isFinite(parsed) ? parsed : 0
+}
+
+export function artifactTouchForChat(record, chatId) {
+  if (!record || typeof record !== 'object') return null
+  if (!ARTIFACT_ID_RE.test(record.id || '')) return null
+  const owner = String(chatId || '')
+  if (!owner) return null
+  const versionTouches = (Array.isArray(record.versions) ? record.versions : [])
+    .filter(version => String(version?.chat_id || '') === owner)
+  if (versionTouches.length === 0 && String(record.chat_id || '') !== owner) {
+    return null
+  }
+  const latestVersionTouch = versionTouches.reduce((latest, version) => (
+    timestamp(version?.created_at) > timestamp(latest?.created_at)
+      ? version
+      : latest
+  ), null)
+  const touchedAt = latestVersionTouch?.created_at
+    || record.created_at
+    || record.updated_at
+    || ''
+  return {
+    id: record.id,
+    title: String(record.title || 'Untitled artifact'),
+    description: String(record.description || ''),
+    touchedAt,
+    version: Math.max(
+      1,
+      Number(latestVersionTouch?.v ?? record.current_version) || 1,
+    ),
+  }
+}
+
+export function artifactsTouchedByChat(records, chatId) {
+  return (Array.isArray(records) ? records : [])
+    .map(record => artifactTouchForChat(record, chatId))
+    .filter(Boolean)
+    .sort((left, right) => timestamp(right.touchedAt) - timestamp(left.touchedAt))
+}
+
+export async function loadChatArtifacts(appId, chatId, { signal, request } = {}) {
+  if (typeof request !== 'function') {
+    throw new Error('Artifact loading requires a request function.')
+  }
+  const records = []
+  let cursor = null
+  do {
+    const params = new URLSearchParams({ limit: '500', include_content: 'true' })
+    if (cursor) params.set('cursor', cursor)
+    const response = await request(
+      `/storage/apps-list/${encodeURIComponent(appId)}/artifacts/?${params}`,
+      { signal },
+    )
+    if (!response.ok) throw new Error(`Artifacts request failed (${response.status})`)
+    const page = await response.json()
+    for (const entry of Array.isArray(page?.entries) ? page.entries : []) {
+      const record = recordFromEntry(entry)
+      if (record) records.push(record)
+    }
+    cursor = page?.next_cursor || null
+  } while (cursor)
+  return artifactsTouchedByChat(records, chatId)
+}

--- a/frontend/src/components/ChatView/chatDiffs.js
+++ b/frontend/src/components/ChatView/chatDiffs.js
@@ -1,0 +1,89 @@
+/* Pure chat edit-diff projection shared by the Brain menu and full viewer. */
+
+import { toolEditPreview } from './toolEditPreview.js'
+
+function hashText(value) {
+  let hash = 2166136261
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index)
+    hash = Math.imul(hash, 16777619)
+  }
+  return (hash >>> 0).toString(36)
+}
+
+function normalizeEntry(value, fallbackId = '') {
+  const rawPreview = value?.preview || value?.edit_preview
+  const preview = toolEditPreview(rawPreview)
+  if (!preview) return null
+  const rawDiff = String(rawPreview.diff || '')
+  return {
+    id: String(value?.id || value?.tool_use_id || fallbackId
+      || `diff-${rawDiff.length}-${hashText(rawDiff)}`),
+    tool: String(value?.tool || 'Edit'),
+    ts: value?.ts ?? null,
+    preview,
+  }
+}
+
+export function collectChatDiffs(messages) {
+  const entries = []
+  const positions = new Map()
+  for (const message of Array.isArray(messages) ? messages : []) {
+    const blocks = Array.isArray(message?.blocks) ? message.blocks : []
+    for (const block of blocks) {
+      if (block?.type !== 'tool') continue
+      const entry = normalizeEntry({
+        ...block,
+        ts: message?.ts ?? null,
+      })
+      if (!entry) continue
+      const position = positions.get(entry.id)
+      if (position === undefined) {
+        positions.set(entry.id, entries.length)
+        entries.push(entry)
+      } else {
+        entries[position] = entry
+      }
+    }
+  }
+  return entries
+}
+
+export function normalizeChatDiffEntries(values) {
+  return (Array.isArray(values) ? values : [])
+    .map((value, index) => normalizeEntry(value, `diff-${index}`))
+    .filter(Boolean)
+}
+
+export function mergeChatDiffEntries(authoritative, live) {
+  const merged = [...(Array.isArray(authoritative) ? authoritative : [])]
+  const positions = new Map(merged.map((entry, index) => [entry.id, index]))
+  for (const entry of Array.isArray(live) ? live : []) {
+    const position = positions.get(entry.id)
+    if (position === undefined) {
+      positions.set(entry.id, merged.length)
+      merged.push(entry)
+    } else {
+      // The mounted chat can be a few stream events ahead of the read route.
+      // Keep a complete authoritative sidecar over its bounded live twin.
+      const current = merged[position]
+      merged[position] = current?.preview?.truncated === false
+        ? current
+        : entry
+    }
+  }
+  return merged
+}
+
+export function summarizeChatDiffs(entries) {
+  const paths = new Set()
+  for (const entry of Array.isArray(entries) ? entries : []) {
+    for (const file of entry?.preview?.files || []) {
+      if (file?.path) paths.add(file.path)
+    }
+  }
+  return {
+    updateCount: Array.isArray(entries) ? entries.length : 0,
+    fileCount: paths.size,
+  }
+}

--- a/frontend/src/components/DiffView/FileDiffList.jsx
+++ b/frontend/src/components/DiffView/FileDiffList.jsx
@@ -2,7 +2,7 @@
 // React and its own flat sibling modules. Styles ship as a JavaScript string
 // because the mini-app compiler rejects CSS side-output.
 
-import { useId, useState } from 'react'
+import { useEffect, useId, useMemo, useState } from 'react'
 import DiffView from './DiffView.jsx'
 import { decodeGitPath } from './parseUnifiedDiff.js'
 import { ensureDiffViewerStyles } from './styles.js'
@@ -152,6 +152,10 @@ export function collapseFileRows(rows, showAll = false) {
   }
 }
 
+export function expandedFileKeys(rows, expanded) {
+  return new Set(expanded ? rows.map(row => row.key) : [])
+}
+
 export function filePreviewState(row, truncated, truncatedTail) {
   const hasTextDiff = (row?.file?.hunks?.length || 0) > 0
   if (
@@ -222,14 +226,24 @@ export default function FileDiffList({
   files,
   summaryOverrides,
   diffTruncated = false,
+  expansionCommand = null,
 }) {
-  const parsedFiles = Array.isArray(files) ? files : []
-  const rows = buildFileRows(parsedFiles, summaryOverrides)
+  const parsedFiles = useMemo(() => (Array.isArray(files) ? files : []), [files])
+  const rows = useMemo(
+    () => buildFileRows(parsedFiles, summaryOverrides),
+    [parsedFiles, summaryOverrides],
+  )
   const [openFiles, setOpenFiles] = useState(() => new Set())
   const [showAll, setShowAll] = useState(false)
   const listId = useId()
   const lastParsedFile = parsedFiles.at(-1)
   const { collapsed, visibleRows } = collapseFileRows(rows, showAll)
+
+  useEffect(() => {
+    if (!expansionCommand) return
+    setOpenFiles(expandedFileKeys(rows, expansionCommand.expanded === true))
+    if (expansionCommand.expanded === true) setShowAll(true)
+  }, [expansionCommand, rows])
 
   function toggleFile(key) {
     setOpenFiles((current) => {

--- a/frontend/src/components/DiffView/__tests__/fileDiffList.test.js
+++ b/frontend/src/components/DiffView/__tests__/fileDiffList.test.js
@@ -8,6 +8,7 @@ import FileDiffList, {
   bidiSafeDirectory,
   buildFileRows,
   collapseFileRows,
+  expandedFileKeys,
   filePreviewState,
   splitPath,
 } from '../FileDiffList.jsx'
@@ -142,6 +143,15 @@ test('collapse decision keeps eight rows and samples six above the threshold', (
     collapsed: false,
     visibleRows: nine,
   })
+})
+
+test('global expansion commands address every file without changing row order', () => {
+  const rows = buildFileRows([
+    { path: 'first.js', hunks: [] },
+    { path: 'second.js', hunks: [] },
+  ])
+  assert.deepEqual([...expandedFileKeys(rows, true)], rows.map(row => row.key))
+  assert.equal(expandedFileKeys(rows, false).size, 0)
 })
 
 test('collapsed rows expose valid disclosure and announced stat semantics', () => {

--- a/frontend/src/components/Shell/PaneChatView.jsx
+++ b/frontend/src/components/Shell/PaneChatView.jsx
@@ -25,6 +25,7 @@ function PaneChatView({
   chatId,
   paneId,
   apps,
+  artifactsAppId = null,
   runtimeActive = true,
   previewPresented = false,
   keepTranscriptPainted = false,
@@ -46,6 +47,7 @@ function PaneChatView({
   markChatOwnerActivity,
   loadTheme,
   navTo,
+  openAppWithIntent,
   onInternalNav,
   onChatMissing,
   onFirstMessage,
@@ -106,6 +108,16 @@ function PaneChatView({
     acknowledgeAppPreview?.(app, true)
   }, [acknowledgeAppPreview])
 
+  const handleOpenArtifact = useCallback((artifactId) => {
+    if (artifactsAppId == null || artifactId == null) return
+    void openAppWithIntent(
+      artifactsAppId,
+      `artifact:${artifactId}`,
+      () => true,
+      { paneId },
+    )
+  }, [artifactsAppId, openAppWithIntent, paneId])
+
   const handleChatMissing = useCallback((missingId) => {
     onChatMissing?.(missingId, chatId)
   }, [chatId, onChatMissing])
@@ -146,6 +158,8 @@ function PaneChatView({
         builtApps={builtApps}
         onOpenApp={handleOpenApp}
         onDismissApp={handleDismissApp}
+        artifactsAppId={artifactsAppId}
+        onOpenArtifact={handleOpenArtifact}
         onInternalNav={onInternalNav}
         onMessageStart={handleMessageStart}
         onOwnerActivity={handleOwnerActivity}

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -544,6 +544,7 @@ export default function Shell({ onInitialVisualReady }) {
     reconcile: reconcileCreatedChats,
   })
   const apps = appsQuery.data ?? EMPTY_LIST
+  const artifactsAppId = apps.find(app => app.slug === 'artifacts')?.id ?? null
   const chats = chatsQuery.data ?? EMPTY_LIST
   const appsStatus = apps.length > 0 || appsQuery.isSuccess
     ? 'success'
@@ -4083,6 +4084,7 @@ export default function Shell({ onInitialVisualReady }) {
                 chatId={chatId}
                 paneId={paneId}
                 apps={apps}
+                artifactsAppId={artifactsAppId}
                 // Runtime activity and painting are independent during a handoff:
                 // staging owns the work while held remains the visual cover.
                 runtimeActive={surfaceVisible && chatPanesVisible && role !== 'held'}
@@ -4114,6 +4116,7 @@ export default function Shell({ onInitialVisualReady }) {
                 markChatOwnerActivity={markChatOwnerActivity}
                 loadTheme={loadTheme}
                 navTo={stablePaneNavTo}
+                openAppWithIntent={openAppWithIntent}
                 onInternalNav={handleChatInternalNav}
                 onChatMissing={handlePaneChatMissing}
                 onFirstMessage={handlePaneChatFirstMessage}


### PR DESCRIPTION
## Summary
- add a chat-scoped Changes entry to the composer’s Brain menu, with a focused full-diff viewer and mobile-friendly expand/collapse controls
- retain complete large edit diffs in compressed sidecars while keeping chat transcripts and live events bounded
- surface the most recently touched artifact for the current chat, with older artifacts available on demand

## Safety and behavior
- diff loading remains owner-only and only expands sidecars referenced by that chat’s transcript
- older already-truncated diffs stay clearly marked as excerpts
- artifact records are filtered by chat provenance and opened in the originating pane

## Tests
- `scripts/wt-pytest.sh tests/test_tool_edit_preview.py tests/test_tool_output_stash.py -q`
- focused frontend unit tests for artifact attribution, chat-diff projection, and global expansion
- `npm run lint -- --quiet`
- `npm run build`