### PR TITLE
Add bounded exact-endpoint source review

### DIFF
--- a/backend/app/deps.py
+++ b/backend/app/deps.py
@@ -864,8 +864,9 @@ def get_owner_or_app_with_github_access(
   """Owner JWT, OR an app-scoped JWT whose App row has github_access=true.
 
   This is the GitHub data grant: the GET-only REST proxy, mutation-rejecting
-  GraphQL proxy, sanitized local source status, and Contribute's narrow reviewed
-  submit endpoints. Credential management is a separate github_connect grant.
+  GraphQL proxy, sanitized local source status, project-bound bounded source
+  previews, and Contribute's narrow reviewed submit endpoints. Credential
+  management is a separate github_connect grant.
   Neither capability can exfiltrate the stored token (INV1).
 
   Permission is read from the App row at request time (not baked into

--- a/backend/app/routes/github.py
+++ b/backend/app/routes/github.py
@@ -22,10 +22,12 @@ never bypassed. An app-scoped github_access token may act only on records from
 its own storage; it cannot use either path as a general GitHub write proxy.
 
 The fetch-free /source-status read is the local companion for Contribute's
-Sources view. It exposes only sanitized repository identity, refs, diff
-magnitudes, and capped relative path names — never source contents, absolute
-paths, raw remotes, or credentials — so Contribute does not need the broader
-filesystem capability merely to explain where local work sits.
+Projects view. It exposes only sanitized repository identity, refs, diff
+magnitudes, and capped relative path names. The separate /source-diff read
+returns one bounded unified patch for an exact inspected project/head; callers
+cannot provide a repository path or Git ref. Neither route exposes absolute
+paths, raw remotes, or credentials, so Contribute does not need general
+filesystem access to review local work.
 
 The token itself never appears in any response or log line (INV1).
 """
@@ -580,6 +582,81 @@ async def github_source_status(
     "platform": platform,
     "apps": projects,
   }
+
+
+@router.get("/source-diff")
+async def github_source_diff(
+  project: str,
+  head: str,
+  comparison: str | None = None,
+  _: models.Owner = Depends(get_owner_or_app_with_github_access),
+  db: Session = Depends(get_db),
+):
+  """Return a bounded unified diff for one source-map project snapshot."""
+  if not re.fullmatch(r"[0-9a-f]{40}", head):
+    raise HTTPException(status_code=422, detail="Invalid source revision.")
+  if comparison is not None and not re.fullmatch(r"[0-9a-f]{40}", comparison):
+    raise HTTPException(status_code=422, detail="Invalid comparison revision.")
+
+  async def build_diff(repo: Path, inspected: dict) -> dict:
+    """Map the narrow source-preview outcomes consistently for every owner."""
+    try:
+      return await asyncio.to_thread(
+        source_status.build_project_diff,
+        repo,
+        inspected,
+        expected_head=head,
+        expected_comparison=comparison,
+      )
+    except RuntimeError as exc:
+      if str(exc) != "source_snapshot_changed":
+        raise
+      raise HTTPException(
+        status_code=409,
+        detail={
+          "code": "source_snapshot_changed",
+          "message": "The project changed; refresh before opening its diff.",
+        },
+      ) from exc
+    except ValueError as exc:
+      raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+  if project == "platform":
+    db.close()
+    repo = Path(get_settings().data_dir).resolve() / "platform"
+    async with fs_locks.source_dir_lock(repo):
+      inspected = await asyncio.to_thread(source_status.build_platform_status)
+      return await build_diff(repo, inspected)
+
+  match = re.fullmatch(r"app:([1-9][0-9]*)", project)
+  if match is None:
+    raise HTTPException(status_code=404, detail="Project not found.")
+  row = (
+    db.query(models.App)
+    .filter(
+      models.App.id == int(match.group(1)),
+      models.App.deleted_at.is_(None),
+      models.App.source_dir.isnot(None),
+    )
+    .first()
+  )
+  if row is None:
+    raise HTTPException(status_code=404, detail="Project not found.")
+  app = {
+    "id": row.id,
+    "name": row.name,
+    "slug": row.slug,
+    "version": row.version,
+    "manifest_url": row.manifest_url,
+    "published_manifest_url": row.published_manifest_url,
+    "source_dir": row.source_dir,
+  }
+  db.close()
+  async with fs_locks.source_dir_lock(app["source_dir"]):
+    inspected = await asyncio.to_thread(source_status.build_app_status, app)
+    if inspected is None:
+      raise HTTPException(status_code=404, detail="Project not found.")
+    return await build_diff(Path(app["source_dir"]), inspected)
 
 
 @router.delete("/connect", dependencies=[Depends(reject_cross_site)])

--- a/backend/app/source_status.py
+++ b/backend/app/source_status.py
@@ -18,7 +18,10 @@ from __future__ import annotations
 
 import os
 import re
+import selectors
+import stat
 import subprocess
+import time
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -28,6 +31,8 @@ from app.config import get_settings
 
 _GIT_TIMEOUT = 8
 _DIFF_PREVIEW_BYTES = 800_000
+_UNTRACKED_PATH_BYTES = 512_000
+_UNTRACKED_PATHS = 5_000
 _EMPTY_TREE_SHA = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
 # Filenames and numstat counts are safe metadata (never source contents). Keep
 # a generous ceiling so Contribute can offer a truthful "Show all files" for
@@ -445,49 +450,115 @@ def _working_summary(repo: Path) -> dict[str, Any]:
   }
 
 
