### PR TITLE
Normalize Codex file-change previews

### DIFF
--- a/backend/app/codex_events.py
+++ b/backend/app/codex_events.py
@@ -667,17 +667,10 @@ def _tool_completed_events(item: Any, sdk: dict[str, Any]) -> list[dict[str, Any
     return events
 
   if isinstance(item, sdk["FileChangeThreadItem"]):
-    lines: list[str] = []
-    for change in item.changes:
-      change_dict = _model_dump(change) or {}
-      kind = change_dict.get("kind", "?")
-      path = change_dict.get("path", "")
-      line = f"{kind} {path}".strip()
-      if line:
-        lines.append(line)
     events: list[dict[str, Any]] = []
-    if lines:
-      events.append({"type": "tool_output", "content": "\n".join(lines)})
+    summary = _file_change_patch_summary(item.changes)
+    if summary:
+      events.append({"type": "tool_output", "content": summary})
     events.append({"type": "tool_end"})
     return events
 
@@ -972,13 +965,23 @@ def _observe_skill_reads(
 
 
 def _file_change_patch_summary(changes: list[Any]) -> str:
-  """Summarizes one file-change patch update as `kind path` lines."""
+  """Summarize file changes without exposing provider model reprs."""
   lines: list[str] = []
   for change in changes:
     change_dict = _model_dump(change) or {}
-    kind = change_dict.get("kind", "?")
+    raw_kind = change_dict.get("kind")
+    kind = raw_kind if isinstance(raw_kind, dict) else {}
+    kind_type = str(kind.get("type") or "update")
     path = change_dict.get("path", "")
-    line = f"{kind} {path}".strip()
+    move_path = kind.get("move_path")
+    if kind_type == "add":
+      line = f"Added {path}".strip()
+    elif kind_type == "delete":
+      line = f"Deleted {path}".strip()
+    elif isinstance(move_path, str) and move_path:
+      line = f"Moved {path} → {move_path}".strip()
+    else:
+      line = f"Updated {path}".strip()
     if line:
       lines.append(line)
   return "\n".join(lines)

--- a/backend/app/codex_events.py
+++ b/backend/app/codex_events.py
@@ -668,7 +668,8 @@ def _tool_completed_events(item: Any, sdk: dict[str, Any]) -> list[dict[str, Any
 
   if isinstance(item, sdk["FileChangeThreadItem"]):
     events: list[dict[str, Any]] = []
-    summary = _file_change_patch_summary(item.changes)
+    status = _enum_wire_value(getattr(item, "status", None))
+    summary = _file_change_patch_summary(item.changes, status=status)
     if summary:
       events.append({"type": "tool_output", "content": summary})
     events.append({"type": "tool_end"})
@@ -964,26 +965,40 @@ def _observe_skill_reads(
     log.debug("codex skill_loaded observability failed", exc_info=True)
 
 
-def _file_change_patch_summary(changes: list[Any]) -> str:
-  """Summarize file changes without exposing provider model reprs."""
+def _file_change_patch_summary(
+  changes: list[Any], *, status: str | None,
+) -> str:
+  """Summarize proposed or settled file changes in outcome-honest language."""
   lines: list[str] = []
   for change in changes:
     change_dict = _model_dump(change) or {}
     raw_kind = change_dict.get("kind")
     kind = raw_kind if isinstance(raw_kind, dict) else {}
     kind_type = str(kind.get("type") or "update")
-    path = change_dict.get("path", "")
+    path = change_dict.get("path")
+    if not isinstance(path, str) or not path:
+      continue
     move_path = kind.get("move_path")
     if kind_type == "add":
-      line = f"Added {path}".strip()
+      action = f"add {path}"
+      completed = f"Added {path}"
     elif kind_type == "delete":
-      line = f"Deleted {path}".strip()
+      action = f"delete {path}"
+      completed = f"Deleted {path}"
     elif isinstance(move_path, str) and move_path:
-      line = f"Moved {path} → {move_path}".strip()
+      action = f"move {path} → {move_path}"
+      completed = f"Moved {path} → {move_path}"
     else:
-      line = f"Updated {path}".strip()
-    if line:
-      lines.append(line)
+      action = f"update {path}"
+      completed = f"Updated {path}"
+    if status == "completed":
+      lines.append(completed)
+    elif status == "failed":
+      lines.append(f"Failed to {action}")
+    elif status == "declined":
+      lines.append(f"Declined: {action}")
+    else:
+      lines.append(f"Proposed: {action}")
   return "\n".join(lines)
 
 

--- a/backend/app/codex_sdk_runner.py
+++ b/backend/app/codex_sdk_runner.py
@@ -2193,7 +2193,9 @@ async def run_codex_sdk_turn(
             }
             _stamp_notification_item_id(event, payload)
             bc.publish(event)
-          summary = _file_change_patch_summary(payload.changes)
+          summary = _file_change_patch_summary(
+            payload.changes, status="inProgress",
+          )
           if summary:
             event = {"type": "tool_output", "content": summary}
             _stamp_notification_item_id(event, payload)

--- a/backend/app/tool_edit_preview.py
+++ b/backend/app/tool_edit_preview.py
@@ -65,6 +65,15 @@ def _selection_hunk(edit: dict[str, Any]) -> list[str]:
   ))[2:]
 
 
+def _content_hunk(content: str, kind_type: str) -> list[str]:
+  """Turn Codex's raw add/delete file body into a real unified hunk."""
+  if kind_type not in {"add", "delete"} or not content:
+    return []
+  before = content.splitlines() if kind_type == "delete" else []
+  after = content.splitlines() if kind_type == "add" else []
+  return list(difflib.unified_diff(before, after, lineterm=""))[2:]
+
+
 def claude_edit_preview(tool: str, inp: Any) -> dict | None:
   """Build an honest selection-relative preview from Claude edit arguments."""
   if not isinstance(inp, dict) or tool not in {"Edit", "MultiEdit"}:
@@ -136,5 +145,26 @@ def codex_edit_preview(changes: Any) -> dict | None:
         f"--- {_git_path('a', path)}",
         f"+++ {_git_path('b', new_path)}",
       ])
-    sections.append("\n".join([*header, patch]))
+    # FileUpdateChange.diff is not one stable shape: updates and some
+    # add/delete events carry hunk text, while other add/delete events carry
+    # the complete file body with no @@ header or +/- prefixes. Normalize that
+    # provider variation here so every durable preview is an honest unified
+    # diff rather than a file header followed by unparseable source text.
+    patch_lines = patch.splitlines()
+    first_patch_line = patch_lines[0] if patch_lines else ""
+    patch_is_diff = (
+      first_patch_line.startswith("@@ ")
+      or (
+        first_patch_line.startswith("Binary files ")
+        and first_patch_line.endswith(" differ")
+      )
+      or first_patch_line == "GIT binary patch"
+    )
+    if (
+      kind_type in {"add", "delete"}
+      and patch
+      and not patch_is_diff
+    ):
+      patch_lines = _content_hunk(patch, kind_type)
+    sections.append("\n".join([*header, *patch_lines]))
   return _bounded_preview("\n".join(sections))

--- a/backend/app/tool_edit_preview.py
+++ b/backend/app/tool_edit_preview.py
@@ -111,12 +111,20 @@ def codex_edit_preview(changes: Any) -> dict | None:
     patch = change.get("diff")
     if not isinstance(path, str) or not path or not isinstance(patch, str):
       continue
-    if patch.startswith("diff --git "):
-      sections.append(patch)
-      continue
     raw_kind = change.get("kind")
     kind = raw_kind if isinstance(raw_kind, dict) else {}
     kind_type = str(kind.get("type") or "update")
+    # The pinned Codex app-server contract carries complete file content for
+    # add/delete changes and unified diff text for updates. Dispatch on that
+    # typed distinction before inspecting content: a valid new file may itself
+    # begin with diff metadata such as `diff --git`, `@@`, or `GIT binary patch`.
+    if kind_type in {"add", "delete"}:
+      patch_lines = _content_hunk(patch, kind_type)
+    elif patch.startswith("diff --git "):
+      sections.append(patch)
+      continue
+    else:
+      patch_lines = patch.splitlines()
     move_path = kind.get("move_path")
     new_path = move_path if isinstance(move_path, str) and move_path else path
     header = [
@@ -145,26 +153,5 @@ def codex_edit_preview(changes: Any) -> dict | None:
         f"--- {_git_path('a', path)}",
         f"+++ {_git_path('b', new_path)}",
       ])
-    # FileUpdateChange.diff is not one stable shape: updates and some
-    # add/delete events carry hunk text, while other add/delete events carry
-    # the complete file body with no @@ header or +/- prefixes. Normalize that
-    # provider variation here so every durable preview is an honest unified
-    # diff rather than a file header followed by unparseable source text.
-    patch_lines = patch.splitlines()
-    first_patch_line = patch_lines[0] if patch_lines else ""
-    patch_is_diff = (
-      first_patch_line.startswith("@@ ")
-      or (
-        first_patch_line.startswith("Binary files ")
-        and first_patch_line.endswith(" differ")
-      )
-      or first_patch_line == "GIT binary patch"
-    )
-    if (
-      kind_type in {"add", "delete"}
-      and patch
-      and not patch_is_diff
-    ):
-      patch_lines = _content_hunk(patch, kind_type)
     sections.append("\n".join([*header, *patch_lines]))
   return _bounded_preview("\n".join(sections))

--- a/backend/tests/test_tool_edit_preview.py
+++ b/backend/tests/test_tool_edit_preview.py
@@ -1,6 +1,10 @@
 """Provider edit tools preserve bounded, renderable diff previews."""
 
-from app.codex_events import _tool_start_event
+from app.codex_events import (
+  _file_change_patch_summary,
+  _tool_completed_events,
+  _tool_start_event,
+)
 from app.events import process_event
 from app.tool_edit_preview import (
   MAX_EDIT_PREVIEW_CHARS,
@@ -67,6 +71,38 @@ def test_codex_patch_preview_keeps_multiple_file_kinds_and_bounds_payload():
   assert len(large["_full_diff"]) > len(large["diff"])
 
 
+def test_codex_raw_add_and_delete_bodies_become_countable_hunks():
+  preview = codex_edit_preview([
+    {
+      "path": "new.py",
+      "kind": {"type": "add"},
+      "diff": "import os\n\nprint(os.getcwd())\n",
+    },
+    {
+      "path": "gone.txt",
+      "kind": {"type": "delete"},
+      "diff": "first\nsecond\n",
+    },
+  ])
+
+  assert "@@ -0,0 +1,3 @@\n+import os\n+\n+print(os.getcwd())" in preview["diff"]
+  assert "@@ -1,2 +0,0 @@\n-first\n-second" in preview["diff"]
+
+
+def test_codex_empty_file_and_existing_hunks_are_not_invented_or_rewritten():
+  preview = codex_edit_preview([
+    {"path": "empty.txt", "kind": {"type": "add"}, "diff": ""},
+    {
+      "path": "new.txt",
+      "kind": {"type": "add"},
+      "diff": "@@ -0,0 +1 @@\n+already unified",
+    },
+  ])
+
+  assert preview["diff"].count("@@ ") == 1
+  assert preview["diff"].count("+already unified") == 1
+
+
 def test_preview_quoting_preserves_unicode_paths():
   preview = codex_edit_preview([{
     "path": "/data/café file.py",
@@ -98,6 +134,44 @@ def test_codex_file_change_start_carries_shared_edit_preview():
   assert event["tool"] == "Edit"
   assert event["input"] == "src/app.js"
   assert "-old\n+new" in event["edit_preview"]["diff"]
+
+
+def test_codex_file_change_fallback_summary_uses_owner_language():
+  summary = _file_change_patch_summary([
+    {"path": "new.py", "kind": {"type": "add"}},
+    {"path": "old.py", "kind": {"type": "delete"}},
+    {
+      "path": "before.py",
+      "kind": {"type": "update", "move_path": "after.py"},
+    },
+    {"path": "same.py", "kind": {"type": "update"}},
+  ])
+
+  assert summary.splitlines() == [
+    "Added new.py",
+    "Deleted old.py",
+    "Moved before.py → after.py",
+    "Updated same.py",
+  ]
+  assert "{'type':" not in summary
+
+
+def test_codex_completed_file_change_emits_the_owner_language_fallback():
+  class FileChangeThreadItem:
+    changes = [{"path": "new.py", "kind": {"type": "add"}}]
+
+  sdk = {
+    "CommandExecutionThreadItem": type("CommandExecutionThreadItem", (), {}),
+    "FileChangeThreadItem": FileChangeThreadItem,
+    "McpToolCallThreadItem": type("McpToolCallThreadItem", (), {}),
+    "DynamicToolCallThreadItem": type("DynamicToolCallThreadItem", (), {}),
+    "WebSearchThreadItem": type("WebSearchThreadItem", (), {}),
+  }
+
+  assert _tool_completed_events(FileChangeThreadItem(), sdk) == [
+    {"type": "tool_output", "content": "Added new.py"},
+    {"type": "tool_end"},
+  ]
 
 
 def test_tool_lifecycle_persists_preview_from_start_and_input_updates():

--- a/backend/tests/test_tool_edit_preview.py
+++ b/backend/tests/test_tool_edit_preview.py
@@ -1,10 +1,5 @@
 """Provider edit tools preserve bounded, renderable diff previews."""
 
-from openai_codex.generated.v2_all import (
-  FileChangeThreadItem as CodexFileChangeThreadItem,
-  PatchApplyStatus,
-)
-
 from app.codex_events import (
   _file_change_patch_summary,
   _tool_completed_events,
@@ -194,17 +189,20 @@ def test_codex_completed_file_change_summary_uses_owner_language():
   assert "{'type':" not in summary
 
 
-def _codex_file_change_item(status: PatchApplyStatus):
-  return CodexFileChangeThreadItem.model_validate({
-    "id": "edit-1",
-    "type": "fileChange",
-    "status": status.value,
-    "changes": [{
+class CodexFileChangeThreadItem:
+  """Minimal generated-SDK-shaped item for dependency-independent tests."""
+
+  def __init__(self, status: str):
+    self.status = status
+    self.changes = [{
       "path": "new.py",
       "kind": {"type": "add"},
       "diff": "hello\n",
-    }],
-  })
+    }]
+
+
+def _codex_file_change_item(status: str):
+  return CodexFileChangeThreadItem(status)
 
 
 def test_codex_completed_file_change_emits_applied_owner_language():
@@ -214,7 +212,7 @@ def test_codex_completed_file_change_emits_applied_owner_language():
   }
 
   assert _tool_completed_events(
-    _codex_file_change_item(PatchApplyStatus.completed), sdk,
+    _codex_file_change_item("completed"), sdk,
   ) == [
     {"type": "tool_output", "content": "Added new.py"},
     {"type": "tool_end"},
@@ -228,8 +226,8 @@ def test_codex_failed_and_declined_file_changes_never_claim_application():
   }
 
   expected = {
-    PatchApplyStatus.failed: "Failed to add new.py",
-    PatchApplyStatus.declined: "Declined: add new.py",
+    "failed": "Failed to add new.py",
+    "declined": "Declined: add new.py",
   }
   for status, summary in expected.items():
     assert _tool_completed_events(_codex_file_change_item(status), sdk) == [

--- a/backend/tests/test_tool_edit_preview.py
+++ b/backend/tests/test_tool_edit_preview.py
@@ -1,5 +1,10 @@
 """Provider edit tools preserve bounded, renderable diff previews."""
 
+from openai_codex.generated.v2_all import (
+  FileChangeThreadItem as CodexFileChangeThreadItem,
+  PatchApplyStatus,
+)
+
 from app.codex_events import (
   _file_change_patch_summary,
   _tool_completed_events,
@@ -53,7 +58,7 @@ def test_codex_patch_preview_keeps_multiple_file_kinds_and_bounds_payload():
     {
       "path": "new.py",
       "kind": {"type": "add"},
-      "diff": "@@ -0,0 +1 @@\n+hello",
+      "diff": "hello\n",
     },
   ])
 
@@ -64,7 +69,7 @@ def test_codex_patch_preview_keeps_multiple_file_kinds_and_bounds_payload():
   large = codex_edit_preview([{
     "path": "large.txt",
     "kind": {"type": "add"},
-    "diff": "@@ -0,0 +1 @@\n+" + ("x" * (MAX_EDIT_PREVIEW_CHARS + 100)),
+    "diff": "x" * (MAX_EDIT_PREVIEW_CHARS + 100),
   }])
   assert large["truncated"] is True
   assert len(large["diff"]) == MAX_EDIT_PREVIEW_CHARS
@@ -89,18 +94,51 @@ def test_codex_raw_add_and_delete_bodies_become_countable_hunks():
   assert "@@ -1,2 +0,0 @@\n-first\n-second" in preview["diff"]
 
 
-def test_codex_empty_file_and_existing_hunks_are_not_invented_or_rewritten():
+def test_codex_empty_file_and_update_hunks_are_not_invented_or_rewritten():
   preview = codex_edit_preview([
     {"path": "empty.txt", "kind": {"type": "add"}, "diff": ""},
     {
       "path": "new.txt",
-      "kind": {"type": "add"},
-      "diff": "@@ -0,0 +1 @@\n+already unified",
+      "kind": {"type": "update"},
+      "diff": "@@ -1 +1 @@\n-old\n+already unified",
     },
   ])
 
   assert preview["diff"].count("@@ ") == 1
   assert preview["diff"].count("+already unified") == 1
+
+
+def test_codex_raw_file_bodies_treat_diff_metadata_prefixes_as_content():
+  changes = [
+    {
+      "path": "patch-fixture.txt",
+      "kind": {"type": "add"},
+      "diff": "diff --git a/old b/new\n@@ -1 +1 @@\n-old\n+new\n",
+    },
+    {
+      "path": "release-marker.txt",
+      "kind": {"type": "add"},
+      "diff": "@@ release marker\nactual body\n",
+    },
+    {
+      "path": "binary-sentence.txt",
+      "kind": {"type": "delete"},
+      "diff": "Binary files cats and dogs differ\nsecond line\n",
+    },
+    {
+      "path": "binary-patch.txt",
+      "kind": {"type": "delete"},
+      "diff": "GIT binary patch\nliteral text\n",
+    },
+  ]
+
+  diff = codex_edit_preview(changes)["diff"]
+
+  assert "diff --git a/patch-fixture.txt b/patch-fixture.txt" in diff
+  assert "+diff --git a/old b/new" in diff
+  assert "+@@ release marker\n+actual body" in diff
+  assert "-Binary files cats and dogs differ\n-second line" in diff
+  assert "-GIT binary patch\n-literal text" in diff
 
 
 def test_preview_quoting_preserves_unicode_paths():
@@ -136,7 +174,7 @@ def test_codex_file_change_start_carries_shared_edit_preview():
   assert "-old\n+new" in event["edit_preview"]["diff"]
 
 
-def test_codex_file_change_fallback_summary_uses_owner_language():
+def test_codex_completed_file_change_summary_uses_owner_language():
   summary = _file_change_patch_summary([
     {"path": "new.py", "kind": {"type": "add"}},
     {"path": "old.py", "kind": {"type": "delete"}},
@@ -145,7 +183,7 @@ def test_codex_file_change_fallback_summary_uses_owner_language():
       "kind": {"type": "update", "move_path": "after.py"},
     },
     {"path": "same.py", "kind": {"type": "update"}},
-  ])
+  ], status="completed")
 
   assert summary.splitlines() == [
     "Added new.py",
@@ -156,21 +194,57 @@ def test_codex_file_change_fallback_summary_uses_owner_language():
   assert "{'type':" not in summary
 
 
-def test_codex_completed_file_change_emits_the_owner_language_fallback():
-  class FileChangeThreadItem:
-    changes = [{"path": "new.py", "kind": {"type": "add"}}]
+def _codex_file_change_item(status: PatchApplyStatus):
+  return CodexFileChangeThreadItem.model_validate({
+    "id": "edit-1",
+    "type": "fileChange",
+    "status": status.value,
+    "changes": [{
+      "path": "new.py",
+      "kind": {"type": "add"},
+      "diff": "hello\n",
+    }],
+  })
 
+
+def test_codex_completed_file_change_emits_applied_owner_language():
   sdk = {
     "CommandExecutionThreadItem": type("CommandExecutionThreadItem", (), {}),
-    "FileChangeThreadItem": FileChangeThreadItem,
-    "McpToolCallThreadItem": type("McpToolCallThreadItem", (), {}),
-    "DynamicToolCallThreadItem": type("DynamicToolCallThreadItem", (), {}),
-    "WebSearchThreadItem": type("WebSearchThreadItem", (), {}),
+    "FileChangeThreadItem": CodexFileChangeThreadItem,
   }
 
-  assert _tool_completed_events(FileChangeThreadItem(), sdk) == [
+  assert _tool_completed_events(
+    _codex_file_change_item(PatchApplyStatus.completed), sdk,
+  ) == [
     {"type": "tool_output", "content": "Added new.py"},
     {"type": "tool_end"},
+  ]
+
+
+def test_codex_failed_and_declined_file_changes_never_claim_application():
+  sdk = {
+    "CommandExecutionThreadItem": type("CommandExecutionThreadItem", (), {}),
+    "FileChangeThreadItem": CodexFileChangeThreadItem,
+  }
+
+  expected = {
+    PatchApplyStatus.failed: "Failed to add new.py",
+    PatchApplyStatus.declined: "Declined: add new.py",
+  }
+  for status, summary in expected.items():
+    assert _tool_completed_events(_codex_file_change_item(status), sdk) == [
+      {"type": "tool_output", "content": summary},
+      {"type": "tool_end"},
+    ]
+
+
+def test_codex_in_progress_file_change_summary_is_explicitly_proposed():
+  assert _file_change_patch_summary([
+    {"path": "new.py", "kind": {"type": "add"}},
+    {"path": "old.py", "kind": {"type": "delete"}},
+  ], status="inProgress").splitlines() == [
+    "Proposed: add new.py",
+    "Proposed: delete old.py",
   ]
 
 


### PR DESCRIPTION
## Summary
- normalize Codex raw add/delete file bodies into renderable unified hunks while preserving existing and binary diff shapes
- translate completed file changes into concise Added, Deleted, Moved, and Updated summaries instead of provider model representations
- cover raw bodies, empty files, moves, final event output, and bounded preview behavior

## Prior work
This is a focused follow-up to merged PR #754, which established shared provider edit previews. The follow-up closes two gaps exposed by Codex's current event shapes: some add/delete payloads contain raw file bodies, and completion summaries otherwise expose provider-internal dictionaries.

## Testing
- focused edit-preview suite: 10 passed
- complete backend suite: 4,307 passed, 3 skipped
- canonical diff and whitespace checks passed