### PR TITLE
Stabilize push subscription worker-refresh tests

### DIFF
--- a/frontend/src/lib/__tests__/pushSubscription.test.js
+++ b/frontend/src/lib/__tests__/pushSubscription.test.js
@@ -134,6 +134,20 @@ function fakePush() {
   return push
 }
 
+// Yield the macrotask queue until `predicate()` holds. subscribeToPush reaches
+// the refreshed worker through checkForUpdatedWorker's own setTimeout(0) hop,
+// which is not ordered against a single setImmediate — so a fixed one-tick wait
+// occasionally observed the worker before its activation listener was attached.
+// Waiting on the observable condition is deterministic; the tick budget keeps a
+// genuine regression failing fast instead of hanging.
+async function waitForCondition(predicate, { maxTicks = 50 } = {}) {
+  for (let tick = 0; tick <= maxTicks; tick += 1) {
+    if (predicate()) return
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  }
+  throw new Error('waitForCondition: predicate not satisfied within tick budget')
+}
+
 test('the push worker is registered inside the shell PWA scope', async () => {
   const container = fakeContainer()
   await subscribeToPush({ container, push: fakePush() })
@@ -243,7 +257,7 @@ test('an existing worker refresh waits for its replacement before subscribing',
     const push = fakePush()
 
     const done = subscribeToPush({ container, push })
-    await new Promise((resolve) => setImmediate(resolve))
+    await waitForCondition(() => worker.listeners.length === 1)
 
     assert.equal(container.pushWorker.updateCalls, 1)
     assert.deepEqual(push.sent, [], 'does not subscribe through the stale active worker')
@@ -266,7 +280,7 @@ test('a replacement published after update resolves is still awaited', async () 
 
   const done = subscribeToPush({ container, push })
   await container.updatePublished
-  await new Promise((resolve) => setImmediate(resolve))
+  await waitForCondition(() => worker.listeners.length === 1)
 
   assert.deepEqual(push.sent, [], 'does not miss the queued worker announcement')
   assert.equal(worker.listeners.length, 1, 'waits for the late-published worker')


### PR DESCRIPTION
## Summary

Two `pushSubscription` unit tests waited a fixed single tick (`setImmediate`) for `subscribeToPush` to reach the refreshed service worker and attach its activation listener. But `checkForUpdatedWorker` gets to that worker through its own `setTimeout(0)` hop, which Node does not order against a single `setImmediate`. When that internal timer landed in a later event-loop iteration than the `setImmediate`, the assertion ran before the listener was attached and `worker.listeners.length` was still `0`, failing the `frontend-unit` job.

This replaces the fixed one-tick wait with a small bounded helper that yields the macrotask queue until the observed condition holds, so each test synchronizes on the state it actually asserts instead of racing the source’s internal timing. No product code changes.

## Why it flaked

`a replacement published after update resolves is still awaited` reproduced on `main` roughly 1 in 20 local runs with the exact CI assertion (`0 !== 1`). The sibling `an existing worker refresh waits for its replacement before subscribing` used the same fragile fixed-tick pattern, so it is converted to the same helper.

## Testing

- The two tests ran 60/60 green after the change (previously ~1/20 red).
- The full frontend `test:lib` suite passed (2690/2690).