### PR TITLE
Keep Brain menu model and fill truthful

### DIFF
--- a/frontend/src/components/ChatView/BrainUsageIcon.jsx
+++ b/frontend/src/components/ChatView/BrainUsageIcon.jsx
@@ -32,6 +32,7 @@
 
 import { useId } from 'react'
 import { Brain } from '@openai/apps-sdk-ui/components/Icon'
+import { visibleBrainFillBounds } from './brainUsage.js'
 
 const PROVIDER_COLOR = 'var(--accent)'
 const CONTEXT_COLOR = '#d97757'
@@ -62,11 +63,15 @@ const BRAIN_SILHOUETTE_PATH = 'M14.8974 2.29998C15.8303 2.29013 16.802 2.58194 1
 // Fill grows bottom-up across the path's actual ink, not the full viewBox.
 const TOP = 2.3
 const BOTTOM = 21.7
-
+// The mask removes FILL_INSET from the silhouette's edge. Percentages must map
+// to the remaining visible interior, not to the now-invisible outer contour;
+// otherwise the last ~8% paints above every visible lobe and looks identical.
 function HemisphereFill({ percent, side, color }) {
-  const clamped = Math.min(100, Math.max(0, percent))
-  const fillHeight = ((BOTTOM - TOP) * clamped) / 100
-  const fillY = BOTTOM - fillHeight
+  const { fillHeight, fillY } = visibleBrainFillBounds(percent, {
+    top: TOP,
+    bottom: BOTTOM,
+    inset: FILL_INSET,
+  })
   const x = side === 'left' ? 0 : 12
 
   return (

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -171,7 +171,7 @@ import {
   reconcileComposerTextarea,
   resetComposerTextarea,
 } from './composerTextareaSizing.js'
-import { needsModelSelection } from './modelSelectionPolicy.js'
+import { needsModelSelection, selectedChatModel } from './modelSelectionPolicy.js'
 import { collectChatDiffs } from './chatDiffs.js'
 import {
   EMPTY_BUILD_PHASE_RAIL,
@@ -4974,7 +4974,7 @@ export default function ChatView({
               usageEnabled={!embedded}
               chatId={chatId}
               provider={chatInfo?.provider}
-              model={chatInfo?.effective?.model}
+              model={selectedChatModel(chatInfo)}
             >
               {({ icon, ariaLabel, providerUsage }) => (
               <ComposerPopover

--- a/frontend/src/components/ChatView/ComposerPopover.jsx
+++ b/frontend/src/components/ChatView/ComposerPopover.jsx
@@ -60,6 +60,7 @@ import {
 } from '../../lib/layoutSpace.js'
 import useModelSelectionPopover from './hooks/useModelSelectionPopover.js'
 import useDiscardUnconfirmedSwitchOnPickerClose from './hooks/useDiscardUnconfirmedSwitchOnPickerClose.js'
+import { resolvedChatSettings } from './modelSelectionPolicy.js'
 import './ChatWork.css'
 
 export default function ComposerPopover({
@@ -425,7 +426,7 @@ export default function ComposerPopover({
                 chatId={chatId}
                 chat={chatInfo}
                 provider={chatInfo.provider}
-                effective={chatInfo.effective}
+                effective={resolvedChatSettings(chatInfo)}
                 hasAssistantTurns={hasAssistantTurns}
                 autoResumeEnabled={autoResumeEnabled}
                 autoResumeSaving={autoResumeSaving}

--- a/frontend/src/components/ChatView/__tests__/brainUsage.test.js
+++ b/frontend/src/components/ChatView/__tests__/brainUsage.test.js
@@ -7,6 +7,7 @@ import {
   formatRoundedTokenCount,
   modelContextTokenCounts,
   resolvedContextTokenCounts,
+  visibleBrainFillBounds,
 } from '../brainUsage.js'
 
 test('context gauge measures the latest model call against its context window', () => {
@@ -73,4 +74,25 @@ test('missing usage in an established session remains unknown', () => {
     input_tokens: null,
     context_window: null,
   }, registry, 'codex', 'gpt-5.6-sol'), null)
+})
+
+test('the final ten percent remains visibly linear inside the inset mask', () => {
+  const geometry = percent => visibleBrainFillBounds(percent, {
+    top: 2.3,
+    bottom: 21.7,
+    inset: 1.75,
+  })
+  const at90 = geometry(90)
+  const at95 = geometry(95)
+  const at100 = geometry(100)
+
+  assert.ok(at95.fillHeight > at90.fillHeight)
+  assert.ok(at100.fillHeight > at95.fillHeight)
+  assert.ok(Math.abs(
+    (at95.fillHeight - at90.fillHeight)
+    - (at100.fillHeight - at95.fillHeight),
+  ) < 1e-12)
+  assert.ok(Math.abs(at100.fillY - 4.05) < 1e-12)
+  assert.deepEqual(geometry(105), at100)
+  assert.equal(geometry(-5).fillHeight, 0)
 })

--- a/frontend/src/components/ChatView/__tests__/modelSelectionPolicy.test.js
+++ b/frontend/src/components/ChatView/__tests__/modelSelectionPolicy.test.js
@@ -1,7 +1,11 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 
-import { needsModelSelection } from '../modelSelectionPolicy.js'
+import {
+  needsModelSelection,
+  resolvedChatSettings,
+  selectedChatModel,
+} from '../modelSelectionPolicy.js'
 
 
 test('interactive chats require a model before sending', () => {
@@ -23,6 +27,26 @@ test('an explicit effective model lets the composer send', () => {
     showPicker: true,
     chatInfo: { effective: { model: 'gpt-5.6-sol' } },
   }), false)
+})
+
+test('a retained cache cannot hide the explicit per-chat model', () => {
+  const chatInfo = {
+    agent_settings_json: { model: 'gpt-5.6-sol', effort: 'high' },
+    effective: { model: '  ', effort: 'xhigh' },
+  }
+  assert.equal(selectedChatModel(chatInfo), 'gpt-5.6-sol')
+  assert.deepEqual(resolvedChatSettings(chatInfo), {
+    model: 'gpt-5.6-sol',
+    effort: 'xhigh',
+  })
+  assert.equal(needsModelSelection({ showPicker: true, chatInfo }), false)
+})
+
+test('the effective model remains authoritative when both projections are valid', () => {
+  assert.equal(selectedChatModel({
+    agent_settings_json: { model: 'gpt-old' },
+    effective: { model: 'gpt-current' },
+  }), 'gpt-current')
 })
 
 test('app embeds that intentionally hide the picker retain their configured send path', () => {

--- a/frontend/src/components/ChatView/brainUsage.js
+++ b/frontend/src/components/ChatView/brainUsage.js
@@ -5,6 +5,17 @@ function clampPercent(value) {
   return Math.min(100, Math.max(0, value))
 }
 
+export function visibleBrainFillBounds(percent, { top, bottom, inset }) {
+  const visibleTop = top + inset
+  const visibleBottom = bottom - inset
+  const clamped = clampPercent(percent) ?? 0
+  const fillHeight = ((visibleBottom - visibleTop) * clamped) / 100
+  return {
+    fillHeight,
+    fillY: visibleBottom - fillHeight,
+  }
+}
+
 export function contextTokenCounts(snapshot) {
   const input = snapshot?.input_tokens
   const window = snapshot?.context_window

--- a/frontend/src/components/ChatView/modelSelectionPolicy.js
+++ b/frontend/src/components/ChatView/modelSelectionPolicy.js
@@ -1,4 +1,25 @@
-/* Decides when the interactive composer must ask for an explicit model. */
+/* Owns the model choice the interactive composer presents and sends. */
+
+function configuredModel(value) {
+  return typeof value === 'string' && value.trim() ? value : null
+}
+
+export function resolvedChatSettings(chatInfo) {
+  const explicit = chatInfo?.agent_settings_json
+  const effective = chatInfo?.effective
+  return {
+    ...(explicit && typeof explicit === 'object' ? explicit : {}),
+    ...(effective && typeof effective === 'object' ? effective : {}),
+    // The explicit per-chat choice is durable truth. A retained browser cache
+    // can briefly lack the derived `effective` projection after an upgrade;
+    // never make that look like the owner lost their saved model.
+    model: configuredModel(effective?.model) ?? configuredModel(explicit?.model),
+  }
+}
+
+export function selectedChatModel(chatInfo) {
+  return resolvedChatSettings(chatInfo).model
+}
 
 export function needsModelSelection({ showPicker, chatInfo }) {
   if (!showPicker) return false
@@ -9,5 +30,5 @@ export function needsModelSelection({ showPicker, chatInfo }) {
   // missing made a fast first send impossible even when the persisted chat had
   // an explicit model.
   if (chatInfo == null) return false
-  return !chatInfo?.effective?.model
+  return !selectedChatModel(chatInfo)
 }


### PR DESCRIPTION
## Summary
- preserve the chat’s durable saved model when a retained effective projection is missing or blank
- use the resolved model consistently in the picker, send guard, and Brain usage lookup
- map Brain usage fill across the SVG mask’s visible interior so 90–100% remains visually distinct

## Testing
- `npm test` (2,676 library tests and 93 hook tests)
- `npm run lint` (0 errors; 46 existing warnings)
- focused Brain usage and model-selection tests (11 passing)
- live visual verification of the saved-model state and 90–100% fill progression