### PR TITLE
Make durable-wait cancellation clickable

### DIFF
--- a/frontend/src/components/ChatView/ChatView.css
+++ b/frontend/src/components/ChatView/ChatView.css
@@ -2113,6 +2113,7 @@
 .chat__foot .chat__resume-nudge,
 .chat__foot .chat__jump-latest,
 .chat__foot .chat__progress-step--toggle,
+.chat__foot .chat__wait-cancel,
 .chat__foot .slash-menu,
 .chat__foot .chat__pill,
 .chat__foot .composer-plus,

--- a/frontend/src/components/ChatView/__tests__/scrollCssInvariants.test.js
+++ b/frontend/src/components/ChatView/__tests__/scrollCssInvariants.test.js
@@ -60,6 +60,16 @@ test('the composer backdrop fills the safe area without moving controls into it'
   assert.match(embeddedBackdrop, /bottom:\s*0/)
 })
 
+test('the durable-wait cancel control can receive taps through the footer', () => {
+  const foot = ruleBody('.chat__foot')
+  assert.match(foot, /pointer-events:\s*none/)
+  assert.match(
+    css,
+    /\.chat__foot \.chat__wait-cancel,[\s\S]*?\{\s*pointer-events:\s*auto;\s*\}/,
+    'the pointer-transparent footer must opt its visible wait cancel button back in',
+  )
+})
+
 test('.spacer-dynamic has no CSS transition (instant height change)', () => {
   // A transition on the spacer height makes every pin/anchor correction animate
   // and desyncs the scrollTop math from the painted layout.


### PR DESCRIPTION
## Summary

- let the durable Waiting card's cancel button receive pointer input through the transparent composer footer
- add a regression test that preserves the footer's interactive-control allow-list

## Root cause

The cancellable Waiting state added in [#885](https://github.com/mobius-os/mobius/pull/885) rendered its cancel control inside a deliberately pointer-transparent footer, but the button was missing from the controls that opt back into pointer input. It looked available while taps landed on the transcript behind it.

## Verification

- `node --test src/components/ChatView/__tests__/scrollCssInvariants.test.js`
- `scripts/wt-pytest.sh backend/tests/test_chat_waits.py -q`
- rendered hit-testing against the authenticated chat shell