### PR TITLE
Keep context usage on the active provider session

### DIFF
--- a/backend/app/routes/chats.py
+++ b/backend/app/routes/chats.py
@@ -1935,6 +1935,8 @@ def _latest_model_input_tokens(run: models.ChatRun) -> int | None:
 @router.get("/{chat_id}/usage/current")
 def get_current_chat_usage(
   chat_id: str,
+  provider: str,
+  provider_session_id: str,
   _: models.Owner = Depends(get_current_owner),
   db: Session = Depends(get_db),
 ):
@@ -1944,24 +1946,17 @@ def get_current_chat_usage(
   composer gauge needs only one bounded projection and is mounted for every
   open chat pane, so it must not download an ever-growing usage history.
   """
-  chat = get_active_chat_or_404(
+  get_active_chat_or_404(
     db,
     chat_id,
-    load_fields=(models.Chat.id, models.Chat.provider, models.Chat.session_id),
+    load_fields=(models.Chat.id,),
   )
-  if not chat.session_id:
-    return {
-      "provider": chat.provider,
-      "provider_session_id": None,
-      "input_tokens": None,
-      "context_window": None,
-    }
   run = (
     db.query(models.ChatRun)
     .filter(
       models.ChatRun.chat_id == chat_id,
-      models.ChatRun.provider == chat.provider,
-      models.ChatRun.provider_session_id == chat.session_id,
+      models.ChatRun.provider == provider,
+      models.ChatRun.provider_session_id == provider_session_id,
       models.ChatRun.usage_json.isnot(None),
       models.ChatRun.model_context_window.isnot(None),
     )
@@ -1970,8 +1965,8 @@ def get_current_chat_usage(
   )
   if run is None:
     return {
-      "provider": chat.provider,
-      "provider_session_id": chat.session_id,
+      "provider": provider,
+      "provider_session_id": provider_session_id,
       "input_tokens": None,
       "context_window": None,
     }

--- a/backend/tests/test_chats.py
+++ b/backend/tests/test_chats.py
@@ -240,8 +240,6 @@ def test_current_chat_usage_is_bounded_to_selected_provider_session(
   client, auth, chat, db,
 ):
   now = datetime.now(UTC)
-  chat.provider = "codex"
-  chat.session_id = "thread-current"
   db.add_all([
     models.ChatRun(
       id="older-thread",
@@ -277,6 +275,10 @@ def test_current_chat_usage_is_bounded_to_selected_provider_session(
 
   response = client.get(
     f"/api/chats/{chat.id}/usage/current",
+    params={
+      "provider": "codex",
+      "provider_session_id": "thread-current",
+    },
     headers=auth,
   )
 
@@ -292,8 +294,6 @@ def test_current_chat_usage_is_bounded_to_selected_provider_session(
 def test_current_chat_usage_reads_normalized_claude_call_occupancy(
   client, auth, chat, db,
 ):
-  chat.provider = "claude"
-  chat.session_id = "claude-session-current"
   db.add(models.ChatRun(
     id="selected-claude-session",
     chat_id=chat.id,
@@ -311,6 +311,10 @@ def test_current_chat_usage_reads_normalized_claude_call_occupancy(
 
   response = client.get(
     f"/api/chats/{chat.id}/usage/current",
+    params={
+      "provider": "claude",
+      "provider_session_id": "claude-session-current",
+    },
     headers=auth,
   )
 
@@ -326,8 +330,6 @@ def test_current_chat_usage_reads_normalized_claude_call_occupancy(
 def test_current_chat_usage_reads_codex_shaped_app_provider_metrics(
   client, auth, chat, db,
 ):
-  chat.provider = "mobius"
-  chat.session_id = "mobius-session"
   db.add(models.ChatRun(
     id="mobius-evolve-run",
     chat_id=chat.id,
@@ -348,6 +350,10 @@ def test_current_chat_usage_reads_codex_shaped_app_provider_metrics(
 
   response = client.get(
     f"/api/chats/{chat.id}/usage/current",
+    params={
+      "provider": "mobius",
+      "provider_session_id": "mobius-session",
+    },
     headers=auth,
   )
 
@@ -365,13 +371,17 @@ def test_current_chat_usage_returns_unknown_for_a_fresh_session(
 ):
   response = client.get(
     f"/api/chats/{chat.id}/usage/current",
+    params={
+      "provider": "claude",
+      "provider_session_id": "session-without-a-turn",
+    },
     headers=auth,
   )
 
   assert response.status_code == 200
   assert response.json() == {
     "provider": "claude",
-    "provider_session_id": None,
+    "provider_session_id": "session-without-a-turn",
     "input_tokens": None,
     "context_window": None,
   }

--- a/backend/tests/test_codex_sdk_contract.py
+++ b/backend/tests/test_codex_sdk_contract.py
@@ -340,8 +340,8 @@ def test_web_search_results_survive_generated_sdk_schema_lag():
   }]
 
 
-def test_cache_write_usage_survives_generated_sdk_schema_lag():
-  """The 5.6 cache-write counter must reach cost normalization."""
+def test_cache_write_usage_survives_generated_sdk_schema_evolution():
+  """The cache-write counter reaches normalization on old and new SDKs."""
   pytest.importorskip("openai_codex")
   from openai_codex.generated import v2_all
   from app import codex_sdk_runner
@@ -364,9 +364,11 @@ def test_cache_write_usage_survives_generated_sdk_schema_lag():
       "modelContextWindow": 1_050_000,
     },
   })
-  assert payload.token_usage.last.model_extra == {
-    "cacheWriteInputTokens": 60,
-  }
+  last = payload.token_usage.last
+  assert (
+    getattr(last, "cache_write_input_tokens", None) == 60
+    or (last.model_extra or {}).get("cacheWriteInputTokens") == 60
+  )
   assert codex_sdk_runner.normalize_codex_usage(
     payload.token_usage,
     payload.token_usage,

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -480,10 +480,16 @@ export const api = {
         { signal, timeoutMs },
       )
     },
-    currentUsage: (chatId, { signal } = {}) => apiFetch(
-      `/chats/${encodeURIComponent(chatId)}/usage/current`,
-      { signal },
-    ),
+    currentUsage: (chatId, { provider, providerSessionId, signal } = {}) => {
+      const params = new URLSearchParams({
+        provider,
+        provider_session_id: providerSessionId,
+      })
+      return apiFetch(
+        `/chats/${encodeURIComponent(chatId)}/usage/current?${params}`,
+        { signal },
+      )
+    },
     update: (chatId, payload) => listAffectingMutation('chats', `/chats/${chatId}`, {
       method: 'PATCH',
       body: JSON.stringify(payload),

--- a/frontend/src/components/ChatView/BrainUsageButton.jsx
+++ b/frontend/src/components/ChatView/BrainUsageButton.jsx
@@ -21,6 +21,7 @@ export default function BrainUsageButton({
   usageEnabled = true,
   chatId = null,
   provider = null,
+  providerSessionId = null,
   model = null,
 }) {
   const providerUsageQuery = settingsQueries.providerUsage.useQuery(provider, {
@@ -29,10 +30,11 @@ export default function BrainUsageButton({
   const contextUsageQuery = chatQueries.currentUsage.useQuery(
     chatId,
     provider,
+    providerSessionId,
     { enabled: usageEnabled },
   )
   const modelRegistryQuery = modelQueries.registry.useQuery({
-    enabled: usageEnabled && Boolean(provider && model),
+    enabled: usageEnabled && !providerSessionId && Boolean(provider && model),
   })
   const allowance = providerUsageQuery.isLoading
     ? providerAllowance(provider, null)
@@ -42,6 +44,7 @@ export default function BrainUsageButton({
   const contextSnapshot = (
     contextUsageQuery.isLoading
     || contextUsageQuery.data?.provider !== provider
+    || contextUsageQuery.data?.provider_session_id !== providerSessionId
   )
     ? null
     : contextUsageQuery.data

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -1145,6 +1145,11 @@ export default function ChatView({
       const runtimeGoalObjective = goalObjectiveFromRuntime(
         data, latestGoalObjective(msgs),
       )
+      // A provider creates its session during the first turn, after ChatView
+      // has already mounted. Publish the refreshed detail metadata with the
+      // settled transcript so the context gauge follows that exact session
+      // without waiting for a page reload.
+      const refreshedChatInfo = chatDetailCacheValue(data).chatInfo
       setActiveGoalObjective(runtimeGoalObjective)
       const adoptAssistantOwner = shouldAdoptRuntimeAssistantOwner({
         runtimeRunning: !!data.running,
@@ -1165,6 +1170,7 @@ export default function ChatView({
           activeAssistantMessageId: data.active_assistant_message_id || null,
         } : {}),
         waits: data.waits || [],
+        chatInfo: refreshedChatInfo,
       })
       // Reconcile pending queue against authoritative server state.
       // hydrate() already preserves truly optimistic/in-flight local rows
@@ -5075,6 +5081,7 @@ export default function ChatView({
               usageEnabled={!embedded}
               chatId={chatId}
               provider={chatInfo?.provider}
+              providerSessionId={chatInfo?.session_id}
               model={selectedChatModel(chatInfo)}
             >
               {({ icon, ariaLabel, providerUsage }) => (

--- a/frontend/src/components/ChatView/__tests__/brainUsage.test.js
+++ b/frontend/src/components/ChatView/__tests__/brainUsage.test.js
@@ -9,6 +9,7 @@ import {
   resolvedContextTokenCounts,
   visibleBrainFillBounds,
 } from '../brainUsage.js'
+import { chatQueries } from '../../../hooks/queries.js'
 
 test('context gauge measures the latest model call against its context window', () => {
   assert.equal(contextUsedPercent({
@@ -74,6 +75,15 @@ test('missing usage in an established session remains unknown', () => {
     input_tokens: null,
     context_window: null,
   }, registry, 'codex', 'gpt-5.6-sol'), null)
+})
+
+test('context usage cache identity follows the exact provider session', () => {
+  const first = chatQueries.keys.currentUsage('chat-1', 'codex', 'session-1')
+  const second = chatQueries.keys.currentUsage('chat-1', 'codex', 'session-2')
+  assert.deepEqual(first, [
+    'chat-current-usage', 'chat-1', 'codex', 'session-1',
+  ])
+  assert.notDeepEqual(first, second)
 })
 
 test('the final ten percent remains visibly linear inside the inset mask', () => {

--- a/frontend/src/components/ChatView/__tests__/chatDetailCache.test.js
+++ b/frontend/src/components/ChatView/__tests__/chatDetailCache.test.js
@@ -100,6 +100,7 @@ test('prefetched chat detail matches the synchronous ChatView cache contract', (
     pending_messages: [{ id: 'queued' }],
     pending_question_id: 'question-1',
     provider: 'codex',
+    session_id: 'thread-current',
     created_by_app_id: 7,
     agent_settings_json: { model: 'example' },
     effective_agent_settings: { effort: 'high' },
@@ -119,6 +120,7 @@ test('prefetched chat detail matches the synchronous ChatView cache contract', (
   assert.equal(cached.pending_question_id, 'question-1')
   assert.deepEqual(cached.chatInfo, {
     provider: 'codex',
+    session_id: 'thread-current',
     created_by_app_id: 7,
     agent_settings_json: { model: 'example' },
     effective: { effort: 'high' },

--- a/frontend/src/components/ChatView/__tests__/chatRuntimeCache.test.js
+++ b/frontend/src/components/ChatView/__tests__/chatRuntimeCache.test.js
@@ -62,6 +62,24 @@ test('unchanged durable waits do not republish the persisted chat cache', () => 
   assert.equal(cache.value().waits, waits)
 })
 
+test('unchanged settled chat metadata does not republish the persisted cache', () => {
+  const chatInfo = {
+    provider: 'claude',
+    session_id: 'claude-session-1',
+    effective: { model: 'claude-opus-4-8' },
+  }
+  const cache = cacheHarness({ messages: [], chatInfo })
+
+  updateChatRuntimeCache(
+    cache.queryClient,
+    ['chat-messages', 'chat-1'],
+    { chatInfo: structuredClone(chatInfo) },
+  )
+
+  assert.equal(cache.updates(), 0)
+  assert.equal(cache.value().chatInfo, chatInfo)
+})
+
 test('a runtime transition patches only runtime fields', () => {
   const transcript = [{ role: 'assistant', content: 'history' }]
   const cache = cacheHarness({

--- a/frontend/src/components/ChatView/chatRuntimeCache.js
+++ b/frontend/src/components/ChatView/chatRuntimeCache.js
@@ -10,6 +10,10 @@ function samePendingMessages(current, next) {
 }
 
 function runtimeFieldMatches(current, field, value) {
+  if (field === 'chatInfo') {
+    if (current?.chatInfo === value) return true
+    return JSON.stringify(current?.chatInfo || null) === JSON.stringify(value || null)
+  }
   if (field === 'pending_messages') {
     return samePendingMessages(current?.pending_messages || [], value || [])
   }

--- a/frontend/src/components/ChatView/hooks/__tests__/useChatRuntimePolicy.test.js
+++ b/frontend/src/components/ChatView/hooks/__tests__/useChatRuntimePolicy.test.js
@@ -87,6 +87,76 @@ test('chat-info patches preserve the provider when the response omits it', () =>
   assert.deepEqual(result.current.chatInfo.effective, { effort: 'high' })
 })
 
+test('a settled first turn adopts its provider session without a remount', () => {
+  resetProviderSwitchMemoryForTests()
+  const initial = {
+    chatInfo: {
+      provider: 'claude',
+      session_id: null,
+      effective: { model: 'claude-opus-4-8' },
+    },
+  }
+  const { result, rerender } = renderHook(useChatRuntimePolicy, {
+    chatId: 'policy-first-turn',
+    cached: initial,
+    hidden: false,
+    onProviderSwitchSettled() {},
+    request: unusedRequest,
+  })
+
+  assert.equal(result.current.chatInfo.session_id, null)
+
+  rerender({
+    chatId: 'policy-first-turn',
+    cached: {
+      chatInfo: {
+        ...initial.chatInfo,
+        session_id: 'claude-session-1',
+      },
+    },
+    hidden: false,
+    onProviderSwitchSettled() {},
+    request: unusedRequest,
+  })
+
+  assert.equal(result.current.chatInfo.session_id, 'claude-session-1')
+  assert.deepEqual(
+    result.current.chatInfo.effective,
+    { model: 'claude-opus-4-8' },
+  )
+})
+
+test('a late session from the outgoing provider is never adopted', () => {
+  resetProviderSwitchMemoryForTests()
+  const { result, rerender } = renderHook(useChatRuntimePolicy, {
+    chatId: 'policy-provider-bound-session',
+    cached: {
+      chatInfo: { provider: 'codex', session_id: null },
+    },
+    hidden: false,
+    onProviderSwitchSettled() {},
+    request: unusedRequest,
+  })
+
+  result.current.mergeChatInfo({
+    provider: 'claude',
+    agent_settings_json: { model: 'claude-opus-4-8' },
+    effective: { model: 'claude-opus-4-8' },
+  })
+  rerender({
+    chatId: 'policy-provider-bound-session',
+    cached: {
+      chatInfo: { provider: 'codex', session_id: 'codex-thread-late' },
+    },
+    hidden: false,
+    onProviderSwitchSettled() {},
+    request: unusedRequest,
+  })
+
+  assert.equal(result.current.chatInfo.provider, 'claude')
+  assert.equal(result.current.chatInfo.session_id, null)
+})
+
 test('the auto-resume action persists the setting and updates one chat owner', async () => {
   resetProviderSwitchMemoryForTests()
   const calls = []

--- a/frontend/src/components/ChatView/hooks/useChatRuntimePolicy.js
+++ b/frontend/src/components/ChatView/hooks/useChatRuntimePolicy.js
@@ -1,6 +1,7 @@
 import {
   useCallback,
   useEffect,
+  useLayoutEffect,
   useRef,
   useState,
   useSyncExternalStore,
@@ -43,6 +44,21 @@ export default function useChatRuntimePolicy({
   )
   const providerSwitching = providerSwitchState.status === 'switching'
 
+  const cachedProvider = cached?.chatInfo?.provider || null
+  const cachedSessionId = cached?.chatInfo?.session_id || null
+  useLayoutEffect(() => {
+    if (!cachedSessionId) return
+    setChatInfo(previous => {
+      // A session belongs to exactly one provider. A late settled read from
+      // the outgoing provider must never repoint a chat that has since
+      // switched providers; the incoming provider earns its own session on
+      // its first completed turn.
+      if (!previous || previous.provider !== cachedProvider) return previous
+      if (previous.session_id === cachedSessionId) return previous
+      return { ...previous, session_id: cachedSessionId }
+    })
+  }, [cachedProvider, cachedSessionId])
+
   const clearAutoResumeError = useCallback(() => {
     setAutoResumeError('')
     setAutoResumeErrorSource('')
@@ -53,12 +69,22 @@ export default function useChatRuntimePolicy({
     provider,
     effective,
   }) => {
-    setChatInfo(previous => previous ? ({
-      ...previous,
-      agent_settings_json,
-      provider: provider || previous.provider,
-      effective: effective || previous.effective,
-    }) : previous)
+    setChatInfo(previous => {
+      if (!previous) return previous
+      const nextProvider = provider || previous.provider
+      return {
+        ...previous,
+        agent_settings_json,
+        provider: nextProvider,
+        // Provider sessions are not portable. A switch clears the server's
+        // session immediately; keep the live shell from showing the outgoing
+        // provider's context until the incoming provider completes a turn.
+        session_id: nextProvider === previous.provider
+          ? previous.session_id
+          : null,
+        effective: effective || previous.effective,
+      }
+    })
   }, [])
 
   useEffect(() => {

--- a/frontend/src/hooks/queries.js
+++ b/frontend/src/hooks/queries.js
@@ -21,10 +21,11 @@ const providerUsageKey = (provider) => [...providerUsageRootKey, provider]
 const appsKey = ['apps']
 const chatsKey = ['chats']
 const chatCurrentUsageRootKey = ['chat-current-usage']
-const chatCurrentUsageKey = (chatId, provider) => [
+const chatCurrentUsageKey = (chatId, provider, providerSessionId) => [
   ...chatCurrentUsageRootKey,
   chatId,
   provider,
+  providerSessionId,
 ]
 const providersStatusKey = ['auth', 'providers', 'status']
 const modelRegistryKey = ['models', 'registry']
@@ -144,24 +145,33 @@ async function fetchChatMessages(chatId, { signal } = {}) {
 
 async function fetchChatCurrentUsage(
   chatId,
+  provider,
+  providerSessionId,
   { signal } = {},
 ) {
-  const res = await api.chats.currentUsage(chatId, { signal })
+  const res = await api.chats.currentUsage(chatId, {
+    provider,
+    providerSessionId,
+    signal,
+  })
   return jsonOrThrow(res, 'current chat usage fetch failed:')
 }
 
 function useChatCurrentUsageQuery(
   chatId,
   provider,
+  providerSessionId,
   { enabled = true } = {},
 ) {
   return useQuery({
-    queryKey: chatCurrentUsageKey(chatId, provider),
+    queryKey: chatCurrentUsageKey(chatId, provider, providerSessionId),
     queryFn: context => fetchChatCurrentUsage(
       chatId,
+      provider,
+      providerSessionId,
       context,
     ),
-    enabled: enabled && Boolean(chatId && provider),
+    enabled: enabled && Boolean(chatId && provider && providerSessionId),
     staleTime: 60_000,
     retry: 0,
   })

--- a/frontend/src/lib/chatDetailCache.js
+++ b/frontend/src/lib/chatDetailCache.js
@@ -191,6 +191,7 @@ export function chatDetailCacheValue(data = {}) {
     pending_question_id: data.pending_question_id || null,
     chatInfo: {
       provider: data.provider || 'claude',
+      session_id: data.session_id || null,
       created_by_app_id: data.created_by_app_id ?? null,
       agent_settings_json: data.agent_settings_json || null,
       effective: data.effective_agent_settings || {},


### PR DESCRIPTION
## Summary
- refresh mounted chat metadata after a settled turn so the active provider session appears without a reload
- key and select context usage by the exact provider session visible in the chat
- prevent a late session from the outgoing provider from replacing the current provider session
- preserve the upstream usage strip and inspector; this corrects session selection rather than removing usage tracking

## Tests
- 4 focused backend context-usage tests passed
- 2,722 frontend library tests and 95 ChatView hook tests passed
- production and PWA build passed
- focused ESLint completed with zero errors; 9 existing ChatView dependency warnings remain
- hosted CI remains dependency-authoritative because the checkout dependency lock differs from the live image