### PR TITLE
Simplify synced platform version in Settings

### DIFF
--- a/frontend/src/components/SettingsView/SettingsView.css
+++ b/frontend/src/components/SettingsView/SettingsView.css
@@ -324,12 +324,6 @@
   color: var(--muted);
 }
 
-.settings__update-check {
-  margin: 0;
-  font-size: 12px;
-  color: var(--muted);
-}
-
 .settings__btn--nowrap { white-space: nowrap; }
 
 .settings-bg-list {

--- a/frontend/src/components/SettingsView/SettingsView.jsx
+++ b/frontend/src/components/SettingsView/SettingsView.jsx
@@ -6,10 +6,7 @@ import GripVertical from 'lucide-react/dist/esm/icons/grip-vertical.mjs'
 import { api, clearQueryCache, clearToken } from '../../api/client.js'
 import { authQueries, modelQueries, settingsQueries, themeQueries, versionQueries } from '../../hooks/queries.js'
 import { platformVersionIdentity } from '../../lib/platformVersionIdentity.js'
-import {
-  formatUpstreamCheckTime,
-  formatUpstreamCommitDate,
-} from '../../lib/platformProvenance.js'
+import { formatUpstreamCommitDate } from '../../lib/platformProvenance.js'
 import {
   rebuildIsActive,
   rebuildPollShouldContinue,
@@ -1489,9 +1486,6 @@ export default function SettingsView({
   const upstreamCommitDate = formatUpstreamCommitDate(
     platform?.contained_upstream_committed_at,
   )
-  const upstreamCheckTime = formatUpstreamCheckTime(
-    platform?.upstream_checked_at,
-  )
   // Derived state for the single "Möbius" update row (see the section below).
   const platformConflict = platform?.state === 'conflict'
   // A text-clean update that failed the post-merge import probe was rolled back
@@ -1845,20 +1839,19 @@ export default function SettingsView({
                 {platformUpdateStatusLabel(platform)}
               </StatusDot>
               {mobiusVersion.primarySha && (
-                <>
-                  <p className="settings__build">
-                    {mobiusVersion.synced ? 'Current with upstream ' : 'Serving '}
-                    <span className="settings__standard-highlight">{mobiusVersion.primarySha}</span>
-                    {mobiusVersion.synced && upstreamCommitDate
-                      ? ` · ${upstreamCommitDate}`
-                      : !mobiusVersion.synced && buildDate
-                        ? ` · ${buildDate}`
-                        : ''}
-                  </p>
-                  {mobiusVersion.synced && upstreamCheckTime && (
-                    <p className="settings__update-check">{upstreamCheckTime}</p>
-                  )}
-                </>
+                <p className="settings__build">
+                  {mobiusVersion.synced && upstreamCommitDate
+                    ? `${upstreamCommitDate} (`
+                    : !mobiusVersion.synced
+                      ? 'Serving '
+                      : ''}
+                  <span className="settings__standard-highlight">{mobiusVersion.primarySha}</span>
+                  {mobiusVersion.synced && upstreamCommitDate
+                    ? ')'
+                    : !mobiusVersion.synced && buildDate
+                      ? ` · ${buildDate}`
+                      : ''}
+                </p>
               )}
             </div>
             {platformConflict ? (

--- a/frontend/src/lib/__tests__/platformProvenance.test.js
+++ b/frontend/src/lib/__tests__/platformProvenance.test.js
@@ -1,10 +1,7 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 
-import {
-  formatUpstreamCheckTime,
-  formatUpstreamCommitDate,
-} from '../platformProvenance.js'
+import { formatUpstreamCommitDate } from '../platformProvenance.js'
 
 test('upstream provenance presents the commit date rather than image build time', () => {
   assert.equal(
@@ -12,17 +9,4 @@ test('upstream provenance presents the commit date rather than image build time'
     '26 Aug 2026',
   )
   assert.equal(formatUpstreamCommitDate(null, 'en-GB'), '')
-})
-
-test('upstream provenance makes a fresh and cached check auditable', () => {
-  const now = Date.parse('2026-08-26T12:40:00Z')
-  assert.equal(
-    formatUpstreamCheckTime('2026-08-26T12:39:45Z', now),
-    'Last checked now',
-  )
-  assert.equal(
-    formatUpstreamCheckTime('2026-08-26T12:10:00Z', now),
-    'Last checked 30m ago',
-  )
-  assert.equal(formatUpstreamCheckTime(null, now), '')
 })

--- a/frontend/src/lib/__tests__/settingsViewAppearance.test.js
+++ b/frontend/src/lib/__tests__/settingsViewAppearance.test.js
@@ -22,14 +22,13 @@ test('appearance keeps one icon switch without making the section clickable', ()
   assert.match(css, /\.settings__appearance-toggle\s*\{[^}]*grid-template-columns:\s*repeat\(2, 34px\);/s)
 })
 
-test('model and synced commit use the same normal-weight standard highlight', () => {
+test('model and concise synced version use the same normal-weight standard highlight', () => {
   assert.match(view, /provider-row__status-text settings__last-model/)
   assert.match(view, /Choose which models appear\. New chats use your last pick\./)
   assert.match(view, /Last model: <span className="settings__standard-highlight">/)
-  assert.match(view, /Current with upstream [\s\S]*settings__standard-highlight/)
+  assert.match(view, /upstreamCommitDate[\s\S]*settings__standard-highlight/)
   assert.match(view, /contained_upstream_committed_at/)
-  assert.match(view, /upstream_checked_at/)
-  assert.match(view, /settings__update-check/)
+  assert.doesNotMatch(view, /Current with upstream|Last checked|upstream_checked_at|settings__update-check/)
   assert.doesNotMatch(view, /Serving local \{mobiusVersion\.localSha\}/)
   assert.match(css, /\.settings__last-model\s*\{[^}]*color:\s*var\(--muted\);[^}]*font-weight:\s*400;/s)
   assert.match(css, /\.settings__standard-highlight\s*\{[^}]*color:\s*var\(--green\);[^}]*font-weight:\s*inherit;/s)

--- a/frontend/src/lib/platformProvenance.js
+++ b/frontend/src/lib/platformProvenance.js
@@ -1,5 +1,3 @@
-import { formatRelativeTime } from './relativeTime.js'
-
 export function formatUpstreamCommitDate(value, locale) {
   const match = typeof value === 'string'
     ? value.match(/^(\d{4})-(\d{2})-(\d{2})/)
@@ -17,9 +15,4 @@ export function formatUpstreamCommitDate(value, locale) {
   } catch {
     return `${year}-${month}-${day}`
   }
-}
-
-export function formatUpstreamCheckTime(value, now = Date.now()) {
-  const relative = formatRelativeTime(value, now)
-  return relative ? `Last checked ${relative}` : ''
 }


### PR DESCRIPTION
## Summary
- show the synced Möbius version as a compact date and revision in Settings
- remove the redundant upstream and last-checked copy
- remove the now-unused formatter, styles, and assertions

## Testing
- `node --loader=./src/lib/__tests__/vite-env-loader.mjs --test src/lib/__tests__/platformProvenance.test.js src/lib/__tests__/settingsViewAppearance.test.js`
- focused ESLint (passes with two pre-existing hook-dependency warnings in `SettingsView.jsx`)