### PR TITLE
Recover transient upstream checks before Contribute send

### DIFF
--- a/backend/app/github_contribution_git.py
+++ b/backend/app/github_contribution_git.py
@@ -20,6 +20,38 @@ from app.github_contribution_contract import (
   GIT_SHA as _GIT_SHA,
   SUBMIT_TIMEOUT_SECONDS as _SUBMIT_TIMEOUT,
 )
+from app.terminal_output import readable_output
+
+
+_FETCH_ATTEMPTS = 2
+
+
+def _is_transient_transport_error(message: str) -> bool:
+  """Classify failures worth one safe retry before any public mutation."""
+  detail = str(message or "").lower()
+  transient_markers = (
+    "could not resolve host",
+    "failed to connect",
+    "connection reset",
+    "connection timed out",
+    "operation timed out",
+    "remote end hung up unexpectedly",
+    "remote hung up unexpectedly",
+    "temporarily unavailable",
+    "empty reply from server",
+    "early eof",
+    "http 429",
+    "http 500",
+    "http 502",
+    "http 503",
+    "http 504",
+    "the requested url returned error: 429",
+    "the requested url returned error: 500",
+    "the requested url returned error: 502",
+    "the requested url returned error: 503",
+    "the requested url returned error: 504",
+  )
+  return any(marker in detail for marker in transient_markers)
 
 def _validate_repo_slug(value: object) -> str:
   repo = str(value or "")
@@ -166,6 +198,7 @@ def _merge_error_patch(exc: ContributionSubmitError, patch: dict) -> Contributio
     exc.status_code,
     record_patch={**patch, **exc.record_patch},
     code=exc.code,
+    detail=exc.detail,
   )
 
 
