### PR TITLE
Keep generated chat titles in sync

### DIFF
--- a/backend/app/chat.py
+++ b/backend/app/chat.py
@@ -74,6 +74,7 @@ from app.chat_logging import (
   get_logger as _get_logger,
   safe_commit as _safe_commit,
 )
+from app.chat_titles import apply_generated_title, renamed_event
 from app.goal_commands import is_goal_continue
 from app.chat_writer import (
   AppendPending,
@@ -3737,10 +3738,11 @@ async def _ensure_chat_note(
   """Run the platform-owned turn-end chat-summary publisher.
 
   Spawns the TOOL-FREE summarizer (scripts/chat_note.py) — it reads the chat's
-  transcript and writes chats/<id>/index.md (+ syncs the title); the subagent
-  has no tools, this script does the privileged write. Best-effort + bounded: it
-  runs AFTER the reply is sent, so it never adds user-facing latency, and any
-  failure/timeout is swallowed — a missing note must never break the turn — but
+  transcript and writes chats/<id>/index.md; the subagent has no tools and the
+  server applies its emitted title under the chat transition lock. Best-effort
+  + bounded: it runs AFTER the reply is sent, so it never adds user-facing
+  latency, and any failure/timeout is swallowed — a missing note must never
+  break the turn — but
   a nonzero exit leaves one WARN line (with the script's stderr reason) in
   chat.log, so CLI credits dying no longer silently stops notes. The caller
   gates this on ``ensure_chat_note`` plus the chat being settled."""
@@ -3761,17 +3763,29 @@ async def _ensure_chat_note(
   try:
     proc = await asyncio.create_subprocess_exec(
       *args,
-      stdout=asyncio.subprocess.DEVNULL,
+      stdout=asyncio.subprocess.PIPE,
       stderr=asyncio.subprocess.PIPE,
       env=env,
     )
-    _, err = await asyncio.wait_for(proc.communicate(), timeout=150)
+    out, err = await asyncio.wait_for(proc.communicate(), timeout=150)
     if proc.returncode:
       tail = " ".join((err or b"").decode("utf-8", "replace").split())[-300:]
       log.warning(
         "chat-note summarizer failed for chat %s (rc=%s): %s",
         chat_id, proc.returncode, tail,
       )
+    else:
+      try:
+        title = _chat_note_title_result(out)
+        if title is not None:
+          await _sync_generated_chat_title(chat_id, title)
+      except Exception:
+        # The note is already durable. Keep the turn successful, but make a
+        # partial title-sync failure observable instead of silently leaving
+        # the drawer on its first-message fallback.
+        log.warning(
+          "chat-note title sync failed for chat %s", chat_id, exc_info=True,
+        )
   except asyncio.TimeoutError:
     log.info("ensure_chat_note timed out for chat %s", chat_id)
     if proc is not None:
@@ -3783,12 +3797,45 @@ async def _ensure_chat_note(
     log.debug("ensure_chat_note failed", exc_info=True)
 
 
+def _chat_note_title_result(stdout: bytes | None) -> str | None:
+  """Parse the publisher's single structured title result, when present."""
+  raw = (stdout or b"").decode("utf-8", "replace").strip()
+  if not raw:
+    return None
+  result = json.loads(raw)
+  title = result.get("title") if isinstance(result, dict) else None
+  if not isinstance(title, str) or not title.strip():
+    raise ValueError("chat-note publisher returned an invalid title result")
+  return title.strip()[:200]
+
+
+async def _sync_generated_chat_title(chat_id: str, title: str) -> bool:
+  """Commit one generated title without a revocable self-HTTP credential."""
+  from app.database import SessionLocal
+
+  async with chat_queue.get_transition_lock(chat_id):
+    with SessionLocal() as db:
+      chat = db.query(models.Chat).filter(
+        models.Chat.id == chat_id,
+        models.Chat.deleted_at.is_(None),
+      ).one_or_none()
+      if chat is None or not apply_generated_title(chat, title):
+        return False
+      db.commit()
+      db.refresh(chat)
+      event = renamed_event(chat)
+
+  # Publish only committed truth, after releasing the database connection.
+  get_system_broadcast().publish(event)
+  return True
+
+
 async def _sync_chat_title(data_dir: str, chat_id: str) -> None:
   """Compatibility helper: sync a chat title from an existing note's gist.
 
-  Normal turn-end publication performs this inside ``chat_note.py`` after its
-  compare-and-swap succeeds. This tool-free helper remains useful to older
-  callers and operator repair paths.
+  Normal turn-end publication consumes the structured result emitted by
+  ``chat_note.py`` after its compare-and-swap succeeds. This tool-free helper
+  remains useful to older callers and operator repair paths.
   """
   log = _get_logger()
   script = Path(__file__).parent.parent / "scripts" / "chat_note.py"
@@ -3800,11 +3847,21 @@ async def _sync_chat_title(data_dir: str, chat_id: str) -> None:
   try:
     proc = await asyncio.create_subprocess_exec(
       "python3", str(script), chat_id, "--sync-title",
-      stdout=asyncio.subprocess.DEVNULL,
-      stderr=asyncio.subprocess.DEVNULL,
+      stdout=asyncio.subprocess.PIPE,
+      stderr=asyncio.subprocess.PIPE,
       env=env,
     )
-    await asyncio.wait_for(proc.communicate(), timeout=20)
+    out, err = await asyncio.wait_for(proc.communicate(), timeout=20)
+    if proc.returncode:
+      tail = " ".join((err or b"").decode("utf-8", "replace").split())[-300:]
+      log.warning(
+        "chat-note title repair failed for chat %s (rc=%s): %s",
+        chat_id, proc.returncode, tail,
+      )
+      return
+    title = _chat_note_title_result(out)
+    if title is not None:
+      await _sync_generated_chat_title(chat_id, title)
   except asyncio.TimeoutError:
     if proc is not None:
       try:
@@ -3812,7 +3869,7 @@ async def _sync_chat_title(data_dir: str, chat_id: str) -> None:
       except ProcessLookupError:
         pass
   except Exception:
-    log.debug("sync_chat_title failed", exc_info=True)
+    log.warning("sync_chat_title failed for chat %s", chat_id, exc_info=True)
 
 
 # Fallback viewport for turns no shell initiated (cron, reflection,

--- a/backend/app/chat_titles.py
+++ b/backend/app/chat_titles.py
@@ -1,9 +1,28 @@
-"""Chat naming policy for the immediate first-message fallback."""
+"""Chat naming policy shared by the fallback, owner, and summary paths."""
 
 from app.continuations import is_continuation_message
 from app.goal_commands import goal_objective
 
 FIRST_MESSAGE_TITLE_MAX_CHARS = 80
+
+
+def apply_generated_title(chat, title: str) -> bool:
+  """Apply an agent-generated name only while the owner has not locked one."""
+  title = title.strip()
+  if not title or chat.title_locked or chat.title == title:
+    return False
+  chat.title = title
+  return True
+
+
+def renamed_event(chat) -> dict[str, object]:
+  """Build the live projection event for one committed chat name."""
+  return {
+    "type": "chat_renamed",
+    "chatId": str(chat.id),
+    "title": chat.title,
+    "updatedAt": chat.updated_at.isoformat() if chat.updated_at else None,
+  }
 
 
 def first_message_title(content: object) -> str:

--- a/backend/app/routes/chats.py
+++ b/backend/app/routes/chats.py
@@ -1227,10 +1227,10 @@ async def patch_chat(
     db.commit()
     db.refresh(chat)
     if chat.title != previous_title:
-      # The platform summary publisher PATCHes the generated name immediately
-      # after its durable note CAS. Publish only committed truth so every open
-      # shell can refresh its drawer and tab labels without waiting for another
-      # drawer open or chat-list poll. Manual-title precedence still lives above.
+      # Manual rename and compatibility callers share this projection path.
+      # The normal summary publisher commits in-process through
+      # `_sync_generated_chat_title`; publish only committed route truth here
+      # so older callers update every open drawer and tab without a later poll.
       get_system_broadcast().publish(renamed_event(chat))
     # Record a real provider switch (Claude <-> Codex) once, after this first
     # commit — NOT after the owner-provider mirror commit below, which would

--- a/backend/app/routes/chats.py
+++ b/backend/app/routes/chats.py
@@ -34,7 +34,11 @@ from app.chat import (
 )
 from app.broadcast import get_system_broadcast
 from app.chat_retention import purge_expired_chat_tombstones
-from app.chat_titles import first_user_message_title
+from app.chat_titles import (
+  apply_generated_title,
+  first_user_message_title,
+  renamed_event,
+)
 from app.database import get_db
 from app.memory_observability import record_memory_checkpoint_once
 from app.owner_input import OwnerInputKind
@@ -1093,8 +1097,7 @@ async def patch_chat(
       new_title = body.title.strip()
       if new_title:
         if body.by_agent:
-          if not chat.title_locked:
-            chat.title = new_title
+          apply_generated_title(chat, new_title)
         else:
           chat.title = new_title
           chat.title_locked = True
@@ -1228,12 +1231,7 @@ async def patch_chat(
       # after its durable note CAS. Publish only committed truth so every open
       # shell can refresh its drawer and tab labels without waiting for another
       # drawer open or chat-list poll. Manual-title precedence still lives above.
-      get_system_broadcast().publish({
-        "type": "chat_renamed",
-        "chatId": str(chat_id),
-        "title": chat.title,
-        "updatedAt": chat.updated_at.isoformat() if chat.updated_at else None,
-      })
+      get_system_broadcast().publish(renamed_event(chat))
     # Record a real provider switch (Claude <-> Codex) once, after this first
     # commit — NOT after the owner-provider mirror commit below, which would
     # double-log. Model/effort tweaks within a provider are deliberately not

--- a/backend/scripts/chat_note.py
+++ b/backend/scripts/chat_note.py
@@ -8,9 +8,10 @@ revisions so an older turn cannot overwrite newer state.
 
 Tool-free by design (the anti-exfil pattern — see the agent-tool-scope memory):
 the summarizer subagent gets the transcript in its PROMPT and runs with NO tools
-(it only PRODUCES the note text). THIS script does the privileged writes — the
-note file and the title PATCH. So a prompt-injected chat can't make the subagent
-write outside the note or exfiltrate anything.
+(it only PRODUCES the note text). THIS script performs the privileged note write
+and returns the generated name to its parent server process. So a prompt-
+injected chat can't make the subagent write outside the note or exfiltrate
+anything.
 
 Usage: chat_note.py <chat_id> [--active-goal-checkpoint]
 Exit 0 ok (or nothing-to-do) · 2 bad args · 3 summarizer failed (one-line
@@ -31,7 +32,6 @@ import sqlite3
 import subprocess
 import sys
 import tempfile
-import urllib.request
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import NamedTuple
@@ -41,8 +41,6 @@ DB = DATA_DIR / "db" / "ultimate.db"
 MEMORY_DIR = DATA_DIR / "shared" / "memory"
 CLAUDE_CONFIG_DIR = DATA_DIR / "cli-auth" / "claude"
 CLI_PATH = "/usr/local/bin/claude"
-API_BASE_URL = os.environ.get("API_BASE_URL", "http://localhost:8000")
-SERVICE_TOKEN_FILE = DATA_DIR / "service-token.txt"
 BACKEND_DIR = Path(__file__).resolve().parents[1]
 if str(BACKEND_DIR) not in sys.path:
   sys.path.insert(0, str(BACKEND_DIR))
@@ -729,29 +727,20 @@ def _normalize_chat_name(description: str) -> str:
   return title
 
 
-def _patch_title(chat_id: str, description: str) -> None:
-  """Best-effort title sync (by_agent so it defers to a manual rename)."""
-  description = _normalize_chat_name(description)
-  try:
-    token = SERVICE_TOKEN_FILE.read_text(encoding="utf-8").strip()
-  except OSError:
+def _emit_title_result(note: str) -> None:
+  """Return the generated name to the owning server process.
+
+  The publisher subprocess owns the note CAS, but it deliberately does not
+  authenticate back into its own server. The parent applies this result under
+  the chat transition lock, where manual-title precedence and live projection
+  events already belong.
+  """
+  match = re.search(r"^description:\s*(.+)$", note, re.MULTILINE)
+  if not match:
     return
-  if not token or not description:
-    return
-  body = json.dumps({"title": description[:200], "by_agent": True}).encode()
-  req = urllib.request.Request(
-    f"{API_BASE_URL}/api/chats/{chat_id}",
-    data=body,
-    method="PATCH",
-    headers={
-      "Authorization": f"Bearer {token}",
-      "Content-Type": "application/json",
-    },
-  )
-  try:
-    urllib.request.urlopen(req, timeout=10).read()
-  except Exception:
-    pass
+  title = _normalize_chat_name(match.group(1))[:200]
+  if title:
+    print(json.dumps({"title": title}, separators=(",", ":")))
 
 
 def run() -> int:
@@ -777,17 +766,14 @@ def run() -> int:
     return 2
 
   # --sync-title: compatibility/repair mode with NO summarizer (no LLM, no
-  # tools). Normal publication performs this after its CAS succeeds; older
-  # callers can cheaply resync an existing note's gist. by_agent:true defers to
-  # a manual rename.
+  # tools). The parent process applies the emitted name under the same lock and
+  # manual-title precedence as an ordinary turn-end publication.
   if sync_title_only:
     try:
       text = _note_path(chat_id).read_text(encoding="utf-8")
     except OSError:
       return 0
-    m = re.search(r"^description:\s*(.+)$", text, re.MULTILINE)
-    if m:
-      _patch_title(chat_id, m.group(1).strip())
+    _emit_title_result(text)
     return 0
 
   snapshot = _read_chat_snapshot(
@@ -807,6 +793,10 @@ def run() -> int:
   previous_cursor = _source_cursor(existing)
   current_cursor = snapshot.cursor()
   if previous_cursor is not None and previous_cursor == current_cursor:
+    # Publication may have succeeded while the old HTTP title PATCH failed.
+    # Re-emit the current name so any later settled turn repairs convergence
+    # without another summarizer run.
+    _emit_title_result(existing)
     return 0
   start_index = _incremental_start(snapshot, previous_cursor)
   transcript = (
@@ -841,9 +831,7 @@ def run() -> int:
   if not published:
     return 0
 
-  m = re.search(r"^description:\s*(.+)$", out, re.MULTILINE)
-  if m:
-    _patch_title(chat_id, m.group(1).strip())
+  _emit_title_result(out)
   return 0
 
 

--- a/backend/tests/test_chat_note.py
+++ b/backend/tests/test_chat_note.py
@@ -168,6 +168,73 @@ async def test_goal_checkpoint_publisher_uses_the_active_mode(monkeypatch):
   assert captured["args"][-1] == "--active-goal-checkpoint"
 
 
+@pytest.mark.asyncio
+async def test_publisher_applies_emitted_title_in_process(monkeypatch):
+  captured = {}
+
+  class Proc:
+    returncode = 0
+
+    async def communicate(self):
+      return b'{"title":"Preparing and reconciling Mobius changes"}', b""
+
+  async def spawn(*_args, **_kwargs):
+    return Proc()
+
+  async def sync(chat_id, title):
+    captured.update(chat_id=chat_id, title=title)
+    return True
+
+  monkeypatch.setattr(chat.asyncio, "create_subprocess_exec", spawn)
+  monkeypatch.setattr(chat, "_sync_generated_chat_title", sync)
+
+  await chat._ensure_chat_note("/tmp/data", "c1")
+
+  assert captured == {
+    "chat_id": "c1",
+    "title": "Preparing and reconciling Mobius changes",
+  }
+
+
+@pytest.mark.asyncio
+async def test_generated_title_sync_preserves_manual_lock_and_broadcasts(
+  db, chat: models.Chat, monkeypatch,
+):
+  from app import chat as chat_runtime
+
+  events = []
+  monkeypatch.setattr(
+    chat_runtime, "get_system_broadcast",
+    lambda: types.SimpleNamespace(publish=events.append),
+  )
+  chat.title = "could you go over..."
+  chat.title_locked = False
+  db.commit()
+
+  assert await chat_runtime._sync_generated_chat_title(
+    chat.id, "Preparing and reconciling Mobius changes",
+  )
+  db.expire_all()
+  refreshed = db.query(models.Chat).filter_by(id=chat.id).one()
+  assert refreshed.title == "Preparing and reconciling Mobius changes"
+  assert events == [{
+    "type": "chat_renamed",
+    "chatId": chat.id,
+    "title": "Preparing and reconciling Mobius changes",
+    "updatedAt": refreshed.updated_at.isoformat(),
+  }]
+
+  refreshed.title = "Owner's name"
+  refreshed.title_locked = True
+  db.commit()
+  assert not await chat_runtime._sync_generated_chat_title(
+    chat.id, "A later generated name",
+  )
+  db.expire_all()
+  assert db.query(models.Chat).filter_by(id=chat.id).one().title == "Owner's name"
+  assert len(events) == 1
+
+
 def test_still_fires_if_a_legacy_writer_touched_the_note(tmp_path):
   # A legacy agent/tool write cannot take ownership away from the platform.
   # chat_note.py snapshots that content and publishes with its durable CAS.
@@ -451,20 +518,19 @@ def test_clean_note_output_preserves_human_label_inside_body():
   assert cleaned.endswith("- intent: debug")
 
 
-def test_sync_title_only_patches_from_note_without_summarizing(tmp_path, monkeypatch):
-  # --sync-title reads the note's gist and PATCHes the title, NO summarizer run.
+def test_sync_title_only_emits_note_name_without_summarizing(
+  tmp_path, monkeypatch, capsys,
+):
+  # --sync-title returns the note's name to the server, with NO summarizer run.
   cn = _load_chat_note()
   mem = tmp_path / "shared" / "memory"
   monkeypatch.setattr(cn, "MEMORY_DIR", mem)
-  patched = {}
-  monkeypatch.setattr(cn, "_patch_title",
-                      lambda cid, desc: patched.update(cid=cid, desc=desc))
   note = mem / "chats" / "c9" / "index.md"
   note.parent.mkdir(parents=True)
   note.write_text("---\ntype: chat\ndescription: building a brew timer\n---\n## Summary\nx")
   monkeypatch.setattr(cn.sys, "argv", ["chat_note.py", "c9", "--sync-title"])
   assert cn.run() == 0
-  assert patched == {"cid": "c9", "desc": "building a brew timer"}
+  assert json.loads(capsys.readouterr().out) == {"title": "Building a brew timer"}
   # the note is untouched (the summarizer never ran)
   assert "building a brew timer" in note.read_text()
 
@@ -472,11 +538,37 @@ def test_sync_title_only_patches_from_note_without_summarizing(tmp_path, monkeyp
 def test_sync_title_only_noop_when_note_absent(tmp_path, monkeypatch):
   cn = _load_chat_note()
   monkeypatch.setattr(cn, "MEMORY_DIR", tmp_path / "shared" / "memory")
-  called = []
-  monkeypatch.setattr(cn, "_patch_title", lambda *a: called.append(a))
   monkeypatch.setattr(cn.sys, "argv", ["chat_note.py", "nope", "--sync-title"])
   assert cn.run() == 0
-  assert called == []
+
+
+def test_unchanged_note_reemits_title_for_automatic_repair(
+  tmp_path, monkeypatch, capsys,
+):
+  cn = _load_chat_note()
+  mem = tmp_path / "shared" / "memory"
+  monkeypatch.setattr(cn, "MEMORY_DIR", mem)
+  messages = [{"role": "user", "content": "align the repositories"}]
+  snapshot = cn.ChatSnapshot(
+    transcript="user: align the repositories",
+    updated_at="2026-08-25 17:00:00",
+    messages=messages,
+  )
+  note_text = cn._set_source_cursor(
+    "---\ntype: chat\ndescription: repository alignment\n---\n"
+    "## Digest\nshort\n\n## Summary\nbody",
+    snapshot.cursor(),
+  )
+  note = mem / "chats" / "c9" / "index.md"
+  note.parent.mkdir(parents=True)
+  note.write_text(note_text)
+  monkeypatch.setattr(cn, "_read_chat_snapshot", lambda *_a, **_k: snapshot)
+  monkeypatch.setattr(cn.sys, "argv", ["chat_note.py", "c9"])
+
+  assert cn.run() == 0
+  assert json.loads(capsys.readouterr().out) == {
+    "title": "Repository alignment",
+  }
 
 
 def test_dead_claude_falls_back_to_complete_local_note(tmp_path, monkeypatch):
@@ -707,7 +799,7 @@ def test_unauthenticated_claude_falls_back_without_spawning(
 
 
 def test_first_summary_publication_replaces_the_opening_message_title(
-  tmp_path, monkeypatch,
+  tmp_path, monkeypatch, capsys,
 ):
   """The raw first-message title is only a fallback until a note is ready."""
   cn = _load_chat_note()
@@ -728,14 +820,10 @@ def test_first_summary_publication_replaces_the_opening_message_title(
 
   monkeypatch.setattr(cn, "_summarize", summarize)
   monkeypatch.setattr(cn, "_publish_if_current", lambda *args: True)
-  patched = []
-  monkeypatch.setattr(
-    cn, "_patch_title", lambda cid, name: patched.append((cid, name)),
-  )
   monkeypatch.setattr(cn.sys, "argv", ["chat_note.py", "c1"])
 
   assert cn.run() == 0
-  assert patched == [("c1", "Current work")]
+  assert json.loads(capsys.readouterr().out) == {"title": "Current work"}
   assert summarized["provider"] == "codex"
 
 


### PR DESCRIPTION
## Summary

- return the generated chat name from the summary publisher to the owning server process instead of authenticating back into itself over HTTP
- apply generated names under the chat transition lock while preserving owner-renamed titles
- publish the committed rename to open drawers and automatically repair a missed title from an already-current summary

## Why

The summary note and drawer title could diverge after a successful publication because the final title update depended on a revocable on-disk service token and discarded every failure. That left the durable note with the right generated name while the drawer retained its opening-message fallback.

The server now owns the title commit and live rename event directly. The summary subprocess emits one bounded structured result, and the next settled turn can re-emit an already-current note title without another summarizer run, so a transient partial failure converges naturally. Manual rename precedence remains unchanged.

## Testing

- chat-summary and chat-title focused tests (53 passed)
- complete chat-summary publisher tests (51 passed)
- hermetic fast backend contract suite (86 passed)
- Python compilation and diff checks

The hosted full backend suite remains the final dependency-authoritative gate.