-def _bounded_diff(
-  repo: Path, *args: str, limit: int = _DIFF_PREVIEW_BYTES,
-) -> tuple[bytes, bool]:
-  """Return bounded Git diff bytes without buffering an unbounded patch."""
-  command = [
-    "git", "-C", str(repo), "diff", "--no-ext-diff", "--no-color",
-    "--binary", "--full-index", "--no-renames",
-    "--src-prefix=a/", "--dst-prefix=b/", *args,
-  ]
+def _bounded_stdout(
+  command: list[str], *, env: dict[str, str], limit: int,
+) -> tuple[bytes, bool, int | None]:
+  """Read at most ``limit`` bytes while imposing the Git wall-clock bound."""
   try:
     process = subprocess.Popen(
       command,
       stdout=subprocess.PIPE,
       stderr=subprocess.DEVNULL,
-      env=_git_env(repo),
+      env=env,
     )
   except OSError:
-    return b"", False
+    return b"", False, None
   assert process.stdout is not None
+  selector = selectors.DefaultSelector()
+  output = bytearray()
+  truncated = False
+  deadline = time.monotonic() + _GIT_TIMEOUT
   try:
-    output = process.stdout.read(limit + 1)
-    truncated = len(output) > limit
-    if truncated:
-      output = output[:limit]
+    os.set_blocking(process.stdout.fileno(), False)
+    selector.register(process.stdout, selectors.EVENT_READ)
+    reached_eof = False
+    while not reached_eof:
+      remaining_time = deadline - time.monotonic()
+      if remaining_time <= 0:
+        truncated = True
+        break
+      events = selector.select(remaining_time)
+      if not events:
+        truncated = True
+        break
+      for key, _mask in events:
+        try:
+          chunk = os.read(
+            key.fileobj.fileno(),
+            min(65_536, max(1, limit + 1 - len(output))),
+          )
+        except BlockingIOError:
+          continue
+        if not chunk:
+          reached_eof = True
+          break
+        output.extend(chunk)
+        if len(output) > limit:
+          del output[limit:]
+          truncated = True
+          reached_eof = True
+          break
+
+    if truncated and process.poll() is None:
       process.terminate()
     try:
-      process.wait(timeout=_GIT_TIMEOUT)
+      process.wait(timeout=max(0.05, deadline - time.monotonic()))
     except subprocess.TimeoutExpired:
       process.kill()
-      process.wait()
+      process.wait(timeout=1)
       truncated = True
-    return output, truncated
+    return bytes(output), truncated, process.returncode
   finally:
+    if process.poll() is None:
+      process.kill()
+      try:
+        process.wait(timeout=1)
+      except subprocess.TimeoutExpired:
+        pass
+    selector.close()
     process.stdout.close()
 
 
