### PR TITLE
Carry Connect scripts outside command lines

### DIFF
--- a/backend/app/connect_runner.py
+++ b/backend/app/connect_runner.py
@@ -18,6 +18,7 @@ Manage the installed service:
     python3 ~/.mobius-connect/runner.py --uninstall
 """
 import argparse
+import base64
 from collections import deque
 import ipaddress
 import json
@@ -41,6 +42,13 @@ PID_PATH = os.path.join(CONFIG_DIR, "runner.pid")
 LAUNCHD_LABEL = "sh.mobius.connect"
 LAUNCHD_PLIST = os.path.expanduser("~/Library/LaunchAgents/%s.plist" % LAUNCHD_LABEL)
 SYSTEMD_UNIT = os.path.expanduser("~/.config/systemd/user/mobius-connect.service")
+RUNNER_PROTOCOL_VERSION = 4
+_POWERSHELL_STDIN_BOOTSTRAP = (
+    "$encoded=[Console]::In.ReadToEnd();"
+    "$script=[Text.Encoding]::UTF8.GetString("
+    "[Convert]::FromBase64String($encoded));"
+    "& ([ScriptBlock]::Create($script))"
+)
 
 
 def _validated_base_url(raw):
@@ -330,19 +338,63 @@ def _terminate_process_tree(proc):
             proc.wait()
 
 
-def _spawn_command(cmd, cwd):
+def _script_argv(shell, *, is_windows=None):
+    """Select one interpreter without placing script text on a command line."""
+    windows = os.name == "nt" if is_windows is None else is_windows
+    if windows:
+        executable = shell or "powershell.exe"
+        allowed = {
+            "powershell": "powershell.exe",
+            "powershell.exe": "powershell.exe",
+            "pwsh": "pwsh",
+            "pwsh.exe": "pwsh.exe",
+        }
+        executable = allowed.get(executable.casefold())
+        if executable is None:
+            raise ValueError(
+                "Windows script mode supports powershell or pwsh"
+            )
+        return [
+            executable,
+            "-NoLogo",
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            _POWERSHELL_STDIN_BOOTSTRAP,
+        ]
+    return [shell or "sh"]
+
+
+def _script_input(script, *, is_windows=None):
+    """Encode Windows stdin as ASCII so console code pages cannot alter it."""
+    windows = os.name == "nt" if is_windows is None else is_windows
+    if windows:
+        return base64.b64encode(script.encode("utf-8")).decode("ascii")
+    return script
+
+
+def _spawn_command(cmd, cwd, *, script=None, shell=None):
     popen_args = {
-        "shell": True,
         "stdout": subprocess.PIPE,
         "stderr": subprocess.PIPE,
         "text": True,
         "cwd": (cwd or None),
     }
+    if script is not None:
+        if cmd is not None:
+            raise ValueError("runner received both cmd and script")
+        if "\x00" in script:
+            raise ValueError("a script cannot contain a NUL byte")
+        popen_args["stdin"] = subprocess.PIPE
+        command = _script_argv(shell)
+    else:
+        popen_args["shell"] = True
+        command = cmd
     if os.name == "nt":
         popen_args["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
     else:
         popen_args["start_new_session"] = True
-    return subprocess.Popen(cmd, **popen_args)
+    return subprocess.Popen(command, **popen_args)
 
 
 def _run_command(cmd, cwd, timeout):
@@ -477,6 +529,7 @@ class _CommandRunner:
             "proc": None,
             "reason": None,
             "timeout": max(1, int(evt.get("timeout", 60))),
+            "input": None,
         }
         if refused:
             self._post_result(
@@ -499,7 +552,17 @@ class _CommandRunner:
                     124, "expired", record=record,
                 )
                 return
-            proc = _spawn_command(evt.get("cmd", ""), evt.get("cwd"))
+            script = evt.get("script")
+            if script is not None:
+                proc = _spawn_command(
+                    None,
+                    evt.get("cwd"),
+                    script=script,
+                    shell=evt.get("shell"),
+                )
+                record["input"] = _script_input(script)
+            else:
+                proc = _spawn_command(evt.get("cmd", ""), evt.get("cwd"))
             record["proc"] = proc
             with self.lock:
                 reason = record["reason"]
@@ -522,7 +585,9 @@ class _CommandRunner:
         stdout = ""
         stderr = ""
         try:
-            stdout, stderr = proc.communicate(timeout=record["timeout"])
+            stdout, stderr = proc.communicate(
+                input=record["input"], timeout=record["timeout"],
+            )
         except subprocess.TimeoutExpired:
             with self.lock:
                 if record["reason"] is None:
@@ -578,7 +643,7 @@ def _serve(cfg):
             commands.flush_pending_results()
             active_id, pending_ids = commands.snapshot()
             query = [
-                ("protocol", "3"),
+                ("protocol", str(RUNNER_PROTOCOL_VERSION)),
                 ("platform", plat),
             ]
             if active_id:

--- a/backend/app/routes/connect.py
+++ b/backend/app/routes/connect.py
@@ -56,7 +56,7 @@ from fastapi import (
   WebSocketDisconnect,
 )
 from fastapi.responses import PlainTextResponse, StreamingResponse
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 from slowapi import Limiter
 from slowapi.util import get_remote_address
 
@@ -88,8 +88,15 @@ _DISCONNECT_COMMAND = "python3 ~/.mobius-connect/runner.py --uninstall"
 _LEGACY_DISCONNECT_COMMAND = f'{_DISCONNECT_COMMAND}; kill -TERM "$PPID"'
 _DISCONNECT_ACK_TIMEOUT = 4
 _LEGACY_DISCONNECT_TIMEOUT = 4
-_RUNNER_PROTOCOL_VERSION = 3
-_SSE_PROTOCOL_VERSION = 3
+_RUNNER_PROTOCOL_VERSION = 4
+_SSE_PROTOCOL_VERSION = 4
+# Protocol 3 introduced durable start/result acknowledgement. Keep those
+# lifecycle guarantees independent from later transport features so upgrading
+# the runner does not accidentally make an already-safe v3 runner "legacy".
+_COMMAND_LIFECYCLE_PROTOCOL_VERSION = 3
+# Protocol 4 carries literal scripts separately from command-line strings.
+_LITERAL_SCRIPT_PROTOCOL_VERSION = 4
+_LEGACY_WEBSOCKET_PROTOCOL_VERSION = 3
 # Railway permits active HTTP responses for 15 minutes. Rotate current-runner
 # streams well inside that bound; the host-owned command continues separately.
 _STREAM_ROTATION_SECONDS = 10 * 60
@@ -165,9 +172,25 @@ def _now() -> float:
   return time.time()
 
 
-def _command_fingerprint(cmd: str, cwd: str | None, timeout: int) -> str:
+def _command_fingerprint(
+  cmd: str | None,
+  cwd: str | None,
+  timeout: int,
+  *,
+  script: str | None = None,
+  shell: str | None = None,
+) -> str:
+  # Preserve the v1-v3 command fingerprint shape so a backend restart during
+  # an in-flight legacy command does not turn the caller's retry into a false
+  # request-id conflict. Scripts use a tagged shape that cannot collide with a
+  # command containing the same text.
+  payload_value = (
+    [cmd or "", cwd, timeout]
+    if script is None
+    else {"script": script, "shell": shell, "cwd": cwd, "timeout": timeout}
+  )
   payload = json.dumps(
-    [cmd, cwd, timeout], ensure_ascii=False, separators=(",", ":"),
+    payload_value, ensure_ascii=False, separators=(",", ":"), sort_keys=True,
   )
   return sha256(payload.encode("utf-8")).hexdigest()
 
@@ -200,7 +223,9 @@ class _ActiveCommand:
     request_id: str,
     timeout: int,
     *,
-    cmd: str = "",
+    cmd: str | None = None,
+    script: str | None = None,
+    shell: str | None = None,
     cwd: str | None = None,
     created_at: float | None = None,
     started_at: float | None = None,
@@ -213,13 +238,17 @@ class _ActiveCommand:
     self.request_id = request_id
     self.timeout = timeout
     self.cmd = cmd
+    self.script = script
+    self.shell = shell
     self.cwd = cwd
     self.created_at = created_at if created_at is not None else _now()
     self.started_at = started_at
     self.state = state
     self.not_after = not_after
     self.cancel_not_after = cancel_not_after
-    self.fingerprint = fingerprint or _command_fingerprint(cmd, cwd, timeout)
+    self.fingerprint = fingerprint or _command_fingerprint(
+      cmd, cwd, timeout, script=script, shell=shell,
+    )
     self.started = asyncio.Event()
     if started_at is not None:
       self.started.set()
@@ -230,7 +259,11 @@ class _ActiveCommand:
     return cls(
       str(record["id"]),
       max(1, int(record.get("timeout") or _DEFAULT_EXEC_TIMEOUT)),
-      cmd=str(record.get("cmd") or ""),
+      cmd=(str(record["cmd"]) if record.get("cmd") is not None else None),
+      script=(
+        str(record["script"]) if record.get("script") is not None else None
+      ),
+      shell=(str(record["shell"]) if record.get("shell") is not None else None),
       cwd=record.get("cwd"),
       created_at=float(record.get("created_at") or _now()),
       started_at=(
@@ -264,19 +297,28 @@ class _ActiveCommand:
     # Do not retain command text (which may contain sensitive arguments) for the
     # remainder of a long-running command.
     if self.state == "dispatching":
-      record["cmd"] = self.cmd
+      if self.script is not None:
+        record["script"] = self.script
+        record["shell"] = self.shell
+      else:
+        record["cmd"] = self.cmd
       record["cwd"] = self.cwd
     return record
 
   def event(self) -> dict:
-    return {
+    event = {
       "type": "exec",
       "request_id": self.request_id,
-      "cmd": self.cmd,
       "cwd": self.cwd,
       "timeout": self.timeout,
       "not_after": self.not_after,
     }
+    if self.script is not None:
+      event["script"] = self.script
+      event["shell"] = self.shell
+    else:
+      event["cmd"] = self.cmd
+    return event
 
 
 def _active_public(command: _ActiveCommand | None) -> dict | None:
@@ -404,7 +446,7 @@ async def _request_command_cancel(
   if command.state != "canceling":
     command.state = "canceling"
     changed = True
-  if known_protocol < _RUNNER_PROTOCOL_VERSION:
+  if known_protocol < _COMMAND_LIFECYCLE_PROTOCOL_VERSION:
     if command.cancel_not_after is None:
       command.cancel_not_after = (
         _now() + _LEGACY_CANCEL_RESULT_GRACE_SECONDS
@@ -476,12 +518,22 @@ class ResultBody(BaseModel):
 
 
 class ExecBody(BaseModel):
-  cmd: str = Field(min_length=1, max_length=64 * 1024)
+  cmd: str | None = Field(default=None, min_length=1, max_length=64 * 1024)
+  script: str | None = Field(default=None, min_length=1, max_length=64 * 1024)
+  shell: str | None = Field(default=None, min_length=1, max_length=4096)
   cwd: str | None = Field(default=None, max_length=4096)
   timeout: int = Field(default=_DEFAULT_EXEC_TIMEOUT, ge=1, le=3600)
   request_id: str | None = Field(
     default=None, min_length=16, max_length=64, pattern=r"^[a-f0-9]+$",
   )
+
+  @model_validator(mode="after")
+  def validate_work(self) -> ExecBody:
+    if (self.cmd is None) == (self.script is None):
+      raise ValueError("Provide exactly one of cmd or script.")
+    if self.shell is not None and self.script is None:
+      raise ValueError("shell is only valid with script.")
+    return self
 
 
 class CommandStateBody(BaseModel):
@@ -797,7 +849,13 @@ async def exec_on_host(
     raise HTTPException(status_code=404, detail="No such host.")
   ch = _channels.get(host_id)
   request_id = body.request_id or secrets.token_hex(8)
-  fingerprint = _command_fingerprint(body.cmd, body.cwd, body.timeout)
+  fingerprint = _command_fingerprint(
+    body.cmd,
+    body.cwd,
+    body.timeout,
+    script=body.script,
+    shell=body.shell,
+  )
   _prune_last_command(host)
   last = host.get("last_command")
   if isinstance(last, dict) and last.get("id") == request_id:
@@ -833,23 +891,36 @@ async def exec_on_host(
       status_code=409,
       detail=f"{host.get('name') or 'That machine'} is offline right now.",
     )
+  if (
+    body.script is not None
+    and ch.protocol_version < _LITERAL_SCRIPT_PROTOCOL_VERSION
+  ):
+    raise HTTPException(
+      status_code=409,
+      detail=(
+        "This machine’s runner must be updated before it can receive literal "
+        "scripts. Update it in Connect, or send a command instead."
+      ),
+    )
   timeout = body.timeout
   not_after = _now() + _START_ACK_TIMEOUT
   command = _ActiveCommand(
     request_id,
     timeout,
     cmd=body.cmd,
+    script=body.script,
+    shell=body.shell,
     cwd=body.cwd,
     not_after=not_after,
     fingerprint=fingerprint,
   )
   _commands[host_id] = command
   _persist_command(host_id, command)
-  if ch.protocol_version < _RUNNER_PROTOCOL_VERSION:
+  if ch.protocol_version < _COMMAND_LIFECYCLE_PROTOCOL_VERSION:
     _mark_command_started(host_id, request_id)
   await ch.queue.put(command.event())
   try:
-    if ch.protocol_version >= _RUNNER_PROTOCOL_VERSION:
+    if ch.protocol_version >= _COMMAND_LIFECYCLE_PROTOCOL_VERSION:
       try:
         await asyncio.wait_for(
           command.started.wait(), timeout=_START_ACK_TIMEOUT,
@@ -978,7 +1049,7 @@ async def _reconcile_runner(
   if command.request_id == runner_active:
     _mark_command_started(host_id, command.request_id)
     if command.state == "canceling":
-      if ch.protocol_version >= _RUNNER_PROTOCOL_VERSION:
+      if ch.protocol_version >= _COMMAND_LIFECYCLE_PROTOCOL_VERSION:
         command.cancel_not_after = None
         _persist_command(host_id, command)
       await ch.queue.put({"type": "cancel", "request_id": command.request_id})
@@ -1058,13 +1129,13 @@ async def legacy_command_socket(websocket: WebSocket) -> None:
 
   host_id = host["id"]
   ch = _Channel(
-    protocol_version=_RUNNER_PROTOCOL_VERSION,
+    protocol_version=_LEGACY_WEBSOCKET_PROTOCOL_VERSION,
     transport="websocket",
   )
   platform_name = str(hello.get("platform") or "")[:80]
   if platform_name:
     host["platform"] = platform_name
-  host["runner_protocol"] = _RUNNER_PROTOCOL_VERSION
+  host["runner_protocol"] = _LEGACY_WEBSOCKET_PROTOCOL_VERSION
   host["runner_transport"] = "websocket"
   _save_host(host)
   _replace_channel(host_id, ch)

--- a/backend/tests/test_connect.py
+++ b/backend/tests/test_connect.py
@@ -415,7 +415,7 @@ async def test_protocol_three_stream_rotates_without_losing_running_command(
   host = connect_routes._load_host(pairing["id"])
   assert host["runner_protocol"] == 3
   assert host["platform"] == "TestOS 1"
-  assert connect_routes._public_host(host)["runner_update_available"] is False
+  assert connect_routes._public_host(host)["runner_update_available"] is True
 
   assert await response.body_iterator.__anext__() == ": connected\n\n"
   with pytest.raises(StopAsyncIteration):
@@ -426,7 +426,7 @@ async def test_protocol_three_stream_rotates_without_losing_running_command(
   assert not caller.done()
   host = connect_routes._load_host(pairing["id"])
   assert host["runner_transport"] == "sse"
-  assert connect_routes._public_host(host)["runner_update_available"] is False
+  assert connect_routes._public_host(host)["runner_update_available"] is True
   connect_routes._runner_result(pairing["id"], connect_routes.ResultBody(
     request_id=request_id,
     stdout="rotating",
@@ -527,6 +527,76 @@ async def test_exec_correlates_the_runner_result(client, auth):
     "canceled": False,
   }
   assert connect_routes._ensure_command(pairing["id"]) is None
+
+
+@pytest.mark.asyncio
+async def test_protocol_four_carries_a_literal_script_separately(
+  client, auth,
+):
+  pairing, _ = _paired_host(client, auth)
+  channel = connect_routes._Channel(protocol_version=4)
+  connect_routes._channels[pairing["id"]] = channel
+  request_id = "d" * 16
+  script = "set -eu\nname='$literal'\nprintf '%s\\n' \"$name\"\n"
+
+  request = asyncio.create_task(connect_routes.exec_on_host(
+    pairing["id"],
+    connect_routes.ExecBody(
+      script=script,
+      shell="bash",
+      cwd="/srv/app",
+      timeout=7,
+      request_id=request_id,
+    ),
+    _owner=object(),
+  ))
+  event = await asyncio.wait_for(channel.queue.get(), timeout=1)
+
+  assert event["script"] == script
+  assert event["shell"] == "bash"
+  assert event["cwd"] == "/srv/app"
+  assert "cmd" not in event
+  persisted = connect_routes._load_host(pairing["id"])["active_command"]
+  assert persisted["script"] == script
+  assert persisted["shell"] == "bash"
+
+  connect_routes._mark_command_started(pairing["id"], request_id)
+  persisted = connect_routes._load_host(pairing["id"])["active_command"]
+  assert "script" not in persisted
+  assert "shell" not in persisted
+  connect_routes._finish_command(pairing["id"], request_id, {
+    "stdout": "$literal\n", "stderr": "", "exit_code": 0,
+    "outcome": "completed",
+  })
+  assert (await request)["stdout"] == "$literal\n"
+
+
+@pytest.mark.asyncio
+async def test_literal_script_requires_an_updated_runner(client, auth):
+  pairing, _ = _paired_host(client, auth)
+  channel = connect_routes._Channel(protocol_version=3)
+  connect_routes._channels[pairing["id"]] = channel
+
+  with pytest.raises(connect_routes.HTTPException) as raised:
+    await connect_routes.exec_on_host(
+      pairing["id"],
+      connect_routes.ExecBody(script="printf ready\n"),
+      _owner=object(),
+    )
+
+  assert raised.value.status_code == 409
+  assert "runner must be updated" in raised.value.detail
+  assert channel.queue.empty()
+  assert connect_routes._ensure_command(pairing["id"]) is None
+
+
+def test_exec_body_requires_exactly_one_work_form():
+  with pytest.raises(ValueError, match="exactly one"):
+    connect_routes.ExecBody()
+  with pytest.raises(ValueError, match="exactly one"):
+    connect_routes.ExecBody(cmd="echo ready", script="echo ready")
+  with pytest.raises(ValueError, match="only valid with script"):
+    connect_routes.ExecBody(cmd="echo ready", shell="bash")
 
 
 @pytest.mark.asyncio
@@ -960,7 +1030,7 @@ def test_runner_does_not_mislabel_command_exit_124_as_timeout():
   assert timed_out is False
 
 
-def test_runner_uses_standard_urllib_for_protocol_three_stream(monkeypatch):
+def test_runner_uses_standard_urllib_for_protocol_four_stream(monkeypatch):
   opened = []
   posted = []
 
@@ -993,7 +1063,7 @@ def test_runner_uses_standard_urllib_for_protocol_three_stream(monkeypatch):
 
   request, kwargs = opened[0]
   assert request.full_url.startswith(
-    "https://mobius.test/api/connect/stream?protocol=3&platform=",
+    "https://mobius.test/api/connect/stream?protocol=4&platform=",
   )
   assert request.get_header("Authorization") == "Bearer secret"
   assert request.get_header("Accept") == "text/event-stream"
@@ -1107,6 +1177,72 @@ def test_runner_ignores_duplicate_delivery_of_an_accepted_request(monkeypatch):
   assert spawned == [("do it once", None)]
   assert runner.active["request_id"] == event["request_id"]
   assert runner.pending_messages() == []
+
+
+def test_runner_keeps_literal_script_off_the_process_command_line(monkeypatch):
+  runner = connect_runner._CommandRunner("https://example.test", "token")
+  spawned = []
+  script = "for value in '$literal' one; do printf '%s\\n' \"$value\"; done\n"
+
+  def spawn(cmd, cwd, *, script=None, shell=None):
+    spawned.append((cmd, cwd, script, shell))
+    return object()
+
+  monkeypatch.setattr(connect_runner, "_spawn_command", spawn)
+  monkeypatch.setattr(runner, "_post_started", lambda _request_id: None)
+  monkeypatch.setattr(threading.Thread, "start", lambda self: None)
+
+  runner.start({
+    "request_id": "e" * 16,
+    "script": script,
+    "shell": "bash",
+    "cwd": "/srv/app",
+    "timeout": 30,
+    "not_after": time.time() + 10,
+  })
+
+  assert spawned == [(None, "/srv/app", script, "bash")]
+  assert runner.active["input"] == script
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX shell contract")
+def test_runner_executes_literal_posix_script_through_stdin():
+  script = "name='$literal'\nfor value in \"$name\" two; do printf '<%s>\\n' \"$value\"; done\n"
+  proc = connect_runner._spawn_command(
+    None, None, script=script, shell="sh",
+  )
+
+  stdout, stderr = proc.communicate(input=script, timeout=2)
+
+  assert proc.args == ["sh"]
+  assert stdout == "<$literal>\n<two>\n"
+  assert stderr == ""
+  assert proc.returncode == 0
+
+
+def test_windows_literal_script_uses_a_fixed_powershell_argv():
+  argv = connect_runner._script_argv(None, is_windows=True)
+  assert argv[:-1] == [
+    "powershell.exe",
+    "-NoLogo",
+    "-NoProfile",
+    "-NonInteractive",
+    "-Command",
+  ]
+  assert argv[-1] == connect_runner._POWERSHELL_STDIN_BOOTSTRAP
+  assert "FromBase64String" in argv[-1]
+  assert connect_runner._script_argv("pwsh", is_windows=True)[0] == "pwsh"
+  with pytest.raises(ValueError, match="powershell or pwsh"):
+    connect_runner._script_argv("cmd.exe", is_windows=True)
+
+
+def test_windows_literal_script_stdin_is_unicode_safe_ascii():
+  script = "Write-Output 'café 🛰 $literal'\n"
+  encoded = connect_runner._script_input(script, is_windows=True)
+
+  assert encoded.isascii()
+  assert connect_runner.base64.b64decode(encoded).decode("utf-8") == script
+  assert connect_runner._script_input(script, is_windows=False) == script
 
 
 def test_runner_rechecks_expiry_after_start_ack_before_spawning(monkeypatch):


### PR DESCRIPTION
## Summary
- add a protocol-v4 literal script form to Connect
- keep protocol-v3 lifecycle and cancellation guarantees independent from later transport features
- execute POSIX scripts directly through standard input and carry PowerShell scripts as UTF-8-safe ASCII data
- stop retaining literal script text after the runner acknowledges execution
- preserve existing command fingerprints and protocol-v1-to-v3 compatibility

## Why
Complex scripts currently have to become shell command strings before they reach a paired machine. That creates avoidable quoting layers and preserves Windows command-line ceilings even when the script itself is valid. A structured script boundary carries the exact program as data while leaving ordinary command execution unchanged.

## Testing
- `scripts/wt-pytest.sh tests/test_connect.py -q --tb=short` — 62 passed
- `scripts/test.sh --fast` — 86 passed
- literal POSIX script smoke coverage exercises variables, loops, quotes, and stdin execution
- Windows coverage verifies the fixed PowerShell argv and rejects unsupported shells