### PR TITLE
Keep structured API payloads literal

### DIFF
--- a/backend/scripts/init_skills.py
+++ b/backend/scripts/init_skills.py
@@ -129,6 +129,11 @@ _UNMODIFIED_MIGRATIONS = {
     # The current seed retains its useful shell-scale invariant and removes the
     # dead route, so this exact known-bad generation is safe to reconcile.
     "1d655ec09d7f25c831e105411d59b8428b07defc6f58416f8290a8c1b08ca594",
+    # Untouched baked and locally curated mapi generations that still wrapped
+    # whole CSS documents inside hand-escaped JSON. Migrate both exact copies
+    # to the raw text boundary; any owner-authored variation remains protected.
+    "7994321819a43708debb77104edea12f785beb46d0933c2b94f93cf418f510ee",
+    "cd4d6f03f6ba87d8b3d1799aa81c3ab5444900362e56edc3e48803fa1f1fee4b",
   },
   "workflows-app.md": {
     # Resolved the app by slug=="workflows". An install whose preferred slug
@@ -149,6 +154,11 @@ _UNMODIFIED_MIGRATIONS = {
     # Pre-slimming seed: open_item mechanics still lived in core.md, leaving
     # this policy owner without the executable recipe.
     "309e5969df6f589cc82c17b450e7596a00bae87ef77ab2923a9b0de061ed146e",
+    # Untouched baked and locally curated mapi generations that interpolated
+    # ids through nested shell quotes. Replace only those exact copies with
+    # stdin-delimited JSON guidance.
+    "6fa9c177db508ef05dfc73de224cd3f33350c79d8f807ac9909942d761f21103",
+    "db0c1138ffd0890936ccdeba6ced4ccde867ba3044eeef0a5c87cdf2f279eaaa",
   },
   "building-apps.md": {
     "4126b40d209c422184e0135f611bb9f4197ea280fa27e63cd71c806f8b5ebd79",

--- a/backend/scripts/mapi
+++ b/backend/scripts/mapi
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 # Call the Möbius backend with the current agent's base URL and owner auth.
+# Literal or multiline request bodies can be streamed unchanged with
+# `--data-binary @-`; body-bearing calls receive application/json unless the
+# caller supplies an explicit Content-Type.
 set -euo pipefail
 : "${AGENT_TOKEN:?mapi: AGENT_TOKEN is not set in this environment}"
 : "${API_BASE_URL:?mapi: API_BASE_URL is not set in this environment}"
@@ -7,7 +10,7 @@ set -euo pipefail
 option_takes_value() {
   case "$1" in
     -X|--request|-H|--header|-d|--data|--data-raw|--data-binary|--data-urlencode|\
-    -F|--form|-T|--upload-file|-o|--output|-w|--write-out|\
+    -F|--form|-T|--upload-file|-o|--output|-D|--dump-header|-w|--write-out|\
     --connect-timeout|--max-time|--retry|--retry-delay|--cacert|--cert|--key)
       return 0
       ;;

--- a/backend/scripts/seed-skills/notifications.md
+++ b/backend/scripts/seed-skills/notifications.md
@@ -21,11 +21,17 @@ never stored. Use it when the partner asks to open an item or when a completed
 item should be visible now:
 
 ```bash
-curl -s -X POST "$API_BASE_URL/api/notify" \
-  -H "Authorization: Bearer $AGENT_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"type":"open_item","itemKind":"app","itemId":"42","sourceKind":"chat","sourceId":"'"$CHAT_ID"'","placement":"beside-source","activation":"background"}'
+mapi -X POST /api/notify --data-binary @- <<JSON
+{"type":"open_item","itemKind":"app","itemId":"42","sourceKind":"chat","sourceId":"$CHAT_ID","placement":"beside-source","activation":"background"}
+JSON
 ```
+
+(`mapi` fills in auth + base URL.) For literal or multiline JSON, pass stdin
+with `--data-binary @-` instead of building a shell-escaped `-d` argument.
+Quote the heredoc delimiter when no variable expansion is needed. The examples
+that expand `$CHAT_ID` leave it unquoted only for that machine-generated ID;
+generate arbitrary or user-authored values with a real JSON encoder instead of
+splicing them into JSON text.
 
 - Default `activation` to `background`; use `foreground` only when the partner
   just asked to open that exact item.
@@ -44,33 +50,31 @@ Title: "Möbius needs your answer". Body: the first ~80 chars of your question. 
 
 ---
 
-## The curl forms
+## The authenticated JSON forms
 
 Minimum viable:
 
 ```bash
-curl -s -X POST "$API_BASE_URL/api/notifications/send" \
-  -H "Authorization: Bearer $AGENT_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"title":"Task complete","body":"Your expense tracker app is ready."}'
+mapi -X POST /api/notifications/send --data-binary @- <<'JSON'
+{"title":"Task complete","body":"Your expense tracker app is ready."}
+JSON
 ```
 
 `source_type` defaults to `"agent"`; `source_id` is optional. Full form when you want a deep link + actions:
 
 ```bash
-curl -s -X POST "$API_BASE_URL/api/notifications/send" \
-  -H "Authorization: Bearer $AGENT_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{
+mapi -X POST /api/notifications/send --data-binary @- <<JSON
+{
     "title": "Task complete",
     "body": "Your expense tracker app is ready.",
-    "source_id": "'"$CHAT_ID"'",
+    "source_id": "$CHAT_ID",
     "target": "/shell/?app=APP_ID_HERE",
     "actions": [
       {"action": "open_app", "title": "Open App", "target": "/shell/?app=APP_ID_HERE"},
-      {"action": "open_chat", "title": "View Chat", "target": "/shell/?chat='"$CHAT_ID"'"}
+      {"action": "open_chat", "title": "View Chat", "target": "/shell/?chat=$CHAT_ID"}
     ]
-  }'
+}
+JSON
 ```
 
 ---

--- a/backend/scripts/seed-skills/theming.md
+++ b/backend/scripts/seed-skills/theming.md
@@ -23,17 +23,22 @@ It prints `filename — first-sentence-of-docstring` for each file, so the listi
 Use `/data/shared/theme.css` for visual changes — colors, fonts, gradients, animations. Hot-reloaded instantly.
 
 ```bash
-curl -X PUT "$API_BASE_URL/api/storage/shared/theme.css" \
-  -H "Authorization: Bearer $AGENT_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"content": "<css here>"}'
+mapi -X PUT /api/storage/shared/theme.css \
+  -H "Content-Type: text/css" --data-binary @- <<'CSS'
+:root {
+  /* theme CSS here; quotes, newlines, and $ stay literal */
+}
+CSS
 bash "$SCRIPTS_DIR/notify_theme.sh"
 ```
+
+(`mapi` fills in auth + base URL.) Raw CSS is the storage route's native text
+form, so do not hand-escape a CSS document into a JSON `-d` argument.
 
 **Read the current theme before modifying it:**
 
 ```bash
-curl -s "$API_BASE_URL/api/storage/shared/theme.css" -H "Authorization: Bearer $AGENT_TOKEN"
+mapi /api/storage/shared/theme.css
 ```
 
 Check `/data/shared/theme-mode` for `"light"` / `"dark"`. Make CSS work in both modes by using the standard variables (`--bg`, `--surface`, `--text`, `--accent`, `--border`, `--danger`, `--green`, `--font`, `--mono`, …) rather than hardcoded colors.
@@ -74,10 +79,9 @@ request the apply. This endpoint deliberately returns an empty `204` success, so
 discard its body — do **not** pipe it to a JSON parser:
 
 ```bash
-curl -fsS -o /dev/null -X POST "$API_BASE_URL/api/notify" \
-  -H "Authorization: Bearer $AGENT_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"type":"shell_apply_now"}'
+mapi -o /dev/null -X POST /api/notify --data-binary @- <<'JSON'
+{"type":"shell_apply_now"}
+JSON
 ```
 
 The watcher builds within a few seconds of the last save; the rebuild events

--- a/backend/tests/test_mapi_script.py
+++ b/backend/tests/test_mapi_script.py
@@ -1,6 +1,8 @@
 """Contract tests for the authenticated curl convenience wrapper."""
 
+import json
 import os
+import re
 import subprocess
 from pathlib import Path
 
@@ -8,13 +10,25 @@ from pathlib import Path
 SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "mapi"
 
 
-def _run_mapi(tmp_path: Path, *arguments: str) -> subprocess.CompletedProcess:
+def _run_mapi(
+  tmp_path: Path,
+  *arguments: str,
+  stdin_text: str | None = None,
+) -> subprocess.CompletedProcess:
   bin_dir = tmp_path / "bin"
   bin_dir.mkdir()
   capture = tmp_path / "curl-arguments"
+  stdin_capture = tmp_path / "curl-stdin"
   fake_curl = bin_dir / "curl"
   fake_curl.write_text(
-    "#!/usr/bin/env bash\nprintf '%s\\0' \"$@\" > \"$MAPI_CAPTURE\"\n",
+    "#!/usr/bin/env bash\n"
+    "printf '%s\\0' \"$@\" > \"$MAPI_CAPTURE\"\n"
+    "for argument in \"$@\"; do\n"
+    "  if [[ \"$argument\" == '@-' ]]; then\n"
+    "    cat > \"$MAPI_STDIN_CAPTURE\"\n"
+    "    break\n"
+    "  fi\n"
+    "done\n",
     encoding="utf-8",
   )
   fake_curl.chmod(0o755)
@@ -23,11 +37,13 @@ def _run_mapi(tmp_path: Path, *arguments: str) -> subprocess.CompletedProcess:
     "AGENT_TOKEN": "owner-token",
     "API_BASE_URL": "https://mobius.example/",
     "MAPI_CAPTURE": str(capture),
+    "MAPI_STDIN_CAPTURE": str(stdin_capture),
     "PATH": f"{bin_dir}:{os.environ['PATH']}",
   }
   result = subprocess.run(
     [str(SCRIPT), *arguments],
     env=env,
+    input=stdin_text,
     capture_output=True,
     text=True,
     check=False,
@@ -35,6 +51,7 @@ def _run_mapi(tmp_path: Path, *arguments: str) -> subprocess.CompletedProcess:
   result.curl_arguments = (
     capture.read_bytes().split(b"\0")[:-1] if capture.exists() else None
   )
+  result.curl_stdin = stdin_capture.read_bytes() if stdin_capture.exists() else None
   return result
 
 
@@ -64,6 +81,49 @@ def test_mapi_preserves_an_explicit_content_type(tmp_path: Path):
   )
 
   assert result.returncode == 0, result.stderr
+  assert result.curl_arguments.count(b"Content-Type: text/css") == 1
+  assert b"Content-Type: application/json" not in result.curl_arguments
+
+
+def test_mapi_accepts_a_response_header_capture_path(tmp_path: Path):
+  result = _run_mapi(
+    tmp_path,
+    "-D", "/tmp/response.headers", "-o", "/tmp/response.json", "/api/ready",
+  )
+
+  assert result.returncode == 0, result.stderr
+  assert result.curl_arguments[-5:] == [
+    b"-D", b"/tmp/response.headers",
+    b"-o", b"/tmp/response.json",
+    b"https://mobius.example/api/ready",
+  ]
+
+
+def test_mapi_streams_literal_json_stdin_without_shell_reencoding(tmp_path: Path):
+  payload = '{"text":"$HOME `whoami` \\\"quoted\\\" — line\\nnext"}\n'
+  result = _run_mapi(
+    tmp_path,
+    "-X", "POST", "/api/notifications/send", "--data-binary", "@-",
+    stdin_text=payload,
+  )
+
+  assert result.returncode == 0, result.stderr
+  assert result.curl_stdin == payload.encode("utf-8")
+  assert b"Content-Type: application/json" in result.curl_arguments
+  assert result.curl_arguments[-2:] == [b"--data-binary", b"@-"]
+
+
+def test_mapi_streams_raw_css_with_its_explicit_content_type(tmp_path: Path):
+  css = ':root { --label: "price: $5"; }\n.note::after { content: "`ok`"; }\n'
+  result = _run_mapi(
+    tmp_path,
+    "-X", "PUT", "/api/storage/shared/theme.css",
+    "-H", "Content-Type: text/css", "--data-binary", "@-",
+    stdin_text=css,
+  )
+
+  assert result.returncode == 0, result.stderr
+  assert result.curl_stdin == css.encode("utf-8")
   assert result.curl_arguments.count(b"Content-Type: text/css") == 1
   assert b"Content-Type: application/json" not in result.curl_arguments
 
@@ -108,3 +168,25 @@ def test_mapi_refuses_bare_hosts_even_after_a_valid_api_target(tmp_path: Path):
   assert result.returncode == 2
   assert result.curl_arguments is None
   assert "only Möbius /api paths are allowed" in result.stderr
+
+
+def test_seed_guidance_uses_literal_payload_boundaries():
+  seed = SCRIPT.parent / "seed-skills"
+  notifications = (seed / "notifications.md").read_text(encoding="utf-8")
+  theming = (seed / "theming.md").read_text(encoding="utf-8")
+
+  assert "--data-binary @- <<JSON" in notifications
+  assert "--data-binary @- <<'JSON'" in notifications
+  assert "real JSON encoder" in notifications
+  assert "'\"$CHAT_ID\"'" not in notifications
+  examples = re.findall(
+    r"<<'?JSON'?\n(.*?)\nJSON", notifications, flags=re.DOTALL,
+  )
+  assert len(examples) == 3
+  for example in examples:
+    assert isinstance(json.loads(example.replace("$CHAT_ID", "chat-123")), dict)
+
+  assert "Content-Type: text/css" in theming
+  assert "--data-binary @- <<'CSS'" in theming
+  assert "quotes, newlines, and $ stay literal" in theming
+  assert "{\"content\": \"<css here>\"}" not in theming

--- a/backend/tests/test_memory_boot.py
+++ b/backend/tests/test_memory_boot.py
@@ -180,6 +180,8 @@ def test_controlled_skills_have_fix_forward_migrations():
   }
   assert module._UNMODIFIED_MIGRATIONS["notifications.md"] == {
     "309e5969df6f589cc82c17b450e7596a00bae87ef77ab2923a9b0de061ed146e",
+    "6fa9c177db508ef05dfc73de224cd3f33350c79d8f807ac9909942d761f21103",
+    "db0c1138ffd0890936ccdeba6ced4ccde867ba3044eeef0a5c87cdf2f279eaaa",
   }
   assert module._UNMODIFIED_MIGRATIONS["building-apps.md"] == {
     "4126b40d209c422184e0135f611bb9f4197ea280fa27e63cd71c806f8b5ebd79",
@@ -216,6 +218,8 @@ def test_controlled_skills_have_fix_forward_migrations():
   assert module._UNMODIFIED_MIGRATIONS["theming.md"] == {
     "7fb5ed4c1e29e6822b56394c089984a1a7e5da1bdf552a21ff0cbdc6413bd998",
     "1d655ec09d7f25c831e105411d59b8428b07defc6f58416f8290a8c1b08ca594",
+    "7994321819a43708debb77104edea12f785beb46d0933c2b94f93cf418f510ee",
+    "cd4d6f03f6ba87d8b3d1799aa81c3ab5444900362e56edc3e48803fa1f1fee4b",
   }
   assert "recovery.md" not in module._UNMODIFIED_MIGRATIONS
   assert (


### PR DESCRIPTION
## Summary
- teach seeded notification guidance to stream literal JSON through `mapi`
- send theme CSS through the storage route's native raw-text form instead of a JSON envelope
- hash-gate both baked and known curated predecessors so existing untouched guidance migrates safely
- verify stdin bytes, explicit content types, JSON prompt examples, and response-header capture
- allow `mapi -D/--dump-header` for versioned CAS workflows

## Why
Several examples still turned multiline documents into shell-escaped `-d` arguments. Quotes, newlines, templates, and variable syntax can therefore be changed before the API sees them. `mapi` already owns a literal stdin boundary; the guidance now uses it directly, while arbitrary user-authored values are explicitly routed through a real JSON encoder.

## Testing
- `scripts/wt-pytest.sh tests/test_mapi_script.py tests/test_memory_boot.py -q --tb=short` — 25 passed
- `scripts/test.sh --fast` — 86 passed
- prompt-contract coverage parses all notification JSON heredocs after ID substitution
- byte-for-byte probes cover complex JSON and raw CSS stdin