### PR TITLE
Add light window.mobius.projects primitive (named project workspaces)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -79,6 +79,7 @@ from app.routes import (
   theme_router, uploads_router, platform_router,
   published_router,
   connect_router,
+  projects_router,
 )
 
 _BOOT_ID = os.environ.get("MOBIUS_BOOT_ID") or f"{os.getpid()}-{time.time_ns()}"
@@ -724,6 +725,7 @@ app.include_router(chat_router)
 app.include_router(chat_embed_router)
 app.include_router(chats_router)
 app.include_router(chats_stream_router)
+app.include_router(projects_router)
 app.include_router(secure_inputs_router)
 app.include_router(delegations_router)
 app.include_router(chat_waits_router)

--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -91,6 +91,7 @@ client_signal_router = _load("client_signal")
 platform_router = _load("platform")
 published_router = _load("published")
 connect_router = _load("connect")
+projects_router = _load("projects")
 
 __all__ = [
   "admin_router",
@@ -131,4 +132,5 @@ __all__ = [
   "platform_router",
   "published_router",
   "connect_router",
+  "projects_router",
 ]

--- a/backend/app/routes/projects.py
+++ b/backend/app/routes/projects.py
@@ -1,0 +1,165 @@
+"""Projects — a light, general "named project workspaces" registry.
+
+This is a SHARED platform primitive, not a website builder. It owns only the
+*list* of an app's projects ({id, name, created_at, updated_at}); an app keeps
+its project files in its own storage (conventionally under a `projects/<id>/`
+prefix) and does its own building/publishing/previewing. Any app can use
+`window.mobius.projects` to offer named workspaces without hand-rolling a
+registry.
+
+Deliberately NOT here: files, build, publish, templates, preview. Those are
+app concerns (or existing platform features like storage / run-job / publish).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import secrets
+from datetime import datetime, timezone
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from app import models
+from app.config import get_settings
+from app.database import get_db
+from app.deps import Principal, get_principal, reject_cross_site
+from app.source_dirs import apps_root
+
+router = APIRouter(prefix="/api/projects", tags=["projects"])
+
+_ID_RE = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
+
+
+class ProjectCreate(BaseModel):
+  name: str = Field(default="Untitled", max_length=200)
+  id: str | None = Field(default=None, max_length=64)
+
+
+class ProjectRename(BaseModel):
+  name: str = Field(min_length=1, max_length=200)
+
+
+def _require_app(
+  db: Session, principal: Principal, app_id_hint: int | None = None,
+) -> models.App:
+  """Resolve the owning app. The app runtime token names its own app; the owner
+  token is trusted and may name it via `app_id_hint`."""
+  if principal.app_id is not None:
+    app_id = principal.app_id
+  elif app_id_hint is not None:
+    app_id = app_id_hint
+  else:
+    raise HTTPException(
+      status_code=403,
+      detail="Projects require an app runtime token (or owner + app_id).",
+    )
+  app = (
+    db.query(models.App)
+    .filter(models.App.id == app_id, models.App.deleted_at.is_(None))
+    .first()
+  )
+  if app is None:
+    raise HTTPException(status_code=404, detail="App not found.")
+  return app
+
+
+def _registry_path(app: models.App) -> Path:
+  return apps_root(get_settings().data_dir) / str(app.id) / "projects.json"
+
+
+def _read(app: models.App) -> list[dict]:
+  try:
+    data = json.loads(_registry_path(app).read_text(encoding="utf-8"))
+  except (OSError, ValueError):
+    return []
+  return [p for p in data if isinstance(p, dict) and p.get("id")] if isinstance(data, list) else []
+
+
+def _write(app: models.App, rows: list[dict]) -> None:
+  path = _registry_path(app)
+  path.parent.mkdir(parents=True, exist_ok=True)
+  tmp = path.with_suffix(".json.tmp")
+  tmp.write_text(json.dumps(rows, ensure_ascii=False, indent=2), encoding="utf-8")
+  tmp.replace(path)
+
+
+def _now() -> str:
+  return datetime.now(timezone.utc).isoformat()
+
+
+@router.get("")
+def list_projects(
+  app_id: int | None = None,
+  db: Session = Depends(get_db),
+  principal: Principal = Depends(get_principal),
+):
+  app = _require_app(db, principal, app_id_hint=app_id)
+  rows = _read(app)
+  rows.sort(key=lambda r: r.get("updated_at") or "", reverse=True)
+  return rows
+
+
+@router.post("", status_code=201, dependencies=[Depends(reject_cross_site)])
+def create_project(
+  body: ProjectCreate,
+  app_id: int | None = None,
+  db: Session = Depends(get_db),
+  principal: Principal = Depends(get_principal),
+):
+  app = _require_app(db, principal, app_id_hint=app_id)
+  rows = _read(app)
+
+  pid = (body.id or "").strip() or secrets.token_hex(6)
+  if not _ID_RE.match(pid):
+    raise HTTPException(status_code=422, detail="Invalid project id.")
+  existing = next((r for r in rows if r.get("id") == pid), None)
+  if existing is not None:
+    # Idempotent for a caller-supplied id (e.g. the app's fixed "default").
+    return existing
+
+  name = (body.name or "").strip() or "Untitled"
+  row = {"id": pid, "name": name, "created_at": _now(), "updated_at": _now()}
+  rows.append(row)
+  _write(app, rows)
+  return row
+
+
+@router.patch("/{project_id}", dependencies=[Depends(reject_cross_site)])
+def rename_project(
+  project_id: str,
+  body: ProjectRename,
+  app_id: int | None = None,
+  db: Session = Depends(get_db),
+  principal: Principal = Depends(get_principal),
+):
+  app = _require_app(db, principal, app_id_hint=app_id)
+  rows = _read(app)
+  row = next((r for r in rows if r.get("id") == project_id), None)
+  if row is None:
+    raise HTTPException(status_code=404, detail="Project not found.")
+  row["name"] = body.name.strip() or row.get("name") or "Untitled"
+  row["updated_at"] = _now()
+  _write(app, rows)
+  return row
+
+
+@router.delete("/{project_id}", dependencies=[Depends(reject_cross_site)])
+def remove_project(
+  project_id: str,
+  app_id: int | None = None,
+  db: Session = Depends(get_db),
+  principal: Principal = Depends(get_principal),
+):
+  """Remove the registry entry only. The app owns (and clears) the project's
+  files through storage — the primitive never touches app file trees."""
+  app = _require_app(db, principal, app_id_hint=app_id)
+  rows = _read(app)
+  kept = [r for r in rows if r.get("id") != project_id]
+  if len(kept) == len(rows):
+    raise HTTPException(status_code=404, detail="Project not found.")
+  _write(app, kept)
+  return {"removed": True, "id": project_id}

--- a/backend/tests/test_projects_routes.py
+++ b/backend/tests/test_projects_routes.py
@@ -1,0 +1,67 @@
+"""The light platform projects registry (named project workspaces).
+
+Registry only: list/create/rename/remove of {id, name, ...}, scoped to the
+calling app. No files/build/publish here.
+"""
+
+from test_app_fixtures import create_local_app
+
+
+def _app(client, owner_token, name="Studio"):
+  app = create_local_app(client, {"Authorization": f"Bearer {owner_token}"}, name=name)
+  tok = client.post(
+    "/api/auth/app-token", json={"app_id": app["id"]},
+    headers={"Authorization": f"Bearer {owner_token}"},
+  ).json()["token"]
+  return app, {"Authorization": f"Bearer {tok}"}
+
+
+def test_crud(client, owner_token, db):
+  app, h = _app(client, owner_token)
+  assert client.get("/api/projects", headers=h).json() == []
+
+  # Auto id.
+  a = client.post("/api/projects", json={"name": "Site A"}, headers=h)
+  assert a.status_code == 201, a.text
+  aid = a.json()["id"]
+  assert a.json()["name"] == "Site A"
+
+  # Fixed id, idempotent.
+  d1 = client.post("/api/projects", json={"name": "Project 1", "id": "default"}, headers=h).json()
+  d2 = client.post("/api/projects", json={"name": "Renamed?", "id": "default"}, headers=h).json()
+  assert d1["id"] == "default" and d2["id"] == "default"
+  assert d2["name"] == "Project 1"  # idempotent — not overwritten
+
+  ids = {p["id"] for p in client.get("/api/projects", headers=h).json()}
+  assert ids == {aid, "default"}
+
+  # Rename.
+  r = client.patch(f"/api/projects/{aid}", json={"name": "Site A2"}, headers=h)
+  assert r.status_code == 200 and r.json()["name"] == "Site A2"
+
+  # Remove.
+  assert client.delete(f"/api/projects/{aid}", headers=h).json()["removed"] is True
+  assert {p["id"] for p in client.get("/api/projects", headers=h).json()} == {"default"}
+  assert client.delete(f"/api/projects/{aid}", headers=h).status_code == 404
+
+
+def test_scoped_per_app(client, owner_token, db):
+  app1, h1 = _app(client, owner_token, name="One")
+  app2, h2 = _app(client, owner_token, name="Two")
+  client.post("/api/projects", json={"name": "p1"}, headers=h1)
+  # app2 sees only its own (empty) list.
+  assert client.get("/api/projects", headers=h2).json() == []
+
+
+def test_owner_needs_app_id(client, owner_token, db):
+  owner_h = {"Authorization": f"Bearer {owner_token}"}
+  # Bare owner token has no app scope.
+  assert client.get("/api/projects", headers=owner_h).status_code == 403
+  app, _ = _app(client, owner_token)
+  # Owner may name the app explicitly.
+  assert client.get(f"/api/projects?app_id={app['id']}", headers=owner_h).status_code == 200
+
+
+def test_invalid_id_rejected(client, owner_token, db):
+  _, h = _app(client, owner_token)
+  assert client.post("/api/projects", json={"name": "x", "id": "../../etc"}, headers=h).status_code == 422

--- a/frontend/public/mobius-runtime.js
+++ b/frontend/public/mobius-runtime.js
@@ -3907,6 +3907,45 @@ function makeClipboard() {
 }
 
 //#endregion
+//#region src/runtime/projects.js
+async function jsonOrThrow(res, action) {
+	if (!res.ok) {
+		let detail = "";
+		try {
+			detail = (await res.json())?.detail || "";
+		} catch (e) {}
+		throw new Error(detail || `mobius.projects: ${action} failed (${res.status})`);
+	}
+	if (res.status === 204) return null;
+	return res.json();
+}
+function makeProjects({ getToken }) {
+	const call = (path, init) => fetchWithAppToken(getToken, `/api/projects${path}`, init);
+	const jsonBody = (method, body) => ({
+		method,
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify(body)
+	});
+	return {
+		async list() {
+			return jsonOrThrow(await call(""), "list");
+		},
+		async create(name, id) {
+			return jsonOrThrow(await call("", jsonBody("POST", {
+				name,
+				id
+			})), "create");
+		},
+		async rename(id, name) {
+			return jsonOrThrow(await call(`/${encodeURIComponent(id)}`, jsonBody("PATCH", { name })), "rename");
+		},
+		async remove(id) {
+			return jsonOrThrow(await call(`/${encodeURIComponent(id)}`, { method: "DELETE" }), "remove");
+		}
+	};
+}
+
+//#endregion
 //#region src/runtime/index.js
 let _online = typeof navigator !== "undefined" ? navigator.onLine : true;
 const _onlineListeners = /* @__PURE__ */ new Set();
@@ -3987,7 +4026,8 @@ function init({ appId, appInstanceId = null, getToken, capabilityContract = null
 		nav: makeNav(),
 		split: makeSplit(),
 		immersive: makeImmersive({ appId }),
-		clipboard: makeClipboard()
+		clipboard: makeClipboard(),
+		projects: makeProjects({ getToken: scopedToken })
 	};
 	window.mobius = api;
 	_runtimeContext = {
@@ -4008,4 +4048,4 @@ function init({ appId, appInstanceId = null, getToken, capabilityContract = null
 }
 
 //#endregion
-export { CapabilityError, DurableWriteError, appChatMetadataBody, createUseDocument, init, makeCapabilities, makeChat, makeEmbedAuthorizationHandoff, makeEmbedFrameReveal, makeImmersive, makeNav, makeSignal, makeSplit, makeStorage, overlayPending, purgeAppRuntimeData, runtimeFeatures, sanitizeEmbedGuidance };
+export { CapabilityError, DurableWriteError, appChatMetadataBody, createUseDocument, init, makeCapabilities, makeChat, makeEmbedAuthorizationHandoff, makeEmbedFrameReveal, makeImmersive, makeNav, makeProjects, makeSignal, makeSplit, makeStorage, overlayPending, purgeAppRuntimeData, runtimeFeatures, sanitizeEmbedGuidance };

--- a/frontend/src/runtime/index.js
+++ b/frontend/src/runtime/index.js
@@ -55,6 +55,9 @@
 //   window.mobius.capabilities.open(name, input)  -> capability session
 //     session.ready, session.result, session.on(event, cb), finish(), cancel()
 //   window.mobius.capabilities.invoke(name, input, {signal?}) -> one-shot result
+//   window.mobius.projects.list() / .create(name, id?) / .rename(id, name)
+//     / .remove(id) -> a light "named project workspaces" registry for this app
+//     (list only; the app keeps each project's files in its own storage).
 //
 // "No walls": this runtime is the easy DEFAULT, not a cage. In the default
 // shell mount the app has an opaque origin, so IndexedDB/OPFS/SQLite-wasm are
@@ -82,6 +85,7 @@ import { makeNav, makeSplit } from './navigation.js'
 import { makeCapabilities } from './capabilities.js'
 import { makeImmersive } from './immersive.js'
 import { makeClipboard } from './clipboard.js'
+import { makeProjects } from './projects.js'
 import { tokenMatchesRuntime } from './token.js'
 
 export * from './storage.js'
@@ -90,6 +94,7 @@ export * from './chat.js'
 export * from './navigation.js'
 export * from './capabilities.js'
 export * from './immersive.js'
+export * from './projects.js'
 
 
 // ── P1-A: probed-online reactive backing ─────────────────────────────────────
@@ -212,6 +217,7 @@ export function init({ appId, appInstanceId = null, getToken, capabilityContract
     split: makeSplit(),
     immersive: makeImmersive({ appId }),
     clipboard: makeClipboard(),
+    projects: makeProjects({ getToken: scopedToken }),
   }
   window.mobius = api
   _runtimeContext = { identityKey, tokenRef, storage, signal, capabilities, chat, api }

--- a/frontend/src/runtime/projects.js
+++ b/frontend/src/runtime/projects.js
@@ -1,0 +1,55 @@
+// window.mobius.projects — a light "named project workspaces" registry.
+//
+// A general primitive: an app that wants named projects (a switcher, per-project
+// files/chat) can list/create/rename/remove them here instead of hand-rolling a
+// registry. It owns ONLY the list ({id, name, created_at, updated_at}); the
+// app keeps each project's files in its own storage (conventionally under a
+// `projects/<id>/` prefix) and does its own building/publishing. Every call
+// rides the app runtime token, so the backend scopes the list to the app.
+
+import { fetchWithAppToken } from './network.js'
+
+async function jsonOrThrow(res, action) {
+  if (!res.ok) {
+    let detail = ''
+    try { detail = (await res.json())?.detail || '' } catch (e) {}
+    throw new Error(detail || `mobius.projects: ${action} failed (${res.status})`)
+  }
+  if (res.status === 204) return null
+  return res.json()
+}
+
+export function makeProjects({ getToken }) {
+  const call = (path, init) =>
+    fetchWithAppToken(getToken, `/api/projects${path}`, init)
+  const jsonBody = (method, body) => ({
+    method,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+
+  return {
+    // List this app's projects, most-recently-updated first.
+    async list() {
+      return jsonOrThrow(await call(''), 'list')
+    },
+    // Create a project. Pass an explicit `id` to keep a fixed one (e.g. a
+    // "default"); it is idempotent for a supplied id.
+    async create(name, id) {
+      return jsonOrThrow(await call('', jsonBody('POST', { name, id })), 'create')
+    },
+    async rename(id, name) {
+      return jsonOrThrow(
+        await call(`/${encodeURIComponent(id)}`, jsonBody('PATCH', { name })),
+        'rename',
+      )
+    },
+    // Remove the registry entry only — the app clears the project's files.
+    async remove(id) {
+      return jsonOrThrow(
+        await call(`/${encodeURIComponent(id)}`, { method: 'DELETE' }),
+        'remove',
+      )
+    },
+  }
+}

--- a/frontend/src/sw-cache-policy.js
+++ b/frontend/src/sw-cache-policy.js
@@ -54,7 +54,12 @@ export const SHELL_DATA_CACHE = 'mobius-shell-data'
 // a `?v=<app.updated_at>` key that has not changed, only a cache-name bump forces
 // eviction: activation evicts v7 and the next app open refetches the current
 // WebAssembly-enabled frame.
-export const OFFLINE_APPS_CACHE = 'mobius-offline-apps-v8'
+// Bumped -v8 → -v9 (2026-08-29): the runtime gained the `window.mobius.projects`
+// primitive (a light named-project-workspaces registry). A cache-first app
+// frame/module cached before this keeps serving the OLD runtime with no
+// `projects` capability, so an app using it (Web Studio 1.1.0) can't manage
+// projects until the cache is evicted. Same reason as prior runtime bumps.
+export const OFFLINE_APPS_CACHE = 'mobius-offline-apps-v9'
 // Bumped -v2 → -v3 (2026-07-30): v2 standalone documents executed app-authored
 // modules directly at owner origin. The secure host now mounts the shared
 // opaque AppCanvas frame; activation must evict every cached v2 document so an


### PR DESCRIPTION
Adds a small, general platform primitive so an app that wants **named project workspaces** (a project switcher, per-project files/chat) can list/create/rename/remove them instead of hand-rolling its own registry.

**Scope is deliberately narrow.** The primitive owns only the *list* of projects — `{id, name, created_at, updated_at}`, scoped per app. Each project's actual files stay in the app's own storage (conventionally under a `projects/<id>/` prefix), and the app keeps doing its own building, publishing, and previewing. No files, build, publish, templates, or preview live here.

**What's included**
- `backend/app/routes/projects.py`: `/api/projects` CRUD, app-scoped via the app runtime token (the owner token may name the app with `?app_id`). Ids are validated (`[A-Za-z0-9_-]{1,64}`), create is idempotent for a caller-supplied id, and the registry is stored atomically in the app's storage dir.
- `frontend/src/runtime/projects.js` + `index.js`: `window.mobius.projects.{list, create, rename, remove}`, each riding the scoped app token.
- `frontend/src/sw-cache-policy.js`: offline-apps cache `v8 → v9` so a cache-first app frame refetches the runtime that has the new capability.
- Regenerated `frontend/public/mobius-runtime.js`.
- `backend/tests/test_projects_routes.py`: CRUD, per-app scoping, owner-needs-app_id, and invalid-id rejection.