### PR TITLE
Reclaim locked-down identity state after replacement

### DIFF
--- a/backend/runtime/identity_broker.py
+++ b/backend/runtime/identity_broker.py
@@ -98,6 +98,11 @@ def _reclaim_private_state_after_compat_chown() -> None:
   this root broker starts. Adopt only the broker's fixed, already-private state
   files; reject links, unexpected owners, and permissive modes rather than
   blessing an attacker-controlled path.
+
+  Each entry is validated and fixed up through a single descriptor. A
+  concurrent app-user process can still swap a directory entry, but it can no
+  longer redirect the root chown/chmod onto a target this function never
+  checked.
   """
   if os.geteuid() != 0:
     return
@@ -105,39 +110,58 @@ def _reclaim_private_state_after_compat_chown() -> None:
   mobius = pwd.getpwnam("mobius")
   allowed_owners = {(0, 0), (mobius.pw_uid, mobius.pw_gid)}
   try:
-    current = os.lstat(PRIVATE_DIR)
-  except FileNotFoundError:
     PRIVATE_DIR.mkdir(mode=0o700)
-    current = os.lstat(PRIVATE_DIR)
-  if (
-    stat.S_ISLNK(current.st_mode)
-    or not stat.S_ISDIR(current.st_mode)
-    or (current.st_uid, current.st_gid) not in allowed_owners
-    or stat.S_IMODE(current.st_mode) & 0o077
-  ):
-    raise RuntimeError("identity broker private directory is unsafe")
+  except FileExistsError:
+    pass
 
-  existing: list[Path] = []
-  for path in (KEY_PATH, STATE_PATH, INSTANCE_PATH, PENDING_BOOTSTRAP_PATH):
+  # O_NOFOLLOW rejects a symlink planted at the entry itself, and O_NONBLOCK
+  # keeps a planted FIFO or device node from stalling the open before fstat
+  # can reject it. Both make the open, not a prior lstat, the decisive check.
+  open_flags = os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK
+  opened: list[tuple[int, int]] = []
+  try:
     try:
-      item = os.lstat(path)
-    except FileNotFoundError:
-      continue
+      dir_fd = os.open(PRIVATE_DIR, open_flags | os.O_DIRECTORY)
+    except OSError as exc:
+      raise RuntimeError("identity broker private directory is unsafe") from exc
+    opened.append((dir_fd, 0o700))
+    current = os.fstat(dir_fd)
     if (
-      stat.S_ISLNK(item.st_mode)
-      or not stat.S_ISREG(item.st_mode)
-      or item.st_nlink != 1
-      or (item.st_uid, item.st_gid) not in allowed_owners
-      or stat.S_IMODE(item.st_mode) & 0o077
+      not stat.S_ISDIR(current.st_mode)
+      or (current.st_uid, current.st_gid) not in allowed_owners
+      or stat.S_IMODE(current.st_mode) & 0o077
     ):
-      raise RuntimeError(f"identity broker file is unsafe: {path.name}")
-    existing.append(path)
+      raise RuntimeError("identity broker private directory is unsafe")
 
-  os.chown(PRIVATE_DIR, 0, 0)
-  os.chmod(PRIVATE_DIR, 0o700)
-  for path in existing:
-    os.chown(path, 0, 0)
-    os.chmod(path, 0o600)
+    # These are fixed children of PRIVATE_DIR, so opening them by name relative
+    # to the pinned directory keeps a rename of PRIVATE_DIR itself irrelevant.
+    for path in (KEY_PATH, STATE_PATH, INSTANCE_PATH, PENDING_BOOTSTRAP_PATH):
+      try:
+        file_fd = os.open(path.name, open_flags, dir_fd=dir_fd)
+      except FileNotFoundError:
+        continue
+      except OSError as exc:
+        raise RuntimeError(
+          f"identity broker file is unsafe: {path.name}"
+        ) from exc
+      opened.append((file_fd, 0o600))
+      item = os.fstat(file_fd)
+      if (
+        not stat.S_ISREG(item.st_mode)
+        or item.st_nlink != 1
+        or (item.st_uid, item.st_gid) not in allowed_owners
+        or stat.S_IMODE(item.st_mode) & 0o077
+      ):
+        raise RuntimeError(f"identity broker file is unsafe: {path.name}")
+
+    # Nothing is mutated until every entry has passed, so a rejected tree is
+    # left exactly as found.
+    for fd, mode in opened:
+      os.fchown(fd, 0, 0)
+      os.fchmod(fd, mode)
+  finally:
+    for fd, _mode in opened:
+      os.close(fd)
 
 
 def _prepare_private_dir() -> None:

--- a/backend/runtime/identity_broker.py
+++ b/backend/runtime/identity_broker.py
@@ -13,6 +13,7 @@ import base64
 import hashlib
 import json
 import os
+import pwd
 import re
 import secrets
 import socketserver
@@ -88,6 +89,55 @@ def _atomic_root_write(path: Path, value: bytes) -> None:
     os.replace(temp, path)
   finally:
     temp.unlink(missing_ok=True)
+
+
+def _reclaim_private_state_after_compat_chown() -> None:
+  """Restore root ownership after the broad /data compatibility pass.
+
+  Older official entrypoints make a persisted /data tree app-writable before
+  this root broker starts. Adopt only the broker's fixed, already-private state
+  files; reject links, unexpected owners, and permissive modes rather than
+  blessing an attacker-controlled path.
+  """
+  if os.geteuid() != 0:
+    return
+
+  mobius = pwd.getpwnam("mobius")
+  allowed_owners = {(0, 0), (mobius.pw_uid, mobius.pw_gid)}
+  try:
+    current = os.lstat(PRIVATE_DIR)
+  except FileNotFoundError:
+    PRIVATE_DIR.mkdir(mode=0o700)
+    current = os.lstat(PRIVATE_DIR)
+  if (
+    stat.S_ISLNK(current.st_mode)
+    or not stat.S_ISDIR(current.st_mode)
+    or (current.st_uid, current.st_gid) not in allowed_owners
+    or stat.S_IMODE(current.st_mode) & 0o077
+  ):
+    raise RuntimeError("identity broker private directory is unsafe")
+
+  existing: list[Path] = []
+  for path in (KEY_PATH, STATE_PATH, INSTANCE_PATH, PENDING_BOOTSTRAP_PATH):
+    try:
+      item = os.lstat(path)
+    except FileNotFoundError:
+      continue
+    if (
+      stat.S_ISLNK(item.st_mode)
+      or not stat.S_ISREG(item.st_mode)
+      or item.st_nlink != 1
+      or (item.st_uid, item.st_gid) not in allowed_owners
+      or stat.S_IMODE(item.st_mode) & 0o077
+    ):
+      raise RuntimeError(f"identity broker file is unsafe: {path.name}")
+    existing.append(path)
+
+  os.chown(PRIVATE_DIR, 0, 0)
+  os.chmod(PRIVATE_DIR, 0o700)
+  for path in existing:
+    os.chown(path, 0, 0)
+    os.chmod(path, 0o600)
 
 
 def _prepare_private_dir() -> None:
@@ -557,6 +607,7 @@ class _TcpServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
 def main() -> None:
   if os.geteuid() != 0:
     raise SystemExit("identity broker must run as root")
+  _reclaim_private_state_after_compat_chown()
   broker = Broker()
   _prepare_socket_dir()
   SOCKET_PATH.unlink(missing_ok=True)

--- a/backend/tests/test_identity_broker.py
+++ b/backend/tests/test_identity_broker.py
@@ -4,6 +4,7 @@ import importlib.util
 import hashlib
 import json
 import os
+import signal
 import stat
 import subprocess
 import tempfile
@@ -203,6 +204,35 @@ def test_root_broker_refuses_permissive_legacy_state(tmp_path, monkeypatch):
 
   with pytest.raises(RuntimeError, match="file is unsafe"):
     broker_module._reclaim_private_state_after_compat_chown()
+
+
+def test_root_broker_refuses_planted_fifo_without_stalling(tmp_path, monkeypatch):
+  """The FIFO is refused, and opening it must not wait for a writer.
+
+  A FIFO is the shape that isolates the S_ISREG guard: it has one link, the
+  expected owner, and a private mode, so every other rejection clause passes
+  it. A planted directory is already refused by the link check.
+  """
+  _private, key = _legacy_state_paths(tmp_path, monkeypatch)
+  key.unlink()
+  os.mkfifo(key, 0o600)
+  adopted = _record_adopted_inodes(monkeypatch)
+
+  def _stalled(_signum, _frame):
+    raise AssertionError("opening the planted FIFO blocked on a writer")
+
+  # Without O_NONBLOCK this open waits forever for a writer that never comes,
+  # so fail the assertion instead of hanging the suite.
+  previous = signal.signal(signal.SIGALRM, _stalled)
+  signal.alarm(5)
+  try:
+    with pytest.raises(RuntimeError, match="file is unsafe"):
+      broker_module._reclaim_private_state_after_compat_chown()
+  finally:
+    signal.alarm(0)
+    signal.signal(signal.SIGALRM, previous)
+
+  assert adopted == []
 
 
 def test_socket_parent_must_not_be_app_writable(tmp_path, monkeypatch):

--- a/backend/tests/test_identity_broker.py
+++ b/backend/tests/test_identity_broker.py
@@ -107,23 +107,87 @@ def _legacy_state_paths(tmp_path, monkeypatch):
   return private, key
 
 
+def _record_adopted_inodes(monkeypatch, on_first_call=None):
+  """Capture which inodes the root fixup targets, without needing real root."""
+  adopted = []
+
+  def fake_fchown(fd, uid, gid):
+    if on_first_call is not None and not adopted:
+      on_first_call()
+    adopted.append((os.fstat(fd).st_ino, uid, gid))
+
+  monkeypatch.setattr(broker_module.os, "fchown", fake_fchown)
+  return adopted
+
+
 def test_root_broker_reclaims_only_locked_down_legacy_state(tmp_path, monkeypatch):
   private, key = _legacy_state_paths(tmp_path, monkeypatch)
-  adopted = []
-  monkeypatch.setattr(
-    broker_module.os, "chown",
-    lambda path, uid, gid: adopted.append((Path(path), uid, gid)),
-  )
+  adopted = _record_adopted_inodes(monkeypatch)
 
   broker_module._reclaim_private_state_after_compat_chown()
 
-  assert adopted == [(private, 0, 0), (key, 0, 0)]
+  assert adopted == [(private.stat().st_ino, 0, 0), (key.stat().st_ino, 0, 0)]
   assert stat.S_IMODE(private.stat().st_mode) == 0o700
   assert stat.S_IMODE(key.stat().st_mode) == 0o600
 
 
-def test_root_broker_refuses_linked_legacy_state(tmp_path, monkeypatch):
+def test_root_broker_refuses_symlinked_legacy_state(tmp_path, monkeypatch):
+  _private, key = _legacy_state_paths(tmp_path, monkeypatch)
+  key.unlink()
+  outside = tmp_path / "outside.pem"
+  outside.write_text("do not adopt", encoding="utf-8")
+  # Locked down like genuine state, so being a symlink is the only reason
+  # this can be refused.
+  outside.chmod(0o600)
+  key.symlink_to(outside)
+  adopted = _record_adopted_inodes(monkeypatch)
+
+  with pytest.raises(RuntimeError, match="file is unsafe"):
+    broker_module._reclaim_private_state_after_compat_chown()
+
+  assert adopted == []
+
+
+def test_root_broker_refuses_symlinked_private_directory(tmp_path, monkeypatch):
+  private, _key = _legacy_state_paths(tmp_path, monkeypatch)
+  outside = tmp_path / "outside-dir"
+  outside.mkdir(mode=0o700)
+  link = tmp_path / "identity-broker-link"
+  link.symlink_to(outside, target_is_directory=True)
+  monkeypatch.setattr(broker_module, "PRIVATE_DIR", link)
+  adopted = _record_adopted_inodes(monkeypatch)
+
+  with pytest.raises(RuntimeError, match="private directory is unsafe"):
+    broker_module._reclaim_private_state_after_compat_chown()
+
+  assert adopted == []
+  assert stat.S_IMODE(private.stat().st_mode) == 0o700
+
+
+def test_root_broker_fixup_survives_entry_swapped_after_validation(
+  tmp_path, monkeypatch
+):
+  """A validated entry replaced mid-run must not redirect the root fixup."""
   private, key = _legacy_state_paths(tmp_path, monkeypatch)
+  key_inode = key.stat().st_ino
+  outside = tmp_path / "outside.pem"
+  outside.write_text("do not adopt", encoding="utf-8")
+  outside.chmod(0o644)
+
+  def swap_key_for_symlink():
+    key.unlink()
+    key.symlink_to(outside)
+
+  adopted = _record_adopted_inodes(monkeypatch, on_first_call=swap_key_for_symlink)
+
+  broker_module._reclaim_private_state_after_compat_chown()
+
+  assert adopted == [(private.stat().st_ino, 0, 0), (key_inode, 0, 0)]
+  assert stat.S_IMODE(outside.stat().st_mode) == 0o644
+
+
+def test_root_broker_refuses_linked_legacy_state(tmp_path, monkeypatch):
+  _private, key = _legacy_state_paths(tmp_path, monkeypatch)
   key.unlink()
   outside = tmp_path / "outside"
   outside.write_text("do not adopt", encoding="utf-8")

--- a/backend/tests/test_identity_broker.py
+++ b/backend/tests/test_identity_broker.py
@@ -10,6 +10,7 @@ import tempfile
 import threading
 import time
 from pathlib import Path
+from types import SimpleNamespace
 
 import httpx
 import pytest
@@ -82,6 +83,62 @@ def test_private_directory_and_key_reject_precreated_symlinks(tmp_path, monkeypa
 
   with pytest.raises(RuntimeError, match="file is unsafe"):
     broker_module._load_or_create_key()
+
+
+def _legacy_state_paths(tmp_path, monkeypatch):
+  private = tmp_path / "identity-broker"
+  private.mkdir(mode=0o700)
+  key = private / "instance-ed25519.pem"
+  key.write_text("legacy-key", encoding="utf-8")
+  key.chmod(0o600)
+  owner = (os.getuid(), os.getgid())
+  monkeypatch.setattr(broker_module, "PRIVATE_DIR", private)
+  monkeypatch.setattr(broker_module, "KEY_PATH", key)
+  monkeypatch.setattr(broker_module, "STATE_PATH", private / "identity.json")
+  monkeypatch.setattr(broker_module, "INSTANCE_PATH", private / "instance-id")
+  monkeypatch.setattr(
+    broker_module, "PENDING_BOOTSTRAP_PATH", private / "pending-enrollment.jwt"
+  )
+  monkeypatch.setattr(broker_module.os, "geteuid", lambda: 0)
+  monkeypatch.setattr(
+    broker_module.pwd, "getpwnam",
+    lambda _name: SimpleNamespace(pw_uid=owner[0], pw_gid=owner[1]),
+  )
+  return private, key
+
+
+def test_root_broker_reclaims_only_locked_down_legacy_state(tmp_path, monkeypatch):
+  private, key = _legacy_state_paths(tmp_path, monkeypatch)
+  adopted = []
+  monkeypatch.setattr(
+    broker_module.os, "chown",
+    lambda path, uid, gid: adopted.append((Path(path), uid, gid)),
+  )
+
+  broker_module._reclaim_private_state_after_compat_chown()
+
+  assert adopted == [(private, 0, 0), (key, 0, 0)]
+  assert stat.S_IMODE(private.stat().st_mode) == 0o700
+  assert stat.S_IMODE(key.stat().st_mode) == 0o600
+
+
+def test_root_broker_refuses_linked_legacy_state(tmp_path, monkeypatch):
+  private, key = _legacy_state_paths(tmp_path, monkeypatch)
+  key.unlink()
+  outside = tmp_path / "outside"
+  outside.write_text("do not adopt", encoding="utf-8")
+  os.link(outside, key)
+
+  with pytest.raises(RuntimeError, match="file is unsafe"):
+    broker_module._reclaim_private_state_after_compat_chown()
+
+
+def test_root_broker_refuses_permissive_legacy_state(tmp_path, monkeypatch):
+  _private, key = _legacy_state_paths(tmp_path, monkeypatch)
+  key.chmod(0o640)
+
+  with pytest.raises(RuntimeError, match="file is unsafe"):
+    broker_module._reclaim_private_state_after_compat_chown()
 
 
 def test_socket_parent_must_not_be_app_writable(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- restore root ownership for the broker's persisted private state after the legacy `/data` compatibility ownership sweep
- adopt only fixed, already-private regular files owned by root or the app user
- fail closed on symlinks, hard links, unexpected ownership, permissive modes, and special files

## Why
The entrypoint recursively hands `/data` to the app user before the root identity broker starts. On a later container replacement, that changes the owner of persisted broker keys and state; the broker then correctly refuses those files and the Möbius subscription becomes unavailable. This reclaims only the exact locked-down state the official sweep can produce, without weakening the broker's ordinary root-only checks.

## Prior work
No matching issue or pull request was found.

## Testing
- `python3 -m py_compile backend/runtime/identity_broker.py`
- `scripts/wt-pytest.sh backend/tests/test_identity_broker.py` (14 passed, 1 skipped)
- canonical binary-safe diff check passed