### PR TITLE
Show built apps in the artifact picker

### DIFF
--- a/frontend/src/components/ChatView/ArtifactPickerSection.jsx
+++ b/frontend/src/components/ChatView/ArtifactPickerSection.jsx
@@ -1,0 +1,95 @@
+/* ArtifactPickerSection renders the chat's latest app and document previews. */
+
+import AppIcon from '../AppIcon.jsx'
+import { formatRelativeTime } from '../../lib/relativeTime.js'
+
+function artifactSubtitle(item, latest = false) {
+  const relativeTime = formatRelativeTime(item.touchedAt)
+  if (item.kind === 'app') {
+    return relativeTime ? `App · Updated ${relativeTime}` : 'App · Open preview'
+  }
+  if (latest) {
+    return relativeTime
+      ? `Edited here ${relativeTime} · v${item.version}`
+      : `Edited in this chat · v${item.version}`
+  }
+  return relativeTime || `Version ${item.version}`
+}
+
+function ArtifactIcon({ artifact, documentIcon }) {
+  return artifact.kind === 'app' ? (
+    <AppIcon
+      item={artifact.app}
+      label={artifact.title}
+      className="composer-popover__app-icon"
+    />
+  ) : (
+    <span className="composer-popover__row-icon" aria-hidden="true">
+      {documentIcon}
+    </span>
+  )
+}
+
+export default function ArtifactPickerSection({
+  latestArtifact,
+  otherArtifacts,
+  expanded,
+  onToggle,
+  onOpenArtifact,
+  documentIcon,
+  disclosureIcon,
+}) {
+  const otherCount = otherArtifacts.length
+  return (
+    <div className="composer-popover__section composer-popover__section--artifacts">
+      {otherCount > 0 ? (
+        <button
+          type="button"
+          className={`composer-popover__artifact-heading${expanded ? ' composer-popover__artifact-heading--expanded' : ''}`}
+          aria-expanded={expanded}
+          aria-label={expanded
+            ? 'Hide other artifacts'
+            : `Show ${otherCount} more artifacts`}
+          onClick={onToggle}
+        >
+          <span className="composer-popover__eyebrow">Latest artifacts</span>
+          <span className="composer-popover__artifact-count" aria-hidden="true">
+            {otherCount + 1}
+          </span>
+          {disclosureIcon}
+        </button>
+      ) : (
+        <span className="composer-popover__eyebrow">Latest artifacts</span>
+      )}
+      <button
+        type="button"
+        className="composer-popover__row composer-popover__artifact-latest"
+        onClick={() => onOpenArtifact(latestArtifact)}
+      >
+        <ArtifactIcon artifact={latestArtifact} documentIcon={documentIcon} />
+        <span className="composer-popover__row-main">
+          <span className="composer-popover__row-title">{latestArtifact.title}</span>
+          <span className="composer-popover__row-sub">{artifactSubtitle(latestArtifact, true)}</span>
+        </span>
+      </button>
+      {expanded && otherCount > 0 && (
+        <div className="composer-popover__artifact-list">
+          {otherArtifacts.map(artifact => (
+            <button
+              key={artifact.key}
+              type="button"
+              className="composer-popover__row"
+              onClick={() => onOpenArtifact(artifact)}
+            >
+              <ArtifactIcon artifact={artifact} documentIcon={documentIcon} />
+              <span className="composer-popover__row-main">
+                <span className="composer-popover__row-title">{artifact.title}</span>
+                <span className="composer-popover__row-sub">{artifactSubtitle(artifact)}</span>
+              </span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -5117,6 +5117,8 @@ export default function ChatView({
                 artifactsAppId={artifactsAppId}
                 onOpenArtifact={onOpenArtifact}
                 onOpenUsage={() => setShowUsage(true)}
+                appArtifacts={builtApps}
+                onOpenAppArtifact={onOpenApp}
                 embedded={embedded}
               />
               )}

--- a/frontend/src/components/ChatView/ChatWork.css
+++ b/frontend/src/components/ChatView/ChatWork.css
@@ -15,7 +15,50 @@
   letter-spacing: 0.02em;
 }
 
+.composer-popover__artifact-heading {
+  align-self: flex-start;
+  min-height: 44px;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 0 8px 0 0;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  font: inherit;
+}
+
+.composer-popover__artifact-heading .composer-popover__eyebrow {
+  padding-bottom: 3px;
+}
+
+.composer-popover__artifact-count {
+  font-size: 11px;
+  font-weight: 650;
+  line-height: 1;
+}
+
+.composer-popover__artifact-heading svg {
+  transition: transform 0.16s ease;
+}
+
+.composer-popover__artifact-heading--expanded svg {
+  transform: rotate(180deg);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .composer-popover__artifact-heading:hover { color: var(--text); }
+}
+
+.composer-popover__artifact-heading:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
 .composer-popover__artifact-latest {
+  border-radius: 10px;
   background: color-mix(in srgb, var(--accent) 7%, transparent);
 }
 
@@ -24,49 +67,31 @@
   background: color-mix(in srgb, var(--accent) 11%, var(--surface2));
 }
 
-.composer-popover__artifact-more {
-  margin-top: 2px;
+.composer-popover__app-icon {
+  flex: 0 0 auto;
+  width: 34px;
+  height: 34px;
+  border-radius: 10px;
+  font-size: 10px;
+  box-shadow: 0 5px 14px color-mix(in srgb, var(--text) 10%, transparent);
 }
 
-.composer-popover__artifact-summary {
-  min-height: 36px;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 4px 10px;
-  border-radius: 8px;
-  color: var(--muted);
-  cursor: pointer;
-  list-style: none;
-  font-size: 12px;
-  line-height: 1.35;
-}
-
-.composer-popover__artifact-summary::-webkit-details-marker { display: none; }
-
-.composer-popover__artifact-summary span:first-child { flex: 1; }
-
-.composer-popover__artifact-summary svg {
-  transition: transform 0.16s ease;
-}
-
-.composer-popover__artifact-more[open] .composer-popover__artifact-summary svg {
-  transform: rotate(180deg);
-}
-
-@media (hover: hover) and (pointer: fine) {
-  .composer-popover__artifact-summary:hover { background: var(--surface2); }
+/* Transparent artwork has no container surface to cast a shadow from. Keeping
+   the rectangular shadow here exposed the image's full PNG bounds as a dark
+   square around otherwise transparent app icons. */
+.composer-popover__app-icon.is-image {
+  box-shadow: none;
 }
 
 .composer-popover__artifact-list {
   display: flex;
   flex-direction: column;
   gap: 1px;
-  padding-top: 1px;
+  padding-top: 3px;
 }
 
 .composer-popover__artifact-list .composer-popover__row {
-  padding-left: 14px;
+  padding-left: 10px;
 }
 
 .chat-work__overlay {

--- a/frontend/src/components/ChatView/ComposerPopover.jsx
+++ b/frontend/src/components/ChatView/ComposerPopover.jsx
@@ -4,7 +4,7 @@
  *
  *   1. Attach files + chat changes — calls `onAttachClick` (parent owns the hidden
  *      <input type="file"> so it can clear .value after each pick).
- *   2. Artifacts touched by this chat, with the latest always exposed.
+ *   2. Apps built here and artifacts touched by this chat.
  *   3. Model / effort / summary / automation — renders
  *      <ChatSettingsPanel> when a chatInfo is available; omitted on a fresh
  *      empty chat where chatInfo hasn't loaded yet.
@@ -48,9 +48,12 @@ import {
 } from '@openai/apps-sdk-ui/components/Icon'
 import BrainUsageIcon from './BrainUsageIcon.jsx'
 import ChatSettingsPanel from './ChatSettingsPanel.jsx'
-import { loadChatArtifacts } from './chatArtifacts.js'
+import ArtifactPickerSection from './ArtifactPickerSection.jsx'
+import {
+  chatArtifactPickerItems,
+  loadChatArtifacts,
+} from './chatArtifacts.js'
 import { apiFetch } from '../../api/client.js'
-import { formatRelativeTime } from '../../lib/relativeTime.js'
 import { popoverMaxHeight, nearestClipTop } from './composerPopoverHeight.js'
 import { focusComposerElement } from './composerFocusPolicy.js'
 import {
@@ -90,6 +93,8 @@ export default function ComposerPopover({
   artifactsAppId = null,
   onOpenArtifact,
   onOpenUsage,
+  appArtifacts = [],
+  onOpenAppArtifact,
   embedded = false,
   pending = false,
   triggerIcon = null,
@@ -125,16 +130,18 @@ export default function ComposerPopover({
     staleTime: 0,
   })
   const chatArtifacts = artifactsQuery.data || []
-  const latestArtifact = chatArtifacts[0] || null
-  const latestArtifactRelativeTime = latestArtifact
-    ? formatRelativeTime(latestArtifact.touchedAt)
-    : ''
-  const otherArtifacts = chatArtifacts.slice(1)
+  const artifactItems = chatArtifactPickerItems(appArtifacts, chatArtifacts)
+  const latestArtifact = artifactItems[0] || null
+  const otherArtifacts = artifactItems.slice(1)
+  const [artifactsExpanded, setArtifactsExpanded] = useState(false)
   useDiscardUnconfirmedSwitchOnPickerClose(
     open,
     providerSwitchState?.status,
     chatId,
   )
+  useEffect(() => {
+    if (!open) setArtifactsExpanded(false)
+  }, [open])
   // Measured cap on the panel's height: the space above the trigger inside both
   // the chat pane (which clips with `overflow: hidden`) and the keyboard-shrunk
   // visible viewport. See composerPopoverHeight.js for why CSS viewport units
@@ -269,6 +276,19 @@ export default function ComposerPopover({
     onOpenUsage?.()
   }
 
+  function handleOpenAppArtifact(app) {
+    setOpen(false)
+    onOpenAppArtifact?.(app)
+  }
+
+  function handleOpenArtifactItem(item) {
+    if (item.kind === 'app') {
+      handleOpenAppArtifact(item.app)
+      return
+    }
+    handleOpenArtifact(item.id)
+  }
+
   function togglePopover() {
     const el = composerInputRef?.current
     const wasFocused = document.activeElement === el
@@ -342,7 +362,7 @@ export default function ComposerPopover({
               </button>
             )}
           </div>
-          {!embedded && artifactsAppId && artifactsQuery.isLoading && (
+          {!embedded && artifactsAppId && artifactsQuery.isLoading && !latestArtifact && (
             <div className="composer-popover__section composer-popover__section--artifacts">
               <span className="composer-popover__eyebrow">Latest artifact</span>
               <div className="composer-popover__row" role="status">
@@ -355,7 +375,7 @@ export default function ComposerPopover({
               </div>
             </div>
           )}
-          {!embedded && artifactsAppId && artifactsQuery.isError && (
+          {!embedded && artifactsAppId && artifactsQuery.isError && !latestArtifact && (
             <div className="composer-popover__section composer-popover__section--artifacts">
               <button
                 type="button"
@@ -373,52 +393,15 @@ export default function ComposerPopover({
             </div>
           )}
           {!embedded && latestArtifact && (
-            <div className="composer-popover__section composer-popover__section--artifacts">
-              <span className="composer-popover__eyebrow">Latest artifact</span>
-              <button
-                type="button"
-                className="composer-popover__row composer-popover__artifact-latest"
-                onClick={() => handleOpenArtifact(latestArtifact.id)}
-              >
-                <span className="composer-popover__row-icon" aria-hidden="true">
-                  <FileDocument width={18} height={18} />
-                </span>
-                <span className="composer-popover__row-main">
-                  <span className="composer-popover__row-title">{latestArtifact.title}</span>
-                  <span className="composer-popover__row-sub">
-                    {latestArtifactRelativeTime
-                      ? `Edited here ${latestArtifactRelativeTime} · v${latestArtifact.version}`
-                      : `Edited in this chat · v${latestArtifact.version}`}
-                  </span>
-                </span>
-              </button>
-              {otherArtifacts.length > 0 && (
-                <details className="composer-popover__artifact-more">
-                  <summary className="composer-popover__artifact-summary">
-                    <span>Other artifacts</span>
-                    <span>{otherArtifacts.length}</span>
-                    <ChevronDown width={15} height={15} aria-hidden="true" />
-                  </summary>
-                  <div className="composer-popover__artifact-list">
-                    {otherArtifacts.map(artifact => (
-                      <button
-                        key={artifact.id}
-                        type="button"
-                        className="composer-popover__row"
-                        onClick={() => handleOpenArtifact(artifact.id)}
-                      >
-                        <span className="composer-popover__row-main">
-                          <span className="composer-popover__row-title">{artifact.title}</span>
-                          <span className="composer-popover__row-sub">
-                            {formatRelativeTime(artifact.touchedAt) || `Version ${artifact.version}`}
-                          </span>
-                        </span>
-                      </button>
-                    ))}
-                  </div>
-                </details>
-              )}
-            </div>
+            <ArtifactPickerSection
+              latestArtifact={latestArtifact}
+              otherArtifacts={otherArtifacts}
+              expanded={artifactsExpanded}
+              onToggle={() => setArtifactsExpanded(value => !value)}
+              onOpenArtifact={handleOpenArtifactItem}
+              documentIcon={<FileDocument width={18} height={18} />}
+              disclosureIcon={<ChevronDown width={15} height={15} aria-hidden="true" />}
+            />
           )}
           {chatInfo && chatId && (
             <div className="composer-popover__section composer-popover__section--picker">

--- a/frontend/src/components/ChatView/__tests__/artifactPickerSection.test.js
+++ b/frontend/src/components/ChatView/__tests__/artifactPickerSection.test.js
@@ -1,0 +1,38 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+import ArtifactPickerSection from '../ArtifactPickerSection.jsx'
+
+test('artifact disclosure keeps its count with the heading and shows every app icon', () => {
+  const html = renderToStaticMarkup(createElement(ArtifactPickerSection, {
+    latestArtifact: {
+      key: 'app:8',
+      kind: 'app',
+      title: 'Reflection',
+      touchedAt: '2026-08-27T17:00:00Z',
+      app: { id: 8, name: 'Reflection', icon_url: '/api/apps/8/icon?v=1' },
+    },
+    otherArtifacts: [{
+      key: 'app:9',
+      kind: 'app',
+      title: 'Memory',
+      touchedAt: '2026-08-27T16:00:00Z',
+      app: { id: 9, name: 'Memory', icon_url: '/api/apps/9/icon?v=1' },
+    }],
+    expanded: true,
+    onToggle: () => {},
+    onOpenArtifact: () => {},
+    disclosureIcon: createElement('svg', { 'aria-hidden': 'true' }),
+  }))
+
+  assert.match(
+    html,
+    /composer-popover__artifact-heading[^>]*>[\s\S]*?Latest artifacts[\s\S]*?composer-popover__artifact-count[^>]*>2</,
+  )
+  assert.match(html, /aria-label="Hide other artifacts"/)
+  assert.match(html, /src="\/api\/apps\/8\/icon\?v=1&amp;size=128"/)
+  assert.match(html, /src="\/api\/apps\/9\/icon\?v=1&amp;size=128"/)
+  assert.match(html, />Memory</)
+})

--- a/frontend/src/components/ChatView/__tests__/chatArtifacts.test.js
+++ b/frontend/src/components/ChatView/__tests__/chatArtifacts.test.js
@@ -2,9 +2,41 @@ import test from 'node:test'
 import assert from 'node:assert/strict'
 
 import {
+  appArtifactsFromBuiltApps,
   artifactTouchForChat,
   artifactsTouchedByChat,
+  chatArtifactPickerItems,
 } from '../chatArtifacts.js'
+
+test('built apps become durable chat artifacts without duplicate rows', () => {
+  const apps = appArtifactsFromBuiltApps([
+    { id: 7, name: 'Atlas', updated_at: '2026-08-20T10:00:00Z' },
+    { id: 9, name: 'Canvas', updated_at: '2026-08-21T10:00:00Z' },
+    { id: 7, name: 'Atlas refined', updated_at: '2026-08-22T10:00:00Z' },
+  ])
+  assert.deepEqual(apps.map(app => app.name), ['Atlas refined', 'Canvas'])
+})
+
+test('artifact picker orders apps and documents together by their chat touch', () => {
+  const items = chatArtifactPickerItems([
+    { id: 7, name: 'Atlas', updated_at: '2026-08-22T10:00:00Z' },
+    { id: 9, name: 'Canvas', updated_at: '2026-08-20T10:00:00Z' },
+  ], [
+    {
+      id: 'launch-brief',
+      title: 'Launch brief',
+      touchedAt: '2026-08-21T10:00:00Z',
+      version: 2,
+    },
+  ])
+
+  assert.deepEqual(items.map(item => item.key), [
+    'app:7',
+    'artifact:launch-brief',
+    'app:9',
+  ])
+  assert.equal(items[0].title, 'Atlas')
+})
 
 test('chat artifacts are attributed by version touch, not global record recency', () => {
   const records = [

--- a/frontend/src/components/ChatView/chatArtifacts.js
+++ b/frontend/src/components/ChatView/chatArtifacts.js
@@ -57,6 +57,43 @@ export function artifactsTouchedByChat(records, chatId) {
     .sort((left, right) => timestamp(right.touchedAt) - timestamp(left.touchedAt))
 }
 
+// Apps keep their own durable chat attribution on the app row. Project that
+// same server truth into the chat's artifact picker so opening a preview leaves
+// a reusable way back to the app after the short-lived preview CTA retires.
+// Newest wins if a stale/refetched array briefly carries the same id twice.
+export function appArtifactsFromBuiltApps(builtApps) {
+  const seen = new Set()
+  const items = []
+  for (let index = (Array.isArray(builtApps) ? builtApps.length : 0) - 1;
+    index >= 0; index -= 1) {
+    const app = builtApps[index]
+    const id = Number(app?.id)
+    if (!Number.isInteger(id) || id <= 0 || seen.has(id)) continue
+    seen.add(id)
+    items.push(app)
+  }
+  return items
+}
+
+export function chatArtifactPickerItems(builtApps, artifacts) {
+  const appItems = appArtifactsFromBuiltApps(builtApps).map(app => ({
+    key: `app:${app.id}`,
+    kind: 'app',
+    id: Number(app.id),
+    title: String(app.name || 'Untitled app'),
+    touchedAt: app.updated_at || app.created_at || '',
+    app,
+  }))
+  const documentItems = (Array.isArray(artifacts) ? artifacts : []).map(artifact => ({
+    ...artifact,
+    key: `artifact:${artifact.id}`,
+    kind: 'artifact',
+    title: String(artifact.title || 'Untitled artifact'),
+  }))
+  return [...appItems, ...documentItems]
+    .sort((left, right) => timestamp(right.touchedAt) - timestamp(left.touchedAt))
+}
+
 export async function loadChatArtifacts(appId, chatId, { signal, request } = {}) {
   if (typeof request !== 'function') {
     throw new Error('Artifact loading requires a request function.')

--- a/frontend/src/components/Shell/builtAppState.js
+++ b/frontend/src/components/Shell/builtAppState.js
@@ -57,6 +57,10 @@ export function derivedBuiltApps(apps, chatId) {
   return scoped.map(a => ({
     id: a.id,
     name: a.name,
+    ...(a.slug ? { slug: a.slug } : {}),
+    ...(a.icon_url ? { icon_url: a.icon_url } : {}),
+    ...(a.background_color ? { background_color: a.background_color } : {}),
+    ...(a.theme_color ? { theme_color: a.theme_color } : {}),
     updated_at: a.updated_at,
     preview_seen_updated_at: a.preview_seen_updated_at ?? null,
     preview_seen_final: Boolean(a.preview_seen_final),


### PR DESCRIPTION
## Summary
- combine apps built by a chat with its document artifacts in one touched-time picker
- keep the newest item visible and expand older work on demand
- retain source-driven app icons and clear subtitles for app versus document entries
- reset expansion when the composer menu closes and preserve the current usage/provider controls
- make the visible artifact count match the complete expanded list

## Prior work
Draft PR #954 improves artifact discovery in related app chats. This is intentionally separate: it changes the owner chat’s composer picker and adds built apps as a second artifact kind, so broadening the already-reviewed draft would mix independent behavior.

## Testing
- complete frontend suite: 2,723 library/component tests and 93 hook tests passed
- lint: 0 errors and 46 existing warnings
- production/PWA build passed
- authenticated 426×860 owner-viewport review passed in collapsed and expanded states with real app and document records
- canonical diff and whitespace checks passed