### PR TITLE
Hide <app_state> embed-context block from the displayed transcript

### DIFF
--- a/frontend/src/components/ChatView/msgText.js
+++ b/frontend/src/components/ChatView/msgText.js
@@ -1,5 +1,11 @@
 export function stripAugmentation(text) {
   let cleaned = text.replace(/\s*<agent_experience>[\s\S]*?<\/agent_experience>\s*/g, '\n\n')
+  // An embedded app (window.mobius.chat getContext) appends a compact
+  // <app_state> block to the SENT message so the agent has live app context.
+  // It's machinery, not the user's words — hide it from the displayed
+  // transcript exactly like <agent_experience>. The persisted content keeps it
+  // for the model; only the on-screen render is cleaned.
+  cleaned = cleaned.replace(/\s*<app_state>[\s\S]*?<\/app_state>\s*/g, '\n\n')
   // Preserve a paragraph boundary when removing the hidden attachment manifest.
   // Multiple queued messages are joined with a single newline before steering;
   // if an image-bearing message contributes a trailing "Files in this session"


### PR DESCRIPTION
Embedded-app chats append a compact `<app_state>` block to the sent message so the agent has live app context (via `window.mobius.chat` getContext). That block is machinery, not the user's words — but unlike `<agent_experience>` and the attachment manifest, it was left visible in the on-screen transcript, so reopening an embedded-app chat showed raw `<app_state>` tags.

This extends `stripAugmentation` to strip `<app_state>…</app_state>` from the displayed render exactly like the other machinery blocks. The persisted message content is unchanged and still carries the block for the model; only the on-screen render is cleaned.

Six-line change in `frontend/src/components/ChatView/msgText.js`.