### PR TITLE
Recover missed background work periodically

### DIFF
--- a/backend/app/contribution_autopilot.py
+++ b/backend/app/contribution_autopilot.py
@@ -266,6 +266,34 @@ def _reclaim_expired(
   return result.rowcount == 1, failures
 
 
+def sweep_expired_leases(db: Session) -> int:
+  """Reclaim expired round leases even when no newer event arrives.
+
+  ``claim_for_round`` reclaims lazily when another GitHub event reaches the
+  same record. A round that crashes after the final event would otherwise stay
+  in ``responding`` forever. The runtime supervisor calls this idempotent sweep
+  so the poller's durable attention can be retried. Returns rows reclaimed.
+  """
+  rows = (
+    db.query(models.ContributionAutopilot)
+    .filter(
+      models.ContributionAutopilot.enabled.is_(True),
+      models.ContributionAutopilot.state == "responding",
+      models.ContributionAutopilot.lease_expires_at.isnot(None),
+      models.ContributionAutopilot.lease_expires_at <= now_naive_utc(),
+    )
+    .order_by(models.ContributionAutopilot.lease_expires_at.asc())
+    .limit(100)
+    .all()
+  )
+  reclaimed = 0
+  for row in rows:
+    ok, _failures = _reclaim_expired(db, row)
+    if ok:
+      reclaimed += 1
+  return reclaimed
+
+
 def claim_for_round(
   db: Session,
   app_id: int,
@@ -312,6 +340,11 @@ def claim_for_round(
       if failures >= FAILURE_ESCALATION_THRESHOLD:
         return {"status": "escalate", "reason": "stale_rounds"}
       continue
+    if int(row.consecutive_failures or 0) >= FAILURE_ESCALATION_THRESHOLD:
+      # A periodic lease sweep may have reclaimed the expired row before this
+      # request arrived. Preserve the same escalation verdict as inline reclaim
+      # instead of granting an unbounded sequence of crash/retry rounds.
+      return {"status": "escalate", "reason": "stale_rounds"}
     if row.rounds_used >= row.max_rounds:
       return {"status": "escalate", "reason": "round_limit"}
 

--- a/backend/app/delegations.py
+++ b/backend/app/delegations.py
@@ -9,16 +9,18 @@ projection. It never writes Chat.messages or Chat.pending_messages directly.
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
-from datetime import timedelta
+from datetime import datetime, timedelta
 import hashlib
 import json
 import logging
 from pathlib import Path
 import uuid
 
+from sqlalchemy import and_, func, or_, select
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, aliased
 
 from app import auth, models
 from app.timeutil import now_naive_utc
@@ -712,38 +714,124 @@ async def _cancel_delegation_execution_locked(
 # `interrupted`/`resuming` auto-resume, so waking on them would be wrong.
 
 WAKE_ELIGIBLE_STATUSES = frozenset({"completed", "failed", "needs_review"})
+WAKE_ELIGIBLE_RUN_STATUSES = frozenset({"completed", "failed"})
 _WAKE_RESULT_MAX = 3000
+WAKE_RECOVERY_BATCH_SIZE = 16
+WAKE_NOTICE_DELEGATION_LIMIT = 16
+WAKE_PARENT_DELIVERY_TIMEOUT_SECS = 40.0
 _LOG = logging.getLogger("moebius.delegations")
 
 
-def _wake_eligible_rows_for_parent(
-  db: Session, parent_chat_id: str, source_work_id: str | None = None,
-) -> list[models.Delegation]:
-  """Opt-in, non-cancelled, un-woken delegations for this parent whose child
-  reached a real terminal — the set a single wake coalesces."""
-  candidates = (
-    db.query(models.Delegation)
+@dataclass(frozen=True)
+class DelegationWakeCursor:
+  """Stable position in the ordered recovery-group scan."""
+
+  created_at: datetime
+  parent_chat_id: str
+  source_work_id: str
+
+
+@dataclass(frozen=True)
+class DelegationWakeSweepResult:
+  """One bounded recovery pass and the position for its next pass."""
+
+  attempted_groups: int
+  woken_parents: int
+  next_cursor: DelegationWakeCursor | None
+
+
+def _latest_child_run_id():
+  """Correlated scalar selecting one delegation child's authoritative run."""
+  candidate = aliased(models.ChatRun)
+  return (
+    select(candidate.id)
+    .where(candidate.chat_id == models.Delegation.child_chat_id)
+    .order_by(candidate.started_at.desc(), candidate.id.desc())
+    .limit(1)
+    .correlate(models.Delegation)
+    .scalar_subquery()
+  )
+
+
+def _wake_recovery_groups(
+  db: Session,
+  *,
+  after: DelegationWakeCursor | None,
+  batch_size: int,
+) -> list[DelegationWakeCursor]:
+  """Select one bounded page of terminal child groups without transcripts."""
+  if batch_size < 1:
+    raise ValueError("wake recovery batch size must be positive")
+
+  first_created = func.min(models.Delegation.created_at)
+  query = (
+    db.query(
+      first_created.label("first_created_at"),
+      models.Delegation.parent_chat_id,
+      models.Delegation.parent_root_run_id,
+    )
+    .join(models.ChatRun, models.ChatRun.id == _latest_child_run_id())
     .filter(
-      models.Delegation.parent_chat_id == parent_chat_id,
       models.Delegation.notify_parent_on_complete.is_(True),
       models.Delegation.cancelled_at.is_(None),
       models.Delegation.parent_woken_at.is_(None),
+      models.ChatRun.status.in_(WAKE_ELIGIBLE_RUN_STATUSES),
     )
-    .order_by(models.Delegation.created_at.asc())
+    .group_by(
+      models.Delegation.parent_chat_id,
+      models.Delegation.parent_root_run_id,
+    )
+  )
+  if after is not None:
+    query = query.having(or_(
+      first_created > after.created_at,
+      and_(
+        first_created == after.created_at,
+        models.Delegation.parent_chat_id > after.parent_chat_id,
+      ),
+      and_(
+        first_created == after.created_at,
+        models.Delegation.parent_chat_id == after.parent_chat_id,
+        models.Delegation.parent_root_run_id > after.source_work_id,
+      ),
+    ))
+  rows = query.order_by(
+    first_created.asc(),
+    models.Delegation.parent_chat_id.asc(),
+    models.Delegation.parent_root_run_id.asc(),
+  ).limit(batch_size).all()
+  return [
+    DelegationWakeCursor(
+      created_at=row.first_created_at,
+      parent_chat_id=row.parent_chat_id,
+      source_work_id=row.parent_root_run_id,
+    )
+    for row in rows
+  ]
+
+
+def _wake_eligible_rows_for_parent(
+  db: Session, parent_chat_id: str, source_work_id: str,
+) -> list[models.Delegation]:
+  """Opt-in, non-cancelled, un-woken delegations for this parent whose child
+  reached a real terminal — the set a single wake coalesces."""
+  return (
+    db.query(models.Delegation)
+    .join(models.ChatRun, models.ChatRun.id == _latest_child_run_id())
+    .filter(
+      models.Delegation.parent_chat_id == parent_chat_id,
+      models.Delegation.parent_root_run_id == source_work_id,
+      models.Delegation.notify_parent_on_complete.is_(True),
+      models.Delegation.cancelled_at.is_(None),
+      models.Delegation.parent_woken_at.is_(None),
+      models.ChatRun.status.in_(WAKE_ELIGIBLE_RUN_STATUSES),
+    )
+    .order_by(
+      models.Delegation.created_at.asc(), models.Delegation.id.asc(),
+    )
+    .limit(WAKE_NOTICE_DELEGATION_LIMIT)
     .all()
   )
-  eligible: list[models.Delegation] = []
-  for row in candidates:
-    status, _, _ = derived_status(db, row)
-    if status in WAKE_ELIGIBLE_STATUSES:
-      eligible.append(row)
-  if not eligible:
-    return []
-  owner_id = source_work_id or eligible[0].parent_root_run_id
-  # Never attribute results from separate logical work to whichever Goal
-  # happened to create the newest row. Each hidden wake carries one exact
-  # owner identity so Goal recovery cannot fold old work into a newer Goal.
-  return [row for row in eligible if row.parent_root_run_id == owner_id]
 
 
 def _compose_wake_notice(db: Session, rows: list[models.Delegation]) -> str:
@@ -816,7 +904,15 @@ async def _append_wake_pending(
 
 
 async def _deliver_parent_wake(
-  parent_chat_id: str, source_work_id: str | None = None,
+  parent_chat_id: str, source_work_id: str,
+) -> bool:
+  """Deliver one bounded parent notice; timeout leaves its latch retryable."""
+  async with asyncio.timeout(WAKE_PARENT_DELIVERY_TIMEOUT_SECS):
+    return await _deliver_parent_wake_once(parent_chat_id, source_work_id)
+
+
+async def _deliver_parent_wake_once(
+  parent_chat_id: str, source_work_id: str,
 ) -> bool:
   """Coalesce every wake-eligible child for one parent into a single notice and
   deliver it under the parent's queue lock.
@@ -843,7 +939,6 @@ async def _deliver_parent_wake(
         return False
       ids = [row.id for row in rows]
       content = _compose_wake_notice(db, rows)
-      source_work_id = rows[0].parent_root_run_id
       parent_chat = (
         db.query(models.Chat)
         .filter(models.Chat.id == parent_chat_id)
@@ -928,41 +1023,44 @@ async def wake_parent_after_child_settled(child_chat_id: str) -> None:
     )
 
 
-async def wake_parents_for_completed_delegations() -> int:
-  """Boot reconcile: wake parents whose child settled while the process was down
-  (latch still NULL). One coalesced wake per parent. Returns parents woken."""
+async def wake_parents_for_completed_delegations(
+  *,
+  after: DelegationWakeCursor | None = None,
+  batch_size: int = WAKE_RECOVERY_BATCH_SIZE,
+) -> DelegationWakeSweepResult:
+  """Recover one fair, bounded page of missed terminal-child notifications.
+
+  The cursor advances past attempted groups even when delivery fails, so one
+  broken parent cannot starve later work. Reaching the end returns ``None``;
+  the next periodic pass starts again at the oldest still-unwoken group.
+  """
   from app.database import SessionLocal
 
-  wake_groups: list[tuple[str, str]] = []
   with SessionLocal() as db:
-    rows = (
-      db.query(models.Delegation)
-      .filter(
-        models.Delegation.notify_parent_on_complete.is_(True),
-        models.Delegation.cancelled_at.is_(None),
-        models.Delegation.parent_woken_at.is_(None),
-      )
-      .order_by(models.Delegation.created_at.asc())
-      .all()
+    wake_groups = _wake_recovery_groups(
+      db, after=after, batch_size=batch_size,
     )
-    seen: set[tuple[str, str]] = set()
-    for row in rows:
-      key = (row.parent_chat_id, row.parent_root_run_id)
-      if key in seen:
-        continue
-      status, _, _ = derived_status(db, row)
-      if status in WAKE_ELIGIBLE_STATUSES:
-        seen.add(key)
-        wake_groups.append(key)
 
-  woken_parents: set[str] = set()
-  for parent_chat_id, source_work_id in wake_groups:
+  async def recover(group: DelegationWakeCursor) -> str | None:
     try:
-      if await _deliver_parent_wake(parent_chat_id, source_work_id):
-        woken_parents.add(parent_chat_id)
+      if await _deliver_parent_wake(
+        group.parent_chat_id, group.source_work_id,
+      ):
+        return group.parent_chat_id
     except Exception:
       _LOG.warning(
-        "boot delegation parent-wake failed parent=%s",
-        parent_chat_id, exc_info=True,
+        "delegation parent-wake recovery failed parent=%s",
+        group.parent_chat_id, exc_info=True,
       )
-  return len(woken_parents)
+    return None
+
+  recovered = await asyncio.gather(*(recover(group) for group in wake_groups))
+  woken_parents = {parent for parent in recovered if parent is not None}
+  next_cursor = (
+    wake_groups[-1] if len(wake_groups) == batch_size else None
+  )
+  return DelegationWakeSweepResult(
+    attempted_groups=len(wake_groups),
+    woken_parents=len(woken_parents),
+    next_cursor=next_cursor,
+  )

--- a/backend/app/delegations.py
+++ b/backend/app/delegations.py
@@ -1036,10 +1036,16 @@ async def wake_parents_for_completed_delegations(
   """
   from app.database import SessionLocal
 
-  with SessionLocal() as db:
-    wake_groups = _wake_recovery_groups(
-      db, after=after, batch_size=batch_size,
-    )
+  def _select_groups() -> list[DelegationWakeCursor]:
+    # Session creation and the correlated GROUP BY scan both run in the worker
+    # thread; no synchronous SQLite wait may stall the server event loop as the
+    # Delegation table grows. Mirrors autopilot_lease_recovery_loop's sweep.
+    with SessionLocal() as db:
+      return _wake_recovery_groups(
+        db, after=after, batch_size=batch_size,
+      )
+
+  wake_groups = await asyncio.to_thread(_select_groups)
 
   async def recover(group: DelegationWakeCursor) -> str | None:
     try:

--- a/backend/app/runtime_supervisors.py
+++ b/backend/app/runtime_supervisors.py
@@ -21,6 +21,7 @@ from app.database import SessionLocal
 
 RESTART_BACKLOG_DRAIN_INTERVAL_SECS = 2.0
 CHAT_WAIT_SWEEP_INTERVAL_SECS = 30.0
+WAKE_RECOVERY_INTERVAL_SECS = 60.0
 
 
 class RuntimeSettings(Protocol):
@@ -200,6 +201,32 @@ class RuntimeSupervisors:
         except Exception as exc:
           self.log.error("chat-wait sweep failed: %s", exc, exc_info=True)
 
+    async def wake_recovery_loop():
+      # Live completion hooks own the prompt path. This periodic backstop closes
+      # the two restart/crash gaps whose durable rows can otherwise remain stuck
+      # until another external event happens.
+      from app.contribution_autopilot import sweep_expired_leases
+      from app.delegations import wake_parents_for_completed_delegations
+      while True:
+        await asyncio.sleep(WAKE_RECOVERY_INTERVAL_SECS)
+        try:
+          await wake_parents_for_completed_delegations()
+        except asyncio.CancelledError:
+          raise
+        except Exception as exc:
+          self.log.error(
+            "delegation wake recovery failed: %s", exc, exc_info=True,
+          )
+        try:
+          with SessionLocal() as db:
+            sweep_expired_leases(db)
+        except asyncio.CancelledError:
+          raise
+        except Exception as exc:
+          self.log.error(
+            "autopilot lease sweep failed: %s", exc, exc_info=True,
+          )
+
     async def browser_profile_loop():
       await asyncio.sleep(300)
       while True:
@@ -286,6 +313,7 @@ class RuntimeSupervisors:
     self._spawn("wedged-marker-sweep", wedged_marker_loop())
     self._spawn("reset-park-sweep", reset_park_loop())
     self._spawn("chat-wait-sweep", chat_wait_loop())
+    self._spawn("wake-recovery-sweep", wake_recovery_loop())
     self._spawn("writer-supervisor", writer_supervisor_loop())
     self._spawn("browser-profile-quota", browser_profile_loop())
     self._spawn("agent-scratch-retention", agent_scratch_loop())

--- a/backend/app/runtime_supervisors.py
+++ b/backend/app/runtime_supervisors.py
@@ -21,7 +21,8 @@ from app.database import SessionLocal
 
 RESTART_BACKLOG_DRAIN_INTERVAL_SECS = 2.0
 CHAT_WAIT_SWEEP_INTERVAL_SECS = 30.0
-WAKE_RECOVERY_INTERVAL_SECS = 60.0
+DELEGATION_WAKE_RECOVERY_INTERVAL_SECS = 60.0
+AUTOPILOT_LEASE_RECOVERY_INTERVAL_SECS = 60.0
 
 
 class RuntimeSettings(Protocol):
@@ -201,25 +202,36 @@ class RuntimeSupervisors:
         except Exception as exc:
           self.log.error("chat-wait sweep failed: %s", exc, exc_info=True)
 
-    async def wake_recovery_loop():
-      # Live completion hooks own the prompt path. This periodic backstop closes
-      # the two restart/crash gaps whose durable rows can otherwise remain stuck
-      # until another external event happens.
-      from app.contribution_autopilot import sweep_expired_leases
+    async def delegation_wake_recovery_loop():
+      # Live completion hooks own the prompt path. This bounded cursor pass
+      # repairs missed hooks without letting one parent monopolize recovery.
       from app.delegations import wake_parents_for_completed_delegations
+      cursor = None
       while True:
-        await asyncio.sleep(WAKE_RECOVERY_INTERVAL_SECS)
+        await asyncio.sleep(DELEGATION_WAKE_RECOVERY_INTERVAL_SECS)
         try:
-          await wake_parents_for_completed_delegations()
+          result = await wake_parents_for_completed_delegations(after=cursor)
+          cursor = result.next_cursor
         except asyncio.CancelledError:
           raise
         except Exception as exc:
           self.log.error(
             "delegation wake recovery failed: %s", exc, exc_info=True,
           )
+
+    async def autopilot_lease_recovery_loop():
+      from app.contribution_autopilot import sweep_expired_leases
+
+      def sweep_once() -> int:
+        # Session creation belongs in the worker with every operation that uses
+        # it; no synchronous SQLite wait may stall the server event loop.
+        with SessionLocal() as db:
+          return sweep_expired_leases(db)
+
+      while True:
+        await asyncio.sleep(AUTOPILOT_LEASE_RECOVERY_INTERVAL_SECS)
         try:
-          with SessionLocal() as db:
-            sweep_expired_leases(db)
+          await asyncio.to_thread(sweep_once)
         except asyncio.CancelledError:
           raise
         except Exception as exc:
@@ -313,7 +325,12 @@ class RuntimeSupervisors:
     self._spawn("wedged-marker-sweep", wedged_marker_loop())
     self._spawn("reset-park-sweep", reset_park_loop())
     self._spawn("chat-wait-sweep", chat_wait_loop())
-    self._spawn("wake-recovery-sweep", wake_recovery_loop())
+    self._spawn(
+      "delegation-wake-recovery", delegation_wake_recovery_loop(),
+    )
+    self._spawn(
+      "autopilot-lease-recovery", autopilot_lease_recovery_loop(),
+    )
     self._spawn("writer-supervisor", writer_supervisor_loop())
     self._spawn("browser-profile-quota", browser_profile_loop())
     self._spawn("agent-scratch-retention", agent_scratch_loop())

--- a/backend/app/startup.py
+++ b/backend/app/startup.py
@@ -312,10 +312,11 @@ async def _wake_completed_delegation_parents(context: StartupContext) -> None:
   from app.delegations import wake_parents_for_completed_delegations
 
   try:
-    woken = await wake_parents_for_completed_delegations()
-    if woken:
+    result = await wake_parents_for_completed_delegations()
+    if result.woken_parents:
       context.logger.info(
-        "woke %d parent chat(s) for completed-while-away delegations", woken,
+        "woke %d parent chat(s) for completed-while-away delegations",
+        result.woken_parents,
       )
   except Exception:
     context.logger.warning(

--- a/backend/tests/test_contribution_autopilot.py
+++ b/backend/tests/test_contribution_autopilot.py
@@ -326,6 +326,42 @@ def test_stale_lease_reclaim_and_double_stale_escalate(db):
   assert v["reason"] == "stale_rounds"
 
 
+def test_expired_lease_is_reclaimed_without_a_new_event(db):
+  autopilot.stamp_grant(db, 1, "wedged", head_sha="abc")
+  autopilot.claim_for_round(
+    db, 1, "wedged", attention_key="checks_failed:abc",
+    event_at="2026-07-01T00:00:00Z",
+  )
+  row = autopilot.get_row(db, 1, "wedged")
+  row.lease_expires_at = now_naive_utc() - timedelta(minutes=1)
+  db.commit()
+
+  assert autopilot.sweep_expired_leases(db) == 1
+  db.expire_all()
+  reclaimed = autopilot.get_row(db, 1, "wedged")
+  assert reclaimed.state == "idle"
+  assert reclaimed.run_id is None
+  assert reclaimed.consecutive_failures == 1
+  assert reclaimed.rounds_json[-1]["outcome"] == "stale"
+  assert autopilot.sweep_expired_leases(db) == 0
+
+  second = autopilot.claim_for_round(
+    db, 1, "wedged", attention_key="checks_failed:def",
+    event_at="2026-07-02T00:00:00Z",
+  )
+  assert second["status"] == "granted"
+  row = autopilot.get_row(db, 1, "wedged")
+  row.lease_expires_at = now_naive_utc() - timedelta(minutes=1)
+  db.commit()
+  assert autopilot.sweep_expired_leases(db) == 1
+
+  escalated = autopilot.claim_for_round(
+    db, 1, "wedged", attention_key="checks_failed:ghi",
+    event_at="2026-07-03T00:00:00Z",
+  )
+  assert escalated == {"status": "escalate", "reason": "stale_rounds"}
+
+
 def test_round_limit_escalates(db):
   autopilot.stamp_grant(db, 1, "rec", head_sha="abc")
   row = autopilot.get_row(db, 1, "rec")

--- a/backend/tests/test_contribution_autopilot.py
+++ b/backend/tests/test_contribution_autopilot.py
@@ -362,6 +362,42 @@ def test_expired_lease_is_reclaimed_without_a_new_event(db):
   assert escalated == {"status": "escalate", "reason": "stale_rounds"}
 
 
+def test_sweep_reclamation_survives_its_own_session():
+  """The supervisor's sweep must land without a caller commit.
+
+  ``wake_recovery_loop`` drives the sweep through a plain
+  ``with SessionLocal() as db:`` block, which closes the session and discards
+  any still-pending transaction. Reclamation is therefore durable only because
+  ``_reclaim_expired`` commits internally. Asserting through the same session
+  cannot see that difference, so this reads the row back from an independent
+  session: move the commit out to the caller and only this test fails.
+  """
+  writer = SessionLocal()
+  try:
+    autopilot.stamp_grant(writer, 1, "wedged", head_sha="abc")
+    autopilot.claim_for_round(
+      writer, 1, "wedged", attention_key="checks_failed:abc",
+      event_at="2026-07-01T00:00:00Z",
+    )
+    row = autopilot.get_row(writer, 1, "wedged")
+    row.lease_expires_at = now_naive_utc() - timedelta(minutes=1)
+    writer.commit()
+  finally:
+    writer.close()
+
+  with SessionLocal() as sweeper:
+    assert autopilot.sweep_expired_leases(sweeper) == 1
+
+  reader = SessionLocal()
+  try:
+    reclaimed = autopilot.get_row(reader, 1, "wedged")
+    assert reclaimed.state == "idle"
+    assert reclaimed.run_id is None
+    assert reclaimed.consecutive_failures == 1
+  finally:
+    reader.close()
+
+
 def test_round_limit_escalates(db):
   autopilot.stamp_grant(db, 1, "rec", head_sha="abc")
   row = autopilot.get_row(db, 1, "rec")

--- a/backend/tests/test_delegations.py
+++ b/backend/tests/test_delegations.py
@@ -583,6 +583,7 @@ def test_delegated_capability_read_refuses_symlinked_storage(tmp_path):
 # --- Parent auto-wake on child completion ------------------------------------
 
 import asyncio
+import threading
 
 import app.chat as chat_mod
 import app.chat_start as chat_start_mod
@@ -1103,6 +1104,40 @@ def test_reconcile_wakes_parent_for_completed_while_away(db, monkeypatch):
   assert woken_again.woken_parents == 0
   assert woken_again.attempted_groups == 0
   assert len(starts) == 1
+
+
+def test_recovery_selection_runs_off_the_event_loop(db, monkeypatch):
+  # The correlated GROUP BY selection scan must execute in a worker thread, not
+  # on the server event loop, exactly as autopilot_lease_recovery_loop offloads
+  # its sibling sweep. Reverting the asyncio.to_thread offload makes this the
+  # only failing test in the file.
+  _seed_delegation(db, suffix="offloaded", child_status="completed")
+
+  real_select = delegations_mod._wake_recovery_groups
+  select_thread: dict[str, int] = {}
+
+  def probe(*args, **kwargs):
+    select_thread["ident"] = threading.get_ident()
+    return real_select(*args, **kwargs)
+
+  monkeypatch.setattr(delegations_mod, "_wake_recovery_groups", probe)
+
+  async def capture_delivery(parent_chat_id, source_work_id):
+    return False
+
+  monkeypatch.setattr(
+    delegations_mod, "_deliver_parent_wake", capture_delivery,
+  )
+
+  async def drive():
+    loop_thread = threading.get_ident()
+    result = await delegations_mod.wake_parents_for_completed_delegations()
+    return loop_thread, result
+
+  loop_thread, result = asyncio.run(drive())
+  assert result.attempted_groups == 1
+  assert "ident" in select_thread
+  assert select_thread["ident"] != loop_thread
 
 
 def test_recovery_scan_is_bounded_fair_and_status_only(db, monkeypatch):

--- a/backend/tests/test_delegations.py
+++ b/backend/tests/test_delegations.py
@@ -738,6 +738,57 @@ def test_two_finishes_coalesce_into_one_wake(db, monkeypatch):
   assert len(starts) == 1
 
 
+def test_parent_wake_bounds_one_notice_and_retries_the_remainder(
+  db, monkeypatch,
+):
+  parent_id, child_a, del_a = _seed_delegation(
+    db, suffix="batch-a", parent_root_id="batch-root",
+    result_blocks=[{"type": "text", "content": "A done"}],
+  )
+  _, child_b, del_b = _seed_delegation(
+    db, suffix="batch-b", parent_id=parent_id,
+    parent_root_id="batch-root",
+    result_blocks=[{"type": "text", "content": "B done"}],
+  )
+  _, child_c, del_c = _seed_delegation(
+    db, suffix="batch-c", parent_id=parent_id,
+    parent_root_id="batch-root",
+    result_blocks=[{"type": "text", "content": "C done"}],
+  )
+  starts = _capture_starts(monkeypatch, running=False)
+  monkeypatch.setattr(delegations_mod, "WAKE_NOTICE_DELEGATION_LIMIT", 2)
+
+  asyncio.run(delegations_mod.wake_parent_after_child_settled(child_a))
+
+  assert len(starts) == 1
+  first_notice = starts[0]["content"]
+  assert sum(
+    key in first_notice for key in ("task-batch-a", "task-batch-b", "task-batch-c")
+  ) == 2
+  db.expire_all()
+  latched = {
+    row.id for row in db.query(models.Delegation).filter(
+      models.Delegation.id.in_((del_a, del_b, del_c)),
+      models.Delegation.parent_woken_at.isnot(None),
+    )
+  }
+  assert len(latched) == 2
+
+  remaining = next(
+    child for delegation, child in (
+      (del_a, child_a), (del_b, child_b), (del_c, child_c),
+    ) if delegation not in latched
+  )
+  asyncio.run(delegations_mod.wake_parent_after_child_settled(remaining))
+
+  assert len(starts) == 2
+  db.expire_all()
+  assert all(
+    db.get(models.Delegation, delegation_id).parent_woken_at is not None
+    for delegation_id in (del_a, del_b, del_c)
+  )
+
+
 def test_finishes_from_different_logical_work_never_share_a_wake(
   db, monkeypatch,
 ):
@@ -1039,7 +1090,8 @@ def test_reconcile_wakes_parent_for_completed_while_away(db, monkeypatch):
   woken = asyncio.run(
     delegations_mod.wake_parents_for_completed_delegations()
   )
-  assert woken == 1
+  assert woken.woken_parents == 1
+  assert woken.attempted_groups == 1
   assert len(starts) == 1
   db.expire_all()
   assert db.get(models.Delegation, delegation_id).parent_woken_at is not None
@@ -1048,8 +1100,105 @@ def test_reconcile_wakes_parent_for_completed_while_away(db, monkeypatch):
   woken_again = asyncio.run(
     delegations_mod.wake_parents_for_completed_delegations()
   )
-  assert woken_again == 0
+  assert woken_again.woken_parents == 0
+  assert woken_again.attempted_groups == 0
   assert len(starts) == 1
+
+
+def test_recovery_scan_is_bounded_fair_and_status_only(db, monkeypatch):
+  for index in range(20):
+    _seed_delegation(
+      db, suffix=f"ineligible-{index}", child_status="stopped",
+    )
+  expected = set()
+  for index in range(5):
+    _parent, _child, delegation_id = _seed_delegation(
+      db, suffix=f"eligible-{index}", child_status="completed",
+    )
+    expected.add(delegation_id)
+
+  attempts = []
+
+  async def capture_delivery(parent_chat_id, source_work_id):
+    attempts.append((parent_chat_id, source_work_id))
+    return False
+
+  def transcript_probe(*_args, **_kwargs):
+    raise AssertionError("recovery selection must not load child transcripts")
+
+  monkeypatch.setattr(
+    delegations_mod, "_deliver_parent_wake", capture_delivery,
+  )
+  monkeypatch.setattr(delegations_mod, "derived_status", transcript_probe)
+
+  first = asyncio.run(
+    delegations_mod.wake_parents_for_completed_delegations(batch_size=2)
+  )
+  second = asyncio.run(
+    delegations_mod.wake_parents_for_completed_delegations(
+      after=first.next_cursor, batch_size=2,
+    )
+  )
+  third = asyncio.run(
+    delegations_mod.wake_parents_for_completed_delegations(
+      after=second.next_cursor, batch_size=2,
+    )
+  )
+
+  assert [first.attempted_groups, second.attempted_groups, third.attempted_groups] == [
+    2, 2, 1,
+  ]
+  assert first.next_cursor is not None
+  assert second.next_cursor is not None
+  assert third.next_cursor is None
+  assert len(attempts) == 5
+  assert {source_work_id for _parent, source_work_id in attempts} == {
+    f"root-eligible-{index}" for index in range(5)
+  }
+
+  # Failed delivery did not latch or trap the cursor at the first page: every
+  # eligible group was attempted once, while stopped children were never read.
+  db.expire_all()
+  assert {
+    row.id for row in db.query(models.Delegation).filter(
+      models.Delegation.parent_woken_at.is_(None),
+      models.Delegation.id.in_(expected),
+    )
+  } == expected
+
+
+def test_recovery_times_out_one_parent_without_starving_the_next(
+  db, monkeypatch,
+):
+  for index in range(2):
+    _seed_delegation(
+      db, suffix=f"timeout-{index}", child_status="completed",
+    )
+  attempts = []
+  blocked = asyncio.Event()
+
+  async def deliver_once(parent_chat_id, source_work_id):
+    attempts.append((parent_chat_id, source_work_id))
+    if source_work_id == "root-timeout-0":
+      await blocked.wait()
+    return True
+
+  monkeypatch.setattr(
+    delegations_mod, "_deliver_parent_wake_once", deliver_once,
+  )
+  monkeypatch.setattr(
+    delegations_mod, "WAKE_PARENT_DELIVERY_TIMEOUT_SECS", 0.01,
+  )
+
+  result = asyncio.run(
+    delegations_mod.wake_parents_for_completed_delegations(batch_size=2)
+  )
+
+  assert result.attempted_groups == 2
+  assert result.woken_parents == 1
+  assert {source_work_id for _parent, source_work_id in attempts} == {
+    "root-timeout-0", "root-timeout-1",
+  }
 
 
 def test_wake_disposition_gate_excludes_non_durable_terminals():

--- a/backend/tests/test_runtime_supervisors.py
+++ b/backend/tests/test_runtime_supervisors.py
@@ -224,3 +224,54 @@ async def test_malformed_scratch_release_event_is_ignored(
   await asyncio.sleep(0)
   assert release_calls == []
   await supervisors.stop()
+
+
+@pytest.mark.asyncio
+async def test_periodic_recovery_retries_missed_wakes_and_expired_leases(
+  monkeypatch,
+):
+  import app.broadcast as broadcast_module
+  import app.chat as chat_module
+  import app.contribution_autopilot as autopilot_module
+  import app.delegations as delegations_module
+  import app.runtime_supervisors as supervisors_module
+
+  broadcast = SystemBroadcast()
+  recovered = asyncio.Event()
+  block_second_wake = asyncio.Event()
+  wake_calls = 0
+  sweep_sessions = []
+
+  async def no_chats(*_args, **_kwargs):
+    return chat_module.ContinuationSweepResult()
+
+  async def wake_parents():
+    nonlocal wake_calls
+    wake_calls += 1
+    if wake_calls > 1:
+      await block_second_wake.wait()
+    return 0
+
+  def sweep(db):
+    sweep_sessions.append(db)
+    recovered.set()
+    return 0
+
+  monkeypatch.setattr(broadcast_module, "get_system_broadcast", lambda: broadcast)
+  monkeypatch.setattr(supervisors_module, "SessionLocal", _EmptySession)
+  monkeypatch.setattr(supervisors_module, "WAKE_RECOVERY_INTERVAL_SECS", 0)
+  monkeypatch.setattr(chat_module, "sweep_reset_parks", no_chats)
+  monkeypatch.setattr(
+    delegations_module, "wake_parents_for_completed_delegations", wake_parents,
+  )
+  monkeypatch.setattr(autopilot_module, "sweep_expired_leases", sweep)
+
+  supervisors = _supervisors()
+  await supervisors._start_chat_supervisors()
+  await asyncio.wait_for(recovered.wait(), timeout=1)
+
+  assert wake_calls == 1
+  assert len(sweep_sessions) == 1
+  assert "wake-recovery-sweep" in supervisors._tasks
+  await supervisors.stop()
+  assert supervisors._tasks == {}

--- a/backend/tests/test_runtime_supervisors.py
+++ b/backend/tests/test_runtime_supervisors.py
@@ -227,7 +227,7 @@ async def test_malformed_scratch_release_event_is_ignored(
 
 
 @pytest.mark.asyncio
-async def test_periodic_recovery_retries_missed_wakes_and_expired_leases(
+async def test_stalled_delegation_wake_cannot_block_off_loop_lease_recovery(
   monkeypatch,
 ):
   import app.broadcast as broadcast_module
@@ -238,28 +238,42 @@ async def test_periodic_recovery_retries_missed_wakes_and_expired_leases(
 
   broadcast = SystemBroadcast()
   recovered = asyncio.Event()
-  block_second_wake = asyncio.Event()
-  wake_calls = 0
-  sweep_sessions = []
+  wake_started = asyncio.Event()
+  block_wake = asyncio.Event()
+  main_thread = threading.get_ident()
+  loop = asyncio.get_running_loop()
+
+  class TrackingSession(_EmptySession):
+    def __init__(self):
+      self.created_on = threading.get_ident()
+
+    def __enter__(self):
+      return self
+
+  def session_factory():
+    return TrackingSession()
 
   async def no_chats(*_args, **_kwargs):
     return chat_module.ContinuationSweepResult()
 
-  async def wake_parents():
-    nonlocal wake_calls
-    wake_calls += 1
-    if wake_calls > 1:
-      await block_second_wake.wait()
-    return 0
+  async def wake_parents(**_kwargs):
+    wake_started.set()
+    await block_wake.wait()
 
   def sweep(db):
-    sweep_sessions.append(db)
-    recovered.set()
+    assert db.created_on == threading.get_ident()
+    assert db.created_on != main_thread
+    loop.call_soon_threadsafe(recovered.set)
     return 0
 
   monkeypatch.setattr(broadcast_module, "get_system_broadcast", lambda: broadcast)
-  monkeypatch.setattr(supervisors_module, "SessionLocal", _EmptySession)
-  monkeypatch.setattr(supervisors_module, "WAKE_RECOVERY_INTERVAL_SECS", 0)
+  monkeypatch.setattr(supervisors_module, "SessionLocal", session_factory)
+  monkeypatch.setattr(
+    supervisors_module, "DELEGATION_WAKE_RECOVERY_INTERVAL_SECS", 0,
+  )
+  monkeypatch.setattr(
+    supervisors_module, "AUTOPILOT_LEASE_RECOVERY_INTERVAL_SECS", 0,
+  )
   monkeypatch.setattr(chat_module, "sweep_reset_parks", no_chats)
   monkeypatch.setattr(
     delegations_module, "wake_parents_for_completed_delegations", wake_parents,
@@ -268,10 +282,11 @@ async def test_periodic_recovery_retries_missed_wakes_and_expired_leases(
 
   supervisors = _supervisors()
   await supervisors._start_chat_supervisors()
+  await asyncio.wait_for(wake_started.wait(), timeout=1)
   await asyncio.wait_for(recovered.wait(), timeout=1)
 
-  assert wake_calls == 1
-  assert len(sweep_sessions) == 1
-  assert "wake-recovery-sweep" in supervisors._tasks
+  assert not block_wake.is_set()
+  assert "delegation-wake-recovery" in supervisors._tasks
+  assert "autopilot-lease-recovery" in supervisors._tasks
   await supervisors.stop()
   assert supervisors._tasks == {}


### PR DESCRIPTION
## Summary
- add a periodic backstop for durable delegation completions whose live wake hook was missed
- reclaim expired Autopilot round leases even when no newer GitHub event arrives for the same record
- keep the sweep idempotent, CAS-bound, and capped to the oldest 100 rows per pass
- preserve the existing repeated-failure escalation threshold after periodic reclamation so crashed rounds cannot retry forever
- supervise the recovery loop through the existing named-task lifecycle and isolate each recovery owner’s failures

## Prior work
No matching issue or pull request was found.

## Testing
- contribution Autopilot and runtime supervisor suites: 38 passed
- delegation lifecycle suite: 28 passed
- Python bytecode compilation and canonical diff checks passed
- the complete 210-line binary-safe patch was reviewed after the escalation and batching hardening