### PR TITLE
Remove ordinary Subagent ceilings

### DIFF
--- a/backend/app/claude_sdk_runner.py
+++ b/backend/app/claude_sdk_runner.py
@@ -1219,7 +1219,6 @@ async def run_claude_sdk_turn(
         "permission_mode": (
           "plan" if run_policy.scope == "read" else "acceptEdits"
         ),
-        "max_budget_usd": run_policy.max_budget_usd,
         "disallowed_tools": [
           "AskUserQuestion", "Task", "TaskOutput", "TaskStop",
           "Workflow", "Workflows", "Agent",

--- a/backend/app/delegations.py
+++ b/backend/app/delegations.py
@@ -30,7 +30,6 @@ TERMINAL_DELEGATION_STATUSES = frozenset({
   "interrupted",
 })
 REVIEW_REQUIRED_MARKER = "DELEGATION_WRITE_REVIEW_REQUIRED"
-MAX_DELEGATION_DEPTH = 4
 
 
 @dataclass(frozen=True)
@@ -44,7 +43,6 @@ class RunPolicy:
   effort: str | None
   scope: str
   cwd: str
-  max_budget_usd: float | None
   depth: int = 1
 
   @property
@@ -114,7 +112,6 @@ class DelegationIntent:
   effort: str | None
   scope: str
   cwd: str
-  max_budget_usd: float | None
   notify_parent_on_complete: bool = True
 
 
@@ -132,7 +129,6 @@ def same_delegation_intent(
     row.effort == intent.effort,
     row.scope == intent.scope,
     row.cwd == intent.cwd,
-    row.max_budget_usd == intent.max_budget_usd,
     row.notify_parent_on_complete == intent.notify_parent_on_complete,
     row.prompt_sha256 == hashlib.sha256(
       intent.prompt.encode("utf-8")
@@ -175,7 +171,10 @@ def create_or_attach_delegation(
     scope=intent.scope,
     cwd=intent.cwd,
     prompt_sha256=hashlib.sha256(intent.prompt.encode("utf-8")).hexdigest(),
-    max_budget_usd=intent.max_budget_usd,
+    # Older rows may retain the retired ordinary delegated-run budget. New
+    # work deliberately leaves it unset; provider/account limits remain the
+    # observable boundary instead of a hidden local spending ceiling.
+    max_budget_usd=None,
     notify_parent_on_complete=intent.notify_parent_on_complete,
   )
   child = models.Chat(
@@ -250,14 +249,6 @@ def policy_for_chat(db: Session, chat_id: str) -> RunPolicy | None:
     digest = hashlib.sha256(prompt.encode("utf-8")).hexdigest()
     if digest != row.prompt_sha256:
       raise RuntimeError("delegation prompt no longer matches immutable intent")
-  remaining_budget = row.max_budget_usd
-  if remaining_budget is not None:
-    known_prior_cost = float(sum(
-      float(value or 0.0) for (value,) in db.query(
-        models.ChatRun.cost_usd,
-      ).filter(models.ChatRun.chat_id == chat_id).all()
-    ))
-    remaining_budget = max(0.001, remaining_budget - known_prior_cost)
   depth = delegation_depth(db, row)
   return RunPolicy(
     delegation_id=row.id,
@@ -267,7 +258,6 @@ def policy_for_chat(db: Session, chat_id: str) -> RunPolicy | None:
     effort=row.effort,
     scope=row.scope,
     cwd=row.cwd,
-    max_budget_usd=remaining_budget,
     depth=depth,
   )
 
@@ -450,7 +440,6 @@ def serialize_delegation(
     "effort": row.effort,
     "scope": row.scope,
     "cwd": row.cwd,
-    "max_budget_usd": row.max_budget_usd,
     "status": status,
     "physical_run_id": run.id if run is not None else None,
     "provider_session_id": run.provider_session_id if run is not None else None,

--- a/backend/app/goal_plans.py
+++ b/backend/app/goal_plans.py
@@ -293,7 +293,7 @@ def _delegation_tree(
   db: Session, physical: models.ChatRun, root: models.ChatRun,
 ) -> list[dict[str, Any]]:
   """Project durable immediate-child ownership without copying transcripts."""
-  from app.delegations import MAX_DELEGATION_DEPTH, derived_status
+  from app.delegations import derived_status
 
   run_ids = {root.id}
   if physical.goal_id:
@@ -317,9 +317,7 @@ def _delegation_tree(
   children_by_parent: dict[str, list[models.Delegation]] = {}
   frontier = [row.child_chat_id for row in roots]
   seen_rows = {row.id for row in roots}
-  for _depth in range(1, MAX_DELEGATION_DEPTH):
-    if not frontier:
-      break
+  while frontier:
     child_rows = db.query(models.Delegation).filter(
       models.Delegation.parent_chat_id.in_(frontier),
     ).order_by(models.Delegation.created_at.asc()).all()

--- a/backend/app/routes/delegations.py
+++ b/backend/app/routes/delegations.py
@@ -21,7 +21,6 @@ from app.delegations import (
   cancel_delegation_execution,
   create_or_attach_delegation,
   derived_status,
-  MAX_DELEGATION_DEPTH,
   normalize_cwd,
   parent_root_run_id,
   serialize_delegation,
@@ -153,9 +152,6 @@ def _require_submitter(
       status_code=403,
       detail="Delegation token may only create direct children.",
     )
-  from app.delegations import delegation_depth
-  if delegation_depth(db, parent) >= MAX_DELEGATION_DEPTH:
-    raise HTTPException(status_code=409, detail=f"Delegation depth reached the maximum ({MAX_DELEGATION_DEPTH}).")
   return parent
 
 
@@ -276,7 +272,6 @@ async def submit_or_attach(
       effort=body.effort,
       scope=body.scope,
       cwd=cwd,
-      max_budget_usd=5.0 if body.provider == "claude" else None,
       notify_parent_on_complete=body.notify_parent_on_complete,
     )
     try:

--- a/backend/tests/test_claude_sdk_runner.py
+++ b/backend/tests/test_claude_sdk_runner.py
@@ -2198,6 +2198,68 @@ async def test_can_use_tool_read_of_skill_file_emits_skill_loaded(
 
 
 @pytest.mark.asyncio
+async def test_delegated_claude_has_no_hidden_budget_and_keeps_guards(
+  monkeypatch,
+):
+  captured: dict = {}
+  real_options = claude_sdk_runner.ClaudeAgentOptions
+
+  def capture_options(**kwargs):
+    captured["kwargs"] = dict(kwargs)
+    return real_options(**kwargs)
+
+  class _FakeClient:
+    def __init__(self, options):
+      del options
+
+    async def connect(self):
+      return None
+
+    async def query(self, message):
+      del message
+
+    async def disconnect(self):
+      return None
+
+    async def receive_response(self):
+      yield ResultMessage(
+        subtype="success",
+        duration_ms=10,
+        duration_api_ms=5,
+        is_error=False,
+        num_turns=1,
+        session_id="sess-delegated-budget",
+        stop_reason="end_turn",
+        total_cost_usd=0.01,
+        usage={"input_tokens": 1, "output_tokens": 1},
+      )
+
+  monkeypatch.setattr(claude_sdk_runner, "ClaudeAgentOptions", capture_options)
+  monkeypatch.setattr(claude_sdk_runner, "ClaudeSDKClient", _FakeClient)
+
+  policy = SimpleNamespace(scope="read")
+  await run_claude_sdk_turn(
+    "review",
+    session_id=None,
+    base_env={},
+    cwd="/data",
+    chat_id="delegated-budget",
+    skill_text="system",
+    bc=_Bus(),
+    pending_questions={},
+    db=None,
+    run_policy=policy,
+  )
+
+  kwargs = captured["kwargs"]
+  assert "max_budget_usd" not in kwargs
+  assert kwargs["agents"] == {}
+  assert {
+    "AskUserQuestion", "Task", "Workflow", "Agent",
+  }.issubset(set(kwargs["disallowed_tools"]))
+
+
+@pytest.mark.asyncio
 async def test_rate_limit_resets_at_rides_the_terminal_result(monkeypatch):
   """A RateLimitEvent's structured resets_at lands on the terminal dict so
   the limit park (design §2.4) can use the exact reset time; a turn with NO

--- a/backend/tests/test_connector_grant_policy.py
+++ b/backend/tests/test_connector_grant_policy.py
@@ -100,7 +100,6 @@ def test_delegated_prompt_states_connections_unavailable():
     effort=None,
     scope="read",
     cwd="/data",
-    max_budget_usd=None,
   )
   assert (
     "Owner-managed MCP connections are not available" in policy.system_prompt

--- a/backend/tests/test_delegations.py
+++ b/backend/tests/test_delegations.py
@@ -77,7 +77,6 @@ def test_read_delegation_receives_only_a_delegation_scoped_bearer(
     model=None,
     effort=None,
     cwd="/data/platform",
-    max_budget_usd=None,
   )
 
   read_token = delegation_execution_token(
@@ -138,6 +137,7 @@ def test_submit_is_idempotent_per_parent_root_and_task_key(
   first = client.post("/api/delegations", json=body, headers=auth)
   assert first.status_code == 201, first.text
   assert first.json()["attached"] is False
+  assert "max_budget_usd" not in first.json()
   assert first.json()["parent_root_run_id"] == "parent-root"
   assert first.json()["status"] == "starting"
 
@@ -289,9 +289,9 @@ def test_app_token_can_only_submit_bounded_work_under_its_own_child(
   assert escalated.status_code == 403
   assert "read-only" in escalated.json()["detail"]
 
-  # The backend is the single recursion-policy owner. Descendants may use the
-  # same guarded helper until the fourth level, where another child is refused
-  # regardless of what an installed helper or its documentation claims.
+  # Ownership may continue through as many useful local levels as the work
+  # needs. Every bearer still owns only its direct children, and a read-only
+  # owner still cannot create a write-capable descendant.
   nested_parent = nested.json()["child_chat_id"]
   for depth in (3, 4):
     nested_run_id = f"depth-{depth}-parent-run"
@@ -320,29 +320,30 @@ def test_app_token_can_only_submit_bounded_work_under_its_own_child(
     nested_parent = deeper.json()["child_chat_id"]
 
   db.add(models.ChatRun(
-    id="depth-limit-parent-run",
-    root_run_id="depth-limit-parent-run",
+    id="depth-5-parent-run",
+    root_run_id="depth-5-parent-run",
     chat_id=nested_parent,
     status="running",
     provider="claude",
   ))
   db.commit()
-  depth_limit_policy = policy_for_chat(db, nested_parent)
-  assert depth_limit_policy is not None and depth_limit_policy.depth == 4
-  depth_limit_auth = {
+  fifth_parent_policy = policy_for_chat(db, nested_parent)
+  assert fifth_parent_policy is not None and fifth_parent_policy.depth == 4
+  fifth_parent_auth = {
     "Authorization": (
       "Bearer "
-      f"{delegation_execution_token(db, depth_limit_policy, 'depth-limit-parent-run')}"
+      f"{delegation_execution_token(db, fifth_parent_policy, 'depth-5-parent-run')}"
     )
   }
-  rejected_depth = client.post("/api/delegations", json={
+  fifth = client.post("/api/delegations", json={
     **body,
     "parent_chat_id": nested_parent,
     "task_key": "depth-5",
-    "prompt": "Exceed the recursion limit.",
-  }, headers=depth_limit_auth)
-  assert rejected_depth.status_code == 409
-  assert "maximum (4)" in rejected_depth.json()["detail"]
+    "prompt": "Continue one more bounded level.",
+  }, headers=fifth_parent_auth)
+  assert fifth.status_code == 201, fifth.text
+  fifth_policy = policy_for_chat(db, fifth.json()["child_chat_id"])
+  assert fifth_policy is not None and fifth_policy.depth == 5
 
 
 def test_delegation_listing_exposes_run_usage_without_loading_result(
@@ -426,7 +427,6 @@ def test_child_policy_is_integrity_checked_and_write_loss_needs_review(db):
     prompt_sha256=hashlib.sha256(
       b"Make the bounded edit."
     ).hexdigest(),
-    max_budget_usd=5.0,
   )
   db.add(row)
   db.commit()
@@ -434,14 +434,12 @@ def test_child_policy_is_integrity_checked_and_write_loss_needs_review(db):
   policy = policy_for_chat(db, child.id)
   assert policy is not None
   assert policy.allow_session_reseed is False
-  assert policy.max_budget_usd == 5.0
   assert "$MOBIUS_SUBAGENT_HELPER" in policy.system_prompt
   assert "Do not use any other agent CLI" in policy.system_prompt
 
   codex_policy = RunPolicy(
     delegation_id="codex-child", app_id=app.id, provider="codex",
     model=None, effort=None, scope="read", cwd="/data/platform",
-    max_budget_usd=None,
   )
   assert (
     "Nested delegated work is not available" in codex_policy.system_prompt
@@ -643,7 +641,6 @@ def _seed_delegation(
     scope="read",
     cwd="/data/platform",
     prompt_sha256=hashlib.sha256(b"Do the bounded task.").hexdigest(),
-    max_budget_usd=5.0,
     notify_parent_on_complete=notify,
     parent_woken_at=None,
     cancelled_at=now_naive_utc() if cancelled else None,


### PR DESCRIPTION
## Summary
- let ordinary Subagents continue guarded nested work without a fixed platform depth cap
- remove the hidden Claude spending ceiling from ordinary delegated runs
- preserve exact-run ownership, direct-child identity, read-to-write controls, and provider safety guards
- project the complete delegation tree in the visible Goal plan

## Prior work
- replaces #965 after removing its accidental dependency on the owner-local Gauntlet implementation in #964
- this replacement is based directly on `main` and contains no Gauntlet source, routes, models, or tests

## Tests
- 134 focused delegation, Claude-runner, connector-policy, and Goal-plan tests passed
- 86 hermetic migration, readiness, auth, compilation, source-status, and test-boundary checks passed
- Python compilation, canonical diff, whitespace, co-author, and local-app leakage checks passed
- hosted CI remains dependency-authoritative because the checkout dependency lock differs from the available image runtime