### PR TITLE
Track protected runtime provenance

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -50,6 +50,7 @@ from app.frontend_assets import (
   resolve_frontend_dir,
 )
 from app.memory_observability import record_memory_checkpoint
+from app.runtime_provenance import protected_runtime_status
 from app.response_policy import (
   CHAT_EMBED_CSP,
   PUBLISHED_SITE_CSP,
@@ -966,17 +967,28 @@ def version():
     Changes whenever the watcher swaps a fresh ``vite build`` into the served
     ``dist`` — the frontend analogue of ``served_sha``. Poll it to confirm a
     frontend edit went live.
+  - ``protected_runtime``: content parity between the served platform's desired
+    ``backend/runtime`` tree and the root-started ``/app/runtime`` image copy.
+    This closes the gap where Git and image identities were individually valid
+    while the protected broker still ran older bytes.
 
   A full GitHub-release check + one-click update is a follow-up; this exposes
   the local build identity cleanly so the image-pull path is self-verifying.
   """
   settings = get_settings()
+  protected_runtime = protected_runtime_status(
+    Path(settings.data_dir) / "platform" / "backend" / "runtime",
+  )
   return {"sha": settings.build_sha,
           "build_date": settings.build_date,
           # Browser setup verifies this dedicated test-container marker before
           # any write. Localhost is not sufficient evidence because a preview
           # proxy can still forward to the live app.
           "test_runtime": os.environ.get("MOBIUS_TEST_RUNTIME") == "1",
+          # Keep the state flat as well as detailed: Host shell verification
+          # can parse one stable scalar without reimplementing JSON traversal.
+          "protected_runtime_state": protected_runtime["state"],
+          "protected_runtime": protected_runtime,
           **_served_platform_identity(settings.data_dir),
           **_served_frontend_identity()}
 

--- a/backend/app/platform_update.py
+++ b/backend/app/platform_update.py
@@ -64,7 +64,7 @@ from typing import Callable, Literal, TypedDict
 
 from sqlalchemy.orm import Session
 
-from app import app_git, platform_activation
+from app import app_git, platform_activation, runtime_provenance
 from app.platform_activation import PlatformActivationImpact
 
 
@@ -952,20 +952,61 @@ def _read_activation_marker() -> _ActivationMarker | None:
   }
 
 
-def container_replacement_blockers() -> list[str]:
+def _protected_runtime_status(
+  repo: Path = PLATFORM_REPO,
+) -> runtime_provenance.RuntimeParity:
+  return runtime_provenance.protected_runtime_status(
+    repo / "backend" / "runtime",
+  )
+
+
+def container_replacement_blockers(
+  expected_sha: str | None = None,
+  repo: Path = PLATFORM_REPO,
+  *,
+  preserve_active_runtime: bool = False,
+) -> list[str]:
   """Return local image/runtime changes absent from the official target.
 
   An official image can retire only activation paths whose desired content is
   exactly the applied upstream revision. Replacing a working container while a
   local-only Dockerfile or baked-runtime change remains would silently remove
   that runtime addition, so the owner action must fail closed before cutover.
+
+  A replacement controller with the active-runtime overlay contract owns the
+  narrower protected-runtime case at the root boundary: it carries forward
+  only bytes already executing from ``/app/runtime`` and never promotes newer
+  editable source. Other image inputs remain blockers because no equivalent
+  active-generation receipt exists for them.
   """
   marker = _read_activation_marker()
-  if not marker:
-    return []
-  covered = set(marker["image_paths"])
+  covered = set(marker["image_paths"]) if marker else set()
+  pending = list(marker["paths"]) if marker else []
+
+  # Activation markers record intended work, not the bytes actually mounted at
+  # /app/runtime. When the caller supplies the official replacement target,
+  # verify deployed parity directly and prove that target contains every stale
+  # path. This catches lost markers without blocking a replacement whose exact
+  # official image will repair the drift.
+  if expected_sha:
+    runtime = _protected_runtime_status(repo)
+    if runtime["state"] == "unavailable":
+      pending.append("backend/runtime")
+    else:
+      runtime_paths = runtime_provenance.activation_paths(runtime)
+      pending.extend(runtime_paths)
+      head = _rev(repo, _local_branch(repo))
+      if head:
+        covered.update(_paths_matching_upstream(
+          repo, head, expected_sha, runtime_paths,
+        ))
+
   blockers: list[str] = []
-  for path in marker["paths"]:
+  for path in sorted(set(pending)):
+    if preserve_active_runtime and (
+      path == "backend/runtime" or path.startswith("backend/runtime/")
+    ):
+      continue
     impact = platform_activation.classify_activation(
       [path], deployment="self_hosted",
     )
@@ -1084,6 +1125,9 @@ def _tree_change_needs_import_probe(
 def _pending_activation_paths(repo: Path = PLATFORM_REPO) -> list[str]:
   marker = _read_activation_marker()
   paths = list(marker["paths"]) if marker else []
+  paths.extend(runtime_provenance.activation_paths(
+    _protected_runtime_status(repo),
+  ))
   served = _served_platform_sha()
   if served:
     try:

--- a/backend/app/runtime_provenance.py
+++ b/backend/app/runtime_provenance.py
@@ -1,0 +1,156 @@
+"""Prove that the protected image runtime matches the served source tree.
+
+``/data/platform`` owns the desired platform generation, while ``/app/runtime``
+contains the root-started broker modules that only an image replacement can
+activate.  Git ancestry and BUILD_SHA prove the two generations independently;
+neither proves that these protected bytes agree.  This module provides that
+missing, read-only comparison for version diagnostics, Settings activation
+status, and deployment cutover checks.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import stat
+from pathlib import Path
+from typing import Literal, TypedDict
+
+
+RuntimeParityState = Literal["current", "stale", "unavailable"]
+
+
+class RuntimeParity(TypedDict):
+  """Serializable protected-runtime parity result."""
+
+  state: RuntimeParityState
+  source_sha256: str | None
+  deployed_sha256: str | None
+  mismatched_paths: list[str]
+
+
+class _TreeSnapshot(TypedDict):
+  digest: str
+  files: dict[str, str]
+  invalid_paths: list[str]
+
+
+def _deployed_root() -> Path:
+  return Path(os.environ.get("MOBIUS_PROTECTED_RUNTIME_DIR", "/app/runtime"))
+
+
+def _ignored(relative: Path) -> bool:
+  return "__pycache__" in relative.parts or relative.suffix in {".pyc", ".pyo"}
+
+
+def _hash_regular_file(path: Path) -> str:
+  """Hash one final regular file without following a last-component link."""
+  flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+  fd = os.open(path, flags)
+  try:
+    if not stat.S_ISREG(os.fstat(fd).st_mode):
+      raise OSError(f"not a regular file: {path}")
+    digest = hashlib.sha256()
+    while chunk := os.read(fd, 1024 * 1024):
+      digest.update(chunk)
+    return digest.hexdigest()
+  finally:
+    os.close(fd)
+
+
+def _snapshot(root: Path) -> _TreeSnapshot:
+  """Hash a tree without following links or including Python bytecode."""
+  if root.is_symlink() or not root.is_dir():
+    raise FileNotFoundError(root)
+
+  files: dict[str, str] = {}
+  invalid: list[str] = []
+  for path in sorted(root.rglob("*")):
+    relative = path.relative_to(root)
+    if _ignored(relative):
+      continue
+    name = relative.as_posix()
+    if path.is_symlink():
+      invalid.append(name)
+      continue
+    if path.is_dir():
+      continue
+    if not path.is_file():
+      invalid.append(name)
+      continue
+    files[name] = _hash_regular_file(path)
+
+  tree = hashlib.sha256()
+  for name, digest in sorted(files.items()):
+    tree.update(name.encode("utf-8"))
+    tree.update(b"\0")
+    tree.update(digest.encode("ascii"))
+    tree.update(b"\n")
+  for name in sorted(invalid):
+    tree.update(b"invalid\0")
+    tree.update(name.encode("utf-8"))
+    tree.update(b"\n")
+  return {
+    "digest": tree.hexdigest(),
+    "files": files,
+    "invalid_paths": sorted(invalid),
+  }
+
+
+def protected_runtime_status(
+  source_root: Path,
+  deployed_root: Path | None = None,
+) -> RuntimeParity:
+  """Compare desired and deployed protected trees; never raise.
+
+  ``unavailable`` means the desired source tree itself could not be read, so
+  no deployment conclusion is possible.  A missing/unreadable deployed tree is
+  ``stale`` when the source is available: replacement status must not silently
+  report current merely because the protected copy disappeared.
+  """
+  source: _TreeSnapshot
+  try:
+    source = _snapshot(source_root)
+  except (OSError, UnicodeError):
+    return {
+      "state": "unavailable",
+      "source_sha256": None,
+      "deployed_sha256": None,
+      "mismatched_paths": [],
+    }
+
+  target_root = deployed_root if deployed_root is not None else _deployed_root()
+  try:
+    deployed = _snapshot(target_root)
+  except (OSError, UnicodeError):
+    return {
+      "state": "stale",
+      "source_sha256": source["digest"],
+      "deployed_sha256": None,
+      "mismatched_paths": sorted({
+        *source["files"], *source["invalid_paths"],
+      }),
+    }
+
+  mismatches = {
+    name
+    for name in set(source["files"]) | set(deployed["files"])
+    if source["files"].get(name) != deployed["files"].get(name)
+  }
+  mismatches.update(source["invalid_paths"])
+  mismatches.update(deployed["invalid_paths"])
+  return {
+    "state": "stale" if mismatches else "current",
+    "source_sha256": source["digest"],
+    "deployed_sha256": deployed["digest"],
+    "mismatched_paths": sorted(mismatches),
+  }
+
+
+def activation_paths(status: RuntimeParity) -> list[str]:
+  """Translate a stale parity result into canonical platform source paths."""
+  if status["state"] != "stale":
+    return []
+  if not status["mismatched_paths"]:
+    return ["backend/runtime"]
+  return [f"backend/runtime/{path}" for path in status["mismatched_paths"]]

--- a/backend/tests/test_platform_update.py
+++ b/backend/tests/test_platform_update.py
@@ -1327,6 +1327,94 @@ def test_container_replacement_accepts_image_input_covered_by_upstream(
   assert pu.container_replacement_blockers() == []
 
 
+def test_active_runtime_overlay_owns_only_protected_runtime_blockers(
+  tmp_path, monkeypatch,
+):
+  marker = tmp_path / "activation.json"
+  monkeypatch.setattr(pu, "RESTART_NEEDED_FLAG", marker)
+  pu._write_activation_marker(
+    "a" * 40,
+    ["Dockerfile", "backend/runtime/identity_broker.py"],
+    upstream_sha="b" * 40,
+    image_paths=[],
+  )
+
+  assert pu.container_replacement_blockers(
+    preserve_active_runtime=True,
+  ) == ["Dockerfile"]
+
+
+def test_stale_protected_runtime_restores_image_activation_without_marker(
+  clone_env, monkeypatch, tmp_path,
+):
+  _, platform = clone_env
+  head = _local_commit(
+    platform,
+    edits={"backend/runtime/identity_broker.py": "wanted\n"},
+  )
+  deployed = tmp_path / "deployed-runtime"
+  deployed.mkdir()
+  (deployed / "identity_broker.py").write_text("old\n", encoding="utf-8")
+  monkeypatch.setenv("MOBIUS_PROTECTED_RUNTIME_DIR", str(deployed))
+  pu.SERVING_SOURCE_FILE.write_text("platform\n")
+  pu.SERVING_SHA_FILE.write_text(head + "\n")
+
+  status = pu.platform_status(platform)
+
+  assert status["state"] == pu.PlatformUpdateState.ACTIVATION_NEEDED.value
+  assert status["activation"]["level"] == "image_rebuild"
+  assert status["activation"]["reasons"] == [{
+    "code": "baked_runtime",
+    "summary": "Baked scripts, supervisors, or protected-file rules changed.",
+    "paths": ["backend/runtime/identity_broker.py"],
+  }]
+
+
+def test_replacement_allows_runtime_drift_covered_by_exact_official_target(
+  clone_env, monkeypatch, tmp_path,
+):
+  _, platform = clone_env
+  official = _local_commit(
+    platform,
+    edits={"backend/runtime/identity_broker.py": "official\n"},
+  )
+  deployed = tmp_path / "deployed-runtime"
+  deployed.mkdir()
+  (deployed / "identity_broker.py").write_text("old\n", encoding="utf-8")
+  monkeypatch.setenv("MOBIUS_PROTECTED_RUNTIME_DIR", str(deployed))
+
+  assert pu.container_replacement_blockers(official, platform) == []
+
+  _local_commit(
+    platform,
+    edits={"backend/runtime/identity_broker.py": "local-only\n"},
+  )
+  assert pu.container_replacement_blockers(official, platform) == [
+    "backend/runtime/identity_broker.py",
+  ]
+
+
+def test_replacement_blocks_when_desired_runtime_cannot_be_verified(
+  clone_env, monkeypatch,
+):
+  _, platform = clone_env
+  official = _git(platform, "rev-parse", "HEAD").stdout.strip()
+  monkeypatch.setattr(
+    pu,
+    "_protected_runtime_status",
+    lambda _repo: {
+      "state": "unavailable",
+      "source_sha256": None,
+      "deployed_sha256": None,
+      "mismatched_paths": [],
+    },
+  )
+
+  assert pu.container_replacement_blockers(official, platform) == [
+    "backend/runtime",
+  ]
+
+
 def test_legacy_activation_marker_cannot_claim_official_image_coverage(
   tmp_path, monkeypatch,
 ):

--- a/backend/tests/test_runtime_provenance.py
+++ b/backend/tests/test_runtime_provenance.py
@@ -1,0 +1,99 @@
+"""Protected image-runtime parity is explicit and fail closed."""
+
+from pathlib import Path
+
+from app import runtime_provenance as provenance
+
+
+def _write(root: Path, relative: str, content: bytes = b"same") -> None:
+  path = root / relative
+  path.parent.mkdir(parents=True, exist_ok=True)
+  path.write_bytes(content)
+
+
+def test_matching_trees_are_current_and_ignore_python_bytecode(tmp_path):
+  source = tmp_path / "source"
+  deployed = tmp_path / "deployed"
+  _write(source, "identity_broker.py")
+  _write(deployed, "identity_broker.py")
+  _write(deployed, "__pycache__/identity_broker.cpython-312.pyc", b"cache")
+
+  status = provenance.protected_runtime_status(source, deployed)
+
+  assert status["state"] == "current"
+  assert status["source_sha256"] == status["deployed_sha256"]
+  assert status["mismatched_paths"] == []
+
+
+def test_changed_missing_and_extra_files_are_stale(tmp_path):
+  source = tmp_path / "source"
+  deployed = tmp_path / "deployed"
+  _write(source, "changed.py", b"wanted")
+  _write(deployed, "changed.py", b"old")
+  _write(source, "missing.py")
+  _write(deployed, "extra.py")
+
+  status = provenance.protected_runtime_status(source, deployed)
+
+  assert status["state"] == "stale"
+  assert status["mismatched_paths"] == ["changed.py", "extra.py", "missing.py"]
+  assert provenance.activation_paths(status) == [
+    "backend/runtime/changed.py",
+    "backend/runtime/extra.py",
+    "backend/runtime/missing.py",
+  ]
+
+
+def test_missing_source_is_unavailable_but_missing_deployed_tree_is_stale(
+  tmp_path,
+):
+  source = tmp_path / "source"
+  deployed = tmp_path / "deployed"
+
+  unavailable = provenance.protected_runtime_status(source, deployed)
+  assert unavailable == {
+    "state": "unavailable",
+    "source_sha256": None,
+    "deployed_sha256": None,
+    "mismatched_paths": [],
+  }
+
+  _write(source, "restart_ledger.py")
+  stale = provenance.protected_runtime_status(source, deployed)
+  assert stale["state"] == "stale"
+  assert stale["deployed_sha256"] is None
+  assert stale["mismatched_paths"] == ["restart_ledger.py"]
+
+
+def test_symlinks_are_reported_without_following_them(tmp_path):
+  source = tmp_path / "source"
+  deployed = tmp_path / "deployed"
+  source.mkdir()
+  deployed.mkdir()
+  outside = tmp_path / "outside"
+  outside.write_text("secret", encoding="utf-8")
+  (source / "linked.py").symlink_to(outside)
+  _write(deployed, "linked.py", b"secret")
+
+  status = provenance.protected_runtime_status(source, deployed)
+
+  assert status["state"] == "stale"
+  assert status["mismatched_paths"] == ["linked.py"]
+
+
+def test_symlinked_root_is_unavailable_without_traversing_it(tmp_path):
+  outside = tmp_path / "outside"
+  _write(outside, "private.py", b"do not traverse")
+  linked_source = tmp_path / "source"
+  linked_source.symlink_to(outside, target_is_directory=True)
+
+  status = provenance.protected_runtime_status(
+    linked_source, tmp_path / "deployed",
+  )
+
+  assert status == {
+    "state": "unavailable",
+    "source_sha256": None,
+    "deployed_sha256": None,
+    "mismatched_paths": [],
+  }

--- a/backend/tests/test_version.py
+++ b/backend/tests/test_version.py
@@ -25,6 +25,24 @@ def test_version_endpoint_exposes_build_sha(client):
   assert isinstance(body.get("sha"), str) and body["sha"]
 
 
+def test_version_exposes_protected_runtime_parity(client, monkeypatch):
+  parity = {
+    "state": "stale",
+    "source_sha256": "a" * 64,
+    "deployed_sha256": "b" * 64,
+    "mismatched_paths": ["identity_broker.py"],
+  }
+  monkeypatch.setattr(
+    "app.main.protected_runtime_status",
+    lambda _source: parity,
+  )
+
+  body = client.get("/api/version").json()
+
+  assert body["protected_runtime_state"] == "stale"
+  assert body["protected_runtime"] == parity
+
+
 def test_health_exposes_stable_normal_target_identity(client):
   body = client.get("/api/health").json()
   assert body["status"] == "ok"


### PR DESCRIPTION
## Summary
- compare the desired protected runtime with the root-started image copy using content-addressed, symlink-safe tree snapshots
- expose the exact running runtime digest through build provenance and restore image activation when marker state is missing
- allow only a host controller with the active-runtime carry-forward contract to own protected-runtime drift; keep every other local image input fail-closed

## Prior work
This is a focused foundation for the safe container-replacement flows established in #813 and #903. Those changes verify image and served-source identities; this layer closes the remaining gap where the protected root runtime could still contain different bytes.

## Testing
- 146 focused provenance, platform-update, deployment, activation, and version tests passed on the reviewed stack head
- Python bytecode compilation and canonical diff validation passed
- hosted CI remains dependency-authoritative because the live image dependency lock differs from the checkout