-def _untracked_paths(repo: Path) -> list[str]:
-  proc = _git(
-    repo, "ls-files", "--others", "--exclude-standard", "-z", "--",
+def _bounded_diff(
+  repo: Path, *args: str, limit: int = _DIFF_PREVIEW_BYTES,
+) -> tuple[bytes, bool]:
+  """Return bounded Git diff bytes without an unbounded read or wait."""
+  output, truncated, _returncode = _bounded_stdout(
+    [
+      "git", "-C", str(repo), "diff", "--no-ext-diff", "--no-color",
+      "--binary", "--full-index", "--no-renames",
+      "--src-prefix=a/", "--dst-prefix=b/", *args,
+    ],
+    env=_git_env(repo),
+    limit=limit,
   )
-  if proc.returncode != 0:
-    return []
-  return [path for path in proc.stdout.split("\0") if path]
+  return output, truncated or _returncode not in (0, 1)
+
+
+def _untracked_paths(repo: Path) -> tuple[list[str], bool]:
+  """Return a bounded set of complete, NUL-delimited untracked paths."""
+  output, truncated, returncode = _bounded_stdout(
+    [
+      "git", "-C", str(repo), "ls-files", "--others",
+      "--exclude-standard", "-z", "--",
+    ],
+    env=_git_env(repo),
+    limit=_UNTRACKED_PATH_BYTES,
+  )
+  if returncode != 0:
+    return [], True
+  records = output.split(b"\0")
+  if output and not output.endswith(b"\0"):
+    records.pop()
+    truncated = True
+  paths = [
+    record.decode("utf-8", errors="surrogateescape")
+    for record in records if record
+  ]
+  if len(paths) > _UNTRACKED_PATHS:
+    paths = paths[:_UNTRACKED_PATHS]
+    truncated = True
+  return paths, truncated
 
 
 def build_project_diff(
@@ -508,11 +579,16 @@ def build_project_diff(
   head = project.get("head_sha")
   if not isinstance(head, str) or not head:
     raise ValueError("Source is not available for diff review.")
-  comparison_ref = project.get("comparison_ref") or project.get("base_ref")
   comparison_sha = project.get("comparison_sha") or project.get("base_sha")
   if head != expected_head or comparison_sha != expected_comparison:
     raise RuntimeError("source_snapshot_changed")
-  left = comparison_ref if isinstance(comparison_ref, str) and comparison_ref else _EMPTY_TREE_SHA
+  if _rev(repo, "HEAD") != head:
+    raise RuntimeError("source_snapshot_changed")
+  left = (
+    comparison_sha
+    if isinstance(comparison_sha, str) and comparison_sha
+    else _EMPTY_TREE_SHA
+  )
 
   managed_paths: set[str] = set()
   if project.get("kind") == "app":
@@ -521,7 +597,7 @@ def build_project_diff(
     # managed set here rather than trusting the status response's capped path
     # preview; one explicit diff open can afford the bounded extra inventory.
     _summary, managed_paths = _diff_inventory(
-      repo, left, "HEAD", classify_install=True,
+      repo, left, head, classify_install=True,
     )
     managed_paths.add(".gitignore")
   pathspec = ["."] + [
@@ -532,8 +608,20 @@ def build_project_diff(
     repo, left, "--", *pathspec, limit=_DIFF_PREVIEW_BYTES,
   )
   remaining = max(0, _DIFF_PREVIEW_BYTES - len(patch))
-  for path in _untracked_paths(repo):
+  untracked_paths, untracked_truncated = _untracked_paths(repo)
+  truncated = truncated or untracked_truncated
+  for path in untracked_paths:
     if path in managed_paths:
+      continue
+    try:
+      mode = (repo / path).lstat().st_mode
+    except OSError:
+      truncated = True
+      continue
+    if stat.S_ISLNK(mode) or not stat.S_ISREG(mode):
+      # Git's no-index diff opens its operands. Refuse untracked symlinks and
+      # special files so a review cannot escape the project or wait on a FIFO.
+      truncated = True
       continue
     if remaining <= 0:
       truncated = True

--- a/backend/app/source_status.py
+++ b/backend/app/source_status.py
@@ -27,6 +27,8 @@ from app import app_git
 from app.config import get_settings
 
 _GIT_TIMEOUT = 8
+_DIFF_PREVIEW_BYTES = 800_000
+_EMPTY_TREE_SHA = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
 # Filenames and numstat counts are safe metadata (never source contents). Keep
 # a generous ceiling so Contribute can offer a truthful "Show all files" for
 # normal projects while still bounding pathological repositories.
@@ -440,6 +442,121 @@ def _working_summary(repo: Path) -> dict[str, Any]:
     "merge_active": merge_active,
     "paths": paths,
     "truncated": files > len(paths),
+  }
+
+
+def _bounded_diff(
+  repo: Path, *args: str, limit: int = _DIFF_PREVIEW_BYTES,
+) -> tuple[bytes, bool]:
+  """Return bounded Git diff bytes without buffering an unbounded patch."""
+  command = [
+    "git", "-C", str(repo), "diff", "--no-ext-diff", "--no-color",
+    "--binary", "--full-index", "--no-renames",
+    "--src-prefix=a/", "--dst-prefix=b/", *args,
+  ]
+  try:
+    process = subprocess.Popen(
+      command,
+      stdout=subprocess.PIPE,
+      stderr=subprocess.DEVNULL,
+      env=_git_env(repo),
+    )
+  except OSError:
+    return b"", False
+  assert process.stdout is not None
+  try:
+    output = process.stdout.read(limit + 1)
+    truncated = len(output) > limit
+    if truncated:
+      output = output[:limit]
+      process.terminate()
+    try:
+      process.wait(timeout=_GIT_TIMEOUT)
+    except subprocess.TimeoutExpired:
+      process.kill()
+      process.wait()
+      truncated = True
+    return output, truncated
+  finally:
+    process.stdout.close()
+
+
+def _untracked_paths(repo: Path) -> list[str]:
+  proc = _git(
+    repo, "ls-files", "--others", "--exclude-standard", "-z", "--",
+  )
+  if proc.returncode != 0:
+    return []
+  return [path for path in proc.stdout.split("\0") if path]
+
+
+def build_project_diff(
+  repo: Path,
+  project: dict[str, Any],
+  *,
+  expected_head: str,
+  expected_comparison: str | None,
+) -> dict[str, Any]:
+  """Build one bounded working-tree preview for an inspected project.
+
+  The project key chooses the repository at the route boundary; callers never
+  provide a path or ref. ``expected_head`` and ``expected_comparison`` bind the
+  preview to both accepted endpoints from the source-map row, while ordinary
+  working edits are intentionally read at preview time. Ignored files stay
+  excluded by Git's own repository policy.
+  """
+  head = project.get("head_sha")
+  if not isinstance(head, str) or not head:
+    raise ValueError("Source is not available for diff review.")
+  comparison_ref = project.get("comparison_ref") or project.get("base_ref")
+  comparison_sha = project.get("comparison_sha") or project.get("base_sha")
+  if head != expected_head or comparison_sha != expected_comparison:
+    raise RuntimeError("source_snapshot_changed")
+  left = comparison_ref if isinstance(comparison_ref, str) and comparison_ref else _EMPTY_TREE_SHA
+
+  managed_paths: set[str] = set()
+  if project.get("kind") == "app":
+    # Installed app trees deliberately carry installer adaptations that are
+    # useful for runtime but not owner-authored review. Recompute the complete
+    # managed set here rather than trusting the status response's capped path
+    # preview; one explicit diff open can afford the bounded extra inventory.
+    _summary, managed_paths = _diff_inventory(
+      repo, left, "HEAD", classify_install=True,
+    )
+    managed_paths.add(".gitignore")
+  pathspec = ["."] + [
+    f":(exclude,literal){path}" for path in sorted(managed_paths)
+  ]
+
+  patch, truncated = _bounded_diff(
+    repo, left, "--", *pathspec, limit=_DIFF_PREVIEW_BYTES,
+  )
+  remaining = max(0, _DIFF_PREVIEW_BYTES - len(patch))
+  for path in _untracked_paths(repo):
+    if path in managed_paths:
+      continue
+    if remaining <= 0:
+      truncated = True
+      break
+    addition, addition_truncated = _bounded_diff(
+      repo, "--no-index", "--", "/dev/null", path, limit=remaining,
+    )
+    if patch and addition and not patch.endswith(b"\n"):
+      patch += b"\n"
+      remaining -= 1
+    patch += addition
+    remaining = max(0, _DIFF_PREVIEW_BYTES - len(patch))
+    truncated = truncated or addition_truncated
+    if addition_truncated:
+      break
+
+  return {
+    "schema": 1,
+    "project": project.get("key"),
+    "head_sha": head,
+    "comparison_sha": comparison_sha,
+    "diff": patch.decode("utf-8", errors="replace"),
+    "diff_truncated": truncated,
   }
 
 

--- a/backend/tests/test_github_routes.py
+++ b/backend/tests/test_github_routes.py
@@ -874,6 +874,77 @@ def test_source_status_requires_github_access_for_app_tokens(
   assert allowed.status_code == 200, allowed.text
 
 
+def test_source_diff_is_project_bound_bounded_and_stale_safe(
+  client, owner_token,
+):
+  from app import models
+  from app.database import SessionLocal
+
+  app_id, app_token = _app_token(
+    client, owner_token, github_access=True,
+  )
+  session = SessionLocal()
+  try:
+    row = session.query(models.App).filter(models.App.id == app_id).one()
+    source = Path(row.source_dir)
+  finally:
+    session.close()
+  head = subprocess.run(
+    ["git", "-C", str(source), "rev-parse", "HEAD"],
+    check=True, capture_output=True, text=True,
+  ).stdout.strip()
+  comparison = subprocess.run(
+    ["git", "-C", str(source), "rev-parse", "upstream"],
+    check=True, capture_output=True, text=True,
+  ).stdout.strip()
+  (source / "new-source.js").write_text(
+    "export const reviewed = true\n", encoding="utf-8",
+  )
+  headers = {"Authorization": f"Bearer {app_token}"}
+
+  response = client.get(
+    "/api/github/source-diff",
+    params={
+      "project": f"app:{app_id}",
+      "head": head,
+      "comparison": comparison,
+    },
+    headers=headers,
+  )
+
+  assert response.status_code == 200, response.text
+  body = response.json()
+  assert body["project"] == f"app:{app_id}"
+  assert body["head_sha"] == head
+  assert "diff --git a/new-source.js b/new-source.js" in body["diff"]
+  assert "+export const reviewed = true" in body["diff"]
+  assert str(source) not in response.text
+
+  stale = client.get(
+    "/api/github/source-diff",
+    params={
+      "project": f"app:{app_id}",
+      "head": "0" * 40,
+      "comparison": comparison,
+    },
+    headers=headers,
+  )
+  assert stale.status_code == 409
+  assert stale.json()["detail"]["code"] == "source_snapshot_changed"
+
+
+def test_source_diff_requires_github_access_for_app_tokens(
+  client, owner_token,
+):
+  _, denied_token = _app_token(client, owner_token, github_access=False)
+  denied = client.get(
+    "/api/github/source-diff",
+    params={"project": "platform", "head": "0" * 40},
+    headers={"Authorization": f"Bearer {denied_token}"},
+  )
+  assert denied.status_code == 403
+
+
 def test_source_status_projects_local_distribution_manifest_identity(
   client, owner_token, auth, monkeypatch,
 ):

--- a/backend/tests/test_source_status.py
+++ b/backend/tests/test_source_status.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import hashlib
+import os
 import subprocess
+import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -177,6 +180,32 @@ def test_project_diff_refuses_a_stale_source_map_head():
       expected_comparison="0" * 40,
     )
 
+  (repo / "later.js").write_text("later\n", encoding="utf-8")
+  _git(repo, "add", "later.js")
+  _commit(repo, "later source edit")
+  with pytest.raises(RuntimeError, match="source_snapshot_changed"):
+    source_status.build_project_diff(
+      repo, project, expected_head=project["head_sha"],
+      expected_comparison=project["comparison_sha"],
+    )
+
+
+def test_project_diff_uses_captured_sha_after_comparison_ref_moves():
+  repo = _repo("immutable-diff-endpoints")
+  (repo / "index.jsx").write_text("export default 2\n", encoding="utf-8")
+  _git(repo, "add", "index.jsx")
+  head = _commit(repo, "accepted local edit")
+  project = source_status.build_app_status(_app(repo))
+  assert project is not None
+
+  _git(repo, "update-ref", "refs/heads/upstream", head)
+  preview = source_status.build_project_diff(
+    repo, project, expected_head=project["head_sha"],
+    expected_comparison=project["comparison_sha"],
+  )
+
+  assert "+export default 2" in preview["diff"]
+
 
 def test_project_diff_caps_large_source_without_buffering_it(monkeypatch):
   repo = _repo("bounded-diff-preview")
@@ -192,6 +221,49 @@ def test_project_diff_caps_large_source_without_buffering_it(monkeypatch):
 
   assert preview["diff_truncated"] is True
   assert len(preview["diff"].encode()) <= 256
+
+
+def test_bounded_reader_enforces_time_without_waiting_for_output(monkeypatch):
+  monkeypatch.setattr(source_status, "_GIT_TIMEOUT", 0.05)
+  started = time.monotonic()
+
+  output, truncated, returncode = source_status._bounded_stdout(
+    [sys.executable, "-c", "import time; time.sleep(10)"],
+    env=dict(os.environ),
+    limit=256,
+  )
+
+  assert time.monotonic() - started < 1
+  assert output == b""
+  assert truncated is True
+  assert returncode is not None
+
+
+def test_untracked_inventory_is_bounded_by_path_count(monkeypatch):
+  repo = _repo("bounded-untracked-paths")
+  for index in range(3):
+    (repo / f"new-{index}.js").write_text("new\n", encoding="utf-8")
+  monkeypatch.setattr(source_status, "_UNTRACKED_PATHS", 2)
+
+  paths, truncated = source_status._untracked_paths(repo)
+
+  assert len(paths) == 2
+  assert truncated is True
+
+
+def test_project_diff_skips_untracked_symlinks():
+  repo = _repo("untracked-symlink")
+  os.symlink("index.jsx", repo / "outside-review")
+  project = source_status.build_app_status(_app(repo))
+  assert project is not None
+
+  preview = source_status.build_project_diff(
+    repo, project, expected_head=project["head_sha"],
+    expected_comparison=project["comparison_sha"],
+  )
+
+  assert preview["diff_truncated"] is True
+  assert "outside-review" not in preview["diff"]
 
 
 def test_typical_project_returns_its_complete_changed_filename_list():

--- a/backend/tests/test_source_status.py
+++ b/backend/tests/test_source_status.py
@@ -133,6 +133,67 @@ def test_committed_and_working_deltas_are_reported_separately():
   assert result["working"]["untracked"] == 1
 
 
+def test_project_diff_combines_committed_working_and_untracked_source():
+  repo = _repo("diff-preview")
+  (repo / "index.jsx").write_text("export default 2\n", encoding="utf-8")
+  _git(repo, "add", "index.jsx")
+  _commit(repo, "accepted local edit")
+  (repo / "index.jsx").write_text("export default 3\n", encoding="utf-8")
+  (repo / "new-file.js").write_text("export const newFile = true\n", encoding="utf-8")
+  (repo / ".gitignore").write_text("ignored.log\n", encoding="utf-8")
+  (repo / "ignored.log").write_text("runtime noise\n", encoding="utf-8")
+
+  project = source_status.build_app_status(_app(repo))
+  assert project is not None
+  preview = source_status.build_project_diff(
+    repo, project, expected_head=project["head_sha"],
+    expected_comparison=project["comparison_sha"],
+  )
+
+  assert preview["project"] == project["key"]
+  assert preview["head_sha"] == project["head_sha"]
+  assert preview["diff_truncated"] is False
+  assert "diff --git a/index.jsx b/index.jsx" in preview["diff"]
+  assert "+export default 3" in preview["diff"]
+  assert "diff --git a/new-file.js b/new-file.js" in preview["diff"]
+  assert "+export const newFile = true" in preview["diff"]
+  assert "diff --git a/.gitignore b/.gitignore" not in preview["diff"]
+  assert "diff --git a/ignored.log b/ignored.log" not in preview["diff"]
+
+
+def test_project_diff_refuses_a_stale_source_map_head():
+  repo = _repo("stale-diff-preview")
+  project = source_status.build_app_status(_app(repo))
+  assert project is not None
+
+  with pytest.raises(RuntimeError, match="source_snapshot_changed"):
+    source_status.build_project_diff(
+      repo, project, expected_head="0" * 40,
+      expected_comparison=project["comparison_sha"],
+    )
+  with pytest.raises(RuntimeError, match="source_snapshot_changed"):
+    source_status.build_project_diff(
+      repo, project, expected_head=project["head_sha"],
+      expected_comparison="0" * 40,
+    )
+
+
+def test_project_diff_caps_large_source_without_buffering_it(monkeypatch):
+  repo = _repo("bounded-diff-preview")
+  (repo / "large.js").write_text("x" * 4096, encoding="utf-8")
+  project = source_status.build_app_status(_app(repo))
+  assert project is not None
+  monkeypatch.setattr(source_status, "_DIFF_PREVIEW_BYTES", 256)
+
+  preview = source_status.build_project_diff(
+    repo, project, expected_head=project["head_sha"],
+    expected_comparison=project["comparison_sha"],
+  )
+
+  assert preview["diff_truncated"] is True
+  assert len(preview["diff"].encode()) <= 256
+
+
 def test_typical_project_returns_its_complete_changed_filename_list():
   repo = _repo("many-files")
   for index in range(25):
@@ -187,6 +248,14 @@ def test_install_managed_app_deltas_do_not_look_like_customization(monkeypatch):
   assert customized["tree"]["paths"][0]["path"] == "index.jsx"
   assert customized["tree"]["paths"][0]["group"] == "authored"
   assert len(log_calls) == 2, "each status build should need one history scan"
+
+  preview = source_status.build_project_diff(
+    repo, customized, expected_head=customized["head_sha"],
+    expected_comparison=customized["comparison_sha"],
+  )
+  assert "diff --git a/index.jsx b/index.jsx" in preview["diff"]
+  assert "diff --git a/runner.sh b/runner.sh" not in preview["diff"]
+  assert "diff --git a/.gitignore b/.gitignore" not in preview["diff"]
 
 
 def test_history_subject_boundary_cannot_be_forged_by_a_filename():

--- a/frontend/src/components/DiffView/UnifiedDiff.jsx
+++ b/frontend/src/components/DiffView/UnifiedDiff.jsx
@@ -1,0 +1,23 @@
+// CANONICAL DIFF VIEWER: copy this entire folder verbatim. It imports only
+// React and its own flat sibling modules. Styles ship as a JavaScript string
+// because the mini-app compiler rejects CSS side-output.
+// Parse and render one raw unified patch through the canonical file viewer.
+
+import { useMemo } from 'react'
+import FileDiffList from './FileDiffList.jsx'
+import { parseUnifiedDiff } from './parseUnifiedDiff.js'
+
+export default function UnifiedDiff({
+  diff,
+  summaryOverrides,
+  diffTruncated = false,
+}) {
+  const files = useMemo(() => parseUnifiedDiff(diff), [diff])
+  return (
+    <FileDiffList
+      files={files}
+      summaryOverrides={summaryOverrides}
+      diffTruncated={diffTruncated}
+    />
+  )
+}

--- a/frontend/src/components/DiffView/__tests__/fileDiffList.test.js
+++ b/frontend/src/components/DiffView/__tests__/fileDiffList.test.js
@@ -13,6 +13,7 @@ import FileDiffList, {
   splitPath,
 } from '../FileDiffList.jsx'
 import DiffView from '../DiffView.jsx'
+import UnifiedDiff from '../UnifiedDiff.jsx'
 import {
   DIFF_VIEWER_STYLES,
   ensureDiffViewerStyles,
@@ -27,6 +28,7 @@ test('canonical sources are flat, self-contained, and have no CSS imports', () =
   assert.deepEqual(sourceNames, [
     'DiffView.jsx',
     'FileDiffList.jsx',
+    'UnifiedDiff.jsx',
     'parseUnifiedDiff.js',
     'styles.js',
   ])
@@ -53,6 +55,23 @@ test('canonical sources are flat, self-contained, and have no CSS imports', () =
       `${name} has a non-flat sibling import`,
     )
   }
+})
+
+test('UnifiedDiff owns raw patch parsing for list-based callers', () => {
+  const html = renderToStaticMarkup(createElement(UnifiedDiff, {
+    diff: [
+      'diff --git a/example.js b/example.js',
+      '--- a/example.js',
+      '+++ b/example.js',
+      '@@ -1 +1 @@',
+      '-before',
+      '+after',
+    ].join('\n'),
+  }))
+
+  assert.match(html, />example\.js</)
+  assert.match(html, /aria-expanded="false"/)
+  assert.match(html, /aria-label="1 additions, 1 deletions"/)
 })
 
 test('splitPath and bidi anchoring preserve leading-neutral directories', () => {

--- a/frontend/src/components/SettingsView/UpdateReviewModal.jsx
+++ b/frontend/src/components/SettingsView/UpdateReviewModal.jsx
@@ -20,18 +20,17 @@
  * 1px borders, sentence-case titles, the shared .settings tokens.
  */
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { Alert } from '@openai/apps-sdk-ui/components/Alert'
 import { api } from '../../api/client.js'
 import useDialogFocus from '../../hooks/useDialogFocus.js'
-import { parseUnifiedDiff } from '../DiffView/parseUnifiedDiff.js'
 import {
   shortSha,
   summarizePreview,
   isTrivialUpdate,
 } from '../../lib/platformUpdatePreview.js'
 import { deploymentKindLabel, platformActivationLabel } from '../../lib/platformUpdateState.js'
-import FileDiffList from '../DiffView/FileDiffList.jsx'
+import UnifiedDiff from '../DiffView/UnifiedDiff.jsx'
 import './UpdateReviewModal.css'
 
 function fileCountLabel(count) {
@@ -139,10 +138,6 @@ export default function UpdateReviewModal({
   const activationReasons = Array.isArray(activation?.reasons)
     ? activation.reasons
     : []
-  const parsedFiles = useMemo(
-    () => parseUnifiedDiff(preview?.diff),
-    [preview?.diff],
-  )
   // A preview that resolved to "not available" (e.g. the update landed from
   // another surface between status and open) has nothing to apply.
   const notAvailable = preview && preview.available === false && !loadError
@@ -297,8 +292,8 @@ export default function UpdateReviewModal({
 
               <section className="urm__section">
                 <h3 className="urm__section-title">{fileCountLabel(files.length)}</h3>
-                <FileDiffList
-                  files={parsedFiles}
+                <UnifiedDiff
+                  diff={preview?.diff}
                   summaryOverrides={files}
                   diffTruncated={!!preview?.diff_truncated}
                 />

--- a/frontend/src/lib/__tests__/updateReviewModal.test.js
+++ b/frontend/src/lib/__tests__/updateReviewModal.test.js
@@ -12,10 +12,8 @@ const diffView = read('../../components/DiffView/DiffView.jsx')
 const diffStyles = read('../../components/DiffView/styles.js')
 
 test('platform update delegates file disclosures to the canonical list', () => {
-  assert.match(modal, /import FileDiffList from '\.\.\/DiffView\/FileDiffList\.jsx'/)
-  assert.match(modal, /import \{ parseUnifiedDiff \} from '\.\.\/DiffView\/parseUnifiedDiff\.js'/)
-  assert.match(modal, /parseUnifiedDiff\(preview\?\.diff\)/)
-  assert.match(modal, /<FileDiffList[\s\S]*files=\{parsedFiles\}/)
+  assert.match(modal, /import UnifiedDiff from '\.\.\/DiffView\/UnifiedDiff\.jsx'/)
+  assert.match(modal, /<UnifiedDiff[\s\S]*diff=\{preview\?\.diff\}/)
   assert.match(modal, /summaryOverrides=\{files\}/)
   assert.match(modal, /diffTruncated=\{!!preview\?\.diff_truncated\}/)
   assert.doesNotMatch(modal, /urm__file|toggleFile|diffByPath|<DiffView/)


### PR DESCRIPTION
## Summary
- add a source-diff route bound to the project key and exact source-map head/comparison endpoints
- generate a binary-safe full-index patch without accepting caller-controlled filesystem paths or Git refs
- include confined untracked source while excluding installed-app projections managed by the platform
- reuse the shared UnifiedDiff file list in the update review instead of maintaining a second parser and renderer

## Safety and bounds
- source ownership is locked while endpoints are resolved and diffed
- only server-resolved source-map commits may be inspected; request paths and arbitrary refs are not accepted
- output is capped at 800 kB and generated without loading an unbounded process result into memory
- symlinks remain Git link records and are never followed for source reads
- authorization uses the existing source-map project resolver

## Testing
- complete backend suite: 4,308 passed, 3 environment-specific skips
- focused source-status and GitHub-route contracts: 182 passed
- complete frontend suite: 2,814 passed
- production/PWA build passed
- lint completed with zero errors and the existing 46-warning baseline