### PR TITLE
Add an owner-approved anonymous contribution relay

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,3 +33,9 @@ MOBIUS_AGENT_SUDO=1
 # automatically from mobius.you.
 # MOBIUS_IDENTITY_ISSUER=https://www.mobius.you
 # MOBIUS_AGENT_GATEWAY_URL=https://www.mobius.you
+# Anonymous contribution relay. The relay URL defaults to the identity issuer,
+# but the reviewed target is deliberately explicit. Non-mobius-os targets are
+# rejected unless they are also named in the test-only allowlist.
+# MOBIUS_CONTRIBUTION_RELAY_URL=https://www.mobius.you
+# MOBIUS_CONTRIBUTION_TARGET_REPO=mobius-os/mobius
+# MOBIUS_CONTRIBUTION_RELAY_TEST_REPOSITORIES=owner/test-repository

--- a/backend/app/contribution_broker.py
+++ b/backend/app/contribution_broker.py
@@ -1,0 +1,165 @@
+"""Narrow client for the root-owned Möbius contribution relay surface."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+
+DEFAULT_SOCKET = "/run/mobius-identity-broker.sock"
+CONTRIBUTION_PREFIX = "/v1/contributions"
+MAX_REQUEST_BYTES = 3_000_000
+MAX_RESPONSE_BYTES = 1_000_000
+_CONTRIBUTION_ID = re.compile(r"^ctr_[0-9a-f]{32}$")
+_WITHDRAW_PATH = re.compile(
+  r"^/v1/contributions/(ctr_[0-9a-f]{32})/withdraw$"
+)
+_IDEMPOTENCY_KEY = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{15,127}$")
+
+
+@dataclass
+class ContributionBrokerError(Exception):
+  status_code: int
+  detail: str
+  code: str = "contribution_unavailable"
+  retry_after: int | None = None
+
+
+def canonical_body(value: Any | None) -> bytes:
+  if value is None:
+    return b""
+  return json.dumps(
+    value, sort_keys=True, separators=(",", ":"), ensure_ascii=False,
+  ).encode("utf-8")
+
+
+def bound_request_id(
+  method: str, path: str, body: bytes, idempotency_key: str | None,
+) -> str:
+  material = b"mobius-contribution-bff-v1\0"
+  material += method.upper().encode("ascii") + b"\0" + path.encode("utf-8")
+  material += b"\0" + (idempotency_key or "").encode("utf-8") + b"\0" + body
+  return "contribution:" + hashlib.sha256(material).hexdigest()
+
+
+class ContributionBrokerClient:
+  def __init__(
+    self,
+    *,
+    socket_path: str | None = None,
+    transport: httpx.AsyncBaseTransport | None = None,
+  ) -> None:
+    self.socket_path = socket_path or os.environ.get(
+      "MOBIUS_IDENTITY_BROKER_SOCKET", DEFAULT_SOCKET,
+    )
+    self.transport = transport
+
+  @staticmethod
+  def _allowed(method: str, path: str) -> bool:
+    return (
+      method == "POST" and path == CONTRIBUTION_PREFIX
+    ) or (
+      method == "POST" and _WITHDRAW_PATH.fullmatch(path) is not None
+    ) or (
+      method == "GET"
+      and path.startswith(CONTRIBUTION_PREFIX + "/")
+      and _CONTRIBUTION_ID.fullmatch(path.removeprefix(CONTRIBUTION_PREFIX + "/"))
+      is not None
+    )
+
+  async def request(
+    self,
+    method: str,
+    path: str,
+    *,
+    body: Any | None = None,
+    idempotency_key: str | None = None,
+  ) -> tuple[Any, int, dict[str, str]]:
+    method = method.upper()
+    if not self._allowed(method, path):
+      raise ValueError("contribution broker path is outside its allow-list")
+    if method == "POST" and not _IDEMPOTENCY_KEY.fullmatch(
+      str(idempotency_key or "")
+    ):
+      raise ContributionBrokerError(
+        400, "A valid Idempotency-Key is required.", "invalid_idempotency_key",
+      )
+    encoded = canonical_body(body)
+    if len(encoded) > MAX_REQUEST_BYTES:
+      raise ContributionBrokerError(
+        413,
+        "This contribution is too large to send safely as one pull request.",
+        "contribution_too_large",
+      )
+    headers = {
+      "Accept": "application/json",
+      "X-Mobius-Request-Id": bound_request_id(
+        method, path, encoded, idempotency_key,
+      ),
+    }
+    if encoded:
+      headers["Content-Type"] = "application/json"
+    if idempotency_key:
+      headers["Idempotency-Key"] = idempotency_key
+    transport = self.transport or httpx.AsyncHTTPTransport(uds=self.socket_path)
+    try:
+      async with httpx.AsyncClient(
+        transport=transport,
+        base_url="http://mobius-identity-broker",
+        timeout=120.0,
+        follow_redirects=False,
+      ) as client:
+        async with client.stream(
+          method, path, content=encoded if encoded else None, headers=headers,
+        ) as response:
+          content = bytearray()
+          async for chunk in response.aiter_bytes():
+            if len(content) + len(chunk) > MAX_RESPONSE_BYTES:
+              raise ContributionBrokerError(
+                502, "The Möbius contribution service response was too large."
+              )
+            content.extend(chunk)
+          status_code = response.status_code
+          response_headers = {
+            key.lower(): value for key, value in response.headers.items()
+            if key.lower() in {"retry-after"}
+          }
+    except httpx.HTTPError as exc:
+      raise ContributionBrokerError(
+        503, "The Möbius contribution service could not be reached.",
+      ) from exc
+    try:
+      payload = json.loads(content) if content else {}
+    except ValueError as exc:
+      raise ContributionBrokerError(
+        502, "The Möbius contribution service returned an invalid response."
+      ) from exc
+    if status_code >= 400:
+      error = payload.get("error") if isinstance(payload, dict) else None
+      if isinstance(error, dict):
+        detail = str(error.get("message") or "The contribution request failed.")
+        code = str(error.get("code") or "contribution_error")
+        retry_after = error.get("retry_after")
+      else:
+        detail = "The contribution request failed."
+        code = "contribution_error"
+        retry_after = None
+      try:
+        retry_after = int(
+          retry_after or response_headers.get("retry-after") or 0
+        ) or None
+      except (TypeError, ValueError):
+        retry_after = None
+      raise ContributionBrokerError(
+        status_code, detail, code, retry_after,
+      )
+    return payload, status_code, response_headers
+
+
+contribution_broker = ContributionBrokerClient()

--- a/backend/app/contribution_config.py
+++ b/backend/app/contribution_config.py
@@ -1,0 +1,92 @@
+"""Runtime-resolved contribution relay configuration.
+
+The relay routing an owner tunes while testing — which repository reviewed
+contributions target, and which repositories the anonymous-owner guard treats
+as allowed test targets — is operational configuration, not container topology.
+Reading it live from ``/data`` means changing it is an ordinary settings write,
+never a container recreate: baking it into container environment
+(docker-compose) once forced a chat to recreate the production container just to
+point the relay at a test fork, which stranded the running turn mid-recreate.
+
+Each value resolves from the ``/data`` override file first, then the process
+environment (the compose-provided default). A missing override uses the
+environment. A present but unreadable or malformed override stops publication
+rather than silently falling back to a different repository.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from app.config import get_settings
+
+TARGET_REPO_ENV = "MOBIUS_CONTRIBUTION_TARGET_REPO"
+TEST_REPOSITORIES_ENV = "MOBIUS_CONTRIBUTION_RELAY_TEST_REPOSITORIES"
+
+_OVERRIDE_RELPATH = "shared/contribution-relay.json"
+
+
+class ContributionConfigError(RuntimeError):
+  """The owner-authored runtime override exists but cannot be trusted."""
+
+
+def _override_path() -> Path:
+  return Path(get_settings().data_dir) / _OVERRIDE_RELPATH
+
+
+def _override(key: str) -> str | None:
+  """Return an owner-set value, or None when that key/file is absent."""
+  try:
+    raw = _override_path().read_text(encoding="utf-8")
+  except FileNotFoundError:
+    return None
+  except (OSError, ValueError) as exc:
+    raise ContributionConfigError(
+      "the contribution relay override could not be read"
+    ) from exc
+  try:
+    data = json.loads(raw)
+  except ValueError as exc:
+    raise ContributionConfigError(
+      "the contribution relay override is not valid JSON"
+    ) from exc
+  if not isinstance(data, dict):
+    raise ContributionConfigError(
+      "the contribution relay override must be a JSON object"
+    )
+  if key not in data:
+    return None
+  value = data[key]
+  if not isinstance(value, str):
+    raise ContributionConfigError(
+      f"the contribution relay override field {key!r} must be a string"
+    )
+  return value.strip()
+
+
+def target_repo() -> str:
+  """The GitHub repository reviewed contributions are opened against.
+
+  Resolved live so the owner can retarget or deliberately clear the relay
+  target without recreating the container.
+  """
+  override = _override("target_repo")
+  if override is not None:
+    return override
+  return os.environ.get(TARGET_REPO_ENV, "").strip()
+
+
+def test_repositories() -> set[str]:
+  """Casefolded repositories the anonymous-owner guard treats as allowed test
+  targets.
+
+  Resolved live (override then environment) from the same comma-separated
+  string format the environment variable uses.
+  """
+  override = _override("test_repositories")
+  raw = override if override is not None else os.environ.get(
+    TEST_REPOSITORIES_ENV, "",
+  )
+  return {item.strip().casefold() for item in raw.split(",") if item.strip()}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -76,7 +76,7 @@ from app.routes import (
   public_apps_router,
   secrets_router, self_reminders_router, settings_router, skills_router,
   client_error_router, client_signal_router, standalone_router, storage_router,
-  theme_router, uploads_router, platform_router,
+  theme_router, uploads_router, platform_router, contribution_relay_router,
   published_router,
   connect_router,
 )
@@ -750,6 +750,7 @@ app.include_router(local_services_router)
 app.include_router(connect_router)
 app.include_router(client_error_router)
 app.include_router(client_signal_router)
+app.include_router(contribution_relay_router)
 app.include_router(settings_router)
 app.include_router(platform_router)
 app.include_router(uploads_router)

--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -88,6 +88,7 @@ skills_router = _load("skills")
 standalone_router = _load("standalone")
 client_error_router = _load("client_error")
 client_signal_router = _load("client_signal")
+contribution_relay_router = _load("contribution_relay")
 platform_router = _load("platform")
 published_router = _load("published")
 connect_router = _load("connect")
