### PR TITLE
Avoid loading flash on fast app opens

### DIFF
--- a/frontend/src/components/AppCanvas/AppCanvas.css
+++ b/frontend/src/components/AppCanvas/AppCanvas.css
@@ -89,9 +89,10 @@
   max-width: 300px;
 }
 
-/* Shown until the iframe fires `load`. The iframe is below it (DOM
-   order — overlay is rendered after iframe in the React tree).
-   Fades in slightly to avoid a hard flash on very-fast loads. */
+/* Shown until the iframe reports its first committed app paint. The iframe is
+   below it (DOM order — overlay follows the iframe in the React tree). Delay
+   the reveal long enough that a cached frame can settle without ever painting
+   placeholder chrome; genuinely slow opens still get a smooth loading state. */
 .canvas-loading {
   position: absolute;
   inset: 0;
@@ -103,7 +104,7 @@
   background: var(--bg);
   pointer-events: none;
   z-index: 1;
-  animation: canvas-loading-in 80ms ease-out;
+  animation: canvas-loading-in 80ms 120ms ease-out both;
 }
 
 /* The ordinary first-load fade intentionally lets a fast app feel immediate.

--- a/frontend/src/components/AppCanvas/AppCanvas.jsx
+++ b/frontend/src/components/AppCanvas/AppCanvas.jsx
@@ -222,7 +222,7 @@ function readDeviceInsets() {
 // accent-forward rather than a generic gray spinner: the app name is present,
 // and shimmer skeleton bars hint a header + list are on their way. Shared by
 // both loading branches (no-token and online-fetching) so they never drift.
-// Presentational only; the 80ms fade-in guard lives on .canvas-loading.
+// Presentational only; the delayed fade-in guard lives on .canvas-loading.
 function CanvasLoadingBrand({ appName }) {
   return (
     <>

--- a/frontend/src/lib/__tests__/appIntentHandoff.test.js
+++ b/frontend/src/lib/__tests__/appIntentHandoff.test.js
@@ -23,6 +23,7 @@ test('a direct app intent stays covered until the exact live frame applies it', 
   assert.match(canvas, /\(!swap\.liveLoaded \|\| intentHandoffPending\)/)
   assert.match(canvas, /canvas--intent-pending/)
   assert.match(canvasCss, /\.canvas--intent-pending\s*\{[\s\S]*pointer-events:\s*none/)
+  assert.match(canvasCss, /\.canvas-loading\s*\{[\s\S]*animation:\s*canvas-loading-in 80ms 120ms ease-out both/)
   assert.match(canvasCss, /\.canvas-loading--intent-handoff\s*\{[\s\S]*animation:\s*none/)
 })
 


### PR DESCRIPTION
## Summary
- delay the ordinary app-loading overlay by 120ms so a cached frame can settle without painting placeholder chrome
- keep the existing immediate, non-animated cover for exact intent handoffs
- lock the distinction into the App Canvas handoff contract

## Why
Fast cached app opens could paint an 80ms loading overlay immediately and remove it almost at once, creating a visible flash even though the app frame was ready quickly. The delay only affects the presentational ordinary-loading state; genuinely slow opens still receive the same smooth branded loading treatment.

## Testing
- 2,669 frontend library tests and 93 hook tests pass at the exact prepared head
- production build, offline worker, and push-worker checks pass
- full lint reports 0 errors (46 pre-existing warnings)
- Impeccable anti-pattern scan returns no findings