### PR TITLE
Make service-token refresh use the selected backend

### DIFF
--- a/backend/scripts/entrypoint.sh
+++ b/backend/scripts/entrypoint.sh
@@ -681,18 +681,34 @@ done
 # Stored outside /data/shared/ so it's not accessible via the storage API.
 # Token lifetime is 90 days; auto-regenerated when within 30 days of expiry.
 # Only runs after first-time setup (requires an owner to exist).
-_token=$(python3 -c "
+_token=$(
+  cd "$_serve_workdir" || exit 1
+  $_env_scrub timeout 15 python3 -c "
 from app.auth import create_access_token, decode_access_token
 from app.database import SessionLocal
 from app import models
 from datetime import datetime, UTC, timedelta
-import os
+import os, sys, time
 
-try:
-    db = SessionLocal()
-    owner = db.query(models.Owner).first()
-    db.close()
-except Exception:
+owner = None
+queried = False
+last_error = None
+for attempt in range(3):
+    try:
+        with SessionLocal() as db:
+            owner = db.query(models.Owner).first()
+        queried = True
+        break
+    except Exception as exc:
+        last_error = exc
+        if attempt < 2:
+            time.sleep(1)
+if not queried:
+    detail = str(last_error)[:240] if last_error else 'unknown error'
+    print(
+        f'WARNING: service token refresh skipped after database errors: {detail}',
+        file=sys.stderr,
+    )
     exit(0)
 if not owner:
     exit(0)
@@ -724,6 +740,10 @@ token = create_access_token(
 )
 print(token, end='')
 ")
+_token_status=$?
+if [ "$_token_status" -ne 0 ]; then
+  echo "WARNING: service token refresh command failed (exit $_token_status)." >&2
+fi
 if [ -n "$_token" ]; then
   # Atomic write: tmp + rename. A crash mid-write would otherwise leave
   # an empty service-token.txt that cron jobs read as an empty token.

--- a/backend/tests/test_recovery_boundary.py
+++ b/backend/tests/test_recovery_boundary.py
@@ -75,3 +75,18 @@ def test_boot_fallback_never_moves_or_prunes_owner_platform_source():
   assert "platform.crashloop-prev" not in entrypoint
   assert "boot_attempt_counter" not in entrypoint
   assert "app.data_volume" not in entrypoint
+
+
+def test_service_token_refresh_uses_selected_backend_and_retries_db_lookup():
+  entrypoint = (ROOT / "backend/scripts/entrypoint.sh").read_text(
+    encoding="utf-8",
+  )
+  refresh = entrypoint.split(
+    "# Generate (or refresh) a service token", 1,
+  )[1].split("# The python block above", 1)[0]
+
+  assert 'cd "$_serve_workdir"' in refresh
+  assert "timeout 15 python3" in refresh
+  assert "for attempt in range(3)" in refresh
+  assert "service token refresh skipped after database errors" in refresh
+  assert "service token refresh command failed" in refresh


### PR DESCRIPTION
## Summary
- run service-token refresh from the backend that the boot probe actually selected, including the baked fallback
- bound the refresh command and retry transient database startup failures before giving up
- keep the existing token intact on failure while emitting a useful warning instead of failing silently

## Prior work
No matching issue or pull request was found. This is distinct from the earlier app-scoped credential migrations in #465 and #487: it hardens the platform-owned service token during container startup.

## Testing
- `bash -n backend/scripts/entrypoint.sh`
- `scripts/wt-pytest.sh backend/tests/test_recovery_boundary.py` (5 passed)
- canonical binary-safe diff check passed