### PR TITLE
Bound database startup failures to one readiness verdict

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -151,7 +151,7 @@ FastAPI app. `main.py` is the factory (CORS, rate limiting, routers, static serv
 | `config.py` | `Settings` via pydantic-settings; reads `.env` |
 | `database.py` | SQLAlchemy engine, pool instrumentation, `SessionLocal`, `Base`, and `get_db`; contains no schema history |
 | `schema_migrations.py` | Append-only schema/data migrations, durable ledger primitives, and ORM/live-schema parity inspection; published functions are semantic-hash frozen |
-| `startup.py` | Two-phase boot: process/schema preflight first, then writer/reconciliation/database supervisors only after schema parity succeeds |
+| `startup.py` | Two-phase boot: process/database preflight first, then writer/reconciliation/database supervisors only after migrations and mapped-shape checks succeed |
 | `models.py` | ORM tables: `Owner`, `Chat`, `ChatRun`, `App`, `PushSubscription`, `Notification` |
 | `schemas.py` | Pydantic request/response models |
 | `auth.py` | bcrypt hashing, JWT creation/decoding, Fernet encryption |
@@ -213,23 +213,25 @@ Self-hosters use the authority they already own:
 `docker compose exec -u 0 app bash`. This attaches to the live container and
 does not replace its normal process.
 
-### Health, readiness, and schema-degraded boot
+### Health, readiness, and database-degraded boot
 
 `GET /api/health` is reachability and remains HTTP 200 whenever the process can
 answer; the shell uses that distinction so a server fault never masquerades as
 the device being offline. `GET /api/ready` is serviceability: it requires both
-an ORM-compatible database and the single-writer persistence actor. Deployment
-and container probes use readiness. `GET /api/health/strict` retains the
-schema-only diagnostic contract.
+a successfully initialized database with every mapped table and column, and
+the single-writer persistence actor. Deployment and container probes use
+readiness. `GET /api/health/strict` retains the database-only diagnostic
+contract.
 
-Boot runs `create_all`, append-only migrations, and `orm_schema_gaps()` before
-starting any database owner. A remaining gap enters a bounded degraded mode:
-ordinary APIs return one deterministic 503, database startup tasks and
-supervisors do not run, cron remains disabled, and static shell plus health,
-version, browser-bootstrap, and authenticated restart surfaces remain. External
-Recovery may alter the database, but the process intentionally keeps its boot
-verdict until restart; promoting only part of the skipped startup plan inside a
-health probe would create a second, race-prone boot mechanism.
+Boot runs `create_all`, append-only migrations, and `mapped_schema_gaps()` before
+starting any database owner. A migration/initialization failure or remaining
+mapped-shape gap enters one bounded degraded mode: ordinary APIs return a
+deterministic 503, database startup tasks and supervisors do not run, cron
+remains disabled, and static shell plus health, version, browser-bootstrap, and
+the normally authenticated restart surface remain. External Recovery may alter
+the database, but the process intentionally keeps its boot verdict until
+restart; promoting only part of the skipped startup plan inside a health probe
+would create a second, race-prone boot mechanism.
 
 ### Misc shared helpers
 
@@ -486,6 +488,13 @@ The in-product agent is a first-class reader of this code, and its behavior has 
 ├── published/<token>/      published site snapshots (shareable /sites/<token>/ URLs)
 └── service-token.txt       owner JWT used only by the platform job wrapper (chmod 600)
 ```
+
+SQLite is the shipped and tested persistence runtime. Some frozen historical
+migrations retain PostgreSQL branches because already-published migration code
+is immutable; those branches are compatibility history, not a second supported
+deployment contract. Adding another database therefore requires an explicit
+driver, end-to-end migration/readiness coverage, and deployment documentation
+rather than relying on those old conditional statements.
 
 `/data` is itself a git repo owned by the `mobius` user, tracking `shared/memory/` and `shared/skills/` with a nightly safety-net commit, so a bad memory consolidation or skill overwrite is recoverable. Inspect it as that user (`docker exec -u mobius ... git -C /data ...`) — as root it dies with "dubious ownership," which reads misleadingly as an empty/non-repo tree.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ frozen previous-release input; never regenerate it from current metadata,
 which would make a missing `ALTER TABLE` invisible. Advance that fixture only
 as an explicit release-baseline change. The upgrade contract runs production's
 `create_all` → migrations order twice, requires an idempotent ledger, and then
-requires `orm_schema_gaps()` to be empty.
+requires `mapped_schema_gaps()` to be empty.
 
 The semantic-history manifest freezes every published migration function. A
 new migration appends its version and hash; a changed existing hash means the
@@ -90,11 +90,11 @@ scripts/test.sh --fast
 scripts/wt-pytest.sh backend/tests/test_db_migrations.py -q
 ```
 
-A boot that still finds an ORM/schema gap deliberately starts no writer,
-reconciliation, scheduled work, or database supervisors. It serves only the
-shell and bounded diagnostic/restart APIs with `/api/ready` at 503. Recovery
-repairs the database externally; a clean restart is then required to run the
-skipped startup phase as one coherent transition.
+A boot whose migrations fail or whose mapped tables/columns remain incomplete
+deliberately starts no writer, reconciliation, scheduled work, or database
+supervisors. It serves only the shell and bounded diagnostic/restart APIs with
+`/api/ready` at 503. Recovery repairs the database externally; a clean restart
+is then required to run the skipped startup phase as one coherent transition.
 
 CI runs the equivalent natively: install `frontend/package-lock.json`, put its
 locked `node_modules/.bin` on `PATH`, install the hashed

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -42,7 +42,7 @@ from app.database import (
   reset_database_request_label,
   set_database_request_label,
 )
-from app.schema_migrations import orm_schema_gaps, run_migrations
+from app.schema_migrations import mapped_schema_gaps, run_migrations
 from app.http_caching import strip_range
 from app.frontend_assets import (
   baked_frontend_dir,
@@ -82,9 +82,46 @@ from app.routes import (
 )
 
 _BOOT_ID = os.environ.get("MOBIUS_BOOT_ID") or f"{os.getpid()}-{time.time_ns()}"
-# ORM-vs-database schema gaps found at startup; non-empty means the process
-# answers but cannot serve turns (see health vs health_strict).
-_SCHEMA_GAPS: list[str] = []
+# One boot verdict feeds startup ownership, middleware, and every health probe.
+# These stay fixed until restart: Recovery may repair the database externally,
+# but only a clean boot can coherently start the skipped database owners.
+_DATABASE_BOOT_RESULT = None
+
+
+def _set_database_boot_state(result) -> None:
+  global _DATABASE_BOOT_RESULT
+  _DATABASE_BOOT_RESULT = result
+
+
+def _database_degraded_payload() -> dict | None:
+  result = _DATABASE_BOOT_RESULT
+  if result is None or result.serviceable:
+    return None
+  if result.failure_reason:
+    return {"reason": result.failure_reason}
+  if result.schema_gaps:
+    return {
+      "reason": "schema_mismatch",
+      "schema_gaps": list(result.schema_gaps),
+    }
+  return None
+
+
+def _database_init_error_is_transient(exc: OperationalError) -> bool:
+  """Retry only connection loss or SQLite lock contention at boot.
+
+  Deterministic migration/DDL errors are also ``OperationalError`` instances.
+  Retrying those ten times only delays the same degraded verdict and obscures
+  the first useful traceback. SQLite lock errors and invalidated connections
+  can genuinely clear without changing the release, so retain the bounded
+  retry for those cases.
+  """
+  if exc.connection_invalidated:
+    return True
+  if engine.dialect.name != "sqlite":
+    return False
+  detail = str(exc.orig or exc).lower()
+  return "locked" in detail or "busy" in detail
 
 
 def _install_pm_commit_launcher(source: Path, target: Path) -> bool:
@@ -104,7 +141,7 @@ def _install_pm_commit_launcher(source: Path, target: Path) -> bool:
   return True
 
 
-def _init_db() -> list[str]:
+def _init_db():
   """Create missing tables, then migrate existing ones, with retries.
 
   Creating tables first lets a migration move legacy data into a newly
@@ -112,12 +149,13 @@ def _init_db() -> list[str]:
   mutates existing tables, so column upgrades remain owned by
   ``run_migrations``.
   """
+  from app.startup import DatabaseBootResult
+
   for attempt in range(10):
     try:
       Base.metadata.create_all(bind=engine)
       run_migrations(engine)
-      gaps = orm_schema_gaps(engine)
-      _SCHEMA_GAPS[:] = gaps
+      gaps = mapped_schema_gaps(engine)
       if gaps:
         # A mapped column with no migration fails at first query, not at
         # boot. Surface it loudly here and through /api/health(+/strict)
@@ -126,9 +164,9 @@ def _init_db() -> list[str]:
           "CRITICAL: database is missing ORM-declared schema: "
           + ", ".join(gaps)
         )
-      return list(gaps)
+      return DatabaseBootResult(schema_gaps=tuple(gaps))
     except OperationalError as e:
-      if attempt < 9:
+      if attempt < 9 and _database_init_error_is_transient(e):
         delay = min(2 ** attempt, 10)
         print(f"DB init retry {attempt + 1}/10 in {delay}s: {e}")
         time.sleep(delay)
@@ -169,7 +207,8 @@ async def lifespan(app):
     assert_provider_defaults=_assert_provider_defaults,
     logger=_log,
   )
