### PR TITLE
Classify platform activation by runtime owner

### DIFF
--- a/backend/app/platform_activation.py
+++ b/backend/app/platform_activation.py
@@ -72,6 +72,25 @@ def _normalize_path(path: str) -> str:
   return normalized[2:] if normalized.startswith("./") else normalized
 
 
+# These scripts run from the protected ``/app/scripts`` image tree before the
+# served ``/data/platform`` checkout can own execution.  Keep this allowlist in
+# sync with absolute ``/app/scripts/<name>`` references in entrypoint.sh.  The
+# rest of backend/scripts is linked from the live checkout and takes effect on
+# its next invocation, so classifying the whole directory as image-bound turns
+# ordinary maintenance work into unnecessary container replacements.
+IMAGE_BOOTSTRAP_SCRIPTS = (
+  "backend/scripts/agent-browser-profile-cleanup.py",
+  "backend/scripts/agent_sudo.sh",
+  "backend/scripts/entrypoint.sh",
+  "backend/scripts/init-cron-scaffold.sh",
+  "backend/scripts/init_agent_context.py",
+  "backend/scripts/init_chat_summaries.py",
+  "backend/scripts/init_skills.py",
+  "backend/scripts/migrate-app-rename.sh",
+  "backend/scripts/self-reminders-dispatch.sh",
+)
+
+
 # Ordered first-match rules.  Narrow baked/deployment inputs precede the broad
 # backend runtime rule.  A path may require only one owning activation boundary;
 # mixed updates still report every distinct rule they touch.