@@ -128,6 +129,7 @@ __all__ = [
   "standalone_router",
   "client_error_router",
   "client_signal_router",
+  "contribution_relay_router",
   "platform_router",
   "published_router",
   "connect_router",

--- a/backend/app/routes/contribution_relay.py
+++ b/backend/app/routes/contribution_relay.py
@@ -363,6 +363,26 @@ def _idempotency_key(app_id: int, record_id: str, revision: int) -> str:
   return "mobius-pr:" + hashlib.sha256(material).hexdigest()
 
 
+_RELAY_GUARD_FIELDS = (
+  "status",
+  "relay_status",
+  "relay_contribution_id",
+  "relay_revision",
+  "relay_request_sha256",
+  "relay_idempotency_key",
+)
+
+
+def _relay_guard(record: dict) -> tuple:
+  """Identity of the exact local relay attempt an outbound call represents."""
+  return tuple(record.get(field) for field in _RELAY_GUARD_FIELDS)
+
+
+def _require_relay_guard(current: dict, expected: tuple, message: str) -> None:
+  if _relay_guard(current) != expected:
+    raise HTTPException(409, message)
+
+
 def _request_revision(record: dict, payload: dict) -> tuple[int, str]:
   """Choose one monotonic revision for the exact body-independent snapshot.
 
@@ -510,6 +530,7 @@ async def submit_through_mobius(
       }
       write_record(record_path, claimed)
   db.close()
+  attempt_guard = None
 
   try:
     async with fs_locks.source_dir_lock(
@@ -554,6 +575,7 @@ async def submit_through_mobius(
         "updated_at": now_iso(),
       }
       write_record(record_path, claimed)
+      attempt_guard = _relay_guard(claimed)
     result, _status, _headers = await contribution_broker.request(
       "POST",
       CONTRIBUTION_PREFIX,
@@ -563,6 +585,11 @@ async def submit_through_mobius(
   except ContributionSubmitError as exc:
     async with fs_locks.app_storage_lock(app_id):
       _recheck_submit_app(db, app_id, expected_nonce)
+      if attempt_guard is not None:
+        _require_relay_guard(
+          read_record(record_path), attempt_guard,
+          "This contribution changed while it was sent.",
+        )
       record = _mark_submit_failure(
         app_id=app_id,
         record_path=record_path,
@@ -581,6 +608,10 @@ async def submit_through_mobius(
   except ContributionBrokerError as exc:
     async with fs_locks.app_storage_lock(app_id):
       _recheck_submit_app(db, app_id, expected_nonce)
+      _require_relay_guard(
+        read_record(record_path), attempt_guard,
+        "This contribution changed while it was sent.",
+      )
       record = _relay_failure(app_id=app_id, record_path=record_path, exc=exc)
     headers = {"Retry-After": str(exc.retry_after)} if exc.retry_after else None
     raise HTTPException(
@@ -599,6 +630,10 @@ async def submit_through_mobius(
   except ContributionBrokerError as invalid:
     async with fs_locks.app_storage_lock(app_id):
       _recheck_submit_app(db, app_id, expected_nonce)
+      _require_relay_guard(
+        read_record(record_path), attempt_guard,
+        "This contribution changed while it was sent.",
+      )
       record = _relay_failure(app_id=app_id, record_path=record_path, exc=invalid)
     raise HTTPException(
       502,
@@ -607,8 +642,10 @@ async def submit_through_mobius(
   async with fs_locks.app_storage_lock(app_id):
     _recheck_submit_app(db, app_id, expected_nonce)
     current = read_record(record_path)
-    if current.get("status") != "submitting":
-      raise HTTPException(409, "This contribution changed while it was sent.")
+    _require_relay_guard(
+      current, attempt_guard,
+      "This contribution changed while it was sent.",
+    )
     submitted = {
       **current,
       **relay_patch,
@@ -637,10 +674,14 @@ async def relay_contribution_status(
 ):
   expected_nonce = _validate_submit_app(app_id, principal, db)
   record_path, _diff_path = record_paths(app_id, record_id)
-  record = read_record(record_path)
-  contribution_id = str(record.get("relay_contribution_id") or "")
-  if not contribution_id:
-    raise HTTPException(404, "This contribution has not reached the relay yet.")
+  async with fs_locks.app_storage_lock(app_id):
+    _recheck_submit_app(db, app_id, expected_nonce)
+    record = read_record(record_path)
+    contribution_id = str(record.get("relay_contribution_id") or "")
+    if not contribution_id:
+      raise HTTPException(404, "This contribution has not reached the relay yet.")
+    attempt_guard = _relay_guard(record)
+  db.close()
   try:
     payload, _status, _headers = await contribution_broker.request(
       "GET", CONTRIBUTION_PREFIX + "/" + contribution_id,
@@ -652,8 +693,10 @@ async def relay_contribution_status(
   async with fs_locks.app_storage_lock(app_id):
     _recheck_submit_app(db, app_id, expected_nonce)
     current = read_record(record_path)
-    if str(current.get("relay_contribution_id") or "") != contribution_id:
-      raise HTTPException(409, "This contribution changed while status was checked.")
+    _require_relay_guard(
+      current, attempt_guard,
+      "This contribution changed while status was checked.",
+    )
     try:
       relay_patch = _relay_result_patch(
         payload,
@@ -728,6 +771,8 @@ async def withdraw_mobius_contribution(
     idempotency_key = "mobius-withdraw:" + hashlib.sha256(
       f"{app_id}\0{record_id}\0{contribution_id}\0{revision}".encode()
     ).hexdigest()
+    attempt_guard = _relay_guard(current)
+  db.close()
 
   try:
     result, _status, _headers = await contribution_broker.request(
@@ -759,8 +804,10 @@ async def withdraw_mobius_contribution(
   async with fs_locks.app_storage_lock(app_id):
     _recheck_submit_app(db, app_id, expected_nonce)
     latest = read_record(record_path)
-    if str(latest.get("relay_contribution_id") or "") != contribution_id:
-      raise HTTPException(409, "This contribution changed while it was withdrawn.")
+    _require_relay_guard(
+      latest, attempt_guard,
+      "This contribution changed while it was withdrawn.",
+    )
     withdrawn = {
       **latest,
       **relay_patch,

--- a/backend/app/routes/contribution_relay.py
+++ b/backend/app/routes/contribution_relay.py
@@ -1,0 +1,776 @@
+"""Owner-confirmed publication of reviewed changes through the Möbius bot."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import hashlib
+import logging
+import re
+import subprocess
+from pathlib import Path
+from typing import Literal
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+from sqlalchemy.orm import Session
+
+from app import contribution_config, fs_locks
+from app.contribution_broker import (
+  CONTRIBUTION_PREFIX,
+  ContributionBrokerError,
+  canonical_body,
+  contribution_broker,
+)
+from app.contribution_records import (
+  now_iso,
+  read_record,
+  record_paths,
+  write_record,
+)
+from app.database import get_db
+from app.deps import Principal, get_principal, reject_cross_site
+from app.github_contribution_git import (
+  _assert_clean_worktree,
+  _assert_coauthor_trailer,
+  _assert_fresh,
+  _assert_merges_with_upstream,
+  _git_env,
+  _validate_branch,
+  _validate_repo_slug,
+)
+from app.github_contributions import (
+  ContributionSubmitError,
+  _claim_record,
+  _equivalence_source_repo,
+  _mark_submit_failure,
+  _merged_upstream_sha,
+  _record_pending_equivalence_locked,
+  _recheck_submit_app,
+  _safe_repo_path,
+  _settle_equivalence,
+  _validate_submit_app,
+)
+
+
+router = APIRouter(prefix="/api/contribution-relay", tags=["contribution-relay"])
+_limiter = Limiter(key_func=get_remote_address)
+log = logging.getLogger(__name__)
+_SHA = re.compile(r"^[0-9a-f]{40}$")
+_CONTRIBUTION_ID = re.compile(r"^ctr_[0-9a-f]{32}$")
+_RELAY_TERMINAL_FAILURES = {"error", "failed", "rejected"}
+_RELAY_TERMINAL_CLOSED = {"closed", "merged", "withdrawn"}
+
+ANONYMOUS_CONTRIBUTION_OWNER = "mobius-os"
+
+
+class RelaySubmitIn(BaseModel):
+  confirm_publication: Literal[True]
+  public_identity: Literal["anonymous"] = "anonymous"
+  submitter: Literal["contribute-button", "chat-review-card"] = (
+    "contribute-button"
+  )
+
+
+class RelayWithdrawIn(BaseModel):
+  confirm_withdrawal: Literal[True]
+
+
+def _run_git_bytes(repo: Path, *args: str) -> bytes:
+  result = subprocess.run(
+    ["git", "-C", str(repo), *args],
+    cwd=str(repo),
+    env=_git_env(repo),
+    capture_output=True,
+    text=False,
+    timeout=60,
+    check=False,
+  )
+  if result.returncode:
+    detail = (result.stderr or result.stdout or b"Git command failed.")[:600]
+    raise ContributionSubmitError(
+      detail.decode("utf-8", errors="replace").strip()
+    )
+  return result.stdout
+
+
+def _configured_target_repo(source_repo: str) -> str:
+  try:
+    configured = contribution_config.target_repo()
+    test_repositories = contribution_config.test_repositories()
+  except contribution_config.ContributionConfigError as exc:
+    raise ContributionSubmitError(
+      "The contribution relay settings are invalid. Nothing was published.",
+      code="relay_config_invalid",
+    ) from exc
+  if not configured:
+    raise ContributionSubmitError(
+      "Choose an explicit contribution target before using the Möbius bot. "
+      "Nothing was published.",
+      code="relay_target_not_configured",
+    )
+  repo = _validate_repo_slug(configured)
+  source = _validate_repo_slug(source_repo)
+  is_test_repo = repo.casefold() in test_repositories
+  if (
+    repo.split("/", 1)[0].casefold() != ANONYMOUS_CONTRIBUTION_OWNER
+    and not is_test_repo
+  ):
+    raise ContributionSubmitError(
+      "Anonymous Möbius contributions are available only for mobius-os "
+      "repositories. Connect GitHub to contribute elsewhere.",
+      code="anonymous_repo_not_allowed",
+    )
+  if repo.casefold() != source.casefold() and not is_test_repo:
+    raise ContributionSubmitError(
+      "The contribution target does not match the reviewed repository. "
+      "Nothing was published.",
+      code="relay_target_mismatch",
+    )
+  return repo
+
+
+def _tree_entry(repo: Path, tree: str, path: str) -> tuple[str, str]:
+  raw = _run_git_bytes(repo, "ls-tree", "-z", tree, "--", path)
+  entries = [item for item in raw.split(b"\0") if item]
+  if len(entries) != 1 or b"\t" not in entries[0]:
+    raise ContributionSubmitError(
+      "The reviewed merge tree contains an unsupported file entry."
+    )
+  metadata, raw_path = entries[0].split(b"\t", 1)
+  parts = metadata.split()
+  if len(parts) != 3 or parts[1] != b"blob":
+    raise ContributionSubmitError(
+      "Only regular files can be submitted through the Möbius bot."
+    )
+  try:
+    resolved_path = raw_path.decode("utf-8")
+  except UnicodeDecodeError as exc:
+    raise ContributionSubmitError(
+      "File names must be valid UTF-8 before this contribution can be sent."
+    ) from exc
+  if resolved_path != path:
+    raise ContributionSubmitError("The reviewed file path could not be verified.")
+  mode = parts[0].decode("ascii")
+  if mode not in {"100644", "100755"}:
+    raise ContributionSubmitError(
+      "Symlinks and special files cannot be submitted through the Möbius bot."
+    )
+  return mode, parts[2].decode("ascii")
+
+
+def _merged_snapshot(record: dict, diff_path: Path) -> tuple[dict, list[dict]]:
+  plan = record.get("plan") if isinstance(record.get("plan"), dict) else {}
+  repo = _safe_repo_path(plan.get("repo_path"))
+  source_repo = _validate_repo_slug(plan.get("repo") or record.get("repo"))
+  repo_slug = _configured_target_repo(source_repo)
+  branch = _validate_branch(plan.get("branch") or record.get("branch"))
+  _assert_clean_worktree(repo)
+  _base_sha, head_sha, _diff_hash = _assert_fresh(
+    record, diff_path, repo, branch,
+  )
+  _assert_coauthor_trailer(repo, branch)
+  upstream = _assert_merges_with_upstream(repo, repo_slug, branch)
+  upstream_sha = str(upstream.get("last_submit_upstream_sha") or "")
+  base_ref = str(upstream.get("last_submit_upstream_branch") or "")
+  if not _SHA.fullmatch(upstream_sha) or not base_ref:
+    raise ContributionSubmitError(
+      "The current upstream branch could not be verified."
+    )
+  merged = _run_git_bytes(
+    repo, "merge-tree", "--write-tree", upstream_sha, head_sha,
+  ).decode("ascii", errors="strict").splitlines()
+  expected_tree_sha = merged[0].strip() if merged else ""
+  if not _SHA.fullmatch(expected_tree_sha):
+    raise ContributionSubmitError(
+      "The exact reviewed merge tree could not be constructed."
+    )
+  raw_changes = _run_git_bytes(
+    repo,
+    "diff",
+    "--name-status",
+    "-z",
+    "--no-renames",
+    upstream_sha,
+    expected_tree_sha,
+  )
+  tokens = raw_changes.split(b"\0")
+  if tokens and tokens[-1] == b"":
+    tokens.pop()
+  if len(tokens) % 2 or len(tokens) > 160:
+    raise ContributionSubmitError(
+      "This contribution is too large to send safely as one pull request. "
+      "Ask your agent to split it into smaller reviewed changes.",
+      code="review_changed_large_diff",
+    )
+  files = []
+  for index in range(0, len(tokens), 2):
+    status = tokens[index].decode("ascii", errors="strict")
+    try:
+      path = tokens[index + 1].decode("utf-8")
+    except UnicodeDecodeError as exc:
+      raise ContributionSubmitError(
+        "File names must be valid UTF-8 before this contribution can be sent."
+      ) from exc
+    if status not in {"A", "M", "D"}:
+      raise ContributionSubmitError(
+        "Renames and special Git changes must be reviewed as ordinary files."
+      )
+    source_tree = upstream_sha if status == "D" else expected_tree_sha
+    mode, _blob_sha = _tree_entry(repo, source_tree, path)
+    content = b"" if status == "D" else _run_git_bytes(
+      repo, "show", f"{expected_tree_sha}:{path}",
+    )
+    files.append({
+      "path": path,
+      "operation": {"A": "add", "M": "modify", "D": "delete"}[status],
+      "mode": mode,
+      "content_base64": base64.b64encode(content).decode("ascii") if content else "",
+    })
+  if not files:
+    raise ContributionSubmitError("This contribution no longer changes any files.")
+  return {
+    "repo": repo_slug,
+    "source_repo": source_repo,
+    "base_ref": base_ref,
+    "base_sha": upstream_sha,
+    "expected_tree_sha": expected_tree_sha,
+    **upstream,
+  }, files
+
+
+def _relay_result_patch(
+  result: object,
+  *,
+  contribution_id: str = "",
+  merge: dict | None = None,
+  expected_revision: int | None = None,
+) -> dict:
+  """Project a relay create/status response onto the durable local record.
+
+  Creation may return before GitHub has opened the draft. In that case the
+  local record stays in the existing ``submitting`` state and the app polls the
+  exact contribution id. A later status response adds the public URL without
+  inventing a second submission.
+  """
+  if not isinstance(result, dict):
+    raise ContributionBrokerError(
+      502, "The contribution relay returned an invalid result.",
+      "invalid_relay_response",
+    )
+  reported_id = str(result.get("id") or "")
+  if reported_id and contribution_id and reported_id != contribution_id:
+    raise ContributionBrokerError(
+      502,
+      "The contribution relay returned a different contribution identity. "
+      "Retry will reconcile the saved request.",
+      "invalid_relay_response",
+    )
+  relay_id = reported_id or contribution_id
+  if not _CONTRIBUTION_ID.fullmatch(relay_id):
+    raise ContributionBrokerError(
+      502,
+      "The contribution relay returned an invalid result. Retry will reconcile the same request.",
+      "invalid_relay_response",
+    )
+  relay_status = str(result.get("status") or "").strip().lower()
+  pr = result.get("pr")
+  patch = {
+    "relay_contribution_id": relay_id,
+    "relay_status": relay_status or "submitted",
+  }
+  revision = result.get("revision")
+  if revision is not None:
+    if not isinstance(revision, int) or isinstance(revision, bool) or revision < 1:
+      raise ContributionBrokerError(
+        502,
+        "The contribution relay returned an invalid revision. Retry will "
+        "reconcile the saved request.",
+        "invalid_relay_response",
+      )
+    if expected_revision is not None and revision != expected_revision:
+      raise ContributionBrokerError(
+        502,
+        "The contribution relay returned a different revision. Retry will "
+        "reconcile the saved request.",
+        "invalid_relay_response",
+      )
+    patch["relay_revision"] = revision
+  publication_repo = str(result.get("publication_repo") or "")
+  if publication_repo:
+    try:
+      patch["relay_publication_repo"] = _validate_repo_slug(publication_repo)
+    except ContributionSubmitError as exc:
+      raise ContributionBrokerError(
+        502,
+        "The contribution relay returned an invalid publication repository.",
+        "invalid_relay_response",
+      ) from exc
+  if isinstance(result.get("retryable"), bool):
+    patch["relay_retryable"] = result["retryable"]
+  if merge:
+    patch.update({
+      "last_submit_upstream_branch": merge["base_ref"],
+      "last_submit_upstream_sha": merge["base_sha"],
+      "relay_target_repo": merge["repo"],
+      "relay_source_repo": merge.get("source_repo") or merge["repo"],
+    })
+  if isinstance(pr, dict) and str(pr.get("url") or ""):
+    url = str(pr.get("url") or "")
+    if not url.startswith("https://github.com/") or pr.get("draft") is not True:
+      raise ContributionBrokerError(
+        502,
+        "The contribution relay returned an invalid draft pull request. "
+        "Retry will reconcile the same request.",
+        "invalid_relay_response",
+      )
+    patch.update({
+      "status": relay_status or "draft",
+      "url": url,
+      "number": pr.get("number"),
+      "relay_branch": pr.get("branch"),
+      "relay_head_sha": pr.get("head_sha"),
+    })
+  elif relay_status in _RELAY_TERMINAL_FAILURES:
+    error = result.get("error")
+    message = (
+      str(error.get("message") or "")
+      if isinstance(error, dict)
+      else str(error or "")
+    ).strip()
+    patch.update({
+      "status": "prepared",
+      "last_submit_error": message or "The Möbius relay could not open this draft pull request.",
+      "last_submit_error_code": relay_status,
+      # A terminal attempt must use a new monotonic revision if the owner
+      # retries the same reviewed snapshot. Replaying its old idempotency key
+      # would only replay the same terminal result forever.
+      "relay_request_sha256": "",
+    })
+  elif relay_status in _RELAY_TERMINAL_CLOSED:
+    patch["status"] = "merged" if relay_status == "merged" else "closed"
+  else:
+    patch["status"] = "submitting"
+  return patch
+
+
+def _idempotency_key(app_id: int, record_id: str, revision: int) -> str:
+  material = "\0".join((
+    str(app_id), record_id, str(revision),
+  )).encode()
+  return "mobius-pr:" + hashlib.sha256(material).hexdigest()
+
+
+def _request_revision(record: dict, payload: dict) -> tuple[int, str]:
+  """Choose one monotonic revision for the exact body-independent snapshot.
+
+  ``revision`` itself is excluded from the digest so a byte-identical retry
+  reuses the same revision and capability-bound request. If current upstream
+  moved and produced a different reviewed merge snapshot, the next request is
+  a new revision rather than an idempotency-key/body contradiction.
+  """
+  snapshot_sha = hashlib.sha256(canonical_body(payload)).hexdigest()
+  try:
+    previous = int(record.get("relay_revision") or 0)
+  except (TypeError, ValueError):
+    previous = 0
+  if previous >= 1 and record.get("relay_request_sha256") == snapshot_sha:
+    return previous, snapshot_sha
+  return max(1, previous + 1), snapshot_sha
+
+
+def _reviewed_description(record: dict) -> str:
+  plan = record.get("plan") if isinstance(record.get("plan"), dict) else {}
+  return str(
+    plan.get("body_draft")
+    or record.get("description")
+    or record.get("summary")
+    or "Reviewed in Möbius."
+  ).strip()
+
+
+def _relay_failure(
+  *, app_id: int, record_path: Path, exc: ContributionBrokerError,
+) -> dict | None:
+  current = read_record(record_path)
+  retryable = exc.status_code in {502, 503, 504} or exc.code in {
+    "submission_in_progress", "github_error", "relay_unavailable",
+  }
+  if retryable and current.get("status") == "submitting":
+    next_record = {
+      **current,
+      "last_submit_error": exc.detail,
+      "last_submit_error_code": exc.code,
+      "updated_at": now_iso(),
+    }
+    write_record(record_path, next_record)
+    return next_record
+  failed = _mark_submit_failure(
+    app_id=app_id,
+    record_path=record_path,
+    message=exc.detail,
+    record_patch={"last_submit_error_code": exc.code},
+  )
+  return _clear_unpublished_relay_attempt(record_path, failed)
+
+
+def _clear_unpublished_relay_attempt(
+  record_path: Path, record: dict | None,
+) -> dict | None:
+  """Remove bot-attribution from an attempt that never reached the relay."""
+  if record is not None and not record.get("relay_contribution_id"):
+    for key in (
+      "submission_mode", "public_identity", "relay_idempotency_key",
+      "relay_request_sha256", "relay_revision",
+    ):
+      record.pop(key, None)
+    write_record(record_path, record)
+  return record
+
+
+async def _record_relay_equivalence(record: dict) -> None:
+  """Best-effort provenance after the relay accepts a reviewed snapshot.
+
+  Personal-GitHub publication records the same pending witness after its PR is
+  opened. Keeping the relay path symmetric is what lets an app-publication PR
+  later prove that its exact reviewed package landed, without making this
+  conflict-avoidance metadata a reason to misreport a successful public action.
+  """
+  try:
+    await _record_pending_equivalence_locked(record)
+  except Exception:
+    log.warning(
+      "relay contribution equivalence witness failed %s",
+      record.get("id"),
+      exc_info=True,
+    )
+
+
+async def _settle_relay_equivalence(record: dict) -> None:
+  """Promote or discard a relay witness after a terminal status result."""
+  if record.get("status") not in {"merged", "closed"}:
+    return
+  try:
+    repos = await asyncio.to_thread(_equivalence_source_repo, record)
+    if repos is None:
+      return
+    source_repo, review_repo = repos
+    upstream_sha = None
+    if record.get("status") == "merged":
+      upstream_sha = await asyncio.to_thread(
+        _merged_upstream_sha, record, review_repo,
+      )
+    async with fs_locks.source_dir_lock(str(source_repo)):
+      await asyncio.to_thread(_settle_equivalence, record, upstream_sha)
+  except Exception:
+    log.warning(
+      "terminal relay contribution equivalence settlement failed %s",
+      record.get("id"),
+      exc_info=True,
+    )
+
+
+@router.post(
+  "/{app_id}/{record_id}/submit",
+  dependencies=[Depends(reject_cross_site)],
+)
+@_limiter.limit("5/minute")
+async def submit_through_mobius(
+  request: Request,
+  app_id: int,
+  record_id: str,
+  body: RelaySubmitIn,
+  db: Session = Depends(get_db),
+  principal: Principal = Depends(get_principal),
+):
+  expected_nonce = _validate_submit_app(app_id, principal, db)
+  async with fs_locks.app_storage_lock(app_id):
+    _recheck_submit_app(db, app_id, expected_nonce)
+    record_path, diff_path = record_paths(app_id, record_id)
+    current = read_record(record_path)
+    if (
+      current.get("status") == "submitting"
+      and current.get("submission_mode") == "mobius-bot"
+    ):
+      claimed = current
+    else:
+      claimed, record_path, diff_path = _claim_record(
+        app_id=app_id,
+        record_id=record_id,
+        db=db,
+        expected_nonce=expected_nonce,
+        submitter=body.submitter,
+      )
+      claimed = {
+        **claimed,
+        "submission_mode": "mobius-bot",
+        "public_identity": "anonymous",
+      }
+      write_record(record_path, claimed)
+  db.close()
+
+  try:
+    async with fs_locks.source_dir_lock(
+      str(_safe_repo_path((claimed.get("plan") or {}).get("repo_path")))
+    ):
+      merge, files = await asyncio.to_thread(
+        _merged_snapshot, claimed, diff_path,
+      )
+    title = str(claimed.get("title") or "Reviewed Möbius contribution").strip()
+    description = _reviewed_description(claimed)
+    payload = {
+      "contract_version": 1,
+      "repo": merge["repo"],
+      "base_ref": merge["base_ref"],
+      "base_sha": merge["base_sha"],
+      "expected_tree_sha": merge["expected_tree_sha"],
+      "title": title[:256],
+      "body": description[:65_536],
+      "commit_message": title[:512],
+      "local_record_id": record_id,
+      "public_identity": "anonymous",
+      "draft": True,
+      "files": files,
+    }
+    async with fs_locks.app_storage_lock(app_id):
+      _recheck_submit_app(db, app_id, expected_nonce)
+      current = read_record(record_path)
+      if (
+        current.get("status") != "submitting"
+        or current.get("submission_mode") != "mobius-bot"
+      ):
+        raise HTTPException(409, "This contribution changed while it was sent.")
+      revision, request_sha = _request_revision(current, payload)
+      payload["revision"] = revision
+      claimed = {
+        **current,
+        "relay_revision": revision,
+        "relay_request_sha256": request_sha,
+        "relay_idempotency_key": _idempotency_key(
+          app_id, record_id, revision,
+        ),
+        "updated_at": now_iso(),
+      }
+      write_record(record_path, claimed)
+    result, _status, _headers = await contribution_broker.request(
+      "POST",
+      CONTRIBUTION_PREFIX,
+      body=payload,
+      idempotency_key=str(claimed["relay_idempotency_key"]),
+    )
+  except ContributionSubmitError as exc:
+    async with fs_locks.app_storage_lock(app_id):
+      _recheck_submit_app(db, app_id, expected_nonce)
+      record = _mark_submit_failure(
+        app_id=app_id,
+        record_path=record_path,
+        message=exc.message,
+        record_patch={
+          **(exc.record_patch or {}),
+          "last_submit_error_code": exc.code or "review_changed",
+        },
+        detail=exc.detail,
+      )
+      record = _clear_unpublished_relay_attempt(record_path, record)
+    raise HTTPException(
+      exc.status_code,
+      {"code": exc.code or "review_changed", "message": exc.message, "record": record},
+    ) from exc
+  except ContributionBrokerError as exc:
+    async with fs_locks.app_storage_lock(app_id):
+      _recheck_submit_app(db, app_id, expected_nonce)
+      record = _relay_failure(app_id=app_id, record_path=record_path, exc=exc)
+    headers = {"Retry-After": str(exc.retry_after)} if exc.retry_after else None
+    raise HTTPException(
+      exc.status_code,
+      {"code": exc.code, "message": exc.detail, "record": record},
+      headers=headers,
+    ) from exc
+
+  try:
+    relay_patch = _relay_result_patch(
+      result,
+      contribution_id=str(claimed.get("relay_contribution_id") or ""),
+      merge=merge,
+      expected_revision=int(claimed["relay_revision"]),
+    )
+  except ContributionBrokerError as invalid:
+    async with fs_locks.app_storage_lock(app_id):
+      _recheck_submit_app(db, app_id, expected_nonce)
+      record = _relay_failure(app_id=app_id, record_path=record_path, exc=invalid)
+    raise HTTPException(
+      502,
+      {"code": invalid.code, "message": invalid.detail, "record": record},
+    )
+  async with fs_locks.app_storage_lock(app_id):
+    _recheck_submit_app(db, app_id, expected_nonce)
+    current = read_record(record_path)
+    if current.get("status") != "submitting":
+      raise HTTPException(409, "This contribution changed while it was sent.")
+    submitted = {
+      **current,
+      **relay_patch,
+      "submitted_at": now_iso(),
+      "updated_at": now_iso(),
+    }
+    if submitted.get("status") != "prepared":
+      submitted.pop("last_submit_error", None)
+      submitted.pop("last_submit_error_code", None)
+      submitted.pop("last_submit_error_detail", None)
+    write_record(record_path, submitted)
+  if submitted.get("status") != "prepared":
+    await _record_relay_equivalence(submitted)
+    await _settle_relay_equivalence(submitted)
+  return {"record": submitted, "contribution": result}
+
+
+@router.get("/{app_id}/{record_id}/status")
+@_limiter.limit("30/minute")
+async def relay_contribution_status(
+  request: Request,
+  app_id: int,
+  record_id: str,
+  db: Session = Depends(get_db),
+  principal: Principal = Depends(get_principal),
+):
+  expected_nonce = _validate_submit_app(app_id, principal, db)
+  record_path, _diff_path = record_paths(app_id, record_id)
+  record = read_record(record_path)
+  contribution_id = str(record.get("relay_contribution_id") or "")
+  if not contribution_id:
+    raise HTTPException(404, "This contribution has not reached the relay yet.")
+  try:
+    payload, _status, _headers = await contribution_broker.request(
+      "GET", CONTRIBUTION_PREFIX + "/" + contribution_id,
+    )
+  except ContributionBrokerError as exc:
+    raise HTTPException(
+      exc.status_code, {"code": exc.code, "message": exc.detail}
+    ) from exc
+  async with fs_locks.app_storage_lock(app_id):
+    _recheck_submit_app(db, app_id, expected_nonce)
+    current = read_record(record_path)
+    if str(current.get("relay_contribution_id") or "") != contribution_id:
+      raise HTTPException(409, "This contribution changed while status was checked.")
+    try:
+      relay_patch = _relay_result_patch(
+        payload,
+        contribution_id=contribution_id,
+        expected_revision=(
+          current.get("relay_revision")
+          if isinstance(current.get("relay_revision"), int)
+          and not isinstance(current.get("relay_revision"), bool)
+          else None
+        ),
+      )
+    except ContributionBrokerError as exc:
+      raise HTTPException(
+        exc.status_code, {"code": exc.code, "message": exc.detail}
+      ) from exc
+    current = {
+      **current,
+      **relay_patch,
+      "updated_at": now_iso(),
+    }
+    if current.get("status") != "prepared":
+      current.pop("last_submit_error", None)
+      current.pop("last_submit_error_code", None)
+      current.pop("last_submit_error_detail", None)
+    write_record(record_path, current)
+  await _settle_relay_equivalence(current)
+  return {"record": current, "contribution": payload}
+
+
+@router.post(
+  "/{app_id}/{record_id}/withdraw",
+  dependencies=[Depends(reject_cross_site)],
+)
+@_limiter.limit("5/minute")
+async def withdraw_mobius_contribution(
+  request: Request,
+  app_id: int,
+  record_id: str,
+  body: RelayWithdrawIn,
+  db: Session = Depends(get_db),
+  principal: Principal = Depends(get_principal),
+):
+  """Withdraw one bot-published draft after the owner confirms that action."""
+  expected_nonce = _validate_submit_app(app_id, principal, db)
+  record_path, _diff_path = record_paths(app_id, record_id)
+  async with fs_locks.app_storage_lock(app_id):
+    _recheck_submit_app(db, app_id, expected_nonce)
+    current = read_record(record_path)
+    contribution_id = str(current.get("relay_contribution_id") or "")
+    if not _CONTRIBUTION_ID.fullmatch(contribution_id):
+      raise HTTPException(409, "This contribution has no Möbius draft to withdraw.")
+    if current.get("status") in {"merged", "closed", "abandoned"}:
+      return {"record": current, "contribution": {
+        "id": contribution_id,
+        "status": current.get("relay_status") or current.get("status"),
+      }}
+    try:
+      revision = int(current.get("relay_revision") or 1)
+    except (TypeError, ValueError):
+      raise HTTPException(
+        409, "This contribution has an invalid saved relay revision."
+      ) from None
+    if revision < 1:
+      raise HTTPException(
+        409, "This contribution has an invalid saved relay revision."
+      )
+    payload = {
+      "contract_version": 1,
+      "revision": revision,
+      "reason": "owner_withdrawn",
+    }
+    idempotency_key = "mobius-withdraw:" + hashlib.sha256(
+      f"{app_id}\0{record_id}\0{contribution_id}\0{revision}".encode()
+    ).hexdigest()
+
+  try:
+    result, _status, _headers = await contribution_broker.request(
+      "POST",
+      f"{CONTRIBUTION_PREFIX}/{contribution_id}/withdraw",
+      body=payload,
+      idempotency_key=idempotency_key,
+    )
+    relay_patch = _relay_result_patch(
+      result,
+      contribution_id=contribution_id,
+      expected_revision=revision,
+    )
+    if relay_patch.get("status") not in {"closed", "merged"}:
+      raise ContributionBrokerError(
+        502,
+        "The contribution relay did not confirm that the draft was closed. "
+        "Retry will reconcile the same withdrawal request.",
+        "invalid_relay_response",
+      )
+  except ContributionBrokerError as exc:
+    headers = {"Retry-After": str(exc.retry_after)} if exc.retry_after else None
+    raise HTTPException(
+      exc.status_code,
+      {"code": exc.code, "message": exc.detail, "record": current},
+      headers=headers,
+    ) from exc
+
+  async with fs_locks.app_storage_lock(app_id):
+    _recheck_submit_app(db, app_id, expected_nonce)
+    latest = read_record(record_path)
+    if str(latest.get("relay_contribution_id") or "") != contribution_id:
+      raise HTTPException(409, "This contribution changed while it was withdrawn.")
+    withdrawn = {
+      **latest,
+      **relay_patch,
+      "updated_at": now_iso(),
+    }
+    if withdrawn.get("status") == "closed":
+      withdrawn["withdrawn_at"] = now_iso()
+    withdrawn.pop("last_submit_error", None)
+    withdrawn.pop("last_submit_error_code", None)
+    withdrawn.pop("last_submit_error_detail", None)
+    write_record(record_path, withdrawn)
+  await _settle_relay_equivalence(withdrawn)
+  return {"record": withdrawn, "contribution": result}

--- a/backend/runtime/identity_broker.py
+++ b/backend/runtime/identity_broker.py
@@ -19,6 +19,7 @@ import socketserver
 import stat
 import threading
 import time
+import urllib.parse
 from http.server import BaseHTTPRequestHandler
 from pathlib import Path
 from typing import Any
@@ -54,7 +55,11 @@ GATEWAY_BASE_URL = os.environ.get(
   # authenticate every exact gateway route.
   "MOBIUS_AGENT_GATEWAY_URL", "https://www.mobius.you"
 ).rstrip("/")
+CONTRIBUTION_BASE_URL = os.environ.get(
+  "MOBIUS_CONTRIBUTION_RELAY_URL", IDENTITY_BASE_URL
+).rstrip("/")
 MAX_BODY = 2_000_000
+MAX_CONTRIBUTION_BODY = 3_000_000
 REQUEST_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{7,199}$")
 INSTANCE_RE = re.compile(r"^mob_[A-Za-z0-9_-]{3,160}$")
 
@@ -67,6 +72,42 @@ INFERENCE_ROUTES = {
     "inference:responses", "mobius-agent-gateway"
   ),
 }