@@ -493,20 +526,59 @@ def _assert_merges_with_upstream(
   upstream_ref = f"refs/mobius-submit/upstream-{ref_key}"
   preflight_patch = {"last_submit_upstream_branch": upstream_branch}
   try:
-    fetched = _git(
-      repo,
-      "fetch", "--no-tags", "--force",
-      remote_url,
-      f"+refs/heads/{upstream_branch}:{upstream_ref}",
-      check=False,
-    )
-    if fetched.returncode != 0:
+    fetch_detail = ""
+    fetched = None
+    fetch_was_transient = False
+    for attempt in range(_FETCH_ATTEMPTS):
+      fetched = None
+      try:
+        fetched = _git(
+          repo,
+          "fetch", "--no-tags", "--force",
+          remote_url,
+          f"+refs/heads/{upstream_branch}:{upstream_ref}",
+          check=False,
+        )
+      except subprocess.TimeoutExpired as exc:
+        fetch_detail = readable_output(
+          exc.stderr or exc.stdout or
+          f"Git fetch timed out after {exc.timeout} seconds."
+        )
+        fetch_was_transient = True
+        if attempt + 1 < _FETCH_ATTEMPTS:
+          continue
+        break
+      if fetched.returncode == 0:
+        break
+      observed_detail = readable_output(fetched.stderr or fetched.stdout or "")
+      if observed_detail:
+        fetch_detail = observed_detail
+      fetch_was_transient = _is_transient_transport_error(fetch_detail)
+      if not fetch_was_transient:
+        break
+      # Starting a fresh git process is the recovery boundary. There is no
+      # sleep here: Send remains bounded, and deterministic rejections never
+      # consume a second attempt.
+      if attempt + 1 >= _FETCH_ATTEMPTS:
+        break
+    if fetched is None or fetched.returncode != 0:
+      transient = fetch_was_transient
       raise ContributionSubmitError(
         (
-          "Could not verify that this PR merges with the upstream branch. "
-          "Leave feedback so your agent can refresh it."
+          "GitHub was temporarily unreachable while Contribute checked "
+          f"upstream {upstream_branch}. Nothing was published. Try Send "
+          "again; leave feedback only if it keeps failing."
+          if transient else
+          f"GitHub could not provide upstream {upstream_branch} while "
+          "Contribute checked mergeability. Nothing was published. Leave "
+          "feedback so your agent can inspect it."
         ),
         record_patch=preflight_patch,
+        code=(
+          "upstream_fetch_unavailable" if transient
+          else "upstream_fetch_failed"
+        ),
+        detail=fetch_detail or "Git fetch failed without diagnostic output.",
       ) from None
     upstream_sha = _git(
       repo, "rev-parse", "--verify", f"{upstream_ref}^{{commit}}",

--- a/backend/app/github_contribution_git.py
+++ b/backend/app/github_contribution_git.py
@@ -27,7 +27,13 @@ _FETCH_ATTEMPTS = 2
 
 
 def _is_transient_transport_error(message: str) -> bool:
-  """Classify failures worth one safe retry before any public mutation."""
+  """Classify failures worth one safe retry before any public mutation.
+
+  Rate limiting (429) is deliberately absent. The preflight retry below is
+  sleepless, and GitHub answers a throttled caller with Retry-After, so an
+  immediate second attempt would spend the only retry on a near-certain
+  second rejection and add one more request to the throttle.
+  """
   detail = str(message or "").lower()
   transient_markers = (
     "could not resolve host",
@@ -40,18 +46,17 @@ def _is_transient_transport_error(message: str) -> bool:
     "temporarily unavailable",
     "empty reply from server",
     "early eof",
-    "http 429",
     "http 500",
     "http 502",
     "http 503",
     "http 504",
-    "the requested url returned error: 429",
     "the requested url returned error: 500",
     "the requested url returned error: 502",
     "the requested url returned error: 503",
     "the requested url returned error: 504",
   )
   return any(marker in detail for marker in transient_markers)
+
 
 def _validate_repo_slug(value: object) -> str:
   repo = str(value or "")

--- a/backend/app/github_contributions.py
+++ b/backend/app/github_contributions.py
@@ -960,6 +960,7 @@ def _mark_submit_failure(
   record_path: Path,
   message: str,
   record_patch: dict | None = None,
+  code: str = "",
   detail: str = "",
 ) -> dict | None:
   try:
@@ -981,6 +982,10 @@ def _mark_submit_failure(
     next_record["last_submit_error_detail"] = detail
   else:
     next_record.pop("last_submit_error_detail", None)
+  if code:
+    next_record["last_submit_error_code"] = code
+  else:
+    next_record.pop("last_submit_error_code", None)
   _write_record(record_path, next_record)
   return next_record
 
@@ -1006,6 +1011,7 @@ def _mark_submit_success(
     next_record["number"] = number
   next_record.pop("last_submit_error", None)
   next_record.pop("last_submit_error_detail", None)
+  next_record.pop("last_submit_error_code", None)
   _write_record(record_path, next_record)
   return next_record
 
@@ -1047,6 +1053,7 @@ def _mark_stack_submit_failure(
   *,
   failed_id: str | None = None,
   record_patch: dict | None = None,
+  code: str = "",
   detail: str = "",
 ) -> list[dict]:
   snapshots = []
@@ -1060,6 +1067,7 @@ def _mark_stack_submit_failure(
         record_path=row["record_path"],
         message=message,
         record_patch=patch,
+        code=code if is_failed else "",
         # Only the layer that actually failed owns the transcript; the
         # siblings were stopped, not rejected.
         detail=detail if is_failed else "",
@@ -1366,26 +1374,7 @@ def _existing_branch_pr(
 
 def _is_transient_push_error(message: str) -> bool:
   """Retry transport/server failures, never deterministic push rejections."""
-  detail = str(message or "").lower()
-  transient_markers = (
-    "could not resolve host",
-    "failed to connect",
-    "connection reset",
-    "connection timed out",
-    "operation timed out",
-    "remote end hung up unexpectedly",
-    "remote hung up unexpectedly",
-    "temporarily unavailable",
-    "http 500",
-    "http 502",
-    "http 503",
-    "http 504",
-    "the requested url returned error: 500",
-    "the requested url returned error: 502",
-    "the requested url returned error: 503",
-    "the requested url returned error: 504",
-  )
-  return any(marker in detail for marker in transient_markers)
+  return _git_ops._is_transient_transport_error(message)
 
 
 def _push_branch(

--- a/backend/app/github_contributions.py
+++ b/backend/app/github_contributions.py
@@ -982,8 +982,11 @@ def _mark_submit_failure(
     next_record["last_submit_error_detail"] = detail
   else:
     next_record.pop("last_submit_error_detail", None)
-  if code:
-    next_record["last_submit_error_code"] = code
+  effective_code = code or str(
+    (record_patch or {}).get("last_submit_error_code") or ""
+  )
+  if effective_code:
+    next_record["last_submit_error_code"] = effective_code
   else:
     next_record.pop("last_submit_error_code", None)
   _write_record(record_path, next_record)

--- a/backend/app/routes/github.py
+++ b/backend/app/routes/github.py
@@ -1335,11 +1335,17 @@ async def submit_contribution(
         record_path=record_path,
         message=exc.message,
         record_patch=exc.record_patch,
+        code=exc.code or "",
         detail=exc.detail,
       )
     raise HTTPException(
       status_code=exc.status_code,
-      detail={"message": exc.message, "detail": exc.detail, "record": record},
+      detail={
+        "message": exc.message,
+        "detail": exc.detail,
+        "record": record,
+        **({"code": exc.code} if exc.code else {}),
+      },
     )
   except Exception as exc:
     log.exception("Contribution submit failed for %s/%s", app_id, record_id)
@@ -1695,6 +1701,7 @@ async def submit_contribution_stack(
               exc.message,
               failed_id=str(record.get("id") or ""),
               record_patch=exc.record_patch,
+              code=exc.code or "",
               detail=exc.detail,
             )
           raise HTTPException(
@@ -1704,6 +1711,7 @@ async def submit_contribution_stack(
               "detail": exc.detail,
               "records": snapshots,
               "submitted": submitted_urls,
+              **({"code": exc.code} if exc.code else {}),
             },
           ) from exc
 
@@ -1737,11 +1745,17 @@ async def submit_contribution_stack(
         rows,
         exc.message,
         record_patch=exc.record_patch,
+        code=exc.code or "",
         detail=exc.detail,
       )
     raise HTTPException(
       status_code=exc.status_code,
-      detail={"message": exc.message, "detail": exc.detail, "records": snapshots},
+      detail={
+        "message": exc.message,
+        "detail": exc.detail,
+        "records": snapshots,
+        **({"code": exc.code} if exc.code else {}),
+      },
     ) from exc
   except Exception as exc:
     log.exception("Contribution stack submit failed for app %s", app_id)

--- a/backend/tests/test_github_routes.py
+++ b/backend/tests/test_github_routes.py
@@ -5708,6 +5708,48 @@ def test_submit_persists_precise_upstream_fetch_failure(
   assert detail["record"]["last_submit_upstream_branch"] == "main"
 
 
+def test_submit_failure_keeps_a_compatible_patch_error_code(tmp_path):
+  from app.github_contributions import _mark_submit_failure
+
+  record_path = tmp_path / "compatible-failure.json"
+  record_path.write_text(json.dumps({
+    "id": "compatible-failure",
+    "status": "submitting",
+  }))
+
+  failed = _mark_submit_failure(
+    app_id=0,
+    record_path=record_path,
+    message="Rejected payload.",
+    record_patch={"last_submit_error_code": "invalid_payload"},
+  )
+
+  assert failed["status"] == "prepared"
+  assert failed["last_submit_error_code"] == "invalid_payload"
+  assert json.loads(record_path.read_text())["last_submit_error_code"] == "invalid_payload"
+
+
+def test_submit_failure_does_not_reuse_a_previous_attempt_error_code(tmp_path):
+  from app.github_contributions import _mark_submit_failure
+
+  record_path = tmp_path / "new-failure.json"
+  record_path.write_text(json.dumps({
+    "id": "new-failure",
+    "status": "submitting",
+    "last_submit_error_code": "upstream_fetch_unavailable",
+  }))
+
+  failed = _mark_submit_failure(
+    app_id=0,
+    record_path=record_path,
+    message="Rejected payload.",
+  )
+
+  assert failed["status"] == "prepared"
+  assert "last_submit_error_code" not in failed
+  assert "last_submit_error_code" not in json.loads(record_path.read_text())
+
+
 # ── Pre-publication branch truth check ──────────────────────────────────────
 # The reviewed-diff preflights prove WHAT would be sent; _existing_branch_pr
 # proves WHETHER it was already sent, from GitHub itself, because the

--- a/backend/tests/test_github_routes.py
+++ b/backend/tests/test_github_routes.py
@@ -1928,6 +1928,30 @@ def test_push_topic_branch_briefly_retries_transient_transport_errors(
   assert sleeps == [0.5, 1.0]
 
 
+def test_rate_limited_transport_is_surfaced_instead_of_retried(
+  tmp_path, monkeypatch,
+):
+  """A 429 carries Retry-After, so an instant second attempt is wasted."""
+  from app.routes.github import _push_topic_branch
+
+  calls = []
+  sleeps = []
+  monkeypatch.setattr(
+    "app.github_contribution_git._git",
+    lambda _repo, *args, **kwargs: calls.append(args) or _cp(
+      stderr="fatal: unable to access: The requested URL returned error: 429",
+      returncode=1,
+    ),
+  )
+  monkeypatch.setattr("app.github_contributions.time.sleep", sleeps.append)
+
+  error = _push_topic_branch(tmp_path, "fix/demo")
+
+  assert "429" in error
+  assert len(calls) == 1
+  assert sleeps == []
+
+
 def test_inspect_owner_fork_reports_strictly_behind_without_mutation(
   tmp_path, monkeypatch,
 ):

--- a/backend/tests/test_github_routes.py
+++ b/backend/tests/test_github_routes.py
@@ -1729,6 +1729,161 @@ def _submit_preflight_response(args, *, merge_conflict: bool = False):
   return None
 
 
+def test_upstream_merge_preflight_retries_one_transient_fetch(tmp_path, monkeypatch):
+  from app.github_contribution_git import _assert_merges_with_upstream
+
+  repo = tmp_path / "repo"
+  repo.mkdir()
+  calls = []
+  fetches = iter((
+    _cp(stderr="fatal: unable to access: HTTP 503", returncode=1),
+    _cp(),
+  ))
+  monkeypatch.setattr(
+    "app.github_contribution_git._upstream_default_branch",
+    lambda *_args: "main",
+  )
+
+  def fake_git(_repo, *args, check=True):
+    calls.append(args)
+    if args[:1] == ("fetch",):
+      return next(fetches)
+    if args[:2] == ("rev-parse", "--verify"):
+      return _cp(_UPSTREAM_SHA + "\n")
+    return _cp()
+
+  monkeypatch.setattr("app.github_contribution_git._git", fake_git)
+
+  patch = _assert_merges_with_upstream(
+    repo, "mobius-os/app-demo", "fix/demo",
+  )
+
+  assert patch == {
+    "last_submit_upstream_branch": "main",
+    "last_submit_upstream_sha": _UPSTREAM_SHA,
+  }
+  assert sum(call[:1] == ("fetch",) for call in calls) == 2
+  assert sum(call[:1] == ("merge-tree",) for call in calls) == 1
+
+
+def test_upstream_merge_preflight_recovers_one_fetch_timeout(tmp_path, monkeypatch):
+  from app.github_contribution_git import _assert_merges_with_upstream
+
+  repo = tmp_path / "repo"
+  repo.mkdir()
+  fetch_attempts = 0
+  monkeypatch.setattr(
+    "app.github_contribution_git._upstream_default_branch",
+    lambda *_args: "main",
+  )
+
+  def fake_git(_repo, *args, check=True):
+    nonlocal fetch_attempts
+    if args[:1] == ("fetch",):
+      fetch_attempts += 1
+      if fetch_attempts == 1:
+        raise subprocess.TimeoutExpired(["git", "fetch"], timeout=30)
+      return _cp()
+    if args[:2] == ("rev-parse", "--verify"):
+      return _cp(_UPSTREAM_SHA + "\n")
+    return _cp()
+
+  monkeypatch.setattr("app.github_contribution_git._git", fake_git)
+
+  patch = _assert_merges_with_upstream(
+    repo, "mobius-os/app-demo", "fix/demo",
+  )
+
+  assert patch["last_submit_upstream_sha"] == _UPSTREAM_SHA
+  assert fetch_attempts == 2
+
+
+def test_upstream_merge_preflight_preserves_persistent_fetch_diagnosis(
+  tmp_path, monkeypatch,
+):
+  from app.github_contribution_git import _assert_merges_with_upstream
+
+  repo = tmp_path / "repo"
+  repo.mkdir()
+  calls = []
+  monkeypatch.setattr(
+    "app.github_contribution_git._upstream_default_branch",
+    lambda *_args: "main",
+  )
+
+  def fake_git(_repo, *args, check=True):
+    calls.append(args)
+    if args[:1] == ("fetch",):
+      return _cp(
+        stderr="\x1b[31mfatal: Could not resolve host: github.com\x1b[0m",
+        returncode=1,
+      )
+    return _cp()
+
+  monkeypatch.setattr("app.github_contribution_git._git", fake_git)
+
+  with pytest.raises(ContributionSubmitError) as raised:
+    _assert_merges_with_upstream(repo, "mobius-os/app-demo", "fix/demo")
+
+  error = raised.value
+  assert error.code == "upstream_fetch_unavailable"
+  assert error.record_patch == {"last_submit_upstream_branch": "main"}
+  assert error.detail == "fatal: Could not resolve host: github.com"
+  assert "Try Send again" in error.message
+  assert "Nothing was published" in error.message
+  assert sum(call[:1] == ("fetch",) for call in calls) == 2
+  assert not any(call[:1] == ("merge-tree",) for call in calls)
+
+
+def test_upstream_merge_preflight_does_not_retry_deterministic_fetch_rejection(
+  tmp_path, monkeypatch,
+):
+  from app.github_contribution_git import _assert_merges_with_upstream
+
+  repo = tmp_path / "repo"
+  repo.mkdir()
+  calls = []
+  monkeypatch.setattr(
+    "app.github_contribution_git._upstream_default_branch",
+    lambda *_args: "main",
+  )
+
+  def fake_git(_repo, *args, check=True):
+    calls.append(args)
+    if args[:1] == ("fetch",):
+      return _cp(stderr="fatal: repository not found", returncode=128)
+    return _cp()
+
+  monkeypatch.setattr("app.github_contribution_git._git", fake_git)
+
+  with pytest.raises(ContributionSubmitError) as raised:
+    _assert_merges_with_upstream(repo, "mobius-os/app-demo", "fix/demo")
+
+  assert raised.value.code == "upstream_fetch_failed"
+  assert raised.value.detail == "fatal: repository not found"
+  assert sum(call[:1] == ("fetch",) for call in calls) == 1
+
+
+def test_merge_error_patch_keeps_transport_diagnosis():
+  from app.github_contribution_git import _merge_error_patch
+
+  original = ContributionSubmitError(
+    "GitHub was temporarily unreachable.",
+    record_patch={"last_submit_upstream_branch": "main"},
+    code="upstream_fetch_unavailable",
+    detail="fatal: Could not resolve host: github.com",
+  )
+
+  merged = _merge_error_patch(original, {"head_sha": "a" * 40})
+
+  assert merged.code == original.code
+  assert merged.detail == original.detail
+  assert merged.record_patch == {
+    "head_sha": "a" * 40,
+    "last_submit_upstream_branch": "main",
+  }
+
+
 def test_push_topic_branch_does_not_retry_deterministic_rejections(
   tmp_path, monkeypatch,
 ):
@@ -5517,6 +5672,40 @@ def test_submit_records_where_the_owner_pressed_send(
   assert submitted.status_code == 200, submitted.text
   record_path, _ = github_routes._record_paths(app_id, "provenance")
   assert json.loads(record_path.read_text())["submitter"] == "chat-review-card"
+
+
+def test_submit_persists_precise_upstream_fetch_failure(
+  client, owner_token, monkeypatch,
+):
+  _write_token(login="octocat", user_id=42)
+  app_id, _ = _app_token(client, owner_token, github_access=True)
+  _prepared_for_chat(app_id, "fetch-diagnosis", "chat-a")
+
+  def fail_submit(*_args, **_kwargs):
+    raise ContributionSubmitError(
+      "GitHub was temporarily unreachable while Contribute checked upstream "
+      "main. Nothing was published. Try Send again; leave feedback only if "
+      "it keeps failing.",
+      record_patch={"last_submit_upstream_branch": "main"},
+      code="upstream_fetch_unavailable",
+      detail="fatal: Could not resolve host: github.com",
+    )
+
+  monkeypatch.setattr(github_routes, "_submit_prepared_pr", fail_submit)
+
+  response = client.post(
+    f"/api/github/contributions/{app_id}/fetch-diagnosis/submit",
+    headers={"Authorization": f"Bearer {owner_token}"},
+  )
+
+  assert response.status_code == 409, response.text
+  detail = response.json()["detail"]
+  assert detail["code"] == "upstream_fetch_unavailable"
+  assert detail["detail"] == "fatal: Could not resolve host: github.com"
+  assert detail["record"]["status"] == "prepared"
+  assert detail["record"]["last_submit_error_code"] == detail["code"]
+  assert detail["record"]["last_submit_error_detail"] == detail["detail"]
+  assert detail["record"]["last_submit_upstream_branch"] == "main"
 
 
 # ── Pre-publication branch truth check ──────────────────────────────────────


### PR DESCRIPTION
## Summary
- retry one transient upstream fetch or timeout before Contribute gives up, while deterministic repository/permission failures remain single-attempt
- share the transport classifier with the existing idempotent branch-push retry path
- preserve a bounded sanitized diagnosis and stable error code in individual and stacked contribution records
- clear stale error codes on success so the durable record stays truthful

## Prior work
No matching issue or pull request was found for recovering transient upstream mergeability checks before Send. This strengthens the existing pre-mutation verification path rather than adding a parallel submit mechanism.

## Testing
- all 175 GitHub route and contribution-error tests passed
- Python bytecode compilation and canonical diff validation passed
- hosted CI remains dependency-authoritative because the live image dependency lock differs from the checkout