### PR TITLE
Add owner-consented live screen control

### DIFF
--- a/CAPABILITIES.md
+++ b/CAPABILITIES.md
@@ -173,6 +173,7 @@ The host registry maps a capability id to:
   version: 1,
   exclusive: true,
   onDeactivate: 'finish',
+  preserveOnDetach: false,
   async open({ input, declaration, channel }) {
     channel.ready(metadata)
     channel.event('progress', value)
@@ -194,6 +195,13 @@ Provider methods must be idempotent under repeated finish/cancel, release every
 browser resource, and tolerate cancellation after the app frame has gone away.
 They must clamp requests to reviewed declaration limits rather than trusting
 app input.
+
+`preserveOnDetach` is exceptional and platform-reviewed. It is reserved for a
+background grant whose independent, owner-visible stop surface survives frame
+replacement. A preserving provider receives `control('detach')`, must drop the
+old frame channel without ending the grant, and must offer a narrow reattach
+operation bound to the same app-owned identity. Ordinary providers keep the
+default `false` and are cancelled on frame or host teardown.
 
 ## Lifecycle and grants
 
@@ -246,6 +254,15 @@ Add primitives only after a real app needs them. Likely families are:
 - `notifications.request`, `share.open`
 - `device.midi`, `device.serial`, `device.bluetooth`
 - `display.fullscreen`, `display.wake_lock`
+
+The current `workspace.screen-control` provider is intentionally narrower than
+a general DOM or browser-debugging bridge. Only an app-owned support chat can
+be bound to a session. The owner must start current-tab capture from a visible
+app gesture, an active-only shell pill keeps Stop available after navigation,
+and the provider exposes no arbitrary script execution. The session may remain
+active while its app is behind another workspace view so the support agent can
+investigate that view; frame teardown, capture stop, relay disconnect, expiry,
+or the owner/agent Stop path releases it.
 
 Today external HTTP remains an app-token-authenticated server surface rather
 than a host session. Its reviewable permission should describe destinations and

--- a/backend/app/app_capabilities.py
+++ b/backend/app/app_capabilities.py
@@ -274,6 +274,21 @@ RUNTIME_CAPABILITY_DEFINITIONS: dict[str, dict[str, Any]] = {
     "default_limits": {"max_duration_ms": 30_000},
     "hard_limits": {"max_duration_ms": (100, 60_000)},
   },
+  "workspace.screen-control": {
+    "version": 1,
+    "kind": "session",
+    "title": "Control this M\u00f6bius screen",
+    "description": (
+      "Let this app's support chat inspect and control the current M\u00f6bius tab."
+    ),
+    "risk": "device",
+    # The owner may navigate away from the control app while the exact app-owned
+    # support chat continues investigating. The browser's capture indicator and
+    # M\u00f6bius's active-session stop affordance remain authoritative.
+    "lifecycle": "background",
+    "default_limits": {},
+    "hard_limits": {},
+  },
 }
 
 