-  database_serviceable = await run_startup_plan(startup_context)
+  database_boot = await run_startup_plan(startup_context)
+  _set_database_boot_state(database_boot)
   from app.runtime_supervisors import RuntimeSupervisors
   supervisors = RuntimeSupervisors(
     settings=settings,
@@ -179,7 +218,7 @@ async def lifespan(app):
   )
   await supervisors.start_process_services()
   record_memory_checkpoint("startup_frontend_watcher_started")
-  if database_serviceable:
+  if database_boot.serviceable:
     await supervisors.start_database_services()
     record_memory_checkpoint("startup_ready")
   try:
@@ -568,7 +607,7 @@ class _ServiceSurfaceHostMiddleware:
     return await self.app(scope, receive, send)
 
 
-_SCHEMA_DEGRADED_API_PATHS = frozenset({
+_DATABASE_DEGRADED_API_PATHS = frozenset({
   "/api/health",
   "/api/health/strict",
   "/api/ready",
@@ -578,8 +617,8 @@ _SCHEMA_DEGRADED_API_PATHS = frozenset({
 })
 
 
-class _SchemaServiceabilityMiddleware:
-  """Reject ordinary API work after a schema-incompatible boot.
+class _DatabaseServiceabilityMiddleware:
+  """Reject ordinary API work after an incompatible database boot.
 
   Readiness keeps a new deployment out of rotation, but an already-running
   reverse proxy can still reach an unhealthy replacement directly. Centralize
@@ -595,15 +634,16 @@ class _SchemaServiceabilityMiddleware:
 
   async def __call__(self, scope, receive, send):
     path = scope.get("path", "")
+    degraded = _database_degraded_payload()
     if (
       scope["type"] == "http"
-      and _SCHEMA_GAPS
+      and degraded
       and path.startswith("/api/")
-      and path not in _SCHEMA_DEGRADED_API_PATHS
+      and path not in _DATABASE_DEGRADED_API_PATHS
     ):
       body = json.dumps({
-        "detail": "database schema mismatch; restart after Recovery",
-        "schema_gaps": list(_SCHEMA_GAPS),
+        "detail": "database is not serviceable; use Recovery, then restart",
+        **degraded,
       }, separators=(",", ":")).encode()
       await send({
         "type": "http.response.start",
@@ -710,7 +750,7 @@ app.add_middleware(_OpaqueOriginCorsMiddleware)
 # before routing so it can never serve the shell, APIs, or another
 # service prefix.
 app.add_middleware(_ServiceSurfaceHostMiddleware)
-app.add_middleware(_SchemaServiceabilityMiddleware)
+app.add_middleware(_DatabaseServiceabilityMiddleware)
 app.add_middleware(_SecurityHeadersMiddleware)
 app.add_middleware(_DatabaseRequestContextMiddleware)
 app.add_middleware(_RequestErrorTelemetryMiddleware)
@@ -786,36 +826,36 @@ def health(response: Response):
   reloading while the old process is still briefly answering before SIGTERM.
   """
   response.headers["Cache-Control"] = "no-store"
+  degraded = _database_degraded_payload()
   payload = {
-    "status": "schema_mismatch" if _SCHEMA_GAPS else "ok",
+    "status": degraded["reason"] if degraded else "ok",
     "target": "mobius",
-    "mode": "normal",
+    "mode": "degraded" if degraded else "normal",
     "build_sha": settings.build_sha,
     "boot_id": _BOOT_ID,
   }
-  if _SCHEMA_GAPS:
-    # Still HTTP 200: the shell's reachability probe requires response.ok,
-    # and a schema gap must not masquerade as "device offline". The strict
-    # variant below carries the 5xx for container health.
-    payload["schema_gaps"] = _SCHEMA_GAPS
+  if degraded:
+    # Still HTTP 200: database failure must never masquerade as device offline.
+    # The strict and readiness variants below carry the 5xx service verdict.
+    payload.update(degraded)
   return payload
 
 
 @app.get("/api/health/strict")
 def health_strict(response: Response):
-  """Schema-focused serviceability probe retained for diagnostics.
+  """Database-focused serviceability probe retained for diagnostics.
 
   Distinct from `/api/health` (reachability — must stay 200 whenever the
   process answers, or the shell would flip devices to offline UI): this
-  variant fails when the database is missing ORM-declared schema. Deployment
-  healthchecks use `/api/ready`, which includes this schema contract plus the
-  chat-persistence writer contract.
+  variant fails when database initialization fails or mapped schema is absent.
+  Deployment healthchecks use `/api/ready`, which includes this database
+  contract plus the chat-persistence writer contract.
   """
   response.headers["Cache-Control"] = "no-store"
-  gaps = list(_SCHEMA_GAPS)
-  if gaps:
+  degraded = _database_degraded_payload()
+  if degraded:
     response.status_code = 503
-    return {"status": "schema_mismatch", "schema_gaps": gaps}
+    return {"status": degraded["reason"], **degraded}
   return {"status": "ok", "boot_id": _BOOT_ID}
 
 
@@ -838,7 +878,8 @@ def ready(response: Response):
   """Readiness probe: 200 only when chats can actually be served.
 
   Distinct from `/api/health` (reachability — the process is answering HTTP),
-  this route also requires an ORM-compatible database and a usable
+  this route also requires a successfully initialized database with every
+  mapped table and column, plus a usable
   single-writer chat-persistence actor. A deploy must not green while a mapped
   column is absent or every chat write will fail, even though the process can
   still answer ordinary HTTP requests.
@@ -851,13 +892,12 @@ def ready(response: Response):
   window where this false-fails.
   """
   response.headers["Cache-Control"] = "no-store"
-  gaps = list(_SCHEMA_GAPS)
-  if gaps:
+  degraded = _database_degraded_payload()
+  if degraded:
     response.status_code = 503
     return {
       "ready": False,
-      "reason": "schema_mismatch",
-      "schema_gaps": gaps,
+      **degraded,
     }
   from app.chat_writer import writer_readiness
   is_ready, reason = writer_readiness()

--- a/backend/app/runtime_supervisors.py
+++ b/backend/app/runtime_supervisors.py
@@ -4,7 +4,7 @@ Startup reconciliation is owned by ``startup.py``. This module owns only work
 that remains alive after readiness: watcher processes, periodic chat recovery,
 durable continuation wakeups, writer health, background compression, and
 browser-profile quota enforcement. Process-only and database-backed services
-have distinct start boundaries so a schema-degraded boot can keep source
+have distinct start boundaries so a database-degraded boot can keep source
 diagnostics alive without starting database work. ``stop`` remains the single
 shutdown boundary.
 """

--- a/backend/app/schema_migrations.py
+++ b/backend/app/schema_migrations.py
@@ -1348,8 +1348,8 @@ def _add_connector_capability_identity(eng) -> None:
       ))
 
 
-def orm_schema_gaps(eng) -> list[str]:
-  """ORM-mapped columns/tables the live database lacks (``table.column``).
+def mapped_schema_gaps(eng) -> list[str]:
+  """Mapped columns/tables the live database lacks (``table.column``).
 
   Runs after ``create_all`` + migrations, so any gap is a written-code bug
   (a declared column with no migration), not a pending upgrade. Such a gap

--- a/backend/app/startup.py
+++ b/backend/app/startup.py
@@ -1,9 +1,9 @@
 """Two-phase startup for the owner-facing service.
 
-Process setup and schema verification run first. Database-backed ownership,
-reconciliation, and background work run only after the live database matches
-the ORM. A schema-incompatible process can therefore serve bounded diagnostics
-without executing partial maintenance against a database it cannot understand.
+Process setup and database verification run first. Database-backed ownership,
+reconciliation, and background work run only after migrations complete and the
+live database has every mapped table and column. An incompatible database can
+therefore serve bounded diagnostics without executing partial maintenance.
 """
 
 from __future__ import annotations
@@ -31,12 +31,32 @@ class StartupSettings(Protocol):
   data_dir: str
 
 
+@dataclass(frozen=True)
+class DatabaseBootResult:
+  """One explicit verdict for every database-backed startup owner."""
+
+  schema_gaps: tuple[str, ...] = ()
+  failure_reason: str | None = None
+
+  @property
+  def reason(self) -> str | None:
+    if self.failure_reason:
+      return self.failure_reason
+    if self.schema_gaps:
+      return "schema_mismatch"
+    return None
+
+  @property
+  def serviceable(self) -> bool:
+    return self.reason is None
+
+
 @dataclass
 class StartupContext:
   app: StartupApp
   settings: StartupSettings
   boot_id: str
-  init_db: Callable[[], list[str]]
+  init_db: Callable[[], DatabaseBootResult]
   install_pm_commit_launcher: Callable[[Path, Path], bool]
   assert_provider_defaults: Callable[[object], None]
   logger: logging.Logger = field(
@@ -45,7 +65,7 @@ class StartupContext:
   restart_authorization: str | None = None
   manual_reconciled_chats: list[str] = field(default_factory=list)
   restart_fallback_chats: list[str] = field(default_factory=list)
-  schema_gaps: list[str] = field(default_factory=list)
+  database_boot: DatabaseBootResult = field(default_factory=DatabaseBootResult)
 
 
 TaskAction = Callable[[StartupContext], object | Awaitable[object]]
@@ -55,7 +75,6 @@ TaskAction = Callable[[StartupContext], object | Awaitable[object]]
 class StartupTask:
   name: str
   action: TaskAction
-  critical: bool = False
   checkpoint: str | None = None
 
 
@@ -70,14 +89,6 @@ async def run_startup_tasks(
       if inspect.isawaitable(result):
         await result
     except Exception as exc:
-      if task.critical:
-        context.logger.critical(
-          "critical startup task %s failed: %s",
-          task.name,
-          exc,
-          exc_info=True,
-        )
-        raise
       context.logger.error(
         "startup task %s failed: %s",
         task.name,
@@ -89,24 +100,28 @@ async def run_startup_tasks(
         record_memory_checkpoint(task.checkpoint)
 
 
-async def run_startup_plan(context: StartupContext) -> bool:
+async def run_startup_plan(context: StartupContext) -> DatabaseBootResult:
   """Run process setup, then database services only when schema-safe.
 
-  Returns whether the database-backed application was started. The caller uses
-  that same outcome to decide which long-lived supervisors may start, keeping
-  one schema-serviceability decision for the entire boot.
+  Returns the database verdict used by HTTP diagnostics and long-lived
+  supervisors, keeping one serviceability decision for the entire boot.
   """
   await run_startup_tasks(context, PROCESS_STARTUP_TASKS)
-  if context.schema_gaps:
-    context.logger.critical(
-      "database schema mismatch; skipped %d database startup task(s): %s",
-      len(DATABASE_STARTUP_TASKS),
-      ", ".join(context.schema_gaps),
+  if not context.database_boot.serviceable:
+    detail = (
+      ", ".join(context.database_boot.schema_gaps)
+      or str(context.database_boot.failure_reason)
     )
-    record_memory_checkpoint("startup_schema_degraded")
-    return False
+    context.logger.critical(
+      "database startup degraded (%s); skipped %d database task(s): %s",
+      context.database_boot.reason,
+      len(DATABASE_STARTUP_TASKS),
+      detail,
+    )
+    record_memory_checkpoint("startup_database_degraded")
+    return context.database_boot
   await run_startup_tasks(context, DATABASE_STARTUP_TASKS)
-  return True
+  return context.database_boot
 
 
 def _refresh_commit_launcher(context: StartupContext) -> None:
@@ -130,7 +145,16 @@ def _remove_legacy_auto_resume_setting(context: StartupContext) -> None:
 
 
 def _initialize_database(context: StartupContext) -> None:
-  context.schema_gaps = context.init_db()
+  try:
+    context.database_boot = context.init_db()
+  except Exception as exc:
+    context.logger.critical(
+      "database initialization failed: %s", exc, exc_info=True,
+    )
+    context.database_boot = DatabaseBootResult(
+      failure_reason="database_initialization_failed",
+    )
+  record_memory_checkpoint("startup_database_checked")
 
 
 def _purge_expired_chats(context: StartupContext) -> None:
@@ -372,8 +396,6 @@ PROCESS_STARTUP_TASKS = (
   StartupTask(
     "initialize database",
     _initialize_database,
-    critical=True,
-    checkpoint="startup_database_initialized",
   ),
 )
 

--- a/backend/scripts/seed-skills/platform-maintenance.md
+++ b/backend/scripts/seed-skills/platform-maintenance.md
@@ -222,11 +222,12 @@ edit a migration already present in the ledger. Test both a fresh database and
 the frozen previous-release upgrade fixture rather than assuming model metadata
 altered the latter.
 
-If `/api/ready` reports `reason: schema_mismatch`, the process has deliberately
-skipped its writer, reconciliation, cron, and database supervisors. Recovery
-repairs the database externally, then the partner approves one normal restart
-so boot can verify parity and start those owners coherently. Do not hand-edit
-the in-memory readiness verdict or try to start skipped owners piecemeal.
+If `/api/ready` reports `reason: schema_mismatch` or
+`database_initialization_failed`, the process has deliberately skipped its
+writer, reconciliation, cron, and database supervisors. Recovery repairs the
+database externally, then the partner approves one normal restart so boot can
+verify the database and start those owners coherently. Do not hand-edit the
+in-memory readiness verdict or try to start skipped owners piecemeal.
 
 ---
 

--- a/backend/tests/test_db_migrations.py
+++ b/backend/tests/test_db_migrations.py
@@ -63,7 +63,7 @@ def test_previous_release_database_upgrades_to_current_orm(tmp_path):
   first_history = schema_migration_history(eng)
   run_migrations(eng)
 
-  assert migrations.orm_schema_gaps(eng) == []
+  assert migrations.mapped_schema_gaps(eng) == []
   assert schema_migration_history(eng) == first_history
   assert [row["version"] for row in first_history] == [
     version for version, _migration in migrations._SCHEMA_MIGRATIONS
@@ -1790,16 +1790,16 @@ def test_connector_oauth_gcloud_migration_upgrades_legacy_rows_idempotently(
   }
 
 
-def test_orm_schema_gaps_reports_missing_columns(tmp_path):
+def test_mapped_schema_gaps_reports_missing_columns(tmp_path):
   from app.database import Base
-  from app.schema_migrations import orm_schema_gaps
+  from app.schema_migrations import mapped_schema_gaps
 
   eng = create_engine(f"sqlite:///{tmp_path / 'parity.db'}")
   Base.metadata.create_all(bind=eng)
-  assert orm_schema_gaps(eng) == []
+  assert mapped_schema_gaps(eng) == []
   with eng.begin() as conn:
     conn.execute(text("ALTER TABLE apps DROP COLUMN connections_manage"))
-  assert "apps.connections_manage" in orm_schema_gaps(eng)
+  assert "apps.connections_manage" in mapped_schema_gaps(eng)
 
 
 def test_connectors_migration_preserves_preview_era_rows(tmp_path):

--- a/backend/tests/test_readiness.py
+++ b/backend/tests/test_readiness.py
@@ -16,9 +16,13 @@ singleton.
 
 from pathlib import Path
 
+import pytest
+from sqlalchemy.exc import OperationalError
+
 from app import chat_writer, main as main_module
 from app.chat_writer import get_writer
 from app.database import SessionLocal
+from app.startup import DatabaseBootResult
 
 
 def _wait_for_healthy_writer():
@@ -44,7 +48,7 @@ def test_ready_returns_200_when_writer_running(client):
 def test_schema_gap_fails_serviceability_but_not_reachability(client):
   """A mapped-column gap must keep every deployment probe fail-closed."""
   gap = "apps.paused_capabilities"
-  main_module._SCHEMA_GAPS[:] = [gap]
+  main_module._set_database_boot_state(DatabaseBootResult(schema_gaps=(gap,)))
   try:
     ready = client.get("/api/ready")
     assert ready.status_code == 503
@@ -57,32 +61,72 @@ def test_schema_gap_fails_serviceability_but_not_reachability(client):
     assert strict.status_code == 503
     assert strict.json() == {
       "status": "schema_mismatch",
+      "reason": "schema_mismatch",
       "schema_gaps": [gap],
     }
     reachable = client.get("/api/health")
     assert reachable.status_code == 200
     assert reachable.json()["status"] == "schema_mismatch"
+    assert reachable.json()["reason"] == "schema_mismatch"
+    assert reachable.json()["mode"] == "degraded"
     gated = client.get("/api/apps")
     assert gated.status_code == 503
     assert gated.json() == {
-      "detail": "database schema mismatch; restart after Recovery",
+      "detail": "database is not serviceable; use Recovery, then restart",
+      "reason": "schema_mismatch",
       "schema_gaps": [gap],
     }
     assert client.get("/api/version").status_code == 200
   finally:
-    main_module._SCHEMA_GAPS.clear()
+    main_module._set_database_boot_state(DatabaseBootResult())
+
+
+def test_database_initialization_failure_uses_the_same_degraded_boundary(client):
+  result = DatabaseBootResult(
+    failure_reason="database_initialization_failed",
+  )
+  main_module._set_database_boot_state(result)
+  try:
+    ready = client.get("/api/ready")
+    assert ready.status_code == 503
+    assert ready.json() == {
+      "ready": False,
+      "reason": "database_initialization_failed",
+    }
+    strict = client.get("/api/health/strict")
+    assert strict.status_code == 503
+    assert strict.json() == {
+      "status": "database_initialization_failed",
+      "reason": "database_initialization_failed",
+    }
+    reachable = client.get("/api/health")
+    assert reachable.status_code == 200
+    assert reachable.json()["status"] == "database_initialization_failed"
+    assert reachable.json()["mode"] == "degraded"
+    gated = client.get("/api/apps")
+    assert gated.status_code == 503
+    assert gated.json() == {
+      "detail": "database is not serviceable; use Recovery, then restart",
+      "reason": "database_initialization_failed",
+    }
+  finally:
+    main_module._set_database_boot_state(DatabaseBootResult())
 
 
 def test_external_schema_repair_requires_a_clean_startup(client):
   """A degraded boot never starts skipped DB owners partway through life."""
-  main_module._SCHEMA_GAPS[:] = ["apps.paused_capabilities"]
+  main_module._set_database_boot_state(DatabaseBootResult(
+    schema_gaps=("apps.paused_capabilities",),
+  ))
   try:
     ready = client.get("/api/ready")
     assert ready.status_code == 503
     assert ready.json()["reason"] == "schema_mismatch"
-    assert main_module._SCHEMA_GAPS == ["apps.paused_capabilities"]
+    assert main_module._DATABASE_BOOT_RESULT.schema_gaps == (
+      "apps.paused_capabilities",
+    )
   finally:
-    main_module._SCHEMA_GAPS.clear()
+    main_module._set_database_boot_state(DatabaseBootResult())
 
 
 def test_deployment_healthchecks_use_the_serviceability_probe():
@@ -100,6 +144,54 @@ def test_deployment_healthchecks_use_the_serviceability_probe():
   assert 'http://127.0.0.1:8000/api/ready' in (
     root / "backend/scripts/verify_test_runtime.py"
   ).read_text(encoding="utf-8")
+
+
+def test_database_boot_retries_lock_contention(monkeypatch):
+  locked = OperationalError(
+    "ALTER TABLE apps", {}, RuntimeError("database is locked"),
+  )
+  assert main_module._database_init_error_is_transient(locked) is True
+
+  calls = 0
+  sleeps = []
+
+  def locked_once(*_args, **_kwargs):
+    nonlocal calls
+    calls += 1
+    if calls == 1:
+      raise locked
+
+  monkeypatch.setattr(main_module.Base.metadata, "create_all", locked_once)
+  monkeypatch.setattr(main_module, "run_migrations", lambda _engine: None)
+  monkeypatch.setattr(main_module, "mapped_schema_gaps", lambda _engine: [])
+  monkeypatch.setattr(main_module.time, "sleep", sleeps.append)
+
+  assert main_module._init_db() == DatabaseBootResult()
+  assert calls == 2
+  assert sleeps == [1]
+
+
+def test_database_boot_does_not_retry_broken_migration_sql(monkeypatch):
+  broken = OperationalError(
+    "ALTER TABLE apps", {}, RuntimeError("no such column: broken"),
+  )
+  assert main_module._database_init_error_is_transient(broken) is False
+
+  calls = 0
+  sleeps = []
+
+  def fail_create_all(*_args, **_kwargs):
+    nonlocal calls
+    calls += 1
+    raise broken
+
+  monkeypatch.setattr(main_module.Base.metadata, "create_all", fail_create_all)
+  monkeypatch.setattr(main_module.time, "sleep", sleeps.append)
+  with pytest.raises(OperationalError):
+    main_module._init_db()
+
+  assert calls == 1
+  assert sleeps == []
 
 
 def test_writer_probe_transactions_end_before_readiness():

--- a/backend/tests/test_startup_tasks.py
+++ b/backend/tests/test_startup_tasks.py
@@ -5,6 +5,7 @@ import pytest
 
 import app.startup as startup
 from app.startup import (
+  DatabaseBootResult,
   StartupContext,
   StartupTask,
   run_startup_plan,
@@ -17,7 +18,7 @@ def context():
     app=SimpleNamespace(state=SimpleNamespace()),
     settings=SimpleNamespace(data_dir="/tmp"),
     boot_id="test-boot",
-    init_db=lambda: [],
+    init_db=DatabaseBootResult,
     install_pm_commit_launcher=lambda _source, _target: False,
     assert_provider_defaults=lambda _names: None,
     logger=logging.getLogger("test.startup"),
@@ -48,26 +49,6 @@ async def test_best_effort_startup_failure_is_named_and_does_not_stop_plan(
 
 
 @pytest.mark.asyncio
-async def test_critical_startup_failure_stops_before_later_tasks():
-  events = []
-
-  def fail(_context):
-    events.append("database")
-    raise RuntimeError("database unavailable")
-
-  def must_not_run(_context):
-    events.append("later")
-
-  with pytest.raises(RuntimeError, match="database unavailable"):
-    await run_startup_tasks(context(), (
-      StartupTask("database", fail, critical=True),
-      StartupTask("later", must_not_run),
-    ))
-
-  assert events == ["database"]
-
-
-@pytest.mark.asyncio
 async def test_checkpoints_record_only_successful_named_outcomes(monkeypatch):
   checkpoints = []
   monkeypatch.setattr(
@@ -87,14 +68,11 @@ async def test_checkpoints_record_only_successful_named_outcomes(monkeypatch):
   assert checkpoints == ["complete_checkpoint"]
 
 
-def test_production_startup_plan_has_explicit_unique_order_and_criticality():
+def test_production_startup_plan_has_explicit_unique_order():
   tasks = startup.PROCESS_STARTUP_TASKS + startup.DATABASE_STARTUP_TASKS
   names = [task.name for task in tasks]
 
   assert len(names) == len(set(names))
-  assert [task.name for task in tasks if task.critical] == [
-    "initialize database",
-  ]
   assert startup.PROCESS_STARTUP_TASKS[-1].name == "initialize database"
   assert startup.DATABASE_STARTUP_TASKS[0].name == "start chat writer"
   assert names.index("initialize database") < names.index("start chat writer")
@@ -118,7 +96,9 @@ async def test_schema_mismatch_skips_the_entire_database_startup_phase(
 ):
   events = []
   startup_context = context()
-  startup_context.init_db = lambda: ["apps.paused_capabilities"]
+  startup_context.init_db = lambda: DatabaseBootResult(
+    schema_gaps=("apps.paused_capabilities",),
+  )
   monkeypatch.setattr(startup, "PROCESS_STARTUP_TASKS", (
     StartupTask("initialize database", startup._initialize_database),
   ))
@@ -129,13 +109,52 @@ async def test_schema_mismatch_skips_the_entire_database_startup_phase(
   monkeypatch.setattr(startup, "record_memory_checkpoint", checkpoints.append)
 
   with caplog.at_level(logging.CRITICAL, logger="test.startup"):
-    serviceable = await run_startup_plan(startup_context)
+    result = await run_startup_plan(startup_context)
 
-  assert serviceable is False
-  assert startup_context.schema_gaps == ["apps.paused_capabilities"]
+  assert result.serviceable is False
+  assert startup_context.database_boot.schema_gaps == (
+    "apps.paused_capabilities",
+  )
   assert events == []
-  assert checkpoints == ["startup_schema_degraded"]
-  assert "skipped 1 database startup task" in caplog.text
+  assert checkpoints == [
+    "startup_database_checked",
+    "startup_database_degraded",
+  ]
+  assert "skipped 1 database task" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_database_initialization_failure_enters_bounded_degraded_boot(
+  monkeypatch, caplog,
+):
+  events = []
+  startup_context = context()
+
+  def fail_init():
+    raise RuntimeError("broken migration")
+
+  startup_context.init_db = fail_init
+  monkeypatch.setattr(startup, "PROCESS_STARTUP_TASKS", (
+    StartupTask("initialize database", startup._initialize_database),
+  ))
+  monkeypatch.setattr(startup, "DATABASE_STARTUP_TASKS", (
+    StartupTask("must not run", lambda _context: events.append("database")),
+  ))
+  checkpoints = []
+  monkeypatch.setattr(startup, "record_memory_checkpoint", checkpoints.append)
+
+  with caplog.at_level(logging.CRITICAL, logger="test.startup"):
+    result = await run_startup_plan(startup_context)
+
+  assert result == DatabaseBootResult(
+    failure_reason="database_initialization_failed",
+  )
+  assert events == []
+  assert checkpoints == [
+    "startup_database_checked",
+    "startup_database_degraded",
+  ]
+  assert "database initialization failed: broken migration" in caplog.text
 
 
 @pytest.mark.asyncio
@@ -148,7 +167,7 @@ async def test_schema_safe_boot_runs_the_database_startup_phase(monkeypatch):
     StartupTask("database", lambda _context: events.append("database")),
   ))
 
-  serviceable = await run_startup_plan(context())
+  result = await run_startup_plan(context())
 
-  assert serviceable is True
+  assert result.serviceable is True
   assert events == ["process", "database"]

--- a/scripts/deploy-prod.sh
+++ b/scripts/deploy-prod.sh
@@ -783,9 +783,9 @@ served_version_field() {  # $1 = json key
 }
 
 # The HTTP status of the complete serviceability probe. /api/health is
-# reachability only; /api/ready also requires an ORM-compatible database and a
-# usable single-writer persistence actor. "000" means the container is down or
-# curl could not reach it.
+# reachability only; /api/ready also requires successful database initialization,
+# every mapped table/column, and a usable single-writer persistence actor.
+# "000" means the container is down or curl could not reach it.
 readiness_code() {
   local target="$1"
   docker exec "$target" sh -c "curl -s -o /dev/null -w '%{http_code}' '${INTERNAL_BASE}/api/ready'" 2>/dev/null || echo "000"
@@ -801,6 +801,9 @@ report_readiness_failure() {
   case "$body" in
     *'"reason":"schema_mismatch"'*)
       fail "the database schema does not match this release; run Recovery, then restart cleanly."
+      ;;
+    *'"reason":"database_initialization_failed"'*)
+      fail "database initialization failed; run Recovery, then restart cleanly."
       ;;
     *'"reason":'*)
       fail "the persistence service is not ready."
@@ -1691,8 +1694,9 @@ else
   exit 1
 fi
 
-# Complete readiness: fail if either schema parity or persistence ownership is
-# unavailable, even though the process still answers the reachability probe.
+# Complete readiness: fail if either database initialization/mapped shape or
+# persistence ownership is unavailable, even though the process still answers
+# the reachability probe.
 rcode=$(ready_code)
 if [ "$rcode" = "200" ]; then
   ok "internal /api/ready:  ${rcode}"


### PR DESCRIPTION
## Summary
- drive database boot, readiness, middleware, and runtime supervisors from one DatabaseBootResult
- degrade boundedly on migration or initialization failure instead of crashing or starting partial database owners
- retry invalidated connections and SQLite locked/busy failures, but surface deterministic SQL errors immediately
- make mapped-schema inspection naming explicit and document SQLite as a supported shipped runtime
- keep basic health reachable while strict readiness reports database degradation

## Prior work
This is a focused follow-up to merged PR #811's database migration and bootstrap work. It consolidates the remaining reusable startup, retry, readiness, deployment, and documentation changes found in the local branch.

## Testing
- focused startup, readiness, and migration suite: 79 passed
- complete backend suite: 4,306 passed, 3 skipped
- canonical diff and whitespace checks passed