@@ -80,7 +99,11 @@ _RULES = (
     "host_operator_tooling",
     ActivationLevel.HOST_MAINTENANCE,
     "Host-operated deployment tooling changed.",
-    exact=("scripts/deploy-prod.sh",),
+    exact=(
+      "scripts/deploy-prod.sh",
+      "scripts/install-rebuild-helper.sh",
+      "scripts/mobius-rebuild-host.py",
+    ),
     deployment="self_hosted",
   ),
   _Rule(
@@ -121,9 +144,9 @@ _RULES = (
     "baked_runtime",
     ActivationLevel.IMAGE_REBUILD,
     "Baked scripts, supervisors, or protected-file rules changed.",
-    exact=("protected-files.txt",),
+    exact=("protected-files.txt", "backend/runtime", *IMAGE_BOOTSTRAP_SCRIPTS),
     prefixes=(
-      "backend/scripts/",
+      "backend/scripts/seed-skills/",
       "backend/runtime/",
       "backend/static/",
     ),
@@ -148,6 +171,18 @@ _RULES = (
     "The self-hosted Caddy routing or TLS policy changed.",
     exact=("Caddyfile",),
     deployment="self_hosted",
+  ),
+  _Rule(
+    "commit_launcher",
+    ActivationLevel.SERVER_RESTART,
+    "The commit launcher changed and is refreshed during server startup.",
+    exact=("backend/scripts/pm-commit",),
+  ),
+  _Rule(
+    "live_maintenance_tooling",
+    ActivationLevel.LIVE,
+    "Maintenance tooling is executed from the live platform checkout.",
+    prefixes=("backend/scripts/",),
   ),
   _Rule(
     "backend_development_source",
@@ -238,9 +273,21 @@ def _guidance(level: ActivationLevel, deployment: DeploymentKind) -> str:
         "does not reload the proxy."
       )
     if level is ActivationLevel.CONTAINER_RECREATE:
-      return "Refresh the host checkout, then recreate the affected Docker Compose services."
+      return (
+        "Apply this with scripts/deploy-prod.sh on the host — it recreates from "
+        "the current Compose files with the canonical env-file. Never hand-run "
+        "docker compose against the live instance: it recreates the container "
+        "this agent runs in (stranding the turn mid-recreate) and, without the "
+        "canonical env-file, drifts SECRET_KEY and logs every session out. The "
+        "in-product Settings replacement swaps the image on a frozen Compose "
+        "topology and will not apply Compose changes."
+      )
     if level is ActivationLevel.IMAGE_REBUILD:
-      return "Refresh the host checkout, rebuild the image, then recreate the app container."
+      return (
+        "Rebuild and replace through the in-product Settings container "
+        "replacement or scripts/deploy-prod.sh on the host; do not hand-run "
+        "docker build/compose against the live instance."
+      )
     if level is ActivationLevel.HOST_MAINTENANCE:
       return "Update the host-operated tooling and complete its maintenance outside the container."
   return "Complete this deployment action outside Möbius; an in-product restart is insufficient."

--- a/backend/tests/test_platform_activation.py
+++ b/backend/tests/test_platform_activation.py
@@ -1,5 +1,6 @@
 """Activation classification is one ordered contract across deployments."""
 
+import re
 from pathlib import Path
 
 from app import platform_activation as activation
@@ -40,6 +41,9 @@ def test_dependency_and_baked_runtime_never_degrade_to_restart_only():
     "backend/requirements.lock": "dependency_sync",
     "frontend/package-lock.json": "image_rebuild",
     "backend/scripts/entrypoint.sh": "image_rebuild",
+    "backend/scripts/init_skills.py": "image_rebuild",
+    "backend/scripts/seed-skills/platform-maintenance.md": "image_rebuild",
+    "backend/runtime": "image_rebuild",
     "backend/runtime/restart_ledger.py": "image_rebuild",
     "protected-files.txt": "image_rebuild",
   }
@@ -87,3 +91,45 @@ def test_python_dependencies_apply_in_place_not_via_rebuild():
 
 def test_dependency_sync_requires_an_import_probe():
   assert activation.backend_import_probe_required(["backend/requirements.lock"])
+
+
+def test_only_image_owned_bootstrap_scripts_require_a_rebuild():
+  assert activation.classify_activation([
+    "backend/scripts/goal_plan.py",
+  ])["level"] == "live"
+  assert activation.classify_activation([
+    "backend/scripts/rebuild_shell.sh",
+  ])["level"] == "live"
+  assert activation.classify_activation([
+    "backend/scripts/mapi",
+  ])["level"] == "live"
+  assert activation.classify_activation([
+    "backend/scripts/pm-commit",
+  ])["level"] == "server_restart"
+  assert activation.classify_activation([
+    "scripts/mobius-rebuild-host.py",
+  ])["level"] == "host_maintenance"
+
+
+def test_bootstrap_allowlist_covers_entrypoint_app_script_references():
+  root = Path(__file__).resolve().parents[2]
+  entrypoint = (root / "backend/scripts/entrypoint.sh").read_text(
+    encoding="utf-8",
+  )
+  referenced = set(re.findall(
+    r"/app/scripts/([A-Za-z0-9_-]+(?:\.[A-Za-z0-9_-]+)*)",
+    entrypoint,
+  ))
+  # pm-commit is seeded from the image, then deliberately refreshed from the
+  # live checkout by FastAPI startup; it needs one server restart, not an image.
+  # mapi is an image fallback only: the installed symlink already targets the
+  # live checkout, so changing that target takes effect immediately.
+  image_names = {Path(path).name for path in activation.IMAGE_BOOTSTRAP_SCRIPTS}
+  assert referenced == (image_names - {"entrypoint.sh"}) | {"pm-commit", "mapi"}
+  assert activation.classify_activation([
+    "backend/scripts/entrypoint.sh",
+  ])["level"] == "image_rebuild"
+  for name in referenced - {"pm-commit", "mapi"}:
+    assert activation.classify_activation([
+      f"backend/scripts/{name}",
+    ])["level"] == "image_rebuild", name


### PR DESCRIPTION
## Summary
- classify platform files by the runtime that actually owns them instead of treating every backend helper as image-bound
- keep image-only bootstrap scripts and seeded skills on the rebuild boundary, make the refreshed commit launcher restart-bound, and leave live checkout tools live
- classify host replacement helpers as host-operated maintenance
- give self-hosted operators the safe canonical deployment path without suggesting an in-container Compose command that can strand the running agent or drift the secret key

## Prior work
This is a focused follow-up to #584 and #813. Those changes established deployment-aware activation and safe self-hosted replacement; this patch corrects the script-level ownership map used by that machinery.

## Testing
- `python3 -m py_compile backend/app/platform_activation.py`
- `scripts/wt-pytest.sh backend/tests/test_platform_activation.py` (8 passed)
- the contract test cross-checks every `/app/scripts` reference in the current entrypoint, including the live `mapi` fallback discovered during extraction
- canonical binary-safe diff check passed