+
+
+def _contribution_route(
+  method: str, route_path: str, query: str,
+) -> tuple[str, str, str] | None:
+  if query:
+    return None
+  if method == "POST" and route_path == "/v1/contributions":
+    return (
+      "contribution:submit", "mobius-contribution-relay",
+      CONTRIBUTION_BASE_URL,
+    )
+  if method == "POST" and re.fullmatch(
+    r"/v1/contributions/ctr_[0-9a-f]{32}/withdraw", route_path
+  ):
+    return (
+      "contribution:withdraw", "mobius-contribution-relay",
+      CONTRIBUTION_BASE_URL,
+    )
+  if method == "GET" and re.fullmatch(
+    r"/v1/contributions/ctr_[0-9a-f]{32}", route_path
+  ):
+    return (
+      "contribution:read", "mobius-contribution-relay",
+      CONTRIBUTION_BASE_URL,
+    )
+  return None
+
+
+def _request_body_limit(*, is_unix: bool, method: str, path: str) -> int:
+  if is_unix and method == "POST" and (
+    path == "/v1/contributions"
+    or re.fullmatch(r"/v1/contributions/ctr_[0-9a-f]{32}/withdraw", path)
+  ):
+    return MAX_CONTRIBUTION_BODY
+  return MAX_BODY
 
 
 def _b64(value: bytes) -> str:
@@ -375,6 +416,7 @@ class Broker:
     path: str,
     body: bytes,
     request_id: str,
+    idempotency_key: str = "",
   ) -> str:
     with self.lock:
       state = dict(self.state or {})
@@ -398,6 +440,10 @@ class Broker:
       "exp": now + 60,
       "audit_context": {"source": "runtime-broker"},
     }
+    if idempotency_key:
+      claims["idempotency_key_sha256"] = hashlib.sha256(
+        idempotency_key.encode("utf-8")
+      ).hexdigest()
     response = self.client.post(
       f"{IDENTITY_BASE_URL}/identity/capabilities",
       json={"assertion": self._sign(claims)},
@@ -417,12 +463,44 @@ class Broker:
     path: str,
     body: bytes,
     headers: dict[str, str],
+    allow_contributions: bool = False,
   ) -> httpx.Response:
-    route = INFERENCE_ROUTES.get((method, path))
+    split = urllib.parse.urlsplit(path)
+    route_path = split.path
+    if (
+      not route_path.startswith("/")
+      or split.scheme
+      or split.netloc
+      or split.fragment
+    ):
+      raise FileNotFoundError("broker route not found")
+    declared = INFERENCE_ROUTES.get(
+      (method, route_path)
+    ) if not split.query else None
+    if declared is not None:
+      scope, audience = declared
+      route = (scope, audience, GATEWAY_BASE_URL)
+    else:
+      route = (
+        _contribution_route(method, route_path, split.query)
+        if allow_contributions
+        else None
+      )
     if route is None:
       raise FileNotFoundError("broker route not found")
-    scope, audience = route
+    scope, audience, target = route
     request_id = self._request_id(method, path, body, headers)