--- a/backend/app/deps.py
+++ b/backend/app/deps.py
@@ -303,6 +303,23 @@ def get_current_owner(
   return resolve_owner_only(token, db)
 
 
+def authorize_current_owner_detached(
+  token: str = Depends(_oauth2),
+) -> str:
+  """Authenticate an owner token without retaining a DB session.
+
+  Long-lived owner-only streams use the returned username to bind their
+  transient in-memory resource while releasing the pooled connection before
+  response iteration begins.
+  """
+  db = SessionLocal()
+  try:
+    owner = resolve_owner_only(token, db)
+    return owner.username
+  finally:
+    db.close()
+
+
 def _enforce_delegation_claims(
   payload: dict, db: Session, app_id: int | None,
 ) -> tuple[str, str]:

--- a/backend/app/deps.py
+++ b/backend/app/deps.py
@@ -303,23 +303,6 @@ def get_current_owner(
   return resolve_owner_only(token, db)
 
 
-def authorize_current_owner_detached(
-  token: str = Depends(_oauth2),
-) -> str:
-  """Authenticate an owner token without retaining a DB session.
-
-  Long-lived owner-only streams use the returned username to bind their
-  transient in-memory resource while releasing the pooled connection before
-  response iteration begins.
-  """
-  db = SessionLocal()
-  try:
-    owner = resolve_owner_only(token, db)
-    return owner.username
-  finally:
-    db.close()
-
-
 def _enforce_delegation_claims(
   payload: dict, db: Session, app_id: int | None,
 ) -> tuple[str, str]:
@@ -570,6 +553,23 @@ def authorize_current_owner_or_app_detached(
   db = SessionLocal()
   try:
     resolve_owner_or_app(token, db)
+  finally:
+    db.close()
+
+
+def authorize_current_owner_detached(
+  token: str = Depends(_oauth2),
+) -> str:
+  """Authenticate an owner token without retaining a DB session.
+
+  Long-lived owner-only streams use the returned username to bind their
+  transient in-memory resource while releasing the pooled connection before
+  response iteration begins.
+  """
+  db = SessionLocal()
+  try:
+    owner = resolve_owner_only(token, db)
+    return owner.username
   finally:
     db.close()
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -73,6 +73,7 @@ from app.routes import (
   debug_router, delegations_router, fs_router, goal_plans_router, github_router, media_router,
   identity_router,
   local_services_router, notifications_router, notify_router, proxy_router, push_router,
+  screen_control_router,
   public_apps_router,
   secrets_router, self_reminders_router, settings_router, skills_router,
   client_error_router, client_signal_router, standalone_router, storage_router,
@@ -744,6 +745,7 @@ except Exception as _exc:  # pragma: no cover - defensive boot guard
     "app_chat_router not mounted: %s", _exc, exc_info=True,
   )
 app.include_router(notify_router)
+app.include_router(screen_control_router)
 app.include_router(proxy_router)
 app.include_router(public_apps_router)
 app.include_router(local_services_router)

--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -68,6 +68,7 @@ proxy_router = _load("proxy")
 public_apps_router = _load("public_apps")
 local_services_router = _load("local_services")
 notify_router = _load("notify")
+screen_control_router = _load("screen_control")
 settings_router = _load("settings")
 storage_router = _load("storage")
 fs_router = _load("fs")
@@ -110,6 +111,7 @@ __all__ = [
   "public_apps_router",
   "local_services_router",
   "notify_router",
+  "screen_control_router",
   "settings_router",
   "uploads_router",
   "media_router",

--- a/backend/app/routes/screen_control.py
+++ b/backend/app/routes/screen_control.py
@@ -1,0 +1,301 @@
+"""Owner-started, exact-chat live browser control relay."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import math
+from typing import Any, Literal
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+from sqlalchemy.orm import Session
+
+from app import models
+from app.database import get_db
+from app.deps import (
+  Principal,
+  authorize_current_owner_detached,
+  get_agent_run_principal,
+  get_current_owner,
+  reject_cross_site,
+)
+from app.screen_control import registry
+
+
+router = APIRouter(prefix="/api/screen-control", tags=["screen-control"])
+
+_RESPONSE_MAX_BYTES = 8 * 1024 * 1024
+_KEEPALIVE_SECONDS = 15
+_PRESS_KEYS = frozenset({
+  "Enter", "Escape", "Tab", "Backspace", "Delete", " ",
+  "ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight", "Home", "End",
+  "PageUp", "PageDown",
+})
+
+
+class SessionStartBody(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  appId: int = Field(gt=0)
+  chatId: str = Field(min_length=1, max_length=128)
+  route: str = Field(default="/", max_length=512)
+  viewport: dict[str, float] = Field(default_factory=dict)
+
+  @model_validator(mode="after")
+  def validate_viewport(self) -> "SessionStartBody":
+    allowed = {"width", "height", "pixelRatio"}
+    if any(key not in allowed for key in self.viewport):
+      raise ValueError("viewport contains an unknown field")
+    for key, value in self.viewport.items():
+      ceiling = 8 if key == "pixelRatio" else 10000
+      if not math.isfinite(value) or value < 1 or value > ceiling:
+        raise ValueError(f"viewport {key} is outside the supported range")
+    return self
+
+
+class BrowserResponseBody(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  commandId: str = Field(min_length=1, max_length=128)
+  ok: bool
+  result: dict[str, Any] | list[Any] | str | int | float | bool | None = None
+  error: str | None = Field(default=None, max_length=1000)
+
+
+class AgentCommandBody(BaseModel):
+  """Closed control vocabulary; arbitrary browser script is not a command."""
+
+  model_config = ConfigDict(extra="forbid")
+
+  action: Literal["snapshot", "screenshot", "click", "type", "scroll", "press"]
+  ref: str | None = Field(default=None, max_length=160)
+  x: float | None = None
+  y: float | None = None
+  text: str | None = Field(default=None, max_length=20_000)
+  replace: bool | None = None
+  deltaX: float | None = None
+  deltaY: float | None = None
+  key: str | None = Field(default=None, max_length=24)
+
+  @model_validator(mode="after")
+  def confine_action_fields(self) -> "AgentCommandBody":
+    coordinates = self.x is not None or self.y is not None
+    if coordinates:
+      if self.x is None or self.y is None:
+        raise ValueError("x and y must be supplied together")
+      if not all(math.isfinite(value) and -1000 <= value <= 20_000 for value in (self.x, self.y)):
+        raise ValueError("coordinates are outside the supported range")
+    if self.action in {"snapshot", "screenshot"}:
+      if any(value is not None for value in (
+        self.ref, self.x, self.y, self.text, self.replace,
+        self.deltaX, self.deltaY, self.key,
+      )):
+        raise ValueError(f"{self.action} does not accept a target or value")
+    elif self.action == "click":
+      if not self.ref and not coordinates:
+        raise ValueError("click requires ref or x/y")
+      if any(value is not None for value in (
+        self.text, self.replace, self.deltaX, self.deltaY, self.key,
+      )):
+        raise ValueError("click accepts only ref or x/y")
+    elif self.action == "type":
+      if self.text is None:
+        raise ValueError("type requires text")
+      if any(value is not None for value in (self.deltaX, self.deltaY, self.key)):
+        raise ValueError("type does not accept scroll or key fields")
+    elif self.action == "scroll":
+      if self.deltaX is None and self.deltaY is None:
+        raise ValueError("scroll requires deltaX or deltaY")
+      for value in (self.deltaX, self.deltaY):
+        if value is not None and (not math.isfinite(value) or abs(value) > 20_000):
+          raise ValueError("scroll delta is outside the supported range")
+      if any(value is not None for value in (
+        self.ref, self.text, self.replace, self.key,
+      )):
+        raise ValueError("scroll accepts only deltas and an optional x/y point")
+    elif self.action == "press":
+      if self.key not in _PRESS_KEYS:
+        raise ValueError("press key is not in the supported set")
+      if any(value is not None for value in (
+        self.ref, self.x, self.y, self.text, self.replace,
+        self.deltaX, self.deltaY,
+      )):
+        raise ValueError("press accepts only key")
+    return self
+
+
+def _agent_for_chat(chat_id: str, principal: Principal) -> None:
+  if principal.chat_id != chat_id:
+    raise HTTPException(
+      status_code=403,
+      detail="The agent token is bound to a different chat.",
+    )
+
+
+def _session_wire(session) -> dict[str, Any]:
+  return {
+    "active": session.active,
+    "sessionId": session.id,
+    "appId": session.app_id,
+    "chatId": session.chat_id,
+    "route": session.route,
+    "viewport": session.viewport,
+    "connected": session.browser_connections > 0,
+    "expiresAt": int(session.expires_at * 1000),
+  }
+
+
+@router.post("/sessions", dependencies=[Depends(reject_cross_site)])
+async def start_session(
+  body: SessionStartBody,
+  owner: models.Owner = Depends(get_current_owner),
+  db: Session = Depends(get_db),
+):
+  chat = db.query(models.Chat).filter(
+    models.Chat.id == body.chatId,
+    models.Chat.created_by_app_id == body.appId,
+    models.Chat.deleted_at.is_(None),
+  ).first()
+  if chat is None:
+    raise HTTPException(status_code=404, detail="Chat not found.")
+  session = await registry.start(
+    owner_username=owner.username,
+    app_id=body.appId,
+    chat_id=body.chatId,
+    route=body.route,
+    viewport=body.viewport,
+  )
+  return _session_wire(session)
+
+
+@router.get(
+  "/sessions/{session_id}/events",
+)
+async def browser_events(
+  session_id: str,
+  request: Request,
+  owner_username: str = Depends(authorize_current_owner_detached),
+):
+  # One-owner product today. Authentication is detached before streaming so a
+  # live screen does not pin a database connection for its whole 15-minute
+  # consent window; the unguessable session id is additionally bound at start.
+  session = await registry.get_for_browser(session_id, owner_username)
+  if session is None:
+    raise HTTPException(status_code=404, detail="Shared-screen session not found.")
+
+  async def generate():
+    connected = await registry.connect_browser(session_id, owner_username)
+    if connected is None:
+      return
+    try:
+      yield f"data: {json.dumps({'type': 'screen-control-open'})}\n\n"
+      while session.active:
+        if await request.is_disconnected():
+          break
+        try:
+          command = await asyncio.wait_for(
+            session.commands.get(), timeout=_KEEPALIVE_SECONDS,
+          )
+        except TimeoutError:
+          yield ": keepalive\n\n"
+          continue
+        if command is None:
+          yield f"data: {json.dumps({'type': 'screen-control-stop'})}\n\n"
+          break
+        yield f"data: {json.dumps({'type': 'screen-control-command', **command})}\n\n"
+    finally:
+      await registry.disconnect_browser(session.id)
+
+  return StreamingResponse(
+    generate(),
+    media_type="text/event-stream",
+    headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+  )
+
+
+@router.post(
+  "/sessions/{session_id}/responses",
+  dependencies=[Depends(reject_cross_site)],
+)
+async def browser_response(
+  session_id: str,
+  body: BrowserResponseBody,
+  owner: models.Owner = Depends(get_current_owner),
+):
+  session = await registry.get_for_browser(session_id, owner.username)
+  if session is None:
+    raise HTTPException(status_code=404, detail="Shared-screen session not found.")
+  encoded = json.dumps(body.result, ensure_ascii=True, separators=(",", ":"))
+  if len(encoded.encode("utf-8")) > _RESPONSE_MAX_BYTES:
+    raise HTTPException(status_code=413, detail="Screen-control response is too large.")
+  accepted = await registry.answer(session, body.commandId, {
+    "ok": body.ok,
+    "result": body.result,
+    "error": body.error,
+  })
+  if not accepted:
+    raise HTTPException(status_code=409, detail="Command is no longer pending.")
+  return {"accepted": True}
+
+
+@router.delete(
+  "/sessions/{session_id}",
+  status_code=204,
+  dependencies=[Depends(reject_cross_site)],
+)
+async def stop_browser_session(
+  session_id: str,
+  owner: models.Owner = Depends(get_current_owner),
+):
+  session = await registry.get_for_browser(session_id, owner.username)
+  if session is not None:
+    await registry.stop(session)
+
+
+@router.get("/chats/{chat_id}")
+async def agent_session_status(
+  chat_id: str,
+  principal: Principal = Depends(get_agent_run_principal),
+):
+  _agent_for_chat(chat_id, principal)
+  session = await registry.get_for_chat(chat_id, principal.owner.username)
+  return _session_wire(session) if session is not None else {"active": False}
+
+
+@router.post(
+  "/chats/{chat_id}/commands",
+  dependencies=[Depends(reject_cross_site)],
+)
+async def agent_command(
+  chat_id: str,
+  body: AgentCommandBody,
+  principal: Principal = Depends(get_agent_run_principal),
+):
+  _agent_for_chat(chat_id, principal)
+  session = await registry.get_for_chat(chat_id, principal.owner.username)
+  if session is None:
+    raise HTTPException(status_code=409, detail="No active shared-screen session.")
+  outcome = await registry.issue_command(
+    session,
+    body.model_dump(exclude_none=True, exclude_defaults=True),
+  )
+  if not outcome.get("ok"):
+    raise HTTPException(status_code=409, detail=outcome.get("error") or "Command failed.")
+  return outcome.get("result")
+
+
+@router.delete(
+  "/chats/{chat_id}",
+  status_code=204,
+  dependencies=[Depends(reject_cross_site)],
+)
+async def agent_stop_session(
+  chat_id: str,
+  principal: Principal = Depends(get_agent_run_principal),
+):
+  _agent_for_chat(chat_id, principal)
+  session = await registry.get_for_chat(chat_id, principal.owner.username)
+  if session is not None:
+    await registry.stop(session, "The agent released screen control.")

--- a/backend/app/routes/screen_control.py
+++ b/backend/app/routes/screen_control.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import json
 import math
 from typing import Any, Literal
@@ -191,12 +190,12 @@ async def browser_events(
       return
     try:
       yield f"data: {json.dumps({'type': 'screen-control-open'})}\n\n"
-      while session.active:
+      while True:
         if await request.is_disconnected():
           break
         try:
-          command = await asyncio.wait_for(
-            session.commands.get(), timeout=_KEEPALIVE_SECONDS,
+          command = await registry.next_browser_command(
+            session, keepalive_seconds=_KEEPALIVE_SECONDS,
           )
         except TimeoutError:
           yield ": keepalive\n\n"

--- a/backend/app/screen_control.py
+++ b/backend/app/screen_control.py
@@ -32,7 +32,7 @@ class ScreenControlSession:
   created_at: float
   expires_at: float
   commands: asyncio.Queue[dict[str, Any] | None] = field(
-    default_factory=asyncio.Queue,
+    default_factory=lambda: asyncio.Queue(maxsize=MAX_PENDING_COMMANDS),
   )
   pending: dict[str, asyncio.Future] = field(default_factory=dict)
   browser_connections: int = 0
@@ -58,7 +58,10 @@ class ScreenControlRegistry:
     self._by_chat.pop(session.chat_id, None)
     try:
       session.commands.put_nowait(None)
-    except asyncio.QueueFull:  # pragma: no cover - the queue is unbounded
+    except asyncio.QueueFull:
+      # A full queue already wakes the browser. The active flag makes that
+      # dequeue resolve to the same terminal outcome without needing a fifth
+      # transport slot for a sentinel.
       pass
     outcome = {"ok": False, "error": reason}
     for future in session.pending.values():
@@ -180,7 +183,18 @@ class ScreenControlRegistry:
       if len(current.pending) >= MAX_PENDING_COMMANDS:
         return {"ok": False, "error": "The shared browser is still handling earlier commands."}
       current.pending[command_id] = future
-      current.commands.put_nowait({"commandId": command_id, **command})
+      try:
+        current.commands.put_nowait({
+          "commandId": command_id,
+          "deadlineAt": int((time.time() + COMMAND_TIMEOUT_SECONDS) * 1000),
+          **command,
+        })
+      except asyncio.QueueFull:
+        current.pending.pop(command_id, None)
+        return {
+          "ok": False,
+          "error": "The shared browser is still handling earlier commands.",
+        }
     try:
       return await asyncio.wait_for(future, timeout=COMMAND_TIMEOUT_SECONDS)
     except TimeoutError:
@@ -189,6 +203,54 @@ class ScreenControlRegistry:
         if current is not None:
           current.pending.pop(command_id, None)
       return {"ok": False, "error": "The shared browser did not answer in time."}
+
+  async def next_browser_command(
+    self,
+    session: ScreenControlSession,
+    *,
+    keepalive_seconds: float,
+  ) -> dict[str, Any] | None:
+    """Return only a still-authoritative command, or ``None`` on session end.
+
+    Timed-out commands can remain in the bounded transport queue until the
+    browser catches up. They are transport residue, not latent authority, so
+    discard them here before they cross the browser boundary.
+    """
+    while True:
+      remaining = session.expires_at - time.time()
+      if remaining <= 0:
+        await self.stop(session, "The shared-screen session expired.")
+        return None
+      try:
+        command = await asyncio.wait_for(
+          session.commands.get(),
+          timeout=min(keepalive_seconds, remaining),
+        )
+      except TimeoutError:
+        if session.expires_at <= time.time():
+          await self.stop(session, "The shared-screen session expired.")
+          return None
+        raise
+      if command is None:
+        return None
+      command_id = command.get("commandId")
+      async with self._lock:
+        self._prune_locked()
+        current = self._by_id.get(session.id)
+        if current is None or not current.active:
+          return None
+        future = current.pending.get(command_id)
+        if future is None or future.done():
+          continue
+        deadline_at = command.get("deadlineAt")
+        if not isinstance(deadline_at, int) or deadline_at <= int(time.time() * 1000):
+          current.pending.pop(command_id, None)
+          future.set_result({
+            "ok": False,
+            "error": "The shared browser did not begin the command in time.",
+          })
+          continue
+        return command
 
   async def answer(
     self,

--- a/backend/app/screen_control.py
+++ b/backend/app/screen_control.py
@@ -1,0 +1,217 @@
+"""In-memory relay for an owner-granted live browser control session.
+
+The browser remains the authority and executor: this module never evaluates
+JavaScript or exposes a browser-debugging port.  It only pairs one selected
+browser surface with the ordinary agent token for the exact chat the owner
+named, relays a closed command vocabulary, and forgets everything on stop,
+expiry, or server restart.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import secrets
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+
+SESSION_TTL_SECONDS = 15 * 60
+COMMAND_TIMEOUT_SECONDS = 45
+MAX_PENDING_COMMANDS = 4
+
+
+@dataclass
+class ScreenControlSession:
+  id: str
+  owner_username: str
+  app_id: int
+  chat_id: str
+  route: str
+  viewport: dict[str, float]
+  created_at: float
+  expires_at: float
+  commands: asyncio.Queue[dict[str, Any] | None] = field(
+    default_factory=asyncio.Queue,
+  )
+  pending: dict[str, asyncio.Future] = field(default_factory=dict)
+  browser_connections: int = 0
+  closed_reason: str | None = None
+
+  @property
+  def active(self) -> bool:
+    return self.closed_reason is None and self.expires_at > time.time()
+
+
+class ScreenControlRegistry:
+  """One-process owner of transient live-control sessions and responses."""
+
+  def __init__(self) -> None:
+    self._lock = asyncio.Lock()
+    self._by_id: dict[str, ScreenControlSession] = {}
+    self._by_chat: dict[str, str] = {}
+
+  def _close_locked(self, session: ScreenControlSession, reason: str) -> None:
+    if session.closed_reason is not None:
+      return
+    session.closed_reason = reason
+    self._by_chat.pop(session.chat_id, None)
+    try:
+      session.commands.put_nowait(None)
+    except asyncio.QueueFull:  # pragma: no cover - the queue is unbounded
+      pass
+    outcome = {"ok": False, "error": reason}
+    for future in session.pending.values():
+      if not future.done():
+        future.set_result(outcome)
+    session.pending.clear()
+
+  def _prune_locked(self) -> None:
+    now = time.time()
+    for session in tuple(self._by_id.values()):
+      if session.closed_reason is None and session.expires_at <= now:
+        self._close_locked(session, "The shared-screen session expired.")
+    # Closed sessions carry no authority. Retain no registry history—the chat
+    # transcript is the owner's audit surface and the relay is intentionally
+    # restart-ephemeral.
+    for session_id, session in tuple(self._by_id.items()):
+      if session.closed_reason is not None:
+        self._by_id.pop(session_id, None)
+
+  async def start(
+    self,
+    *,
+    owner_username: str,
+    app_id: int,
+    chat_id: str,
+    route: str,
+    viewport: dict[str, float],
+  ) -> ScreenControlSession:
+    async with self._lock:
+      self._prune_locked()
+      prior_id = self._by_chat.get(chat_id)
+      prior = self._by_id.get(prior_id) if prior_id else None
+      if prior is not None:
+        self._close_locked(prior, "A newer shared-screen session replaced this one.")
+        self._by_id.pop(prior.id, None)
+      now = time.time()
+      session = ScreenControlSession(
+        id=secrets.token_urlsafe(24),
+        owner_username=owner_username,
+        app_id=app_id,
+        chat_id=chat_id,
+        route=route,
+        viewport=viewport,
+        created_at=now,
+        expires_at=now + SESSION_TTL_SECONDS,
+      )
+      self._by_id[session.id] = session
+      self._by_chat[chat_id] = session.id
+      return session
+
+  async def get_for_browser(
+    self, session_id: str, owner_username: str,
+  ) -> ScreenControlSession | None:
+    async with self._lock:
+      self._prune_locked()
+      session = self._by_id.get(session_id)
+      if session is None or session.owner_username != owner_username:
+        return None
+      return session
+
+  async def get_for_chat(
+    self, chat_id: str, owner_username: str,
+  ) -> ScreenControlSession | None:
+    async with self._lock:
+      self._prune_locked()
+      session_id = self._by_chat.get(chat_id)
+      session = self._by_id.get(session_id) if session_id else None
+      if session is None or session.owner_username != owner_username:
+        return None
+      return session
+
+  async def connect_browser(
+    self, session_id: str, owner_username: str,
+  ) -> ScreenControlSession | None:
+    async with self._lock:
+      self._prune_locked()
+      session = self._by_id.get(session_id)
+      if session is None or session.owner_username != owner_username:
+        return None
+      session.browser_connections += 1
+      return session
+
+  async def disconnect_browser(self, session_id: str) -> None:
+    async with self._lock:
+      session = self._by_id.get(session_id)
+      if session is None:
+        return
+      session.browser_connections = max(0, session.browser_connections - 1)
+      if session.browser_connections == 0:
+        # The browser client does not reconnect a capture stream after its
+        # event channel disappears. Retaining the session as active here made
+        # agents see a live-looking but permanently unusable grant until TTL.
+        self._close_locked(session, "The shared browser disconnected.")
+
+  async def stop(
+    self, session: ScreenControlSession, reason: str = "Screen sharing stopped.",
+  ) -> None:
+    async with self._lock:
+      current = self._by_id.get(session.id)
+      if current is None:
+        return
+      self._close_locked(current, reason)
+      self._by_id.pop(current.id, None)
+
+  async def issue_command(
+    self,
+    session: ScreenControlSession,
+    command: dict[str, Any],
+  ) -> dict[str, Any]:
+    command_id = secrets.token_urlsafe(12)
+    loop = asyncio.get_running_loop()
+    future = loop.create_future()
+    async with self._lock:
+      current = self._by_id.get(session.id)
+      if current is None or not current.active:
+        return {"ok": False, "error": "No active shared-screen session."}
+      if current.browser_connections < 1:
+        return {"ok": False, "error": "The shared browser is not connected."}
+      if len(current.pending) >= MAX_PENDING_COMMANDS:
+        return {"ok": False, "error": "The shared browser is still handling earlier commands."}
+      current.pending[command_id] = future
+      current.commands.put_nowait({"commandId": command_id, **command})
+    try:
+      return await asyncio.wait_for(future, timeout=COMMAND_TIMEOUT_SECONDS)
+    except TimeoutError:
+      async with self._lock:
+        current = self._by_id.get(session.id)
+        if current is not None:
+          current.pending.pop(command_id, None)
+      return {"ok": False, "error": "The shared browser did not answer in time."}
+
+  async def answer(
+    self,
+    session: ScreenControlSession,
+    command_id: str,
+    outcome: dict[str, Any],
+  ) -> bool:
+    async with self._lock:
+      current = self._by_id.get(session.id)
+      if current is None:
+        return False
+      future = current.pending.pop(command_id, None)
+      if future is None or future.done():
+        return False
+      future.set_result(outcome)
+      return True
+
+  async def reset_for_tests(self) -> None:
+    async with self._lock:
+      for session in tuple(self._by_id.values()):
+        self._close_locked(session, "Test reset.")
+      self._by_id.clear()
+      self._by_chat.clear()
+
+
+registry = ScreenControlRegistry()

--- a/backend/scripts/screen-control.py
+++ b/backend/scripts/screen-control.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Operate the owner-shared live screen for the current chat agent."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+
+def _environment() -> tuple[str, str, str]:
+  api = (os.environ.get("API_BASE_URL") or "").rstrip("/")
+  token = os.environ.get("AGENT_TOKEN") or ""
+  chat_id = os.environ.get("CHAT_ID") or ""
+  if not api or not token or not chat_id:
+    raise SystemExit("API_BASE_URL, AGENT_TOKEN, and CHAT_ID are required.")
+  if not re.fullmatch(r"[A-Za-z0-9_-]+", chat_id):
+    raise SystemExit("CHAT_ID has an unexpected shape.")
+  return api, token, chat_id
+
+
+def _request(
+  api: str,
+  token: str,
+  method: str,
+  path: str,
+  payload: dict | None = None,
+) -> object | None:
+  data = None if payload is None else json.dumps(payload).encode("utf-8")
+  request = urllib.request.Request(
+    api + path,
+    data=data,
+    method=method,
+    headers={
+      "Authorization": f"Bearer {token}",
+      **({"Content-Type": "application/json"} if data is not None else {}),
+    },
+  )
+  try:
+    with urllib.request.urlopen(request, timeout=60) as response:
+      raw = response.read()
+  except urllib.error.HTTPError as exc:
+    raw = exc.read()
+    try:
+      detail = json.loads(raw.decode("utf-8")).get("detail")
+    except Exception:
+      detail = raw.decode("utf-8", errors="replace") or exc.reason
+    raise SystemExit(f"screen-control request failed ({exc.code}): {detail}")
+  except OSError as exc:
+    raise SystemExit(f"screen-control request failed: {exc}")
+  if not raw:
+    return None
+  return json.loads(raw.decode("utf-8"))
+
+
+def _command(api: str, token: str, chat_id: str, payload: dict) -> object:
+  return _request(
+    api,
+    token,
+    "POST",
+    f"/api/screen-control/chats/{chat_id}/commands",
+    payload,
+  )
+
+
+def _write_screenshot(chat_id: str, result: object) -> Path:
+  if not isinstance(result, dict):
+    raise SystemExit("Shared browser returned an invalid screenshot response.")
+  data_url = result.get("dataUrl")
+  if not isinstance(data_url, str):
+    raise SystemExit("Shared browser returned no screenshot data.")
+  header, separator, encoded = data_url.partition(",")
+  if not separator or not header.startswith("data:image/") or ";base64" not in header:
+    raise SystemExit("Shared browser returned an unsupported screenshot encoding.")
+  mime = str(result.get("mimeType") or "image/jpeg").lower()
+  suffix = ".png" if mime == "image/png" else ".jpg"
+  media_dir = Path("/data/chats") / chat_id / "media"
+  media_dir.mkdir(parents=True, exist_ok=True)
+  output = media_dir / f"live-screen-{time.time_ns()}{suffix}"
+  try:
+    decoded = base64.b64decode(encoded, validate=True)
+  except (ValueError, TypeError) as exc:
+    raise SystemExit(f"Shared browser returned malformed image data: {exc}")
+  if not decoded:
+    raise SystemExit("Shared browser returned an empty screenshot.")
+  output.write_bytes(decoded)
+  return output
+
+
+def main() -> None:
+  parser = argparse.ArgumentParser(description=__doc__)
+  sub = parser.add_subparsers(dest="action", required=True)
+  sub.add_parser("status")
+  sub.add_parser("snapshot")
+  sub.add_parser("screenshot")
+  click = sub.add_parser("click")
+  click.add_argument("ref")
+  click_at = sub.add_parser("click-at")
+  click_at.add_argument("x", type=float)
+  click_at.add_argument("y", type=float)
+  type_cmd = sub.add_parser("type")
+  type_cmd.add_argument("text")
+  type_cmd.add_argument("--ref")
+  type_cmd.add_argument("--append", action="store_true")
+  scroll = sub.add_parser("scroll")
+  scroll.add_argument("delta_y", type=float)
+  scroll.add_argument("--delta-x", type=float, default=0)
+  scroll.add_argument("--x", type=float)
+  scroll.add_argument("--y", type=float)
+  press = sub.add_parser("press")
+  press.add_argument("key")
+  sub.add_parser("stop")
+  args = parser.parse_args()
+  api, token, chat_id = _environment()
+
+  if args.action == "status":
+    result = _request(api, token, "GET", f"/api/screen-control/chats/{chat_id}")
+  elif args.action == "stop":
+    _request(api, token, "DELETE", f"/api/screen-control/chats/{chat_id}")
+    print("Shared-screen session stopped.")
+    return
+  elif args.action == "snapshot":
+    result = _command(api, token, chat_id, {"action": "snapshot"})
+  elif args.action == "screenshot":
+    result = _command(api, token, chat_id, {"action": "screenshot"})
+    output = _write_screenshot(chat_id, result)
+    print(f"SCREENSHOT: {output}")
+    print(f"![live screen](/api/chats/{chat_id}/media/{output.name})")
+    return
+  elif args.action == "click":
+    result = _command(api, token, chat_id, {"action": "click", "ref": args.ref})
+  elif args.action == "click-at":
+    result = _command(api, token, chat_id, {
+      "action": "click", "x": args.x, "y": args.y,
+    })
+  elif args.action == "type":
+    payload = {
+      "action": "type", "text": args.text, "replace": not args.append,
+    }
+    if args.ref:
+      payload["ref"] = args.ref
+    result = _command(api, token, chat_id, payload)
+  elif args.action == "scroll":
+    if (args.x is None) != (args.y is None):
+      parser.error("--x and --y must be supplied together")
+    payload = {
+      "action": "scroll", "deltaX": args.delta_x, "deltaY": args.delta_y,
+    }
+    if args.x is not None:
+      payload.update({"x": args.x, "y": args.y})
+    result = _command(api, token, chat_id, payload)
+  else:
+    result = _command(api, token, chat_id, {"action": "press", "key": args.key})
+  print(json.dumps(result, indent=2, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+  main()

--- a/backend/scripts/seed-skills/live-screen-control.md
+++ b/backend/scripts/seed-skills/live-screen-control.md
@@ -1,0 +1,65 @@
+---
+name: live-screen-control
+description: Use when the partner explicitly activates the shell's Share screen button and asks the agent to inspect or drive their exact current Möbius browser session. Operate only the chat-bound, owner-visible live screen; capture evidence through the live helper and release control before the turn ends.
+---
+
+# Live screen control
+
+Use this only after the partner deliberately clicks **Share screen** for the
+current chat and asks you to inspect or drive the exact screen they are using.
+It is a partner-owned, 15-minute consent window—not ambient browser access.
+
+This is distinct from `agent-browser`: live screen control sees the partner's
+exact signed-in tab, current scroll position, and unsaved UI state. Headless
+visual testing remains the right path when exact session state is unnecessary.
+
+## Check and inspect
+
+```bash
+python3 "$SCRIPTS_DIR/screen-control.py" status
+python3 "$SCRIPTS_DIR/screen-control.py" snapshot
+python3 "$SCRIPTS_DIR/screen-control.py" screenshot
+```
+
+`snapshot` returns current interactive elements with ephemeral refs. Re-run it
+after every mutation before using another ref. `screenshot` writes the final
+image directly under this chat's served `media/` directory and prints the
+ready-to-use embed. View that exact file before describing it, verify its
+served media URL, and put the embed before the description in the same message,
+following `visual-testing.md`.
+
+## Drive
+
+```bash
+python3 "$SCRIPTS_DIR/screen-control.py" click e4
+python3 "$SCRIPTS_DIR/screen-control.py" click app:42:e3
+python3 "$SCRIPTS_DIR/screen-control.py" click-at 520 410
+python3 "$SCRIPTS_DIR/screen-control.py" type "Replacement text" --ref e7
+python3 "$SCRIPTS_DIR/screen-control.py" type " more" --append
+python3 "$SCRIPTS_DIR/screen-control.py" scroll 560
+python3 "$SCRIPTS_DIR/screen-control.py" press Enter
+```
+
+Prefer semantic refs from a fresh snapshot over coordinates. The bridge accepts
+only the closed actions above; it never evaluates arbitrary JavaScript. Password,
+payment, and one-time-code fields stay masked and refuse agent typing. The
+partner's local input always takes priority, and their visible header button or
+browser sharing indicator can stop the session immediately.
+
+The ordinary destructive-action rules still apply. A shared screen is consent
+to inspect and drive the requested investigation, not approval to delete data,
+send messages, submit purchases, change credentials, or perform another
+irreversible action.
+
+## Closeout
+
+Always release the live browser before handing control back, even after an
+error. Do not leave it open for a possible follow-up:
+
+```bash
+python3 "$SCRIPTS_DIR/screen-control.py" stop
+```
+
+If the partner stopped it first, `status` ordinarily reports no active session;
+that is a normal outcome. State any device/browser behavior that could not be
+exercised and do not replace exact-session evidence with a headless proxy.

--- a/backend/tests/test_app_capabilities.py
+++ b/backend/tests/test_app_capabilities.py
@@ -107,6 +107,29 @@ def test_runtime_capability_is_independently_versioned_and_bounded():
   }
 
 
+def test_screen_control_is_reviewed_as_an_app_owned_background_session():
+  runtime = normalize_runtime_capabilities(_manifest(capabilities={
+    "workspace.screen-control": {
+      "version": 1,
+      "reason": "Investigate problems in this M\u00f6bius tab.",
+    },
+  }))
+  assert runtime == {
+    "workspace.screen-control": {
+      "version": 1,
+      "kind": "session",
+      "title": "Control this M\u00f6bius screen",
+      "description": (
+        "Let this app's support chat inspect and control the current M\u00f6bius tab."
+      ),
+      "risk": "device",
+      "lifecycle": "background",
+      "reason": "Investigate problems in this M\u00f6bius tab.",
+      "limits": {},
+    },
+  }
+
+
 def test_device_asset_cache_is_client_only_and_reviewed_by_size():
   runtime = normalize_runtime_capabilities(_manifest(capabilities={
     "device.asset-cache": {

--- a/backend/tests/test_screen_control.py
+++ b/backend/tests/test_screen_control.py
@@ -1,0 +1,193 @@
+"""Owner-consented, exact-chat live screen relay contracts."""
+
+import asyncio
+
+import pytest
+from pydantic import ValidationError
+
+from app import auth as auth_module, models
+from app.routes.screen_control import AgentCommandBody
+from app.screen_control import ScreenControlRegistry
+from test_app_fixtures import create_local_app
+
+
+def _agent_headers(db, chat_id: str) -> dict[str, str]:
+  owner = db.query(models.Owner).filter(models.Owner.username == "test").one()
+  db.add(models.ChatRun(
+    id="screen-control-run", root_run_id="screen-control-run",
+    chat_id=chat_id, status="running", provider="codex",
+  ))
+  db.commit()
+  token = auth_module.create_agent_token(
+    chat_id, "screen-control-run", owner.username, owner.token_epoch,
+  )
+  return {"Authorization": f"Bearer {token}"}
+
+
+def test_owner_can_start_only_for_the_invoking_apps_chat(client, auth, chat, db):
+  app = create_local_app(client, auth, name="Screen Control Test")
+  chat.created_by_app_id = app["id"]
+  db.commit()
+  started = client.post(
+    "/api/screen-control/sessions",
+    headers=auth,
+    json={
+      "appId": app["id"],
+      "chatId": chat.id,
+      "route": f"/chat/{chat.id}",
+      "viewport": {"width": 1170, "height": 2532, "pixelRatio": 2.625},
+    },
+  )
+  assert started.status_code == 200, started.text
+  assert started.json()["active"] is True
+  assert started.json()["appId"] == app["id"]
+
+  # A broad browser login is the wrong role at the chat-side boundary.
+  owner_status = client.get(f"/api/screen-control/chats/{chat.id}", headers=auth)
+  assert owner_status.status_code == 403
+
+  chat_only = auth_module.create_access_token(
+    {"sub": "test", "agent_chat": chat.id}, token_epoch=0,
+  )
+  missing_run = client.get(
+    f"/api/screen-control/chats/{chat.id}",
+    headers={"Authorization": f"Bearer {chat_only}"},
+  )
+  assert missing_run.status_code == 401, missing_run.text
+
+  agent = _agent_headers(db, chat.id)
+  status = client.get(f"/api/screen-control/chats/{chat.id}", headers=agent)
+  assert status.status_code == 200, status.text
+  assert status.json()["sessionId"] == started.json()["sessionId"]
+
+  wrong_chat = client.get("/api/screen-control/chats/another-chat", headers=agent)
+  assert wrong_chat.status_code == 403
+
+  stopped = client.delete(f"/api/screen-control/chats/{chat.id}", headers=agent)
+  assert stopped.status_code == 204, stopped.text
+  assert client.get(f"/api/screen-control/chats/{chat.id}", headers=agent).json() == {
+    "active": False,
+  }
+
+
+def test_owner_cannot_bind_control_to_an_unattributed_or_foreign_app_chat(
+  client, auth, chat, db,
+):
+  app = create_local_app(client, auth, name="Owning Control App")
+  other = create_local_app(client, auth, name="Other Control App")
+
+  unattributed = client.post(
+    "/api/screen-control/sessions",
+    headers=auth,
+    json={"appId": app["id"], "chatId": chat.id},
+  )
+  assert unattributed.status_code == 404
+
+  chat.created_by_app_id = other["id"]
+  db.commit()
+  foreign = client.post(
+    "/api/screen-control/sessions",
+    headers=auth,
+    json={"appId": app["id"], "chatId": chat.id},
+  )
+  assert foreign.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_relay_returns_only_the_browser_answer_to_the_waiting_command():
+  registry = ScreenControlRegistry()
+  session = await registry.start(
+    owner_username="owner",
+    app_id=7,
+    chat_id="chat-a",
+    route="/chat/chat-a",
+    viewport={"width": 1280, "height": 720, "pixelRatio": 1},
+  )
+  assert await registry.connect_browser(session.id, "owner") is session
+
+  waiting = asyncio.create_task(registry.issue_command(session, {
+    "action": "click", "ref": "e3",
+  }))
+  command = await asyncio.wait_for(session.commands.get(), timeout=1)
+  assert command["action"] == "click"
+  assert command["ref"] == "e3"
+
+  accepted = await registry.answer(session, command["commandId"], {
+    "ok": True, "result": {"clicked": "e3"}, "error": None,
+  })
+  assert accepted is True
+  assert await waiting == {
+    "ok": True, "result": {"clicked": "e3"}, "error": None,
+  }
+  assert await registry.answer(session, command["commandId"], {"ok": True}) is False
+  await registry.stop(session)
+
+
+@pytest.mark.asyncio
+async def test_last_browser_disconnect_retires_the_unusable_session():
+  registry = ScreenControlRegistry()
+  session = await registry.start(
+    owner_username="owner",
+    app_id=7,
+    chat_id="chat-a",
+    route="/chat/chat-a",
+    viewport={"width": 1280, "height": 720, "pixelRatio": 1},
+  )
+  await registry.connect_browser(session.id, "owner")
+  await registry.disconnect_browser(session.id)
+
+  assert session.active is False
+  assert await registry.get_for_chat("chat-a", "owner") is None
+
+
+@pytest.mark.asyncio
+async def test_relay_bounds_commands_waiting_on_one_browser():
+  registry = ScreenControlRegistry()
+  session = await registry.start(
+    owner_username="owner",
+    app_id=7,
+    chat_id="chat-a",
+    route="/chat/chat-a",
+    viewport={"width": 1280, "height": 720, "pixelRatio": 1},
+  )
+  await registry.connect_browser(session.id, "owner")
+  waiting = [asyncio.create_task(registry.issue_command(session, {
+    "action": "snapshot",
+  })) for _ in range(4)]
+  await asyncio.sleep(0)
+
+  assert await registry.issue_command(session, {"action": "snapshot"}) == {
+    "ok": False,
+    "error": "The shared browser is still handling earlier commands.",
+  }
+
+  await registry.stop(session)
+  assert all(not outcome["ok"] for outcome in await asyncio.gather(*waiting))
+
+
+@pytest.mark.parametrize("payload", [
+  {"action": "snapshot", "ref": "e1"},
+  {"action": "snapshot", "replace": False},
+  {"action": "click"},
+  {"action": "click", "x": 10},
+  {"action": "type"},
+  {"action": "scroll"},
+  {"action": "press", "key": "F12"},
+  {"action": "evaluate", "text": "document.cookie"},
+])
+def test_command_vocabulary_rejects_ambiguous_or_arbitrary_browser_actions(payload):
+  with pytest.raises(ValidationError):
+    AgentCommandBody.model_validate(payload)
+
+
+@pytest.mark.parametrize("payload", [
+  {"action": "snapshot"},
+  {"action": "screenshot"},
+  {"action": "click", "ref": "app:42:e3"},
+  {"action": "click", "x": 10, "y": 20},
+  {"action": "type", "ref": "e7", "text": "hello", "replace": True},
+  {"action": "scroll", "deltaY": 560},
+  {"action": "press", "key": "Enter"},
+])
+def test_command_vocabulary_accepts_the_reviewed_semantic_actions(payload):
+  assert AgentCommandBody.model_validate(payload).action == payload["action"]

--- a/backend/tests/test_screen_control.py
+++ b/backend/tests/test_screen_control.py
@@ -1,11 +1,13 @@
 """Owner-consented, exact-chat live screen relay contracts."""
 
 import asyncio
+import time
 
 import pytest
 from pydantic import ValidationError
 
 from app import auth as auth_module, models
+from app import screen_control as screen_control_module
 from app.routes.screen_control import AgentCommandBody
 from app.screen_control import ScreenControlRegistry
 from test_app_fixtures import create_local_app
@@ -111,6 +113,7 @@ async def test_relay_returns_only_the_browser_answer_to_the_waiting_command():
   command = await asyncio.wait_for(session.commands.get(), timeout=1)
   assert command["action"] == "click"
   assert command["ref"] == "e3"
+  assert command["deadlineAt"] > int(time.time() * 1000)
 
   accepted = await registry.answer(session, command["commandId"], {
     "ok": True, "result": {"clicked": "e3"}, "error": None,
@@ -163,6 +166,70 @@ async def test_relay_bounds_commands_waiting_on_one_browser():
 
   await registry.stop(session)
   assert all(not outcome["ok"] for outcome in await asyncio.gather(*waiting))
+
+
+@pytest.mark.asyncio
+async def test_timed_out_command_never_crosses_the_browser_boundary(monkeypatch):
+  monkeypatch.setattr(screen_control_module, "COMMAND_TIMEOUT_SECONDS", 0.01)
+  registry = ScreenControlRegistry()
+  session = await registry.start(
+    owner_username="owner",
+    app_id=7,
+    chat_id="chat-a",
+    route="/chat/chat-a",
+    viewport={"width": 1280, "height": 720, "pixelRatio": 1},
+  )
+  await registry.connect_browser(session.id, "owner")
+
+  outcome = await registry.issue_command(session, {"action": "click", "ref": "e3"})
+  assert outcome == {
+    "ok": False,
+    "error": "The shared browser did not answer in time.",
+  }
+  with pytest.raises(TimeoutError):
+    await registry.next_browser_command(session, keepalive_seconds=0.02)
+  assert session.commands.empty()
+  await registry.stop(session)
+
+
+@pytest.mark.asyncio
+async def test_transport_queue_stays_bounded_after_repeated_timeouts(monkeypatch):
+  monkeypatch.setattr(screen_control_module, "COMMAND_TIMEOUT_SECONDS", 0.01)
+  registry = ScreenControlRegistry()
+  session = await registry.start(
+    owner_username="owner",
+    app_id=7,
+    chat_id="chat-a",
+    route="/chat/chat-a",
+    viewport={"width": 1280, "height": 720, "pixelRatio": 1},
+  )
+  await registry.connect_browser(session.id, "owner")
+
+  outcomes = [
+    await registry.issue_command(session, {"action": "snapshot"})
+    for _ in range(8)
+  ]
+
+  assert session.commands.qsize() == screen_control_module.MAX_PENDING_COMMANDS
+  assert all(not outcome["ok"] for outcome in outcomes)
+  await registry.stop(session)
+
+
+@pytest.mark.asyncio
+async def test_browser_wait_ends_at_session_expiry_without_keepalive_delay():
+  registry = ScreenControlRegistry()
+  session = await registry.start(
+    owner_username="owner",
+    app_id=7,
+    chat_id="chat-a",
+    route="/chat/chat-a",
+    viewport={"width": 1280, "height": 720, "pixelRatio": 1},
+  )
+  await registry.connect_browser(session.id, "owner")
+  session.expires_at = time.time() + 0.01
+
+  assert await registry.next_browser_command(session, keepalive_seconds=5) is None
+  assert session.active is False
 
 
 @pytest.mark.parametrize("payload", [

--- a/frontend/public/app-frame.html
+++ b/frontend/public/app-frame.html
@@ -588,6 +588,217 @@
     // well as the document scroller, without walking every node when the drawer
     // opens. Nested third-party frames stay covered by the outer iframe guard.
     const gestureScrollers = new Set();
+    const SCREEN_CONTROL_SELECTOR = [
+      'button', 'a[href]', 'input:not([type="hidden"])', 'textarea', 'select',
+      '[role="button"]', '[role="link"]', '[role="checkbox"]', '[role="tab"]',
+      '[contenteditable="true"]', '[tabindex]:not([tabindex="-1"])'
+    ].join(',');
+    const SCREEN_SENSITIVE_AUTOCOMPLETE = new Set([
+      'current-password', 'new-password', 'one-time-code',
+      'cc-number', 'cc-csc', 'cc-exp', 'cc-exp-month', 'cc-exp-year'
+    ]);
+    let screenControlRefs = new Map();
+    let latestOwnerScreenInputAt = 0;
+
+    ['pointerdown', 'keydown', 'input', 'wheel', 'touchstart'].forEach(function (type) {
+      document.addEventListener(type, function (event) {
+        if (event.isTrusted) latestOwnerScreenInputAt = Date.now();
+      }, { capture: true, passive: true });
+    });
+
+    function screenConcise(value, max) {
+      return String(value || '').replace(/\s+/g, ' ').trim().slice(0, max || 180);
+    }
+
+    function screenVisible(element) {
+      if (!element || !element.getBoundingClientRect) return false;
+      const rect = element.getBoundingClientRect();
+      if (rect.width < 1 || rect.height < 1) return false;
+      const style = getComputedStyle(element);
+      return style.display !== 'none' && style.visibility !== 'hidden' && style.opacity !== '0'
+        && rect.bottom > 0 && rect.right > 0
+        && rect.top < innerHeight && rect.left < innerWidth;
+    }
+
+    function screenRole(element) {
+      const explicit = screenConcise(element.getAttribute('role'), 40);
+      if (explicit) return explicit;
+      const tag = element.tagName.toLowerCase();
+      if (tag === 'a') return 'link';
+      if (tag === 'button') return 'button';
+      if (tag === 'textarea') return 'textbox';
+      if (tag === 'select') return 'combobox';
+      if (tag === 'input') {
+        const type = (element.type || 'text').toLowerCase();
+        if (type === 'checkbox') return 'checkbox';
+        if (type === 'radio') return 'radio';
+        if (['button', 'submit', 'reset'].includes(type)) return 'button';
+        return 'textbox';
+      }
+      return 'control';
+    }
+
+    function screenLabelledBy(element) {
+      const ids = screenConcise(element.getAttribute('aria-labelledby'), 300);
+      if (!ids) return '';
+      return ids.split(/\s+/).map(function (id) {
+        const label = document.getElementById(id);
+        return label ? label.textContent : '';
+      }).join(' ');
+    }
+
+    function screenName(element) {
+      const label = element.labels && element.labels[0] && element.labels[0].textContent;
+      return screenConcise(
+        element.getAttribute('aria-label') || screenLabelledBy(element) || label
+        || element.getAttribute('alt') || element.getAttribute('title')
+        || element.getAttribute('placeholder') || element.textContent
+      );
+    }
+
+    function screenSensitive(element) {
+      if (!element || element.tagName.toLowerCase() !== 'input') return false;
+      if ((element.type || '').toLowerCase() === 'password') return true;
+      return String(element.autocomplete || '').split(/\s+/).some(function (token) {
+        return SCREEN_SENSITIVE_AUTOCOMPLETE.has(token.toLowerCase());
+      });
+    }
+
+    function screenSnapshot() {
+      const refs = new Map();
+      const elements = [];
+      for (const element of Array.from(document.querySelectorAll(SCREEN_CONTROL_SELECTOR))) {
+        if (!screenVisible(element) || element.closest('[inert]')) continue;
+        const ref = 'e' + (elements.length + 1);
+        const rect = element.getBoundingClientRect();
+        const item = {
+          ref: ref,
+          role: screenRole(element),
+          name: screenName(element),
+          disabled: !!element.disabled || element.getAttribute('aria-disabled') === 'true',
+          bounds: {
+            x: Math.round(rect.x), y: Math.round(rect.y),
+            width: Math.round(rect.width), height: Math.round(rect.height)
+          }
+        };
+        if ('value' in element) {
+          item.value = screenSensitive(element) ? '[masked]' : screenConcise(element.value);
+        }
+        refs.set(ref, element);
+        elements.push(item);
+      }
+      screenControlRefs = refs;
+      return { elements: elements };
+    }
+
+    function screenActionTarget(element) {
+      return element && (element.closest(SCREEN_CONTROL_SELECTOR) || element);
+    }
+
+    function screenSetValue(element, value) {
+      const prototype = element.tagName.toLowerCase() === 'textarea'
+        ? HTMLTextAreaElement.prototype : HTMLInputElement.prototype;
+      const setter = Object.getOwnPropertyDescriptor(prototype, 'value');
+      if (setter && setter.set) setter.set.call(element, value);
+      else element.value = value;
+    }
+
+    function screenInputEvent(type, options) {
+      try { return new InputEvent(type, options); }
+      catch (_) { return new Event(type, { bubbles: true }); }
+    }
+
+    function screenType(element, text, replace) {
+      if (!element) throw new Error('No field is focused.');
+      if (element.closest && element.closest('[inert]')) throw new Error('That field is not interactive.');
+      if (screenSensitive(element)) throw new Error('Sensitive fields stay under your control.');
+      const tag = element.tagName.toLowerCase();
+      if (tag === 'input' || tag === 'textarea') {
+        if (element.disabled || element.readOnly) throw new Error('The field is not editable.');
+        element.focus({ preventScroll: true });
+        const next = replace ? text : String(element.value || '') + text;
+        screenSetValue(element, next);
+        element.dispatchEvent(screenInputEvent('input', {
+          bubbles: true, data: text,
+          inputType: replace ? 'insertReplacementText' : 'insertText'
+        }));
+        element.dispatchEvent(new Event('change', { bubbles: true }));
+        return;
+      }
+      if (element.isContentEditable) {
+        element.focus({ preventScroll: true });
+        if (replace) element.textContent = text;
+        else element.append(document.createTextNode(text));
+        element.dispatchEvent(screenInputEvent('input', { bubbles: true, data: text }));
+        return;
+      }
+      throw new Error('The focused element is not editable.');
+    }
+
+    function screenScrollOwner(x, y) {
+      let element = document.elementFromPoint(x, y);
+      while (element && element !== document.body) {
+        const style = getComputedStyle(element);
+        const scrollable = /(auto|scroll)/.test(style.overflowY + ' ' + style.overflowX)
+          && (element.scrollHeight > element.clientHeight || element.scrollWidth > element.clientWidth);
+        if (scrollable) return element;
+        element = element.parentElement;
+      }
+      return document.scrollingElement || document.documentElement;
+    }
+
+    function screenPress(key) {
+      const target = document.activeElement || document.body;
+      target.dispatchEvent(new KeyboardEvent('keydown', { key: key, bubbles: true, cancelable: true }));
+      if (key === 'Enter') {
+        if (target.tagName && target.tagName.toLowerCase() === 'button') target.click();
+        else if (target.form && target.form.requestSubmit) target.form.requestSubmit();
+      } else if (key === ' ') {
+        const action = screenActionTarget(target);
+        if (action && action.click) action.click();
+      }
+      target.dispatchEvent(new KeyboardEvent('keyup', { key: key, bubbles: true, cancelable: true }));
+    }
+
+    function executeScreenControl(command) {
+      if (document.documentElement.hasAttribute('data-mobius-frame-suspended')) {
+        throw new Error('The app is behind another screen and cannot be controlled.');
+      }
+      if (command.action === 'snapshot') return screenSnapshot();
+      if (Date.now() - latestOwnerScreenInputAt < 750) {
+        throw new Error('Your input took priority; inspect the screen and try again.');
+      }
+      const point = command.x != null && command.y != null
+        ? document.elementFromPoint(command.x, command.y) : null;
+      if (command.action === 'click') {
+        const target = command.ref ? screenControlRefs.get(command.ref) : screenActionTarget(point);
+        if (!target || !screenVisible(target)) throw new Error('That control is no longer available.');
+        if (target.closest && target.closest('[inert]')) throw new Error('That control is not interactive.');
+        if (target.disabled || target.getAttribute('aria-disabled') === 'true') {
+          throw new Error('That control is disabled.');
+        }
+        if (target.focus) target.focus({ preventScroll: true });
+        if (target.click) target.click();
+        return { clicked: command.ref || { x: command.x, y: command.y } };
+      }
+      if (command.action === 'type') {
+        screenType(command.ref ? screenControlRefs.get(command.ref) : document.activeElement,
+          command.text, command.replace !== false);
+        return { typed: command.text.length };
+      }
+      if (command.action === 'scroll') {
+        const x = command.x == null ? Math.round(innerWidth / 2) : command.x;
+        const y = command.y == null ? Math.round(innerHeight / 2) : command.y;
+        const target = screenScrollOwner(x, y);
+        target.scrollBy({ left: command.deltaX || 0, top: command.deltaY || 0, behavior: 'auto' });
+        return { scrolled: true };
+      }
+      if (command.action === 'press') {
+        screenPress(command.key);
+        return { pressed: command.key };
+      }
+      throw new Error('Unsupported screen-control action.');
+    }
 
     function setShellShortcuts(value) {
       shellShortcuts = (Array.isArray(value) ? value : []).slice(0, 64).filter(function (item) {
@@ -1238,6 +1449,24 @@
         acknowledgeAppIntent(msg.nonce);
         // Returning from this runtime listener does not stop the message event:
         // the app's own listener still receives the same intent synchronously.
+        return;
+      }
+      if (msg.type === 'moebius:screen-control-command') {
+        const requestId = typeof msg.requestId === 'string' ? msg.requestId : '';
+        if (!requestId || requestId.length > 160 || !msg.command || typeof msg.command !== 'object') return;
+        Promise.resolve().then(function () {
+          return executeScreenControl(msg.command);
+        }).then(function (result) {
+          window.parent.postMessage({
+            type: 'moebius:screen-control-result', requestId: requestId,
+            ok: true, result: result
+          }, window.location.origin);
+        }).catch(function (error) {
+          window.parent.postMessage({
+            type: 'moebius:screen-control-result', requestId: requestId,
+            ok: false, error: String(error && error.message || error).slice(0, 1000)
+          }, window.location.origin);
+        });
         return;
       }
       if (msg.type === 'moebius:frame-init') {

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -635,6 +635,26 @@ export const api = {
       body: JSON.stringify(payload),
     }),
   },
+  screenControl: {
+    start: async (payload) => jsonOrThrow(
+      await apiFetch('/screen-control/sessions', {
+        method: 'POST',
+        body: JSON.stringify(payload),
+      }),
+      'Could not start screen control',
+    ),
+    respond: (sessionId, payload) => apiFetch(
+      `/screen-control/sessions/${encodeURIComponent(sessionId)}/responses`,
+      {
+        method: 'POST',
+        body: JSON.stringify(payload),
+      },
+    ),
+    stop: (sessionId) => apiFetch(
+      `/screen-control/sessions/${encodeURIComponent(sessionId)}`,
+      { method: 'DELETE' },
+    ),
+  },
   notifications: {
     // Cursor pagination: `before` is the last row id of the previous page.
     list: ({ before, limit } = {}) => {

--- a/frontend/src/components/AppCanvas/AppCanvas.jsx
+++ b/frontend/src/components/AppCanvas/AppCanvas.jsx
@@ -171,7 +171,14 @@ function appFrameRequestUrl(appId, version, frameRev) {
 //      interactive frame. Exact source + focus gating prevents arbitrary
 //      keylogging or a hidden frame dispatching workspace behavior.
 //
-//  10. moebius:account-link-*                              three-party broker
+//  10. moebius:screen-control-command/result               bidirectional
+//      The owner-granted shell session may inspect or operate the visible app
+//      through the same closed semantic command set as shell controls. The
+//      frame never evaluates agent-authored script, never exposes credentials,
+//      masks sensitive fields, and rejects commands while shell interactivity
+//      is suspended by a modal surface.
+//
+//  11. moebius:account-link-*                              three-party broker
 //      The CSP-sandboxed app frame has an opaque origin, so an external OAuth
 //      completion page cannot safely target it by the shell's concrete origin.
 //      A live, visible frame with the reviewed identity_manage grant registers
@@ -531,7 +538,10 @@ const AppCanvas = forwardRef(function AppCanvas({
   const capabilityHostRef = useRef(null)
   if (!capabilityHostRef.current) {
     capabilityHostRef.current = createCapabilityHost({
-      providers: builtInCapabilityProviders({ deviceAssets: { appId } }),
+      providers: builtInCapabilityProviders({
+        deviceAssets: { appId },
+        screenControl: { appId },
+      }),
       getDeclaration(capability) {
         return capabilityContractRef.current?.runtime?.[capability] || null
       },

--- a/frontend/src/components/Shell/ScreenControlButton.jsx
+++ b/frontend/src/components/Shell/ScreenControlButton.jsx
@@ -1,0 +1,35 @@
+/* Active-session safety control. Starting screen control belongs to the app. */
+import { useSyncExternalStore } from 'react'
+import { createPortal } from 'react-dom'
+import { ShareScreenFilled } from '@openai/apps-sdk-ui/components/Icon'
+import {
+  getScreenControlState,
+  stopActiveScreenControl,
+  subscribeScreenControlState,
+} from '../../lib/screenControlHost.js'
+
+export default function ScreenControlButton() {
+  const state = useSyncExternalStore(
+    subscribeScreenControlState,
+    getScreenControlState,
+    getScreenControlState,
+  )
+  if (state.phase === 'idle' || typeof document === 'undefined') return null
+  const active = state.phase === 'active'
+  return createPortal(
+    <button
+      type="button"
+      className="screen-control-button screen-control-button--active"
+      aria-label={active ? 'Stop agent control' : 'Agent control is starting'}
+      title={active ? 'Stop agent control' : 'Agent control is starting'}
+      disabled={!active}
+      onClick={() => { void stopActiveScreenControl() }}
+    >
+      <ShareScreenFilled width={18} height={18} aria-hidden="true" />
+      <span>{active ? 'Agent control active' : 'Starting agent control\u2026'}</span>
+      <span className="screen-control-button__live" aria-hidden="true" />
+      {active && <span className="screen-control-button__stop">Stop</span>}
+    </button>,
+    document.body,
+  )
+}

--- a/frontend/src/components/Shell/Shell.css
+++ b/frontend/src/components/Shell/Shell.css
@@ -91,6 +91,81 @@
   gap: 8px;
 }
 
+.screen-control-button {
+  position: fixed;
+  top: max(12px, env(safe-area-inset-top));
+  left: 50%;
+  z-index: 1200;
+  transform: translateX(-50%);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-height: 42px;
+  padding: 7px 8px 7px 12px;
+  border: 1px solid color-mix(in srgb, var(--accent) 58%, var(--border));
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--surface) 94%, transparent);
+  color: var(--accent);
+  font: inherit;
+  font-size: 12px;
+  font-weight: 680;
+  cursor: pointer;
+  box-shadow: 0 10px 32px rgba(0, 0, 0, 0.24);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+  -webkit-tap-highlight-color: transparent;
+}
+
+.screen-control-button:hover {
+  background: var(--surface);
+  border-color: var(--accent);
+}
+
+.screen-control-button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
+.screen-control-button:disabled {
+  cursor: wait;
+  opacity: 0.78;
+}
+
+.screen-control-button__live {
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  background: var(--danger);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--danger) 17%, transparent);
+  animation: screen-control-live 1.8s ease-in-out infinite;
+}
+
+.screen-control-button__stop {
+  min-height: 28px;
+  display: inline-flex;
+  align-items: center;
+  padding: 0 10px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--accent) 15%, transparent);
+  color: var(--text);
+}
+
+@keyframes screen-control-live {
+  50% { opacity: 0.48; }
+}
+
+@media (max-width: 620px) {
+  .screen-control-button {
+    top: max(8px, env(safe-area-inset-top));
+    max-width: calc(100vw - 24px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .screen-control-button__live { animation: none; }
+}
+
 /* Desktop-only quick actions. Declare the closed state outside the media query
    so adding this shared markup can never leak controls into the phone header. */
 .shell__rail-actions {

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -160,6 +160,7 @@ import useAppFrameCache from './useAppFrameCache.js'
 import useShellVisualViewport from './useShellVisualViewport.js'
 import useShellShortcuts from '../../hooks/useShellShortcuts.js'
 import ShellBrand from './ShellBrand.jsx'
+import ScreenControlButton from './ScreenControlButton.jsx'
 import { createMediaSessionOwner } from './mediaSessionOwner.js'
 import { HistoryDismissProvider } from '../../hooks/useHistoryDismiss.jsx'
 
@@ -3846,6 +3847,7 @@ export default function Shell({ onInitialVisualReady }) {
               <span className="shell__sr-only">{reachabilityLabel}</span>
             </span>
           )}
+          <ScreenControlButton chatId={activeChatId} onNotice={showToast} />
           <NotificationCenter
             ref={notificationCenterActionsRef}
             commands={shellCommands}

--- a/frontend/src/lib/__tests__/capabilityHost.test.js
+++ b/frontend/src/lib/__tests__/capabilityHost.test.js
@@ -182,3 +182,29 @@ test('contract revocation cancels an already-open session', async () => {
   assert.equal(harness.host.activeCount(), 0)
   assert.equal(harness.sent.at(-1).message.code, 'aborted')
 })
+
+test('a reviewed background provider can preserve its grant across frame replacement', async () => {
+  const controls = []
+  const source = {}
+  const host = createCapabilityHost({
+    providers: {
+      [CAPABILITY]: {
+        version: 1,
+        preserveOnDetach: true,
+        async open() {
+          return { control(action) { controls.push(action) } }
+        },
+      },
+    },
+    getDeclaration: () => ({ version: 1, lifecycle: 'background' }),
+    isActive: () => true,
+    send() {},
+  })
+  host.handle(source, openMessage())
+  await new Promise((resolve) => setImmediate(resolve))
+
+  host.detachSource(source)
+
+  assert.deepEqual(controls, ['detach'])
+  assert.equal(host.activeCount(), 0)
+})

--- a/frontend/src/lib/__tests__/capabilityProviders.test.js
+++ b/frontend/src/lib/__tests__/capabilityProviders.test.js
@@ -3,9 +3,11 @@ import assert from 'node:assert/strict'
 
 import {
   createMicrophoneProvider,
+  builtInCapabilityProviders,
   createSpeechModelsProvider,
   createSpeechProvider,
 } from '../capabilityProviders.js'
+import { SCREEN_CONTROL } from '../screenControlHost.js'
 import { createCapabilityHost } from '../capabilityHost.js'
 
 test('microphone provider clamps app input to the reviewed manifest ceiling', async () => {
@@ -129,4 +131,62 @@ test('speech providers lazy-load the runtime and preserve the invoking app ident
     ['speech', { text: 'Hello' }],
     ['models', 61, { operation: 'catalog' }],
   ])
+})
+
+test('screen control provider binds the app chat, survives detach, and reattaches', async () => {
+  const sent = []
+  const capture = {
+    stream: { getTracks: () => [{ stop() {} }] },
+    video: { srcObject: {} },
+  }
+  let clientOptions
+  let stopCalls = 0
+  const provider = builtInCapabilityProviders({
+    screenControl: {
+      // App route params reach the canvas as strings.
+      appId: '91',
+      requestCapture: async () => capture,
+      startSession: async (payload) => {
+        sent.push(payload)
+        return { sessionId: 'session-1', expiresAt: 12345 }
+      },
+      makeClient(options) {
+        clientOptions = options
+        return { async stop() { stopCalls += 1 } }
+      },
+    },
+  })[SCREEN_CONTROL]
+  const messages = []
+  const control = await provider.open({
+    input: { chatId: 'chat-1' },
+    channel: {
+      ready(value) { messages.push(['ready', value]) },
+      result(value) { messages.push(['result', value]) },
+      error(error) { throw error },
+    },
+  })
+
+  assert.equal(sent[0].appId, 91)
+  assert.equal(sent[0].chatId, 'chat-1')
+  clientOptions.onConnected()
+  assert.deepEqual(messages, [['ready', { expiresAt: 12345 }]])
+
+  control.control('detach')
+  assert.equal(stopCalls, 0)
+
+  const resumedMessages = []
+  const resumed = await provider.open({
+    input: { chatId: 'chat-1', resume: true },
+    channel: {
+      ready(value) { resumedMessages.push(['ready', value]) },
+      result(value) { resumedMessages.push(['result', value]) },
+      error(error) { throw error },
+    },
+  })
+  assert.deepEqual(resumedMessages, [['ready', { expiresAt: 12345 }]])
+
+  resumed.control('finish')
+  await new Promise((resolve) => setImmediate(resolve))
+  assert.equal(stopCalls, 1)
+  assert.deepEqual(resumedMessages.at(-1), ['result', { reason: 'owner' }])
 })

--- a/frontend/src/lib/__tests__/screenControlPage.test.js
+++ b/frontend/src/lib/__tests__/screenControlPage.test.js
@@ -1,0 +1,35 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  boundedScreenCaptureSize,
+  isSensitiveScreenControlField,
+  parseScreenControlFrameRef,
+} from '../screenControlPage.js'
+
+
+test('live screen refs remain exact-frame and reject ambiguous shapes', () => {
+  assert.deepEqual(parseScreenControlFrameRef('app:42:e7'), {
+    appId: '42', ref: 'e7',
+  })
+  assert.equal(parseScreenControlFrameRef('e7'), null)
+  assert.equal(parseScreenControlFrameRef('app:42:button'), null)
+  assert.equal(parseScreenControlFrameRef('app:42:e7:extra'), null)
+})
+
+
+test('credential and payment fields stay sensitive while ordinary text does not', () => {
+  assert.equal(isSensitiveScreenControlField('password', ''), true)
+  assert.equal(isSensitiveScreenControlField('text', 'section-login current-password'), true)
+  assert.equal(isSensitiveScreenControlField('text', 'one-time-code'), true)
+  assert.equal(isSensitiveScreenControlField('text', 'cc-number'), true)
+  assert.equal(isSensitiveScreenControlField('email', 'email'), false)
+})
+
+
+test('shared screenshots preserve aspect ratio under the response-size ceiling', () => {
+  assert.deepEqual(boundedScreenCaptureSize(1440, 900), { width: 1440, height: 900 })
+  assert.deepEqual(boundedScreenCaptureSize(5120, 2880), { width: 2560, height: 1440 })
+  assert.deepEqual(boundedScreenCaptureSize(1170, 2532), { width: 1170, height: 2532 })
+  assert.equal(boundedScreenCaptureSize(0, 900), null)
+})

--- a/frontend/src/lib/__tests__/screenControlPage.test.js
+++ b/frontend/src/lib/__tests__/screenControlPage.test.js
@@ -3,8 +3,10 @@ import assert from 'node:assert/strict'
 
 import {
   boundedScreenCaptureSize,
+  createScreenControlClient,
   isSensitiveScreenControlField,
   parseScreenControlFrameRef,
+  screenControlCommandExpired,
 } from '../screenControlPage.js'
 
 
@@ -32,4 +34,94 @@ test('shared screenshots preserve aspect ratio under the response-size ceiling',
   assert.deepEqual(boundedScreenCaptureSize(5120, 2880), { width: 2560, height: 1440 })
   assert.deepEqual(boundedScreenCaptureSize(1170, 2532), { width: 1170, height: 2532 })
   assert.equal(boundedScreenCaptureSize(0, 900), null)
+})
+
+
+test('browser command deadlines reject only commands whose start window passed', () => {
+  assert.equal(screenControlCommandExpired(1000, 999), false)
+  assert.equal(screenControlCommandExpired(1000, 1000), true)
+  assert.equal(screenControlCommandExpired(undefined, 1000), false)
+})
+
+
+test('a capture that ended before client attachment is reconciled immediately', async () => {
+  const realFetch = globalThis.fetch
+  const calls = []
+  globalThis.fetch = async (_url, options = {}) => {
+    calls.push(options.method || 'GET')
+    if (options.method === 'DELETE') return { ok: true }
+    return new Promise((_resolve, reject) => {
+      options.signal?.addEventListener('abort', () => {
+        reject(Object.assign(new Error('aborted'), { name: 'AbortError' }))
+      }, { once: true })
+    })
+  }
+  const track = {
+    readyState: 'ended',
+    addEventListener() {},
+    stop() {},
+  }
+  const capture = {
+    stream: {
+      getVideoTracks: () => [track],
+      getTracks: () => [track],
+    },
+    video: { srcObject: {} },
+  }
+  const ended = []
+  try {
+    createScreenControlClient({
+      sessionId: 'session-1',
+      expiresAt: Date.now() + 60_000,
+      capture,
+      onEnded: reason => ended.push(reason),
+    })
+    await new Promise(resolve => setImmediate(resolve))
+
+    assert.deepEqual(ended, ['stopped'])
+    assert.equal(capture.video.srcObject, null)
+    assert.deepEqual(calls, ['GET', 'DELETE'])
+  } finally {
+    globalThis.fetch = realFetch
+  }
+})
+
+
+test('browser capture retires at the local copy of the consent deadline', async () => {
+  const realFetch = globalThis.fetch
+  globalThis.fetch = async (_url, options = {}) => {
+    if (options.method === 'DELETE') return { ok: true }
+    return new Promise((_resolve, reject) => {
+      options.signal?.addEventListener('abort', () => {
+        reject(Object.assign(new Error('aborted'), { name: 'AbortError' }))
+      }, { once: true })
+    })
+  }
+  const track = {
+    readyState: 'live',
+    addEventListener() {},
+    stop() { this.readyState = 'ended' },
+  }
+  const capture = {
+    stream: {
+      getVideoTracks: () => [track],
+      getTracks: () => [track],
+    },
+    video: { srcObject: {} },
+  }
+  const ended = []
+  try {
+    createScreenControlClient({
+      sessionId: 'session-1',
+      expiresAt: Date.now() - 1,
+      capture,
+      onEnded: reason => ended.push(reason),
+    })
+    await new Promise(resolve => setTimeout(resolve, 5))
+
+    assert.deepEqual(ended, ['expired'])
+    assert.equal(track.readyState, 'ended')
+  } finally {
+    globalThis.fetch = realFetch
+  }
 })

--- a/frontend/src/lib/capabilityHost.js
+++ b/frontend/src/lib/capabilityHost.js
@@ -161,7 +161,7 @@ export function createCapabilityHost({
       channel,
     })).then((control) => {
       if (!current(shellSession)) {
-        try { control?.control?.('cancel') } catch {}
+        try { control?.control?.(shellSession.detached ? 'detach' : 'cancel') } catch {}
         return
       }
       shellSession.control = control || {}
@@ -195,6 +195,14 @@ export function createCapabilityHost({
     })
   }
 
+  function detachSession(session) {
+    if (!current(session)) return
+    session.detached = true
+    try { session.control?.control?.('detach') } catch {}
+    session.settled = true
+    sessions.delete(session.requestId)
+  }
+
   return {
     handle(source, msg) {
       if (!msg || typeof msg !== 'object') return false
@@ -214,7 +222,9 @@ export function createCapabilityHost({
     detachSource(source) {
       for (const session of [...sessions.values()]) {
         if (session.source === source) {
-          abortSession(session, 'The app frame that opened this capability was detached.')
+          const provider = providers[session.capability]
+          if (provider?.preserveOnDetach) detachSession(session)
+          else abortSession(session, 'The app frame that opened this capability was detached.')
         }
       }
     },
@@ -229,7 +239,9 @@ export function createCapabilityHost({
     },
     destroy() {
       for (const session of [...sessions.values()]) {
-        abortSession(session, 'Capability host was detached.')
+        const provider = providers[session.capability]
+        if (provider?.preserveOnDetach) detachSession(session)
+        else abortSession(session, 'Capability host was detached.')
       }
     },
     activeCount: () => sessions.size,

--- a/frontend/src/lib/capabilityProviders.js
+++ b/frontend/src/lib/capabilityProviders.js
@@ -3,6 +3,10 @@ import {
   createDeviceAssetCacheProvider,
   DEVICE_ASSET_CACHE,
 } from './deviceAssetCache.js'
+import {
+  createScreenControlProvider,
+  SCREEN_CONTROL,
+} from './screenControlHost.js'
 
 export const MICROPHONE_CAPTURE = 'media.microphone.capture'
 export const SPEECH = 'media.speech'
@@ -87,5 +91,6 @@ export function builtInCapabilityProviders(options = {}) {
       appId: options.deviceAssets?.appId,
       ...options.speechModels,
     }),
+    [SCREEN_CONTROL]: createScreenControlProvider(options.screenControl),
   }
 }

--- a/frontend/src/lib/screenControlHost.js
+++ b/frontend/src/lib/screenControlHost.js
@@ -1,0 +1,196 @@
+import { api } from '../api/client.js'
+import {
+  createScreenControlClient,
+  requestCurrentTabCapture,
+} from './screenControlPage.js'
+
+export const SCREEN_CONTROL = 'workspace.screen-control'
+
+const GLOBAL_KEY = Symbol.for('mobius.screen-control-host.v1')
+const IDLE_STATE = Object.freeze({ phase: 'idle' })
+
+function hostStore() {
+  if (!globalThis[GLOBAL_KEY]) {
+    globalThis[GLOBAL_KEY] = {
+      state: IDLE_STATE,
+      current: null,
+      listeners: new Set(),
+    }
+  }
+  return globalThis[GLOBAL_KEY]
+}
+
+function publish(next) {
+  const store = hostStore()
+  store.state = next
+  for (const listener of store.listeners) listener()
+}
+
+export function getScreenControlState() {
+  return hostStore().state
+}
+
+export function subscribeScreenControlState(listener) {
+  const store = hostStore()
+  store.listeners.add(listener)
+  return () => store.listeners.delete(listener)
+}
+
+export async function stopActiveScreenControl() {
+  await hostStore().current?.finish?.('owner')
+}
+
+function capabilityError(name, message, code) {
+  const error = new Error(message)
+  error.name = name
+  if (code) error.code = code
+  return error
+}
+
+function validatedChatId(value) {
+  const chatId = typeof value === 'string' ? value.trim() : ''
+  if (!chatId || chatId.length > 128) {
+    throw capabilityError('TypeError', 'Open the support chat before sharing.', 'invalid_request')
+  }
+  return chatId
+}
+
+export function createScreenControlProvider({
+  appId,
+  requestCapture = requestCurrentTabCapture,
+  startSession = (payload) => api.screenControl.start(payload),
+  stopSession = (sessionId) => api.screenControl.stop(sessionId),
+  makeClient = createScreenControlClient,
+} = {}) {
+  const boundAppId = Number(appId)
+  return {
+    version: 1,
+    exclusive: true,
+    // A shell Fast Refresh or app-frame replacement must not revoke an active
+    // browser grant. The global owner-visible stop control survives, and the
+    // app reattaches its same app-owned chat after remount.
+    preserveOnDetach: true,
+    async open({ input, channel }) {
+      const store = hostStore()
+      if (!Number.isInteger(boundAppId) || boundAppId < 1) {
+        throw capabilityError('TypeError', 'The control app identity is unavailable.', 'invalid_request')
+      }
+      const chatId = validatedChatId(input?.chatId)
+      if (store.current) {
+        if (input?.resume === true
+            && store.current.appId === boundAppId
+            && store.current.chatId === chatId) {
+          store.current.channel = channel
+          channel.ready({ expiresAt: store.current.expiresAt })
+          return {
+            control(action) {
+              if (action === 'detach') {
+                if (store.current?.channel === channel) store.current.channel = null
+              } else if (action === 'finish' || action === 'cancel') {
+                void store.current?.finish?.('owner')
+              }
+            },
+          }
+        }
+        throw capabilityError(
+          'InvalidStateError',
+          'Another screen-control session is already active.',
+          'busy',
+        )
+      }
+      if (input?.resume === true) {
+        throw capabilityError('NotFoundError', 'No active screen-control session.', 'unavailable')
+      }
+
+      // This must be the first awaited browser operation. A click inside the
+      // opaque app frame activates every ancestor Window, but getDisplayMedia
+      // still rejects after that transient activation is consumed.
+      const capture = await requestCapture()
+      let session
+      let client
+      let finishing = null
+      const current = {
+        appId: boundAppId,
+        chatId,
+        channel,
+        client: null,
+        expiresAt: null,
+        finish: null,
+      }
+
+      const finish = (reason, error) => {
+        if (finishing) return finishing
+        finishing = (async () => {
+          await current.client?.stop?.()
+          if (hostStore().current === current) hostStore().current = null
+          publish(IDLE_STATE)
+          if (error) current.channel?.error(error)
+          else current.channel?.result({ reason })
+          current.channel = null
+        })()
+        return finishing
+      }
+      current.finish = finish
+
+      try {
+        const page = globalThis.location
+        const view = globalThis.window
+        session = await startSession({
+          appId: boundAppId,
+          chatId,
+          route: page ? `${page.pathname}${page.search}${page.hash}` : '/',
+          viewport: {
+            width: Math.round(view?.innerWidth || 1),
+            height: Math.round(view?.innerHeight || 1),
+            pixelRatio: view?.devicePixelRatio || 1,
+          },
+        })
+        current.expiresAt = session.expiresAt
+        client = makeClient({
+          sessionId: session.sessionId,
+          capture,
+          onConnected() {
+            if (hostStore().current !== current) return
+            publish({
+              phase: 'active',
+              appId: boundAppId,
+              chatId,
+              expiresAt: session.expiresAt,
+            })
+            current.channel?.ready({ expiresAt: session.expiresAt })
+          },
+          onEnded(reason, error) {
+            if (hostStore().current !== current) return
+            void finish(
+              reason === 'disconnected' ? 'disconnected' : 'stopped',
+              reason === 'disconnected'
+                ? (error || capabilityError(
+                  'NetworkError', 'Agent control disconnected. Start a new session to continue.',
+                ))
+                : null,
+            )
+          },
+        })
+        current.client = client
+        store.current = current
+        publish({ phase: 'starting', appId: boundAppId, chatId })
+      } catch (error) {
+        capture.stream.getTracks().forEach(track => track.stop())
+        if (session?.sessionId) void stopSession(session.sessionId).catch(() => {})
+        if (hostStore().current === current) hostStore().current = null
+        publish(IDLE_STATE)
+        throw error
+      }
+
+      return {
+        control(action) {
+          if (action === 'detach') {
+            if (current.channel === channel) current.channel = null
+          } else if (action === 'finish' || action === 'cancel') {
+            void finish('owner')
+          }
+        },
+      }
+    },
+  }
+}

--- a/frontend/src/lib/screenControlHost.js
+++ b/frontend/src/lib/screenControlHost.js
@@ -148,6 +148,7 @@ export function createScreenControlProvider({
         current.expiresAt = session.expiresAt
         client = makeClient({
           sessionId: session.sessionId,
+          expiresAt: session.expiresAt,
           capture,
           onConnected() {
             if (hostStore().current !== current) return
@@ -162,7 +163,7 @@ export function createScreenControlProvider({
           onEnded(reason, error) {
             if (hostStore().current !== current) return
             void finish(
-              reason === 'disconnected' ? 'disconnected' : 'stopped',
+              reason === 'disconnected' ? 'disconnected' : reason,
               reason === 'disconnected'
                 ? (error || capabilityError(
                   'NetworkError', 'Agent control disconnected. Start a new session to continue.',

--- a/frontend/src/lib/screenControlPage.js
+++ b/frontend/src/lib/screenControlPage.js
@@ -1,0 +1,495 @@
+/* Browser-owned live-screen capture and the closed semantic command executor. */
+import { BASE, getAuthHeaders } from '../api/client.js'
+
+const INTERACTIVE_SELECTOR = [
+  'button', 'a[href]', 'input:not([type="hidden"])', 'textarea', 'select',
+  '[role="button"]', '[role="link"]', '[role="checkbox"]', '[role="tab"]',
+  '[contenteditable="true"]', '[tabindex]:not([tabindex="-1"])',
+].join(',')
+const SENSITIVE_AUTOCOMPLETE = new Set([
+  'current-password', 'new-password', 'one-time-code',
+  'cc-number', 'cc-csc', 'cc-exp', 'cc-exp-month', 'cc-exp-year',
+])
+const FRAME_TIMEOUT_MS = 2500
+
+let rootRefs = new Map()
+let nextFrameRequest = 0
+let latestOwnerInputAt = 0
+
+if (typeof document !== 'undefined') {
+  for (const type of ['pointerdown', 'keydown', 'input', 'wheel', 'touchstart']) {
+    document.addEventListener(type, event => {
+      if (event.isTrusted) latestOwnerInputAt = Date.now()
+    }, { capture: true, passive: true })
+  }
+}
+
+function concise(value, max = 180) {
+  return String(value || '').replace(/\s+/g, ' ').trim().slice(0, max)
+}
+
+function visibleElement(element) {
+  if (!element?.getBoundingClientRect) return false
+  const rect = element.getBoundingClientRect()
+  if (rect.width < 1 || rect.height < 1) return false
+  const style = element.ownerDocument?.defaultView?.getComputedStyle?.(element)
+  if (style?.display === 'none' || style?.visibility === 'hidden' || style?.opacity === '0') {
+    return false
+  }
+  const view = element.ownerDocument?.defaultView
+  return rect.bottom > 0 && rect.right > 0
+    && rect.top < (view?.innerHeight || 0) && rect.left < (view?.innerWidth || 0)
+}
+
+function elementRole(element) {
+  const explicit = concise(element.getAttribute?.('role'), 40)
+  if (explicit) return explicit
+  const tag = element.tagName?.toLowerCase()
+  if (tag === 'a') return 'link'
+  if (tag === 'button') return 'button'
+  if (tag === 'textarea') return 'textbox'
+  if (tag === 'select') return 'combobox'
+  if (tag === 'input') {
+    const type = (element.type || 'text').toLowerCase()
+    if (type === 'checkbox') return 'checkbox'
+    if (type === 'radio') return 'radio'
+    if (['button', 'submit', 'reset'].includes(type)) return 'button'
+    return 'textbox'
+  }
+  return 'control'
+}
+
+function labelledByText(element) {
+  const ids = concise(element.getAttribute?.('aria-labelledby'), 300)
+  if (!ids) return ''
+  return ids.split(/\s+/).map(id => (
+    element.ownerDocument?.getElementById?.(id)?.textContent || ''
+  )).join(' ')
+}
+
+function elementName(element) {
+  const label = element.labels?.[0]?.textContent
+  return concise(
+    element.getAttribute?.('aria-label')
+      || labelledByText(element)
+      || label
+      || element.getAttribute?.('alt')
+      || element.getAttribute?.('title')
+      || element.getAttribute?.('placeholder')
+      || element.textContent,
+  )
+}
+
+function sensitiveField(element) {
+  if (element?.tagName?.toLowerCase() !== 'input') return false
+  return isSensitiveScreenControlField(element.type, element.autocomplete)
+}
+
+export function isSensitiveScreenControlField(type, autocomplete) {
+  if (String(type || '').toLowerCase() === 'password') return true
+  return String(autocomplete || '').split(/\s+/).some(
+    token => SENSITIVE_AUTOCOMPLETE.has(token.toLowerCase()),
+  )
+}
+
+function snapshotLocalDocument(doc = document) {
+  const refs = new Map()
+  const elements = []
+  const nodes = Array.from(doc.querySelectorAll(INTERACTIVE_SELECTOR))
+  for (const element of nodes) {
+    if (!visibleElement(element) || element.closest?.('[inert]')) continue
+    const ref = `e${elements.length + 1}`
+    const rect = element.getBoundingClientRect()
+    const item = {
+      ref,
+      role: elementRole(element),
+      name: elementName(element),
+      disabled: !!element.disabled || element.getAttribute?.('aria-disabled') === 'true',
+      bounds: {
+        x: Math.round(rect.x), y: Math.round(rect.y),
+        width: Math.round(rect.width), height: Math.round(rect.height),
+      },
+    }
+    if ('value' in element) {
+      item.value = sensitiveField(element) ? '[masked]' : concise(element.value)
+    }
+    refs.set(ref, element)
+    elements.push(item)
+  }
+  rootRefs = refs
+  return elements
+}
+
+function nearestActionTarget(element) {
+  return element?.closest?.(INTERACTIVE_SELECTOR) || element
+}
+
+function nativeValueSetter(element, value) {
+  const tag = element?.tagName?.toLowerCase()
+  const prototype = tag === 'textarea'
+    ? globalThis.HTMLTextAreaElement?.prototype
+    : globalThis.HTMLInputElement?.prototype
+  const setter = prototype && Object.getOwnPropertyDescriptor(prototype, 'value')?.set
+  if (setter) setter.call(element, value)
+  else element.value = value
+}
+
+function screenInputEvent(type, options) {
+  try { return new globalThis.InputEvent(type, options) }
+  catch { return new globalThis.Event(type, { bubbles: true }) }
+}
+
+function typeInto(element, text, replace = true) {
+  if (!element) throw new Error('No field is focused.')
+  if (element.closest?.('[inert]')) throw new Error('That field is not interactive.')
+  if (sensitiveField(element)) {
+    throw new Error('Sensitive fields stay under your control.')
+  }
+  const tag = element.tagName?.toLowerCase()
+  if (tag === 'input' || tag === 'textarea') {
+    if (element.disabled || element.readOnly) throw new Error('The field is not editable.')
+    element.focus({ preventScroll: true })
+    const next = replace ? text : `${element.value || ''}${text}`
+    nativeValueSetter(element, next)
+    element.dispatchEvent(screenInputEvent('input', {
+      bubbles: true, inputType: replace ? 'insertReplacementText' : 'insertText',
+      data: text,
+    }))
+    element.dispatchEvent(new Event('change', { bubbles: true }))
+    return
+  }
+  if (element.isContentEditable) {
+    element.focus({ preventScroll: true })
+    if (replace) element.textContent = text
+    else element.append(docTextNode(element.ownerDocument, text))
+    element.dispatchEvent(screenInputEvent('input', { bubbles: true, data: text }))
+    return
+  }
+  throw new Error('The focused element is not editable.')
+}
+
+function docTextNode(doc, text) {
+  return doc.createTextNode(text)
+}
+
+function scrollOwnerAt(doc, x, y) {
+  let element = doc.elementFromPoint(x, y)
+  while (element && element !== doc.body) {
+    const style = doc.defaultView?.getComputedStyle?.(element)
+    const scrollable = /(auto|scroll)/.test(`${style?.overflowY} ${style?.overflowX}`)
+      && (element.scrollHeight > element.clientHeight || element.scrollWidth > element.clientWidth)
+    if (scrollable) return element
+    element = element.parentElement
+  }
+  return doc.scrollingElement || doc.documentElement
+}
+
+function dispatchPress(doc, key) {
+  const target = doc.activeElement || doc.body
+  const Keyboard = doc.defaultView?.KeyboardEvent || globalThis.KeyboardEvent
+  target.dispatchEvent(new Keyboard('keydown', { key, bubbles: true, cancelable: true }))
+  if (key === 'Enter') {
+    if (target?.tagName?.toLowerCase() === 'button') target.click()
+    else target?.form?.requestSubmit?.()
+  } else if (key === ' ' && nearestActionTarget(target)?.click) {
+    nearestActionTarget(target).click()
+  }
+  target.dispatchEvent(new Keyboard('keyup', { key, bubbles: true, cancelable: true }))
+}
+
+function localCommand(command, doc = document) {
+  if (command.action !== 'snapshot' && Date.now() - latestOwnerInputAt < 750) {
+    throw new Error('Your input took priority; inspect the screen and try again.')
+  }
+  const pointTarget = command.x != null && command.y != null
+    ? doc.elementFromPoint(command.x, command.y)
+    : null
+  if (command.action === 'click') {
+    const target = command.ref ? rootRefs.get(command.ref) : nearestActionTarget(pointTarget)
+    if (!target || !visibleElement(target)) throw new Error('That control is no longer available.')
+    if (target.closest?.('[inert]')) throw new Error('That control is not interactive.')
+    if (target.disabled || target.getAttribute?.('aria-disabled') === 'true') {
+      throw new Error('That control is disabled.')
+    }
+    target.focus?.({ preventScroll: true })
+    target.click?.()
+    return { clicked: command.ref || { x: command.x, y: command.y } }
+  }
+  if (command.action === 'type') {
+    const target = command.ref ? rootRefs.get(command.ref) : doc.activeElement
+    typeInto(target, command.text, command.replace !== false)
+    return { typed: command.text.length }
+  }
+  if (command.action === 'scroll') {
+    const x = command.x ?? Math.round((doc.defaultView?.innerWidth || 0) / 2)
+    const y = command.y ?? Math.round((doc.defaultView?.innerHeight || 0) / 2)
+    const target = scrollOwnerAt(doc, x, y)
+    target.scrollBy?.({ left: command.deltaX || 0, top: command.deltaY || 0, behavior: 'auto' })
+    return { scrolled: true }
+  }
+  if (command.action === 'press') {
+    dispatchPress(doc, command.key)
+    return { pressed: command.key }
+  }
+  throw new Error(`Unsupported local action: ${command.action}`)
+}
+
+function frameForApp(appId) {
+  return Array.from(document.querySelectorAll('iframe[data-app-id]')).find(
+    frame => String(frame.dataset.appId) === String(appId) && visibleElement(frame),
+  ) || null
+}
+
+function requestFrame(frame, command) {
+  const requestId = `screen:${Date.now().toString(36)}:${++nextFrameRequest}`
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      window.removeEventListener('message', onMessage)
+      reject(new Error('The app frame did not answer.'))
+    }, FRAME_TIMEOUT_MS)
+    function onMessage(event) {
+      if (event.source !== frame.contentWindow) return
+      const message = event.data
+      if (message?.type !== 'moebius:screen-control-result' || message.requestId !== requestId) return
+      clearTimeout(timer)
+      window.removeEventListener('message', onMessage)
+      if (message.ok) resolve(message.result)
+      else reject(new Error(message.error || 'The app frame rejected the command.'))
+    }
+    window.addEventListener('message', onMessage)
+    // App frames are intentionally opaque-origin. The exact contentWindow is
+    // selected here and again validates the concrete parent origin, so `*` is
+    // the only delivery target that can reach the sandboxed frame safely.
+    frame.contentWindow?.postMessage({
+      type: 'moebius:screen-control-command', requestId, command,
+    }, '*')
+  })
+}
+
+export function parseScreenControlFrameRef(ref) {
+  const match = /^app:([^:]+):(e\d+)$/.exec(String(ref || ''))
+  return match ? { appId: match[1], ref: match[2] } : null
+}
+
+export function boundedScreenCaptureSize(sourceWidth, sourceHeight, maxEdge = 2560) {
+  if (!Number.isFinite(sourceWidth) || !Number.isFinite(sourceHeight)
+      || sourceWidth <= 0 || sourceHeight <= 0 || maxEdge <= 0) return null
+  const scale = Math.min(1, maxEdge / Math.max(sourceWidth, sourceHeight))
+  return {
+    width: Math.max(1, Math.round(sourceWidth * scale)),
+    height: Math.max(1, Math.round(sourceHeight * scale)),
+  }
+}
+
+async function snapshotPage() {
+  const elements = snapshotLocalDocument()
+  const frames = Array.from(document.querySelectorAll('iframe[data-app-id]')).filter(visibleElement)
+  const frameResults = await Promise.allSettled(frames.map(async frame => {
+    const appId = String(frame.dataset.appId)
+    const rect = frame.getBoundingClientRect()
+    const result = await requestFrame(frame, { action: 'snapshot' })
+    return (result?.elements || []).map(item => ({
+      ...item,
+      ref: `app:${appId}:${item.ref}`,
+      bounds: item.bounds ? {
+        x: Math.round(rect.x + item.bounds.x),
+        y: Math.round(rect.y + item.bounds.y),
+        width: item.bounds.width,
+        height: item.bounds.height,
+      } : undefined,
+    }))
+  }))
+  for (const result of frameResults) {
+    if (result.status === 'fulfilled') elements.push(...result.value)
+  }
+  return {
+    title: document.title,
+    route: `${location.pathname}${location.search}${location.hash}`,
+    viewport: {
+      width: window.innerWidth,
+      height: window.innerHeight,
+      pixelRatio: window.devicePixelRatio || 1,
+    },
+    elements,
+  }
+}
+
+async function executePageCommand(command) {
+  if (command.action === 'snapshot') return snapshotPage()
+  const frameRef = parseScreenControlFrameRef(command.ref)
+  if (frameRef) {
+    const frame = frameForApp(frameRef.appId)
+    if (!frame) throw new Error('That app frame is no longer visible.')
+    return requestFrame(frame, { ...command, ref: frameRef.ref })
+  }
+  if (command.x != null && command.y != null) {
+    const target = document.elementFromPoint(command.x, command.y)
+    if (target?.tagName?.toLowerCase() === 'iframe' && target.dataset.appId) {
+      const rect = target.getBoundingClientRect()
+      return requestFrame(target, {
+        ...command,
+        x: command.x - rect.x,
+        y: command.y - rect.y,
+      })
+    }
+  }
+  if ((command.action === 'type' || command.action === 'press')
+      && document.activeElement?.tagName?.toLowerCase() === 'iframe'
+      && document.activeElement.dataset.appId) {
+    return requestFrame(document.activeElement, command)
+  }
+  return localCommand(command)
+}
+
+export async function requestCurrentTabCapture() {
+  if (!navigator.mediaDevices?.getDisplayMedia) {
+    const error = new Error('Live screen sharing is not supported by this browser.')
+    error.name = 'NotSupportedError'
+    throw error
+  }
+  const stream = await navigator.mediaDevices.getDisplayMedia({
+    video: { frameRate: { ideal: 2, max: 5 } },
+    audio: false,
+    preferCurrentTab: true,
+    selfBrowserSurface: 'include',
+    surfaceSwitching: 'exclude',
+    monitorTypeSurfaces: 'exclude',
+  })
+  const video = document.createElement('video')
+  video.muted = true
+  video.playsInline = true
+  video.srcObject = stream
+  await new Promise((resolve, reject) => {
+    video.onloadedmetadata = resolve
+    video.onerror = () => reject(new Error('The shared screen could not be read.'))
+  })
+  await video.play()
+  return { stream, video }
+}
+
+function captureVideoFrame(video) {
+  const sourceWidth = video.videoWidth
+  const sourceHeight = video.videoHeight
+  if (!sourceWidth || !sourceHeight) throw new Error('The shared screen has no video frame yet.')
+  const size = boundedScreenCaptureSize(sourceWidth, sourceHeight)
+  const { width, height } = size
+  const canvas = document.createElement('canvas')
+  canvas.width = width
+  canvas.height = height
+  canvas.getContext('2d', { alpha: false }).drawImage(video, 0, 0, width, height)
+  return {
+    dataUrl: canvas.toDataURL('image/jpeg', 0.88),
+    mimeType: 'image/jpeg',
+    width,
+    height,
+  }
+}
+
+export function createScreenControlClient({ sessionId, capture, onConnected, onEnded }) {
+  const controller = new AbortController()
+  let stopped = false
+  let stopPromise = null
+  const track = capture.stream.getVideoTracks()[0]
+
+  async function postResponse(commandId, outcome) {
+    const response = await fetch(
+      `${BASE}/api/screen-control/sessions/${encodeURIComponent(sessionId)}/responses`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
+        body: JSON.stringify({ commandId, ...outcome }),
+      },
+    )
+    if (!response.ok && response.status !== 409 && response.status !== 404) {
+      throw new Error(`Screen-control response failed (${response.status}).`)
+    }
+  }
+
+  async function handleCommand(event) {
+    const { commandId, type: _type, ...command } = event
+    if (!commandId) return
+    try {
+      const result = command.action === 'screenshot'
+        ? captureVideoFrame(capture.video)
+        : await executePageCommand(command)
+      await postResponse(commandId, { ok: true, result })
+    } catch (error) {
+      await postResponse(commandId, {
+        ok: false,
+        error: String(error?.message || error).slice(0, 1000),
+      }).catch(() => {})
+    }
+  }
+
+  async function connect() {
+    try {
+      const response = await fetch(
+        `${BASE}/api/screen-control/sessions/${encodeURIComponent(sessionId)}/events`,
+        { headers: getAuthHeaders(), signal: controller.signal },
+      )
+      if (!response.ok || !response.body) throw new Error('The control channel could not connect.')
+      const reader = response.body.getReader()
+      const decoder = new TextDecoder()
+      let buffer = ''
+      while (!stopped) {
+        const { value, done } = await reader.read()
+        if (done) break
+        buffer += decoder.decode(value, { stream: true })
+        let boundary
+        while ((boundary = buffer.indexOf('\n\n')) !== -1) {
+          const block = buffer.slice(0, boundary)
+          buffer = buffer.slice(boundary + 2)
+          for (const line of block.split('\n')) {
+            if (!line.startsWith('data: ')) continue
+            const event = JSON.parse(line.slice(6))
+            if (event.type === 'screen-control-open') {
+              onConnected?.()
+              continue
+            }
+            if (event.type === 'screen-control-stop') {
+              await stop({ notifyServer: false })
+              onEnded?.('stopped')
+              return
+            }
+            if (event.type === 'screen-control-command') await handleCommand(event)
+          }
+        }
+      }
+      if (!stopped) throw new Error('The control channel disconnected.')
+    } catch (error) {
+      if (stopped || error?.name === 'AbortError') return
+      await stop({ notifyServer: false })
+      onEnded?.('disconnected', error)
+    }
+  }
+
+  async function stop({ notifyServer = true } = {}) {
+    if (stopPromise) return stopPromise
+    stopPromise = (async () => {
+      stopped = true
+      controller.abort()
+      capture.stream.getTracks().forEach(item => item.stop())
+      capture.video.srcObject = null
+      if (notifyServer) {
+        void fetch(
+          `${BASE}/api/screen-control/sessions/${encodeURIComponent(sessionId)}`,
+          {
+            method: 'DELETE',
+            headers: getAuthHeaders(),
+            keepalive: true,
+          },
+        ).catch(() => {})
+      }
+    })()
+    return stopPromise
+  }
+
+  if (track) {
+    track.addEventListener('ended', () => {
+      if (stopped) return
+      void stop().finally(() => onEnded?.('stopped'))
+    }, { once: true })
+  }
+  void connect()
+  return { stop }
+}

--- a/frontend/src/lib/screenControlPage.js
+++ b/frontend/src/lib/screenControlPage.js
@@ -11,6 +11,7 @@ const SENSITIVE_AUTOCOMPLETE = new Set([
   'cc-number', 'cc-csc', 'cc-exp', 'cc-exp-month', 'cc-exp-year',
 ])
 const FRAME_TIMEOUT_MS = 2500
+const CAPTURE_START_TIMEOUT_MS = 10_000
 
 let rootRefs = new Map()
 let nextFrameRequest = 0
@@ -347,27 +348,65 @@ export async function requestCurrentTabCapture() {
     error.name = 'NotSupportedError'
     throw error
   }
-  const stream = await navigator.mediaDevices.getDisplayMedia({
-    video: { frameRate: { ideal: 2, max: 5 } },
-    audio: false,
-    preferCurrentTab: true,
-    selfBrowserSurface: 'include',
-    surfaceSwitching: 'exclude',
-    monitorTypeSurfaces: 'exclude',
-  })
-  const video = document.createElement('video')
-  video.muted = true
-  video.playsInline = true
-  video.srcObject = stream
-  await new Promise((resolve, reject) => {
-    video.onloadedmetadata = resolve
-    video.onerror = () => reject(new Error('The shared screen could not be read.'))
-  })
-  await video.play()
-  return { stream, video }
+  let stream
+  let video
+  try {
+    stream = await navigator.mediaDevices.getDisplayMedia({
+      video: { frameRate: { ideal: 2, max: 5 } },
+      audio: false,
+      preferCurrentTab: true,
+      selfBrowserSurface: 'include',
+      surfaceSwitching: 'exclude',
+      monitorTypeSurfaces: 'exclude',
+    })
+    const track = stream.getVideoTracks()[0]
+    if (!track || track.readyState === 'ended') {
+      throw new Error('The shared screen ended before it was ready.')
+    }
+    video = document.createElement('video')
+    video.muted = true
+    video.playsInline = true
+    video.srcObject = stream
+    await new Promise((resolve, reject) => {
+      let settled = false
+      const finish = (callback, value) => {
+        if (settled) return
+        settled = true
+        clearTimeout(timer)
+        track.removeEventListener('ended', onEnded)
+        video.onloadedmetadata = null
+        video.onerror = null
+        callback(value)
+      }
+      const onEnded = () => finish(
+        reject, new Error('The shared screen ended before it was ready.'),
+      )
+      const timer = setTimeout(
+        () => finish(reject, new Error('The shared screen did not become ready in time.')),
+        CAPTURE_START_TIMEOUT_MS,
+      )
+      track.addEventListener('ended', onEnded, { once: true })
+      video.onloadedmetadata = () => finish(resolve)
+      video.onerror = () => finish(
+        reject, new Error('The shared screen could not be read.'),
+      )
+    })
+    await video.play()
+    if (track.readyState === 'ended') {
+      throw new Error('The shared screen ended before it was ready.')
+    }
+    return { stream, video }
+  } catch (error) {
+    stream?.getTracks?.().forEach(track => track.stop())
+    if (video) video.srcObject = null
+    throw error
+  }
 }
 
-function captureVideoFrame(video) {
+function captureVideoFrame(video, track) {
+  if (!track || track.readyState === 'ended') {
+    throw new Error('The shared screen is no longer available.')
+  }
   const sourceWidth = video.videoWidth
   const sourceHeight = video.videoHeight
   if (!sourceWidth || !sourceHeight) throw new Error('The shared screen has no video frame yet.')
@@ -385,11 +424,30 @@ function captureVideoFrame(video) {
   }
 }
 
-export function createScreenControlClient({ sessionId, capture, onConnected, onEnded }) {
+export function screenControlCommandExpired(deadlineAt, now = Date.now()) {
+  const deadline = Number(deadlineAt)
+  return Number.isFinite(deadline) && deadline <= now
+}
+
+export function createScreenControlClient({
+  sessionId,
+  expiresAt,
+  capture,
+  onConnected,
+  onEnded,
+}) {
   const controller = new AbortController()
   let stopped = false
   let stopPromise = null
+  let endedNotified = false
+  let expiryTimer = null
   const track = capture.stream.getVideoTracks()[0]
+
+  function notifyEnded(reason, error) {
+    if (endedNotified) return
+    endedNotified = true
+    onEnded?.(reason, error)
+  }
 
   async function postResponse(commandId, outcome) {
     const response = await fetch(
@@ -406,12 +464,20 @@ export function createScreenControlClient({ sessionId, capture, onConnected, onE
   }
 
   async function handleCommand(event) {
-    const { commandId, type: _type, ...command } = event
-    if (!commandId) return
+    const { commandId, deadlineAt, type: _type, ...command } = event
+    if (!commandId || stopped) return
+    if (screenControlCommandExpired(deadlineAt)) {
+      await postResponse(commandId, {
+        ok: false,
+        error: 'The screen-control command expired before execution.',
+      }).catch(() => {})
+      return
+    }
     try {
       const result = command.action === 'screenshot'
-        ? captureVideoFrame(capture.video)
+        ? captureVideoFrame(capture.video, track)
         : await executePageCommand(command)
+      if (stopped) return
       await postResponse(commandId, { ok: true, result })
     } catch (error) {
       await postResponse(commandId, {
@@ -448,7 +514,7 @@ export function createScreenControlClient({ sessionId, capture, onConnected, onE
             }
             if (event.type === 'screen-control-stop') {
               await stop({ notifyServer: false })
-              onEnded?.('stopped')
+              notifyEnded('stopped')
               return
             }
             if (event.type === 'screen-control-command') await handleCommand(event)
@@ -459,7 +525,7 @@ export function createScreenControlClient({ sessionId, capture, onConnected, onE
     } catch (error) {
       if (stopped || error?.name === 'AbortError') return
       await stop({ notifyServer: false })
-      onEnded?.('disconnected', error)
+      notifyEnded('disconnected', error)
     }
   }
 
@@ -468,6 +534,7 @@ export function createScreenControlClient({ sessionId, capture, onConnected, onE
     stopPromise = (async () => {
       stopped = true
       controller.abort()
+      clearTimeout(expiryTimer)
       capture.stream.getTracks().forEach(item => item.stop())
       capture.video.srcObject = null
       if (notifyServer) {
@@ -485,10 +552,23 @@ export function createScreenControlClient({ sessionId, capture, onConnected, onE
   }
 
   if (track) {
-    track.addEventListener('ended', () => {
+    const onTrackEnded = () => {
       if (stopped) return
-      void stop().finally(() => onEnded?.('stopped'))
-    }, { once: true })
+      void stop().finally(() => notifyEnded('stopped'))
+    }
+    track.addEventListener('ended', onTrackEnded, { once: true })
+    // The grant can end while the session request is still in flight, before
+    // this listener exists. Reconcile that already-ended state immediately.
+    if (track.readyState === 'ended') {
+      Promise.resolve().then(onTrackEnded)
+    }
+  }
+  const expiryDelay = Number(expiresAt) - Date.now()
+  if (Number.isFinite(expiryDelay)) {
+    expiryTimer = setTimeout(() => {
+      if (stopped) return
+      void stop().finally(() => notifyEnded('expired'))
+    }, Math.max(0, expiryDelay))
   }
   void connect()
   return { stop }


### PR DESCRIPTION
## Summary
- add an app-declared, owner-consented current-tab sharing capability for one exact app-owned support chat
- expose only a closed semantic command set; never evaluate arbitrary browser script or open a debugging port
- bind agent-side access to the exact active chat run, mask password, payment, and one-time-code fields, and let recent owner input win
- keep an owner-visible Stop control available across frame replacement, with bounded command concurrency and automatic disconnect and 15-minute expiry cleanup
- relay visible shell and sandboxed-app controls while respecting disabled, inert, and suspended surfaces

## Tests
- 33 focused backend screen-control and capability tests passed
- 2,725 frontend library tests and 93 hook tests passed
- production and PWA build passed
- ESLint completed with zero errors; 46 existing warnings remain
- hosted CI remains dependency-authoritative because the checkout dependency lock differs from the live image