### PR TITLE
Stabilize mobile shell toolbar and Builder layout

### DIFF
--- a/frontend/src/components/ChatView/ManageModelsModal.css
+++ b/frontend/src/components/ChatView/ManageModelsModal.css
@@ -6,13 +6,13 @@
 
 .mmm__overlay {
   position: fixed;
-  /* Settings lives under the persistent 58px shell bar. This modal is inside the
+  /* Settings lives under the responsive shell bar. This modal is inside the
      shell content stacking context, so it cannot paint over that bar anyway;
      start below it so a tall/narrow dialog never hides its title underneath.
      The card's height cap subtracts this same offset (below) so the full modal —
      header included — always fits between the bar and the viewport bottom. One
      var keeps the two in lockstep; they must never drift. */
-  --modal-top-offset: calc(58px + env(safe-area-inset-top, 0px));
+  --modal-top-offset: calc(var(--shell-bar-height, 58px) + env(safe-area-inset-top, 0px));
   top: var(--modal-top-offset);
   right: 0;
   bottom: 0;
@@ -53,8 +53,9 @@
      minmax(0, 1fr) scroll area. dvh tracks mobile browser chrome. Subtract the
      shell-bar offset (the overlay starts below it) plus the 18px overlay padding
      on each side (36px) so the whole card — header included — fits the space the
-     overlay actually offers. Without the offset term the cap overshoots by 58px
-     and the title/× get pushed under the bar on any viewport below ~815px. */
+     overlay actually offers. Without the offset term the cap overshoots by the
+     shell bar's height and the title/× get pushed under the bar on any viewport
+     below ~815px. */
   height: min(720px, calc(100vh - var(--modal-top-offset) - 36px));
   height: min(720px, calc(100dvh - var(--modal-top-offset) - 36px));
   max-height: 100%;

--- a/frontend/src/components/Drawer/Drawer.css
+++ b/frontend/src/components/Drawer/Drawer.css
@@ -36,7 +36,7 @@
 .drawer-close-shield,
 .drawer {
   position: fixed;
-  top: calc(58px + env(safe-area-inset-top));
+  top: calc(var(--shell-bar-height, 58px) + env(safe-area-inset-top));
   left: 0;
   bottom: 0;
   width: min(360px, 90vw);

--- a/frontend/src/components/NotificationBell/NotificationBell.css
+++ b/frontend/src/components/NotificationBell/NotificationBell.css
@@ -1,6 +1,6 @@
 /* Header bell — sized to sit beside the offline pill in shell__bar-actions.
    The BUTTON is the touch target: 44×44 (mobile comfort floor) inside the
-   58px header row; the glyph stays compact and the hit area does the work. */
+   responsive header row; the glyph stays compact and the hit area does the work. */
 
 .notification-bell {
   position: relative;

--- a/frontend/src/components/SettingsView/UpdateReviewModal.css
+++ b/frontend/src/components/SettingsView/UpdateReviewModal.css
@@ -4,10 +4,10 @@
 
 .urm__overlay {
   position: fixed;
-  /* Starts below the 58px shell bar; the card's height cap (below) subtracts the
-     same offset so the header never clips under the bar. One var keeps them in
-     lockstep — mirrors ManageModelsModal. */
-  --modal-top-offset: calc(58px + env(safe-area-inset-top, 0px));
+  /* Starts below the responsive shell bar; the card's height cap (below)
+     subtracts the same offset so the header never clips under the bar. One var
+     keeps them in lockstep — mirrors ManageModelsModal. */
+  --modal-top-offset: calc(var(--shell-bar-height, 58px) + env(safe-area-inset-top, 0px));
   top: var(--modal-top-offset);
   right: 0;
   bottom: 0;

--- a/frontend/src/components/Shell/Shell.css
+++ b/frontend/src/components/Shell/Shell.css
@@ -91,6 +91,14 @@
   gap: 8px;
 }
 
+@media (max-width: 620px) {
+  /* Keep the 44px touch targets, but trim the empty row around them so the
+     visible toolbar sits closer to the phone's safe-area boundary. */
+  .shell {
+    --shell-bar-height: 46px;
+  }
+}
+
 /* Desktop-only quick actions. Declare the closed state outside the media query
    so adding this shared markup can never leak controls into the phone header. */
 .shell__rail-actions {
@@ -309,6 +317,18 @@
   pointer-events: none;
 }
 
+/* A one-pane Builder adds only its tab row. Keep the workspace containing box
+   fixed so the native scene never relocates the transcript or composer; the
+   currently painted surface reserves the row from its top while retaining the
+   same bottom edge. Hidden Standard and parked app surfaces keep their own
+   full-height geometry. */
+.shell__content--single-builder-strip > .shell__view--active,
+.shell__content--single-builder-strip > .shell__chat-view--staging,
+.shell__content--single-builder-strip > .shell__chat-view--held,
+.shell__content--single-builder-strip > .shell__app-view--held {
+  top: var(--shell-tabstrip-height);
+}
+
 .shell__view--active {
   visibility: visible;
   pointer-events: auto;
@@ -395,6 +415,16 @@
   touch-action: pan-x pinch-zoom;
   overscroll-behavior-inline: contain;
   z-index: 2;
+}
+
+/* The single-pane Builder strip is shell chrome, not a flex row that is allowed
+   to resize .shell__content. Its top edge matches the stable content box in both
+   phone-header and desktop-rail layouts. */
+.shell__tabstrip--single-builder {
+  position: absolute;
+  top: calc(var(--shell-bar-height) + env(safe-area-inset-top, 0px));
+  left: 0;
+  right: 0;
 }
 .shell__tabstrip::-webkit-scrollbar { height: 0; width: 0; }
 

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -1003,16 +1003,15 @@ export default function Shell({ onInitialVisualReady }) {
     && openTabs.length >= 1
   const shellTabStripVisible = tabStripVisible && !workspaceChromeActive
 
-  // Reconcile other React-owned chrome changes from committed DOM. Desktop
-  // drawer toggles do not depend on this effect for atomicity: their event
-  // handler primes contentRect in the same state batch.
+  // Reconcile React-owned chrome that changes the actual content box. The
+  // one-pane Builder strip is overlaid and therefore deliberately absent here;
+  // desktop drawer toggles prime contentRect in their event batch.
   useLayoutEffect(() => {
     syncContentRect({ settlePending: true })
   }, [
     desktopSidebarReserved,
     desktopSidebarWidth,
     immersiveActive,
-    shellTabStripVisible,
     syncContentRect,
   ])
 
@@ -3924,20 +3923,19 @@ export default function Shell({ onInitialVisualReady }) {
           boolean prop form emits the attribute only while this is true. */}
       {/* Tab strip: pinned chats/apps to swap between with one tap.
           Switching a tab is ordinary navTo, so back works through the
-          existing navStack. The strip shrinks .shell__content by one row;
-          the chat re-measures its spacer at the new height on the next
-          layout event (a ~1-row imprecision on the 0<->1 crossing that
-          self-corrects). Deliberately NOT a ChatView remount — that would
-          reset the send-reservation and freeze stream-follow (the reason the
-          bespoke split view was parked). */}
-      {tabStripVisible && !workspaceChromeActive && (() => {
+          existing navStack. A one-pane Builder strip is positioned over the
+          stable content box while the painted surface reserves its row. That
+          keeps the transcript and composer bottom edge fixed through every
+          mode flip. Deliberately NOT a ChatView remount — that would reset the
+          send-reservation and freeze stream-follow. */}
+      {shellTabStripVisible && (() => {
         const navPaneId = workspace.focusedPaneId
         const navViewStyle = navPaneId
           ? modeViewTransitionStyle('strip', navPaneId, 'single')
           : null
         return (
         <nav
-          className="shell__tabstrip"
+          className="shell__tabstrip shell__tabstrip--single-builder"
           onWheel={scrollStripWheel}
           // INV 9 (inert beat): the single-pane strip clears WITH its pane during
           // a mode scene, so it is pointer/keyboard inert throughout — not just under
@@ -3984,7 +3982,15 @@ export default function Shell({ onInitialVisualReady }) {
         </nav>
         )
       })()}
-      <main className="shell__content" id="main-content" tabIndex={-1} inert={navigationSurfaceOpen} ref={contentElRef}>
+      <main
+        className={`shell__content${shellTabStripVisible
+          ? ' shell__content--single-builder-strip'
+          : ''}`}
+        id="main-content"
+        tabIndex={-1}
+        inert={navigationSurfaceOpen}
+        ref={contentElRef}
+      >
         {/* Content layer (design §2): app-iframe wrappers (id-sorted) and chat
             wrappers (chatId-sorted) as ONE flat sibling set, never reparented.
             A wrapper is positioned (--paned) when its tab is a visible pane's

--- a/frontend/src/components/Shell/__tests__/dragController.test.js
+++ b/frontend/src/components/Shell/__tests__/dragController.test.js
@@ -186,19 +186,19 @@ test('strip caret beats every other zone at overlapping coordinates', () => {
   assert.equal(z.type, 'strip')
 })
 
-test('a shell-level Builder strip above content still owns its caret preview', () => {
+test('a shell-level Builder strip aligned to content still owns its caret preview', () => {
   const p = pane('p0', { x: 0, y: 0, w: 426, h: 768 }, {
-    stripRect: { x: 0, y: -34, w: 426, h: 34 },
+    stripRect: { x: 0, y: 0, w: 426, h: 34 },
     tabs: [
       { key: 'chat:a', left: 9, right: 142 },
       { key: 'app:62', left: 173, right: 215 },
     ],
   })
-  const z = hitTest({ x: 200, y: -17 }, scene([p], { mode: 'phone' }))
+  const z = hitTest({ x: 200, y: 17 }, scene([p], { mode: 'phone' }))
   assert.equal(z.type, 'strip')
   assert.equal(z.paneId, 'p0')
   assert.equal(z.index, 2)
-  assert.equal(z.rect.y, -29, 'caret stays aligned to the measured shell strip')
+  assert.equal(z.rect.y, 5, 'caret stays aligned to the measured shell strip')
 })
 
 test('root edge beats a pane edge, and only when fine pointers allow it', () => {

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -224,7 +224,10 @@ test('the first-run walkthrough remains dismissible in a short landscape viewpor
 test('the authenticated shell offers a keyboard skip link', () => {
   assert.match(shell, /href="#main-content"/)
   assert.match(shell, /event\.preventDefault\(\)[\s\S]*?contentElRef\.current\?\.focus\(\{ preventScroll: true \}\)/)
-  assert.match(shell, /<main className="shell__content" id="main-content" tabIndex=\{-1\}/)
+  assert.match(
+    shell,
+    /<main\s+[\s\S]*?className=\{`shell__content\$\{shellTabStripVisible[\s\S]*?id="main-content"[\s\S]*?tabIndex=\{-1\}/,
+  )
 })
 
 test('drawer lists distinguish loading, error, and confirmed empty data', () => {
@@ -838,7 +841,10 @@ test('navigation surfaces keep the brand close path while the workspace is inert
   assert.match(shell, /const navigationSurfaceOpen = modalDrawerOpen/)
   assert.doesNotMatch(shell, /const navigationSurfaceOpen = .*apps/,
     'the canonical Apps tab is workspace content, not a modal navigation surface')
-  assert.match(shell, /<main className="shell__content"[^>]*inert=\{navigationSurfaceOpen\}/)
+  assert.match(
+    shell,
+    /<main\s+[\s\S]*?className=\{`shell__content\$\{shellTabStripVisible[\s\S]*?inert=\{navigationSurfaceOpen\}/,
+  )
   assert.match(shellBrand, /aria-expanded=\{navigationOpen\}/)
   assert.match(shell, /drawerOpen \? closeDrawer\(\) : openDrawer\(\)/)
 })
@@ -952,11 +958,19 @@ test('the Möbius header keeps its phone divider but flows into desktop navigati
   )
   assert.match(
     shellCss,
+    /@media \(max-width: 620px\)[\s\S]*?\.shell\s*\{[\s\S]*?--shell-bar-height:\s*46px;/,
+  )
+  assert.match(
+    shellCss,
     /@media \(min-width: 1024px\)[\s\S]*?\.shell__bar\s*\{[\s\S]*?border:\s*0;/,
   )
   assert.match(
     shellCss,
     /\.shell--drawer-docked \.shell__bar\s*\{[\s\S]*?border-bottom:\s*0;/,
+  )
+  assert.match(
+    drawerCss,
+    /top:\s*calc\(var\(--shell-bar-height,\s*58px\) \+ env\(safe-area-inset-top\)\);/,
   )
 })
 

--- a/frontend/src/components/Shell/dragController.js
+++ b/frontend/src/components/Shell/dragController.js
@@ -431,8 +431,8 @@ export function hitTest(point, scene, prevZone = null) {
 
   // 1. strip caret — checked first so a drop over the tabs always reads as an
   // insert, even in the outer-margin corner where a root edge would also apply.
-  // The single-pane Builder strip is outside the content box, so strip ownership
-  // is deliberately independent of paneAt().
+  // The single-pane Builder strip overlays the top of the content box, so strip
+  // ownership is deliberately independent of paneAt().
   if (stripPane) return caretZone(point, stripPane, prevZone)
 
   const pane = paneAt(point, scene)

--- a/frontend/src/components/Shell/useWorkspaceDrag.js
+++ b/frontend/src/components/Shell/useWorkspaceDrag.js
@@ -221,9 +221,8 @@ export default function useWorkspaceDrag({
     }
 
     // Render (or clear) the drop preview for a zone. The geometry engine speaks
-    // content-local pixels, including a negative y for the shell-level one-pane
-    // strip. Translate once to viewport coordinates so the fixed preview can
-    // paint both inside content and over that sibling strip without clipping.
+    // content-local pixels. Translate once to viewport coordinates so the fixed
+    // preview can paint over both pane and strip chrome without clipping.
     function renderPreview(zone, box) {
       if (!previewEl) return
       if (!zone) { previewEl.classList.remove('is-visible'); return }
@@ -275,10 +274,10 @@ export default function useWorkspaceDrag({
       return shell?.querySelector?.(selector) || null
     }
 
-    // Measure one pane's whole strip contract. Most strips are content children;
-    // the one-pane Builder strip is a shell sibling above content, so its local y
-    // is negative. Keeping rect + tabs together prevents hit-testing, previews,
-    // and auto-scroll from inventing different ideas of where the strip lives.
+    // Measure one pane's whole strip contract. The one-pane Builder strip is a
+    // shell sibling aligned with the content top; tiled strips are content
+    // children. Keeping rect + tabs together prevents hit-testing, previews, and
+    // auto-scroll from inventing different ideas of where the strip lives.
     function measureStrip(paneId, box = contentBox()) {
       const strip = findStrip(paneId)
       if (!strip) return null

--- a/tests/mode-transition.spec.mjs
+++ b/tests/mode-transition.spec.mjs
@@ -102,6 +102,12 @@ function standardChatWithEmptyBuilder() {
   )
 }
 
+function onePaneStandardChat() {
+  let ws = paneModel.seedFromFlatTabs([{ kind: 'chat', id: 'aaa' }])
+  ws = paneModel.setSingleScreen(ws, { kind: 'chat', id: 'aaa' })
+  return paneModel.setViewMode(ws, 'single')
+}
+
 // An intentionally asymmetric three-pane tree. Its natural edge vectors differ
 // enough to expose same-duration entry as visibly different pane velocities.
 function unevenThreePaneBuilder(slot) {
@@ -348,6 +354,79 @@ for (const [name, viewport] of [
     await expect(page.locator('.shell__content')).toBeAttached()
   })
 }
+
+test('phone one-pane Builder keeps the workspace and composer anchored across repeated toggles', async ({ page }) => {
+  await bootSeededWorkspace(page, { width: 412, height: 915 }, onePaneStandardChat())
+  const paintedComposer = page.locator(
+    '[data-chat-surface="painted"] textarea.chat__input',
+  )
+  await expect(paintedComposer).toBeVisible()
+
+  const baseline = await page.evaluate(() => {
+    const content = document.querySelector('.shell__content').getBoundingClientRect()
+    const composer = document.querySelector(
+      '[data-chat-surface="painted"] textarea.chat__input',
+    ).getBoundingClientRect()
+    return {
+      contentTop: content.top,
+      contentHeight: content.height,
+      composerBottom: composer.bottom,
+    }
+  })
+
+  const sampleToggle = async () => {
+    const frames = page.evaluate(async () => {
+      const samples = []
+      for (let frame = 0; frame < 42; frame += 1) {
+        await new Promise(resolve => requestAnimationFrame(resolve))
+        const content = document.querySelector('.shell__content')?.getBoundingClientRect()
+        const composer = document.querySelector(
+          '[data-chat-surface="painted"] textarea.chat__input',
+        )?.getBoundingClientRect()
+        const strip = document.querySelector('.shell__tabstrip')?.getBoundingClientRect()
+        samples.push({
+          contentTop: content?.top ?? null,
+          contentHeight: content?.height ?? null,
+          composerBottom: composer?.bottom ?? null,
+          stripTop: strip?.top ?? null,
+        })
+      }
+      return samples
+    })
+    await page.waitForTimeout(32)
+    await toggleMode(page)
+    return frames
+  }
+
+  for (let toggle = 0; toggle < 2; toggle += 1) {
+    const frames = await sampleToggle()
+    for (const frame of frames) {
+      expect(frame.contentTop).toBeCloseTo(baseline.contentTop, 0)
+      expect(frame.contentHeight).toBeCloseTo(baseline.contentHeight, 0)
+      if (frame.composerBottom != null) {
+        expect(frame.composerBottom).toBeCloseTo(baseline.composerBottom, 0)
+      }
+      if (frame.stripTop != null) {
+        expect(frame.stripTop).toBeCloseTo(baseline.contentTop, 0)
+      }
+    }
+    await expect.poll(() => transientClassCount(page), { timeout: 2000 }).toBe(0)
+  }
+
+  await expect.poll(() => builderActive(page)).toBe(false)
+  const returned = await page.evaluate(() => {
+    const content = document.querySelector('.shell__content').getBoundingClientRect()
+    const composer = document.querySelector(
+      '[data-chat-surface="painted"] textarea.chat__input',
+    ).getBoundingClientRect()
+    return {
+      contentTop: content.top,
+      contentHeight: content.height,
+      composerBottom: composer.bottom,
+    }
+  })
+  expect(returned).toEqual(baseline)
+})
 
 // ── Assemble/scatter v3 browser coverage ─────────────────────────────────────
 // Frame-sampled proof of the compositor-only contract in a real browser. Wide only


### PR DESCRIPTION
## Summary

- reduce the mobile shell toolbar from 58px to 46px while preserving 44px control targets
- derive drawer and modal offsets from the same responsive shell geometry
- keep the one-pane Builder tab strip from resizing the workspace, so the chat composer stays anchored through repeated mode toggles

## Visual comparison

The mobile toolbar row moves from 58px to 46px. Control hit targets remain 44px.

## Verification

- 606 focused Shell tests
- production frontend build
- repeated live phone-sized toggles held the content and composer geometry stable
- added a browser regression for repeated one-pane Builder toggles