+    idempotency_key = headers.get("idempotency-key", "")
+    if idempotency_key and not re.fullmatch(
+      r"[A-Za-z0-9][A-Za-z0-9._:-]{15,127}", idempotency_key
+    ):
+      raise ValueError("invalid idempotency key")
+    if (
+      audience == "mobius-contribution-relay"
+      and method != "GET"
+      and not idempotency_key
+    ):
+      raise ValueError("an idempotency key is required")
     capability = self._capability(
       audience=audience,
       scope=scope,
@@ -430,6 +508,7 @@ class Broker:
       path=path,
       body=body,
       request_id=request_id,
+      idempotency_key=idempotency_key,
     )
     forwarded = {
       "Authorization": f"Bearer {capability}",
@@ -441,12 +520,14 @@ class Broker:
     metadata = headers.get("x-codex-turn-metadata")
     if metadata:
       forwarded["x-codex-turn-metadata"] = metadata
+    if idempotency_key:
+      forwarded["Idempotency-Key"] = idempotency_key
     request = self.client.build_request(
       method,
-      GATEWAY_BASE_URL + path,
+      target + path,
       content=body if body else None,
       headers=forwarded,
-      timeout=None if path == "/v1/responses" else 30.0,
+      timeout=None if route_path == "/v1/responses" else 30.0,
     )
     # Do not buffer Responses API streams in the privileged broker. Besides
     # preserving token-by-token UX, this bounds the broker's memory footprint
@@ -472,12 +553,12 @@ class _Handler(BaseHTTPRequestHandler):
     self.end_headers()
     self.wfile.write(body)
 
-  def _body(self) -> bytes:
+  def _body(self, *, maximum: int = MAX_BODY) -> bytes:
     try:
       length = int(self.headers.get("content-length", "0"))
     except ValueError as exc:
       raise ValueError("invalid content length") from exc
-    if length < 0 or length > MAX_BODY:
+    if length < 0 or length > maximum:
       raise ValueError("request body is too large")
     return self.rfile.read(length)
 
@@ -487,6 +568,9 @@ class _Handler(BaseHTTPRequestHandler):
     path = self.path
     route_path = path.split("?", 1)[0]
     is_unix = bool(getattr(self.server, "is_unix", False))
+    body_limit = _request_body_limit(
+      is_unix=is_unix, method=method, path=path,
+    )
     try:
       if is_unix and route_path.startswith("/identity") and path != route_path:
         raise FileNotFoundError("broker route not found")
@@ -504,13 +588,14 @@ class _Handler(BaseHTTPRequestHandler):
         subject = value.get("expected_subject") if isinstance(value, dict) else None
         self._json(200, broker.unlink(str(subject or "")))
         return
-      body = self._body()
+      body = self._body(maximum=body_limit)
       incoming = {key.lower(): value for key, value in self.headers.items()}
       upstream = broker.proxy(
         method=method,
         path=path,
         body=body,
         headers=incoming,
+        allow_contributions=is_unix,
       )
       try:
         self.send_response(upstream.status_code)

--- a/backend/tests/test_contribution_config.py
+++ b/backend/tests/test_contribution_config.py
@@ -1,0 +1,166 @@
+"""Runtime resolution of contribution relay routing config.
+
+Locks in the override-then-environment layering for both the target repository
+and the anonymous-owner test-repository allowlist, the safe rejection of a
+bad override edit instead of fallback to the environment, and the end-to-end guard the route
+enforces — so retargeting the relay never needs a container recreate.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from app import contribution_config
+from app.routes.contribution_relay import (
+  ContributionSubmitError,
+  _configured_target_repo,
+)
+
+
+def test_relay_environment_is_documented_and_passed_into_the_app_container():
+  root = Path(__file__).resolve().parents[2]
+  env_example = (root / ".env.example").read_text(encoding="utf-8")
+  compose = (root / "docker-compose.yml").read_text(encoding="utf-8")
+
+  for name in (
+    "MOBIUS_CONTRIBUTION_RELAY_URL",
+    "MOBIUS_CONTRIBUTION_TARGET_REPO",
+    "MOBIUS_CONTRIBUTION_RELAY_TEST_REPOSITORIES",
+  ):
+    assert name in env_example
+    assert f"- {name}=${{{name}:-" in compose
+
+
+def _point_override(monkeypatch, tmp_path, contents=None, *, raw=None):
+  path = tmp_path / "contribution-relay.json"
+  if raw is not None:
+    path.write_bytes(raw)
+  elif contents is not None:
+    path.write_text(json.dumps(contents), encoding="utf-8")
+  monkeypatch.setattr(contribution_config, "_override_path", lambda: path)
+  return path
+
+
+def test_target_repo_empty_when_unset(monkeypatch, tmp_path):
+  _point_override(monkeypatch, tmp_path)
+  monkeypatch.delenv(contribution_config.TARGET_REPO_ENV, raising=False)
+  assert contribution_config.target_repo() == ""
+
+
+def test_target_repo_from_env(monkeypatch, tmp_path):
+  _point_override(monkeypatch, tmp_path)
+  monkeypatch.setenv(contribution_config.TARGET_REPO_ENV, "owner/repo")
+  assert contribution_config.target_repo() == "owner/repo"
+
+
+def test_target_repo_override_wins(monkeypatch, tmp_path):
+  _point_override(monkeypatch, tmp_path, {"target_repo": "owner/from-file"})
+  monkeypatch.setenv(contribution_config.TARGET_REPO_ENV, "owner/from-env")
+  assert contribution_config.target_repo() == "owner/from-file"
+
+
+def test_target_repo_blank_override_deliberately_blocks_env(monkeypatch, tmp_path):
+  _point_override(monkeypatch, tmp_path, {"target_repo": "   "})
+  monkeypatch.setenv(contribution_config.TARGET_REPO_ENV, "owner/env")
+  assert contribution_config.target_repo() == ""
+
+
+def test_target_repo_bad_override_stops_instead_of_changing_targets(
+  monkeypatch, tmp_path,
+):
+  monkeypatch.setenv(contribution_config.TARGET_REPO_ENV, "owner/env")
+  for kwargs in (
+    {"raw": b"{not json"},          # malformed JSON
+    {"raw": b"\xff\xfe not utf-8"},  # non-UTF-8 bytes
+    {"contents": ["owner/list"]},    # non-object JSON
+    {"contents": {"target_repo": 123}},   # non-string value
+    {"contents": {"target_repo": None}},   # null value
+  ):
+    _point_override(monkeypatch, tmp_path, **kwargs)
+    with pytest.raises(contribution_config.ContributionConfigError):
+      contribution_config.target_repo()
+
+
+def test_configured_target_repo_reports_invalid_override_without_fallback(
+  monkeypatch, tmp_path,
+):
+  _point_override(monkeypatch, tmp_path, raw=b"{not json")
+  monkeypatch.setenv(contribution_config.TARGET_REPO_ENV, "mobius-os/mobius")
+
+  with pytest.raises(ContributionSubmitError) as exc:
+    _configured_target_repo("owner/source")
+
+  assert exc.value.code == "relay_config_invalid"
+
+
+def test_test_repositories_parsed_from_env(monkeypatch, tmp_path):
+  _point_override(monkeypatch, tmp_path)
+  monkeypatch.setenv(
+    contribution_config.TEST_REPOSITORIES_ENV, " Owner/One , owner/two ,",
+  )
+  assert contribution_config.test_repositories() == {"owner/one", "owner/two"}
+
+
+def test_test_repositories_override_wins(monkeypatch, tmp_path):
+  _point_override(
+    monkeypatch, tmp_path, {"test_repositories": "owner/from-file"},
+  )
+  monkeypatch.setenv(
+    contribution_config.TEST_REPOSITORIES_ENV, "owner/from-env",
+  )
+  assert contribution_config.test_repositories() == {"owner/from-file"}
+
+
+def test_configured_target_repo_requires_explicit_target(monkeypatch, tmp_path):
+  _point_override(monkeypatch, tmp_path)
+  monkeypatch.delenv(contribution_config.TARGET_REPO_ENV, raising=False)
+  with pytest.raises(ContributionSubmitError) as exc:
+    _configured_target_repo("owner/source")
+  assert exc.value.code == "relay_target_not_configured"
+
+
+def test_configured_target_repo_anonymous_owner_allowed(monkeypatch, tmp_path):
+  _point_override(monkeypatch, tmp_path)
+  monkeypatch.setenv(contribution_config.TARGET_REPO_ENV, "mobius-os/mobius")
+  monkeypatch.delenv(contribution_config.TEST_REPOSITORIES_ENV, raising=False)
+  assert _configured_target_repo("mobius-os/mobius") == "mobius-os/mobius"
+
+
+def test_configured_target_repo_must_match_the_reviewed_repository(
+  monkeypatch, tmp_path,
+):
+  _point_override(monkeypatch, tmp_path)
+  monkeypatch.setenv(contribution_config.TARGET_REPO_ENV, "mobius-os/mobius")
+  monkeypatch.delenv(contribution_config.TEST_REPOSITORIES_ENV, raising=False)
+
+  with pytest.raises(ContributionSubmitError) as exc:
+    _configured_target_repo("mobius-os/different-app")
+
+  assert exc.value.code == "relay_target_mismatch"
+
+
+def test_configured_target_repo_fork_requires_test_allowlist(
+  monkeypatch, tmp_path
+):
+  _point_override(monkeypatch, tmp_path)
+  monkeypatch.setenv(contribution_config.TARGET_REPO_ENV, "owner/fork")
+  monkeypatch.delenv(contribution_config.TEST_REPOSITORIES_ENV, raising=False)
+  with pytest.raises(ContributionSubmitError) as exc:
+    _configured_target_repo("owner/source")
+  assert exc.value.code == "anonymous_repo_not_allowed"
+
+
+def test_configured_target_repo_fork_allowed_via_override_allowlist(
+  monkeypatch, tmp_path
+):
+  # Both values from the live override — the whole point: retarget to a fork
+  # and allow it without touching container env.
+  _point_override(
+    monkeypatch,
+    tmp_path,
+    {"target_repo": "owner/fork", "test_repositories": "owner/fork"},
+  )
+  monkeypatch.delenv(contribution_config.TARGET_REPO_ENV, raising=False)
+  monkeypatch.delenv(contribution_config.TEST_REPOSITORIES_ENV, raising=False)
+  assert _configured_target_repo("owner/source") == "owner/fork"

--- a/backend/tests/test_contribution_relay_bff.py
+++ b/backend/tests/test_contribution_relay_bff.py
@@ -1,0 +1,805 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+import hashlib
+import json
+import subprocess
+from pathlib import Path
+
+import httpx
+import pytest
+from pydantic import ValidationError
+
+from app.contribution_broker import (
+  MAX_REQUEST_BYTES,
+  MAX_RESPONSE_BYTES,
+  ContributionBrokerClient,
+  ContributionBrokerError,
+  bound_request_id,
+  canonical_body,
+)
+from app.config import get_settings
+from app.github_contribution_git import _reviewed_branch_diff
+from app.routes import contribution_relay as relay_route
+from app.storage_io import atomic_write
+from test_app_fixtures import create_local_app
+
+
+relay_route._limiter.enabled = False
+
+_RELAY_ID = "ctr_1234567890abcdef1234567890abcdef"
+_OTHER_RELAY_ID = "ctr_fedcba0987654321fedcba0987654321"
+
+
+def _git(repo, *args, input_bytes=None):
+  result = subprocess.run(
+    ["git", "-C", str(repo), *args],
+    input=input_bytes,
+    capture_output=True,
+    check=True,
+  )
+  return result.stdout.decode().strip()
+
+
+def _write_relay_record(app_id, record_id, record):
+  base = (
+    Path(get_settings().data_dir) / "apps" / str(app_id) / "contributions"
+  )
+  base.mkdir(parents=True, exist_ok=True)
+  atomic_write(base / f"{record_id}.json", json.dumps(record))
+  atomic_write(base / f"{record_id}.diff", "reviewed diff\n")
+  return base / f"{record_id}.json"
+
+
+def _prepared_relay_record(client, owner_token, tmp_path, record_id):
+  app_id = create_local_app(
+    client,
+    {"Authorization": f"Bearer {owner_token}"},
+    name=f"relay-{record_id}",
+    description="relay lifecycle test",
+  )["id"]
+  record_path = _write_relay_record(app_id, record_id, {
+    "id": record_id,
+    "type": "pr",
+    "repo": "mobius-os/mobius",
+    "status": "prepared",
+    "title": "Reviewed relay change",
+    "branch": "fix/relay-review",
+    "plan": {
+      "action": "pr",
+      "repo": "mobius-os/mobius",
+      "repo_path": str(tmp_path),
+      "branch": "fix/relay-review",
+      "body_draft": "## What\n\nA reviewed relay change.",
+    },
+  })
+  return app_id, record_path
+
+
+def _stub_reviewed_snapshot(monkeypatch, tmp_path):
+  monkeypatch.setattr(relay_route, "_safe_repo_path", lambda _raw: tmp_path)
+  monkeypatch.setattr(
+    relay_route,
+    "_merged_snapshot",
+    lambda _record, _diff_path: ({
+      "repo": "mobius-os/mobius",
+      "source_repo": "mobius-os/mobius",
+      "base_ref": "main",
+      "base_sha": "a" * 40,
+      "expected_tree_sha": "b" * 40,
+    }, [{
+      "path": "backend/app/example.py",
+      "operation": "modify",
+      "mode": "100644",
+      "content_base64": base64.b64encode(b"reviewed\n").decode(),
+    }]),
+  )
+
+
+def test_merged_snapshot_preserves_upstream_and_reviewed_changes(tmp_path, monkeypatch):
+  repo = tmp_path / "review"
+  repo.mkdir()
+  _git(repo, "init", "-q")
+  _git(repo, "config", "user.name", "Möbius")
+  _git(repo, "config", "user.email", "mobius@example.test")
+  (repo / "notes.txt").write_text("first\nmiddle\nlast\n")
+  _git(repo, "add", "notes.txt")
+  _git(repo, "commit", "-qm", "Base")
+  base = _git(repo, "rev-parse", "HEAD")
+
+  _git(repo, "checkout", "-qb", "feature")
+  (repo / "notes.txt").write_text("reviewed\nmiddle\nlast\n")
+  _git(repo, "add", "notes.txt")
+  _git(
+    repo,
+    "commit",
+    "-qm",
+    "Reviewed change\n\nCo-authored-by: Möbius Agent <mobius-agent@users.noreply.github.com>",
+  )
+  head = _git(repo, "rev-parse", "HEAD")
+  reviewed_diff = _reviewed_branch_diff(repo, base, head)
+  diff_path = tmp_path / "review.diff"
+  diff_path.write_bytes(reviewed_diff)
+
+  _git(repo, "checkout", "-q", "-b", "upstream", base)
+  (repo / "notes.txt").write_text("first\nmiddle\nupstream\n")
+  _git(repo, "add", "notes.txt")
+  _git(repo, "commit", "-qm", "Upstream change")
+  upstream = _git(repo, "rev-parse", "HEAD")
+  _git(repo, "checkout", "-q", "feature")
+
+  monkeypatch.setattr(relay_route, "_safe_repo_path", lambda _raw: repo)
+  monkeypatch.setenv("MOBIUS_CONTRIBUTION_TARGET_REPO", "mobius-os/mobius")
+  monkeypatch.setattr(
+    relay_route,
+    "_assert_merges_with_upstream",
+    lambda *_args: {
+      "last_submit_upstream_branch": "main",
+      "last_submit_upstream_sha": upstream,
+    },
+  )
+  record = {
+    "id": "review-1",
+    "type": "pr",
+    "repo": "mobius-os/mobius",
+    "branch": "feature",
+    "plan": {
+      "action": "pr",
+      "repo": "mobius-os/mobius",
+      "repo_path": str(repo),
+      "branch": "feature",
+      "base_sha": base,
+      "head_sha": head,
+      "diff_sha256": hashlib.sha256(reviewed_diff).hexdigest(),
+    },
+  }
+
+  merge, files = relay_route._merged_snapshot(record, diff_path)
+
+  assert merge["base_sha"] == upstream
+  assert merge["repo"] == "mobius-os/mobius"
+  assert merge["source_repo"] == "mobius-os/mobius"
+  assert len(files) == 1
+  assert files[0]["path"] == "notes.txt"
+  assert base64.b64decode(files[0]["content_base64"]) == (
+    b"reviewed\nmiddle\nupstream\n"
+  )
+  assert _git(repo, "show", f"{merge['expected_tree_sha']}:notes.txt") == (
+    "reviewed\nmiddle\nupstream"
+  )
+
+
+def test_contribution_broker_binds_body_and_request_id():
+  seen = []
+
+  async def handler(request: httpx.Request):
+    seen.append(request)
+    return httpx.Response(201, json={"id": "ctr_1234567890abcdef1234567890abcdef"})
+
+  client = ContributionBrokerClient(transport=httpx.MockTransport(handler))
+  body = {"repo": "mobius-os/mobius", "files": []}
+  key = "mobius-pr:1234567890abcdef"
+
+  async def run():
+    created = await client.request(
+      "POST", "/v1/contributions", body=body, idempotency_key=key,
+    )
+    withdrawn = await client.request(
+      "POST", "/v1/contributions/ctr_1234567890abcdef1234567890abcdef/withdraw",
+      body={"contract_version": 1, "revision": 1},
+      idempotency_key="mobius-withdraw:1234567890abcdef",
+    )
+    return created, withdrawn
+
+  created, withdrawn = asyncio.run(run())
+  assert created[0]["id"] == "ctr_1234567890abcdef1234567890abcdef"
+  assert withdrawn[0]["id"] == "ctr_1234567890abcdef1234567890abcdef"
+  encoded = canonical_body(body)
+  assert seen[0].headers["Idempotency-Key"] == key
+  assert seen[0].headers["X-Mobius-Request-Id"] == bound_request_id(
+    "POST", "/v1/contributions", encoded, key,
+  )
+  assert b"user_" not in seen[0].content
+
+
+def test_contribution_broker_rejects_route_expansion_and_surfaces_quota():
+  async def handler(_request: httpx.Request):
+    return httpx.Response(
+      429,
+      headers={"Retry-After": "120"},
+      json={"error": {"code": "quota", "message": "Daily limit reached."}},
+    )
+
+  client = ContributionBrokerClient(transport=httpx.MockTransport(handler))
+
+  async def run():
+    with pytest.raises(ValueError):
+      await client.request("POST", "/v1/contributions/other", body={})
+    with pytest.raises(ValueError):
+      await client.request(
+        "GET",
+        "/v1/contributions/ctr_1234567890abcdef1234567890abcdef"
+        "?subject=other",
+      )
+    with pytest.raises(ValueError):
+      await client.request("GET", "/v1/contributions/github/status")
+    with pytest.raises(ValueError):
+      await client.request("DELETE", "/v1/contributions/github")
+    with pytest.raises(ValueError):
+      await client.request(
+        "POST", "/v1/contributions/ctr_1234567890abcdef1234567890abcdef/withdraw/again",
+        body={}, idempotency_key="mobius-withdraw:1234567890abcdef",
+      )
+    with pytest.raises(ContributionBrokerError) as caught:
+      await client.request(
+        "POST", "/v1/contributions", body={},
+        idempotency_key="mobius-pr:1234567890abcdef",
+      )
+    return caught.value
+
+  error = asyncio.run(run())
+  assert error.status_code == 429
+  assert error.code == "quota"
+  assert error.retry_after == 120
+  assert "Daily limit" in error.detail
+
+
+def test_contribution_broker_bounds_streamed_responses_before_buffering():
+  async def handler(_request: httpx.Request):
+    return httpx.Response(
+      200,
+      content=b"x" * (MAX_RESPONSE_BYTES + 1),
+    )
+
+  client = ContributionBrokerClient(transport=httpx.MockTransport(handler))
+
+  async def run():
+    with pytest.raises(ContributionBrokerError) as caught:
+      await client.request(
+        "GET", "/v1/contributions/ctr_1234567890abcdef1234567890abcdef",
+      )
+    return caught.value
+
+  error = asyncio.run(run())
+  assert error.status_code == 502
+  assert "too large" in error.detail
+
+
+def test_contribution_broker_rejects_oversized_requests_before_transport():
+  touched = False
+
+  async def handler(_request: httpx.Request):
+    nonlocal touched
+    touched = True
+    return httpx.Response(200, json={})
+
+  client = ContributionBrokerClient(transport=httpx.MockTransport(handler))
+
+  async def run():
+    with pytest.raises(ContributionBrokerError) as caught:
+      await client.request(
+        "POST", "/v1/contributions",
+        body={"content": "x" * MAX_REQUEST_BYTES},
+        idempotency_key="mobius-pr:1234567890abcdef",
+      )
+    return caught.value
+
+  error = asyncio.run(run())
+  assert error.status_code == 413
+  assert error.code == "contribution_too_large"
+  assert touched is False
+
+
+def test_anonymous_relay_requires_an_explicit_target(monkeypatch):
+  monkeypatch.delenv("MOBIUS_CONTRIBUTION_TARGET_REPO", raising=False)
+  monkeypatch.delenv(
+    "MOBIUS_CONTRIBUTION_RELAY_TEST_REPOSITORIES", raising=False,
+  )
+
+  with pytest.raises(relay_route.ContributionSubmitError) as caught:
+    relay_route._configured_target_repo("mobius-os/mobius")
+  assert caught.value.code == "relay_target_not_configured"
+
+
+def test_anonymous_relay_rejects_non_mobius_repositories(monkeypatch):
+  monkeypatch.setenv("MOBIUS_CONTRIBUTION_TARGET_REPO", "example/project")
+  monkeypatch.delenv(
+    "MOBIUS_CONTRIBUTION_RELAY_TEST_REPOSITORIES", raising=False,
+  )
+
+  with pytest.raises(relay_route.ContributionSubmitError) as caught:
+    relay_route._configured_target_repo("mobius-os/mobius")
+
+  assert caught.value.code == "anonymous_repo_not_allowed"
+
+
+def test_explicit_test_repository_allows_safe_relay_proof(monkeypatch):
+  monkeypatch.setenv("MOBIUS_CONTRIBUTION_TARGET_REPO", "example/safe-fork")
+  monkeypatch.setenv(
+    "MOBIUS_CONTRIBUTION_RELAY_TEST_REPOSITORIES",
+    "another/repo, example/safe-fork",
+  )
+
+  assert relay_route._configured_target_repo("mobius-os/mobius") == (
+    "example/safe-fork"
+  )
+
+
+def test_mobius_relay_only_accepts_anonymous_public_identity():
+  assert relay_route.RelaySubmitIn.model_validate({
+    "confirm_publication": True,
+  }).public_identity == "anonymous"
+  with pytest.raises(ValidationError):
+    relay_route.RelaySubmitIn.model_validate({
+      "confirm_publication": True,
+      "public_identity": "github",
+    })
+
+
+def test_relay_result_stays_submitting_until_the_draft_url_arrives():
+  merge = {
+    "repo": "example/mobius",
+    "source_repo": "mobius-os/mobius",
+    "base_ref": "main",
+    "base_sha": "a" * 40,
+  }
+  pending = relay_route._relay_result_patch(
+    {"id": "ctr_1234567890abcdef1234567890abcdef", "status": "queued"}, merge=merge,
+  )
+  assert pending == {
+    "relay_contribution_id": "ctr_1234567890abcdef1234567890abcdef",
+    "relay_status": "queued",
+    "relay_target_repo": "example/mobius",
+    "relay_source_repo": "mobius-os/mobius",
+    "last_submit_upstream_branch": "main",
+    "last_submit_upstream_sha": "a" * 40,
+    "status": "submitting",
+  }
+
+  opened = relay_route._relay_result_patch({
+    "id": "ctr_1234567890abcdef1234567890abcdef",
+    "status": "draft",
+    "pr": {
+      "url": "https://github.com/example/mobius/pull/123",
+      "number": 123,
+      "branch": "mobius/contribution-123",
+      "head_sha": "b" * 40,
+      "draft": True,
+    },
+  })
+  assert opened["status"] == "draft"
+  assert opened["url"].endswith("/pull/123")
+  assert opened["relay_branch"] == "mobius/contribution-123"
+
+
+def test_relay_result_tolerates_unpublished_pr_shape_and_tracks_revision():
+  pending = relay_route._relay_result_patch({
+    "id": "ctr_1234567890abcdef1234567890abcdef",
+    "status": "publishing",
+    "revision": 2,
+    "publication_repo": "mobius-bot/mobius",
+    "retryable": True,
+    "pr": {"url": "", "number": None, "repo": "mobius-os/mobius"},
+  })
+  assert pending["status"] == "submitting"
+  assert pending["relay_revision"] == 2
+  assert pending["relay_publication_repo"] == "mobius-bot/mobius"
+  assert pending["relay_retryable"] is True
+
+
+def test_relay_result_rejects_a_different_revision():
+  with pytest.raises(ContributionBrokerError, match="different revision"):
+    relay_route._relay_result_patch({
+      "id": _RELAY_ID,
+      "status": "queued",
+      "revision": 2,
+    }, expected_revision=1)
+
+
+def test_relay_result_preserves_contribution_identity_across_revisions():
+  with pytest.raises(ContributionBrokerError, match="different contribution identity"):
+    relay_route._relay_result_patch(
+      {"id": "ctr_other000", "status": "publishing"},
+      contribution_id="ctr_1234567890abcdef1234567890abcdef",
+    )
+
+
+def test_request_revision_replays_exact_snapshot_and_advances_changed_snapshot():
+  first_payload = {"contract_version": 1, "repo": "example/mobius"}
+  first_revision, first_sha = relay_route._request_revision({}, first_payload)
+  assert first_revision == 1
+
+  exact_revision, exact_sha = relay_route._request_revision({
+    "relay_revision": 1,
+    "relay_request_sha256": first_sha,
+  }, first_payload)
+  assert (exact_revision, exact_sha) == (1, first_sha)
+
+  changed_revision, changed_sha = relay_route._request_revision({
+    "relay_revision": 1,
+    "relay_request_sha256": first_sha,
+  }, {**first_payload, "base_sha": "a" * 40})
+  assert changed_revision == 2
+  assert changed_sha != first_sha
+  assert relay_route._idempotency_key(80, "change-1", 1) != (
+    relay_route._idempotency_key(80, "change-1", 2)
+  )
+
+
+def test_relay_result_rejects_a_non_draft_pr():
+  with pytest.raises(ContributionBrokerError, match="invalid draft"):
+    relay_route._relay_result_patch({
+      "id": "ctr_1234567890abcdef1234567890abcdef",
+      "status": "open",
+      "pr": {
+        "url": "https://github.com/example/mobius/pull/123",
+        "draft": False,
+      },
+    })
+
+
+def test_relay_result_requires_positive_draft_confirmation():
+  with pytest.raises(ContributionBrokerError, match="invalid draft"):
+    relay_route._relay_result_patch({
+      "id": _RELAY_ID,
+      "status": "open",
+      "pr": {"url": "https://github.com/example/mobius/pull/123"},
+    })
+
+
+def test_terminal_relay_result_advances_the_next_identical_revision():
+  payload = {"contract_version": 1, "repo": "mobius-os/mobius"}
+  revision, request_sha = relay_route._request_revision({}, payload)
+  failed = relay_route._relay_result_patch({
+    "id": _RELAY_ID,
+    "status": "failed",
+    "revision": revision,
+    "error": {"message": "GitHub rejected the draft."},
+  })
+
+  assert failed["status"] == "prepared"
+  assert failed["last_submit_error"] == "GitHub rejected the draft."
+  assert failed["relay_request_sha256"] == ""
+  next_revision, _next_sha = relay_route._request_revision({
+    "relay_revision": revision,
+    "relay_request_sha256": failed["relay_request_sha256"],
+  }, payload)
+  assert request_sha
+  assert next_revision == revision + 1
+
+
+def test_submit_route_records_nonretryable_broker_failure(
+  client, owner_token, tmp_path, monkeypatch,
+):
+  record_id = "relay-nonretryable"
+  app_id, record_path = _prepared_relay_record(
+    client, owner_token, tmp_path, record_id,
+  )
+  _stub_reviewed_snapshot(monkeypatch, tmp_path)
+
+  async def fake_request(method, path, *, body=None, idempotency_key=None):
+    raise ContributionBrokerError(400, "Rejected payload.", "invalid_payload")
+
+  monkeypatch.setattr(relay_route.contribution_broker, "request", fake_request)
+  response = client.post(
+    f"/api/contribution-relay/{app_id}/{record_id}/submit",
+    headers={"Authorization": f"Bearer {owner_token}"},
+    json={"confirm_publication": True},
+  )
+
+  assert response.status_code == 400, response.text
+  stored = json.loads(record_path.read_text())
+  assert stored["status"] == "prepared"
+  assert stored["last_submit_error"] == "Rejected payload."
+  assert stored["last_submit_error_code"] == "invalid_payload"
+  assert "submission_mode" not in stored
+
+
+def test_submit_route_retries_terminal_result_as_a_new_revision(
+  client, owner_token, tmp_path, monkeypatch,
+):
+  record_id = "relay-terminal-retry"
+  app_id, record_path = _prepared_relay_record(
+    client, owner_token, tmp_path, record_id,
+  )
+  _stub_reviewed_snapshot(monkeypatch, tmp_path)
+  calls = []
+
+  async def fake_request(method, path, *, body=None, idempotency_key=None):
+    calls.append((body, idempotency_key))
+    if len(calls) == 1:
+      return ({
+        "id": _RELAY_ID,
+        "status": "failed",
+        "revision": body["revision"],
+        "error": {"message": "GitHub rejected the draft."},
+      }, 200, {})
+    return ({
+      "id": _RELAY_ID,
+      "status": "queued",
+      "revision": body["revision"],
+    }, 202, {})
+
+  monkeypatch.setattr(relay_route.contribution_broker, "request", fake_request)
+  headers = {"Authorization": f"Bearer {owner_token}"}
+  url = f"/api/contribution-relay/{app_id}/{record_id}/submit"
+
+  failed = client.post(url, headers=headers, json={
+    "confirm_publication": True,
+  })
+  assert failed.status_code == 200, failed.text
+  first_record = failed.json()["record"]
+  assert first_record["status"] == "prepared"
+  assert first_record["last_submit_error"] == "GitHub rejected the draft."
+  assert first_record["last_submit_error_code"] == "failed"
+
+  retry = client.post(url, headers=headers, json={
+    "confirm_publication": True,
+  })
+  assert retry.status_code == 200, retry.text
+  assert retry.json()["record"]["status"] == "submitting"
+  assert calls[0][0]["revision"] == 1
+  assert calls[1][0]["revision"] == 2
+  assert calls[0][1] != calls[1][1]
+  assert json.loads(record_path.read_text())["relay_revision"] == 2
+
+
+def test_submit_route_retries_one_lost_response_with_the_same_request(
+  client, owner_token, tmp_path, monkeypatch,
+):
+  record_id = "relay-lost-response"
+  app_id, record_path = _prepared_relay_record(
+    client, owner_token, tmp_path, record_id,
+  )
+  _stub_reviewed_snapshot(monkeypatch, tmp_path)
+  calls = []
+  witnessed = []
+
+  async def record_equivalence(record):
+    witnessed.append(record)
+
+  async def fake_request(method, path, *, body=None, idempotency_key=None):
+    calls.append((method, path, body, idempotency_key))
+    if len(calls) == 1:
+      raise ContributionBrokerError(
+        503, "The relay response was lost.", "relay_unavailable",
+      )
+    return ({
+      "id": _RELAY_ID,
+      "status": "queued",
+      "revision": body["revision"],
+    }, 202, {})
+
+  monkeypatch.setattr(relay_route.contribution_broker, "request", fake_request)
+  monkeypatch.setattr(
+    relay_route, "_record_relay_equivalence", record_equivalence,
+  )
+  headers = {"Authorization": f"Bearer {owner_token}"}
+  url = f"/api/contribution-relay/{app_id}/{record_id}/submit"
+
+  first = client.post(url, headers=headers, json={
+    "confirm_publication": True,
+  })
+  assert first.status_code == 503, first.text
+  after_loss = json.loads(record_path.read_text())
+  assert after_loss["status"] == "submitting"
+  assert after_loss["submission_mode"] == "mobius-bot"
+  assert after_loss["relay_revision"] == 1
+  assert after_loss["last_submit_error_code"] == "relay_unavailable"
+
+  retry = client.post(url, headers=headers, json={
+    "confirm_publication": True,
+  })
+  assert retry.status_code == 200, retry.text
+  submitted = retry.json()["record"]
+  assert submitted["status"] == "submitting"
+  assert submitted["relay_contribution_id"] == _RELAY_ID
+  assert submitted["relay_revision"] == 1
+  assert calls[0][2] == calls[1][2]
+  assert calls[0][3] == calls[1][3]
+  assert [record["id"] for record in witnessed] == [record_id]
+
+
+def test_terminal_relay_equivalence_uses_the_verified_merge_commit(
+  tmp_path, monkeypatch,
+):
+  source = tmp_path / "source"
+  review = tmp_path / "review"
+  source.mkdir()
+  review.mkdir()
+  settled = []
+  merge_sha = "c" * 40
+  monkeypatch.setattr(
+    relay_route, "_equivalence_source_repo", lambda _record: (source, review),
+  )
+  monkeypatch.setattr(
+    relay_route, "_merged_upstream_sha", lambda record, repo: (
+      merge_sha if record["status"] == "merged" and repo == review else None
+    ),
+  )
+  monkeypatch.setattr(
+    relay_route, "_settle_equivalence",
+    lambda record, upstream: settled.append((record["status"], upstream)),
+  )
+
+  asyncio.run(relay_route._settle_relay_equivalence({
+    "id": "merged-relay", "status": "merged",
+  }))
+  asyncio.run(relay_route._settle_relay_equivalence({
+    "id": "closed-relay", "status": "closed",
+  }))
+
+  assert settled == [("merged", merge_sha), ("closed", None)]
+
+
+def test_status_route_rejects_a_different_relay_identity(
+  client, owner_token, tmp_path, monkeypatch,
+):
+  record_id = "relay-status-identity"
+  app_id, record_path = _prepared_relay_record(
+    client, owner_token, tmp_path, record_id,
+  )
+  original = json.loads(record_path.read_text())
+  original.update({
+    "status": "submitting",
+    "submission_mode": "mobius-bot",
+    "relay_contribution_id": _RELAY_ID,
+    "relay_revision": 1,
+  })
+  atomic_write(record_path, json.dumps(original))
+
+  async def fake_request(method, path, *, body=None, idempotency_key=None):
+    assert method == "GET"
+    assert path.endswith(_RELAY_ID)
+    return ({"id": _OTHER_RELAY_ID, "status": "draft"}, 200, {})
+
+  monkeypatch.setattr(relay_route.contribution_broker, "request", fake_request)
+  response = client.get(
+    f"/api/contribution-relay/{app_id}/{record_id}/status",
+    headers={"Authorization": f"Bearer {owner_token}"},
+  )
+
+  assert response.status_code == 502, response.text
+  assert response.json()["detail"]["code"] == "invalid_relay_response"
+  stored = json.loads(record_path.read_text())
+  assert stored["relay_contribution_id"] == _RELAY_ID
+  assert stored["status"] == "submitting"
+
+
+def test_status_route_never_overwrites_a_newer_local_relay_identity(
+  client, owner_token, tmp_path, monkeypatch,
+):
+  record_id = "relay-status-race"
+  app_id, record_path = _prepared_relay_record(
+    client, owner_token, tmp_path, record_id,
+  )
+  original = json.loads(record_path.read_text())
+  original.update({
+    "status": "submitting",
+    "submission_mode": "mobius-bot",
+    "relay_contribution_id": _RELAY_ID,
+    "relay_revision": 1,
+  })
+  atomic_write(record_path, json.dumps(original))
+
+  async def fake_request(method, path, *, body=None, idempotency_key=None):
+    assert method == "GET"
+    assert path.endswith(_RELAY_ID)
+    newer = json.loads(record_path.read_text())
+    newer["relay_contribution_id"] = _OTHER_RELAY_ID
+    newer["relay_revision"] = 2
+    atomic_write(record_path, json.dumps(newer))
+    return ({"id": _RELAY_ID, "status": "draft"}, 200, {})
+
+  monkeypatch.setattr(relay_route.contribution_broker, "request", fake_request)
+  response = client.get(
+    f"/api/contribution-relay/{app_id}/{record_id}/status",
+    headers={"Authorization": f"Bearer {owner_token}"},
+  )
+
+  assert response.status_code == 409, response.text
+  stored = json.loads(record_path.read_text())
+  assert stored["relay_contribution_id"] == _OTHER_RELAY_ID
+  assert stored["relay_revision"] == 2
+
+
+def test_withdraw_route_requires_confirmation_and_is_locally_idempotent(
+  client, owner_token, tmp_path, monkeypatch,
+):
+  record_id = "relay-withdraw"
+  app_id, record_path = _prepared_relay_record(
+    client, owner_token, tmp_path, record_id,
+  )
+  original = json.loads(record_path.read_text())
+  original.update({
+    "status": "draft",
+    "submission_mode": "mobius-bot",
+    "relay_contribution_id": _RELAY_ID,
+    "relay_revision": 3,
+    "relay_status": "draft",
+  })
+  atomic_write(record_path, json.dumps(original))
+  calls = []
+  settled = []
+
+  async def settle_equivalence(record):
+    settled.append(record["status"])
+
+  async def fake_request(method, path, *, body=None, idempotency_key=None):
+    calls.append((method, path, body, idempotency_key))
+    return ({
+      "id": _RELAY_ID,
+      "status": "withdrawn",
+      "revision": 3,
+    }, 200, {})
+
+  monkeypatch.setattr(relay_route.contribution_broker, "request", fake_request)
+  monkeypatch.setattr(
+    relay_route, "_settle_relay_equivalence", settle_equivalence,
+  )
+  headers = {"Authorization": f"Bearer {owner_token}"}
+  url = f"/api/contribution-relay/{app_id}/{record_id}/withdraw"
+
+  missing_confirmation = client.post(url, headers=headers, json={})
+  assert missing_confirmation.status_code == 422
+  assert calls == []
+
+  withdrawn = client.post(url, headers=headers, json={
+    "confirm_withdrawal": True,
+  })
+  assert withdrawn.status_code == 200, withdrawn.text
+  assert withdrawn.json()["record"]["status"] == "closed"
+  assert withdrawn.json()["record"]["relay_status"] == "withdrawn"
+  assert settled == ["closed"]
+  assert calls[0][2] == {
+    "contract_version": 1,
+    "revision": 3,
+    "reason": "owner_withdrawn",
+  }
+  assert calls[0][3].startswith("mobius-withdraw:")
+
+  duplicate = client.post(url, headers=headers, json={
+    "confirm_withdrawal": True,
+  })
+  assert duplicate.status_code == 200, duplicate.text
+  assert duplicate.json()["record"]["status"] == "closed"
+  assert len(calls) == 1
+
+
+def test_withdraw_route_never_reports_closed_before_relay_confirmation(
+  client, owner_token, tmp_path, monkeypatch,
+):
+  record_id = "relay-withdraw-pending"
+  app_id, record_path = _prepared_relay_record(
+    client, owner_token, tmp_path, record_id,
+  )
+  original = json.loads(record_path.read_text())
+  original.update({
+    "status": "draft",
+    "submission_mode": "mobius-bot",
+    "relay_contribution_id": _RELAY_ID,
+    "relay_revision": 1,
+    "relay_status": "draft",
+  })
+  atomic_write(record_path, json.dumps(original))
+
+  async def fake_request(method, path, *, body=None, idempotency_key=None):
+    return ({
+      "id": _RELAY_ID,
+      "status": "withdrawing",
+      "revision": 1,
+    }, 202, {})
+
+  monkeypatch.setattr(relay_route.contribution_broker, "request", fake_request)
+  response = client.post(
+    f"/api/contribution-relay/{app_id}/{record_id}/withdraw",
+    headers={"Authorization": f"Bearer {owner_token}"},
+    json={"confirm_withdrawal": True},
+  )
+
+  assert response.status_code == 502, response.text
+  assert response.json()["detail"]["code"] == "invalid_relay_response"
+  stored = json.loads(record_path.read_text())
+  assert stored["status"] == "draft"
+  assert "withdrawn_at" not in stored

--- a/backend/tests/test_contribution_relay_bff.py
+++ b/backend/tests/test_contribution_relay_bff.py
@@ -601,6 +601,44 @@ def test_submit_route_retries_one_lost_response_with_the_same_request(
   assert [record["id"] for record in witnessed] == [record_id]
 
 
+def test_submit_route_never_applies_an_old_response_to_a_newer_revision(
+  client, owner_token, tmp_path, monkeypatch,
+):
+  record_id = "relay-submit-race"
+  app_id, record_path = _prepared_relay_record(
+    client, owner_token, tmp_path, record_id,
+  )
+  _stub_reviewed_snapshot(monkeypatch, tmp_path)
+
+  async def fake_request(method, path, *, body=None, idempotency_key=None):
+    newer = json.loads(record_path.read_text())
+    newer.update({
+      "status": "submitting",
+      "relay_revision": body["revision"] + 1,
+      "relay_request_sha256": "newer-request",
+      "relay_idempotency_key": "mobius-pr:newer",
+    })
+    atomic_write(record_path, json.dumps(newer))
+    return ({
+      "id": _RELAY_ID,
+      "status": "queued",
+      "revision": body["revision"],
+    }, 202, {})
+
+  monkeypatch.setattr(relay_route.contribution_broker, "request", fake_request)
+  response = client.post(
+    f"/api/contribution-relay/{app_id}/{record_id}/submit",
+    headers={"Authorization": f"Bearer {owner_token}"},
+    json={"confirm_publication": True},
+  )
+
+  assert response.status_code == 409, response.text
+  stored = json.loads(record_path.read_text())
+  assert stored["relay_revision"] == 2
+  assert stored["relay_request_sha256"] == "newer-request"
+  assert "relay_contribution_id" not in stored
+
+
 def test_terminal_relay_equivalence_uses_the_verified_merge_commit(
   tmp_path, monkeypatch,
 ):
@@ -704,6 +742,43 @@ def test_status_route_never_overwrites_a_newer_local_relay_identity(
   assert stored["relay_revision"] == 2
 
 
+def test_status_route_never_overwrites_a_newer_revision_of_the_same_identity(
+  client, owner_token, tmp_path, monkeypatch,
+):
+  record_id = "relay-status-revision-race"
+  app_id, record_path = _prepared_relay_record(
+    client, owner_token, tmp_path, record_id,
+  )
+  original = json.loads(record_path.read_text())
+  original.update({
+    "status": "submitting",
+    "submission_mode": "mobius-bot",
+    "relay_contribution_id": _RELAY_ID,
+    "relay_revision": 1,
+    "relay_request_sha256": "revision-one",
+  })
+  atomic_write(record_path, json.dumps(original))
+
+  async def fake_request(method, path, *, body=None, idempotency_key=None):
+    newer = json.loads(record_path.read_text())
+    newer["relay_revision"] = 2
+    newer["relay_request_sha256"] = "revision-two"
+    atomic_write(record_path, json.dumps(newer))
+    return ({"id": _RELAY_ID, "status": "draft", "revision": 1}, 200, {})
+
+  monkeypatch.setattr(relay_route.contribution_broker, "request", fake_request)
+  response = client.get(
+    f"/api/contribution-relay/{app_id}/{record_id}/status",
+    headers={"Authorization": f"Bearer {owner_token}"},
+  )
+
+  assert response.status_code == 409, response.text
+  stored = json.loads(record_path.read_text())
+  assert stored["relay_contribution_id"] == _RELAY_ID
+  assert stored["relay_revision"] == 2
+  assert stored["relay_request_sha256"] == "revision-two"
+
+
 def test_withdraw_route_requires_confirmation_and_is_locally_idempotent(
   client, owner_token, tmp_path, monkeypatch,
 ):
@@ -802,4 +877,48 @@ def test_withdraw_route_never_reports_closed_before_relay_confirmation(
   assert response.json()["detail"]["code"] == "invalid_relay_response"
   stored = json.loads(record_path.read_text())
   assert stored["status"] == "draft"
+  assert "withdrawn_at" not in stored
+
+
+def test_withdraw_route_never_applies_an_old_response_to_a_newer_revision(
+  client, owner_token, tmp_path, monkeypatch,
+):
+  record_id = "relay-withdraw-race"
+  app_id, record_path = _prepared_relay_record(
+    client, owner_token, tmp_path, record_id,
+  )
+  original = json.loads(record_path.read_text())
+  original.update({
+    "status": "draft",
+    "submission_mode": "mobius-bot",
+    "relay_contribution_id": _RELAY_ID,
+    "relay_revision": 3,
+    "relay_request_sha256": "revision-three",
+    "relay_status": "draft",
+  })
+  atomic_write(record_path, json.dumps(original))
+
+  async def fake_request(method, path, *, body=None, idempotency_key=None):
+    newer = json.loads(record_path.read_text())
+    newer["relay_revision"] = 4
+    newer["relay_request_sha256"] = "revision-four"
+    atomic_write(record_path, json.dumps(newer))
+    return ({
+      "id": _RELAY_ID,
+      "status": "withdrawn",
+      "revision": 3,
+    }, 200, {})
+
+  monkeypatch.setattr(relay_route.contribution_broker, "request", fake_request)
+  response = client.post(
+    f"/api/contribution-relay/{app_id}/{record_id}/withdraw",
+    headers={"Authorization": f"Bearer {owner_token}"},
+    json={"confirm_withdrawal": True},
+  )
+
+  assert response.status_code == 409, response.text
+  stored = json.loads(record_path.read_text())
+  assert stored["status"] == "draft"
+  assert stored["relay_revision"] == 4
+  assert stored["relay_request_sha256"] == "revision-four"
   assert "withdrawn_at" not in stored

--- a/backend/tests/test_contribution_relay_description.py
+++ b/backend/tests/test_contribution_relay_description.py
@@ -1,0 +1,16 @@
+from app.routes.contribution_relay import _reviewed_description
+
+
+def test_reviewed_description_prefers_the_visible_plan_body():
+  record = {
+    "plan": {"body_draft": "## Summary\n\nReviewed details.\n"},
+    "description": "Internal description",
+    "summary": "Internal summary",
+  }
+
+  assert _reviewed_description(record) == "## Summary\n\nReviewed details."
+
+
+def test_reviewed_description_has_safe_legacy_fallbacks():
+  assert _reviewed_description({"summary": "  Legacy summary  "}) == "Legacy summary"
+  assert _reviewed_description({}) == "Reviewed in Möbius."

--- a/backend/tests/test_identity_broker.py
+++ b/backend/tests/test_identity_broker.py
@@ -319,6 +319,113 @@ def test_handler_only_supports_identity_and_inference_http_methods():
   assert not hasattr(handler, "do_DELETE")
 
 
+def test_contribution_proxy_is_uds_only_and_binds_exact_requests(
+  broker, monkeypatch,
+):
+  seen = {}
+
+  class FakeClient:
+    def build_request(self, method, url, **kwargs):
+      seen["url"] = url
+      seen["headers"] = kwargs["headers"]
+      return httpx.Request(
+        method, url, content=kwargs.get("content"), headers=kwargs["headers"],
+      )
+
+    def send(self, request, *, stream):
+      return httpx.Response(
+        200, request=request, stream=httpx.ByteStream(b"{}"),
+      )
+
+    def close(self):
+      return None
+
+  capabilities = []
+  broker.client.close()
+  broker.client = FakeClient()
+  monkeypatch.setattr(
+    broker, "_capability",
+    lambda **kwargs: capabilities.append(kwargs) or "one-use",
+  )
+  create_path = "/v1/contributions"
+  create_body = b'{"repo":"mobius-os/mobius"}'
+  key = "contribution:0123456789abcdef"
+
+  with pytest.raises(FileNotFoundError):
+    broker.proxy(
+      method="POST", path=create_path, body=create_body,
+      headers={"idempotency-key": key},
+    )
+
+  response = broker.proxy(
+    method="POST", path=create_path, body=create_body,
+    headers={"idempotency-key": key}, allow_contributions=True,
+  )
+  response.close()
+  assert seen["url"] == broker_module.CONTRIBUTION_BASE_URL + create_path
+  assert seen["headers"]["Idempotency-Key"] == key
+  assert capabilities[-1]["audience"] == "mobius-contribution-relay"
+  assert capabilities[-1]["scope"] == "contribution:submit"
+  assert capabilities[-1]["idempotency_key"] == key
+
+  contribution = "ctr_1234567890abcdef1234567890abcdef"
+  response = broker.proxy(
+    method="GET", path=f"/v1/contributions/{contribution}", body=b"",
+    headers={}, allow_contributions=True,
+  )
+  response.close()
+  assert capabilities[-1]["scope"] == "contribution:read"
+
+  withdraw_path = f"/v1/contributions/{contribution}/withdraw"
+  response = broker.proxy(
+    method="POST", path=withdraw_path, body=b'{"revision":1}',
+    headers={"idempotency-key": "withdraw:0123456789abcdef"},
+    allow_contributions=True,
+  )
+  response.close()
+  assert capabilities[-1]["scope"] == "contribution:withdraw"
+
+  for method, forbidden in (
+    ("GET", "/v1/contributions/github/status"),
+    ("GET", f"/v1/contributions/{contribution}?subject=other"),
+    ("DELETE", f"/v1/contributions/{contribution}"),
+    ("POST", "https://evil.test/v1/contributions"),
+  ):
+    with pytest.raises(FileNotFoundError):
+      broker.proxy(
+        method=method, path=forbidden, body=b"", headers={},
+        allow_contributions=True,
+      )
+
+
+def test_contribution_mutations_require_idempotency(broker):
+  with pytest.raises(ValueError, match="idempotency key is required"):
+    broker.proxy(
+      method="POST", path="/v1/contributions", body=b"{}", headers={},
+      allow_contributions=True,
+    )
+
+
+def test_large_body_exception_is_only_for_exact_contribution_mutations():
+  contribution = "ctr_1234567890abcdef1234567890abcdef"
+  assert broker_module._request_body_limit(
+    is_unix=True, method="POST", path="/v1/contributions",
+  ) == broker_module.MAX_CONTRIBUTION_BODY
+  assert broker_module._request_body_limit(
+    is_unix=True, method="POST",
+    path=f"/v1/contributions/{contribution}/withdraw",
+  ) == broker_module.MAX_CONTRIBUTION_BODY
+  for is_unix, method, path in (
+    (False, "POST", "/v1/contributions"),
+    (True, "POST", "/v1/contributions?x=1"),
+    (True, "GET", f"/v1/contributions/{contribution}"),
+    (True, "POST", "/v1/community/apps"),
+  ):
+    assert broker_module._request_body_limit(
+      is_unix=is_unix, method=method, path=path,
+    ) == broker_module.MAX_BODY
+
+
 def test_unix_handler_rejects_identity_queries_and_forwards_inference():
   # AF_UNIX paths are capped at roughly 108 bytes on Linux; long worktree
   # paths can make pytest's ordinary tmp_path exceed that.
@@ -330,7 +437,9 @@ def test_unix_handler_rejects_identity_queries_and_forwards_inference():
     def identity(self):
       return {"linked": True}
 
-    def proxy(self, *, method, path, body, headers):
+    def proxy(
+      self, *, method, path, body, headers, allow_contributions=False,
+    ):
       seen.append((method, path, body))
       request = httpx.Request(method, "https://central.test" + path)
       payload = json.dumps({"method": method}).encode()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,9 @@ services:
       # only when the browser-facing origin differs from DOMAIN.
       - MOBIUS_ACCOUNT_ORIGIN=${MOBIUS_ACCOUNT_ORIGIN:-https://www.mobius.you}
       - MOBIUS_ACCOUNT_CLIENT_ORIGIN=${MOBIUS_ACCOUNT_CLIENT_ORIGIN:-}
+      - MOBIUS_CONTRIBUTION_RELAY_URL=${MOBIUS_CONTRIBUTION_RELAY_URL:-https://www.mobius.you}
+      - MOBIUS_CONTRIBUTION_TARGET_REPO=${MOBIUS_CONTRIBUTION_TARGET_REPO:-}
+      - MOBIUS_CONTRIBUTION_RELAY_TEST_REPOSITORIES=${MOBIUS_CONTRIBUTION_RELAY_TEST_REPOSITORIES:-}
       # No application default: every public_surface fails closed unless the
       # operator explicitly configures the same shared origin consumed by
       # Caddy above. One gateway serves all owner-trusted service slugs.


### PR DESCRIPTION
## Summary
- publish an owner-approved, exactly reviewed merge snapshot through the root-owned Möbius identity broker without exposing a personal GitHub identity
- allow only exact create, status, and withdraw relay routes and bind every mutation to its idempotency capability
- require the publication target to match the reviewed repository, except for an explicit test-fork allowlist
- require the relay to return a draft pull request for the exact contribution identity and revision
- persist revisions, retries, terminal outcomes, and withdrawal state without letting stale status responses overwrite newer local state
- bound request and streamed response sizes, accept regular files only, cap each contribution at 80 files, and build the publication from an exact Git merge tree
- fail closed when a live relay configuration file exists but is malformed or incomplete
- document the relay controls and pass them explicitly through the standard Compose deployment
- write the same immutable pending/landed equivalence witness as personal-GitHub publication, so reviewed app handoffs work on either submission path

## Security and privacy
- the unprivileged application never receives the publication credential
- mutation routes are Unix-socket-only; loopback TCP remains inference-only
- absolute URLs, unreviewed target repositories, symlinks, special files, oversized bodies, oversized relay responses, and ambiguous publication responses are rejected
- no instance data, account identity, token, or private repository content is included in the contribution

## Prior work
No matching pull request or issue was found.

## Testing
- focused relay, configuration, description, identity-broker, and equivalence-lifecycle suite on the final head: 55 passed, 1 skipped
- complete backend suite on the functional parent: 4,345 passed, 3 skipped; the final amend only documents and wires the existing settings and adds their assertion
- Python bytecode compilation and canonical diff checks passed
- the complete 2,453-line binary-safe diff was reviewed after the final amend