### PR TITLE
Avoid holding SQLite writer locks during app compilation

### DIFF
--- a/backend/app/app_apply.py
+++ b/backend/app/app_apply.py
@@ -351,10 +351,12 @@ async def apply_source_revision(
           slug=manifest["id"],
           cross_app_access="none",
           share_with_apps="none",
+          # SQLAlchemy's Python column defaults materialize on INSERT. This
+          # value participates in the pre-INSERT capability projection, so it
+          # must already match the durable default before compilation.
+          chat_log_access="none",
           offline_capable=False,
         )
-        db.add(app)
-        db.flush()
       assert app is not None
       previous_state = (
         app.name,
@@ -370,9 +372,12 @@ async def apply_source_revision(
         app.icon_override_png,
       )
 
-      staged = _compiled_dir() / f"app-{app.id}.js.staging"
+      # Explicit apply is serialized by the lifecycle lock, so it can compile
+      # under one shared, non-servable name before a new row has a numeric id.
+      # Publication still begins only after the bytes move into the app-owned
+      # staging contract below.
+      staged = _compiled_dir() / "app-apply.js.staging"
       await compile_jsx(
-        app.id,
         source,
         out_path=staged,
         source_path=snapshot_dir / entry_relative,
@@ -405,7 +410,6 @@ async def apply_source_revision(
       if chat_id is not None:
         app.chat_id = chat_id
 
-      previous_bundle = owned_bundle_path(app.id, app.compiled_path)
       committed = await _git_operation(
         "commit",
         app_git.commit_worktree_tree,
@@ -425,6 +429,19 @@ async def apply_source_revision(
         # local source advances, require publication verification again rather
         # than silently offering a stale repository to other people.
         app.published_manifest_url = None
+      if created:
+        # A new App has no numeric id until SQLite inserts it. Compiling after
+        # that insert used to hold the database write lock for the entire
+        # build, so an unrelated chat creation could exhaust SQLite's busy
+        # timeout. Everything slow or failure-prone above this point is
+        # independent of the durable identity; begin the write transaction
+        # only when the accepted Git tree and compiled bytes are ready.
+        db.add(app)
+        db.flush()
+      app_staged = _compiled_dir() / f"app-{app.id}.js.staging"
+      staged.replace(app_staged)
+      staged = app_staged
+      previous_bundle = owned_bundle_path(app.id, app.compiled_path)
       published = publish_staged_bundle(app.id, staged)
       staged = None
 

--- a/backend/app/compiler.py
+++ b/backend/app/compiler.py
@@ -308,10 +308,10 @@ def _remove_unsupported_output(out: Path) -> None:
 
 
 # Rolldown's native compiler has a larger transient RSS than the old compiler.
-# Installs are normally serialized already, but explicit applies to different
-# apps are not. The shared build lease bounds a small instance's peak more
-# strongly than an in-process semaphore could: shell Vite and the validator
-# compile from other processes entirely.
+# Installs and explicit applies already serialize their lifecycle mutations.
+# The shared build lease also bounds recompiles plus shell Vite and validator
+# builds, including compilers running in other processes where an in-process
+# semaphore would have no effect.
 
 
 async def _run_rolldown(
@@ -352,7 +352,6 @@ async def _run_rolldown(
 
 
 async def compile_jsx(
-  app_id: int,
   jsx_source: str,
   *,
   out_path: str | Path,
@@ -361,12 +360,12 @@ async def compile_jsx(
   """Compiles JSX source to an ES module and returns the output path.
 
   Args:
-    app_id: The numeric ID of the mini-app being compiled.
     jsx_source: The JSX source code string.
-    out_path: Where Rolldown writes the bundle. Production callers pass the
-      app's staging path, then publish the output by content hash (see
-      ``recompile_app_bundle``). It is required so a new caller cannot silently
-      bypass immutable publication through the retired fixed live filename.
+    out_path: Caller-owned staging path where Rolldown writes the bundle.
+      Callers either select the app-owned staging contract directly or rename
+      into it before publishing by content hash (see ``recompile_app_bundle``).
+      It is required so a new caller cannot silently bypass immutable
+      publication through the retired fixed live filename.
     source_path: Optional real filesystem entrypoint. When present,
       Rolldown compiles that path directly, allowing relative imports from
       sibling files in the app source tree. When omitted, the legacy
@@ -534,7 +533,6 @@ async def recompile_app_bundle(db, app, jsx_source: str) -> None:
   published = None
   try:
     await compile_jsx(
-      app.id,
       jsx_source,
       out_path=staged,
       source_path=compile_source_path,

--- a/backend/app/install.py
+++ b/backend/app/install.py
@@ -2583,7 +2583,6 @@ async def _activate_install_source(
     journal.commit_actions,
   )
   await compile_jsx(
-    app.id,
     entry_source,
     out_path=staged_bundle,
     source_path=source_dir / plan.entry_key,

--- a/backend/tests/test_app_apply.py
+++ b/backend/tests/test_app_apply.py
@@ -9,6 +9,7 @@ import pytest
 
 from app import app_apply, app_git, icon_assets, models
 from app.config import get_settings
+from app.database import SessionLocal
 
 
 def _source(slug: str = "demo") -> Path:
@@ -88,6 +89,47 @@ def test_apply_creates_from_manifest_and_commits_exact_source(
     source / "index.jsx"
   ).read_bytes()
   assert app_git._run(source, "status", "--porcelain").stdout == ""
+
+
+def test_new_app_compile_does_not_hold_sqlite_write_lock(
+  client, auth, monkeypatch,
+):
+  """A slow first build must not block unrelated durable owner work."""
+  source = _source()
+  concurrent_chat_id = "chat-created-during-app-compile"
+
+  async def compile_while_chat_is_created(
+    _source, *, out_path, source_path=None,
+  ):
+    del source_path
+    concurrent = SessionLocal()
+    try:
+      # A regression should fail promptly instead of waiting out the live
+      # five-second busy timeout. WAL permits this write while the apply owns
+      # only its preflight read transaction; an early App INSERT does not.
+      concurrent.connection().exec_driver_sql("PRAGMA busy_timeout=50")
+      concurrent.add(models.Chat(
+        id=concurrent_chat_id,
+        title="Concurrent chat",
+        messages=[],
+        pending_messages=[],
+      ))
+      concurrent.commit()
+    finally:
+      concurrent.close()
+    Path(out_path).write_text("export default function App(){}\n")
+    return str(out_path)
+
+  monkeypatch.setattr(app_apply, "compile_jsx", compile_while_chat_is_created)
+
+  response = _apply(client, auth, source)
+
+  assert response.status_code == 200, response.text
+  verify = SessionLocal()
+  try:
+    assert verify.get(models.Chat, concurrent_chat_id) is not None
+  finally:
+    verify.close()
 
 
 def test_apply_updates_multifile_revision_once(client, auth, db):
@@ -483,6 +525,42 @@ def test_database_failure_after_git_commit_is_retryable(
   row = db.query(models.App).populate_existing().filter_by(id=app_id).one()
   assert row.compiled_path != previous_bundle
   assert "accepted-ahead" in row.jsx_source
+  assert app_git.head_sha(source, app_git.LOCAL_BRANCH) == accepted_head
+
+
+def test_database_failure_during_create_is_retryable_without_orphan_row(
+  client, auth, db, monkeypatch,
+):
+  source = _source()
+  original_commit = app_apply.Session.commit
+  calls = 0
+
+  def fail_once(session):
+    nonlocal calls
+    calls += 1
+    if calls == 1:
+      raise RuntimeError("simulated database failure")
+    return original_commit(session)
+
+  monkeypatch.setattr(app_apply.Session, "commit", fail_once)
+  with pytest.raises(RuntimeError, match="simulated database failure"):
+    _apply(client, auth, source)
+
+  accepted_head = app_git.head_sha(source, app_git.LOCAL_BRANCH)
+  assert db.query(models.App).filter_by(source_dir=str(source)).first() is None
+  assert not list(app_apply._compiled_dir().glob("app-*-*.js"))
+  assert not list(app_apply._compiled_dir().glob("*.js.staging"))
+
+  retry = _apply(client, auth, source)
+
+  assert retry.status_code == 200, retry.text
+  assert retry.json()["mode"] == "created"
+  row = db.query(models.App).populate_existing().filter_by(
+    source_dir=str(source),
+  ).one()
+  assert row.source_commit == accepted_head
+  assert Path(row.compiled_path).is_file()
+  assert not list(app_apply._compiled_dir().glob("*.js.staging"))
   assert app_git.head_sha(source, app_git.LOCAL_BRANCH) == accepted_head
 
 

--- a/backend/tests/test_app_compile_contract.py
+++ b/backend/tests/test_app_compile_contract.py
@@ -12,7 +12,7 @@ async def test_compile_accepts_default_reexport(tmp_path):
   output = tmp_path / "compiled" / "app.js"
   source = "const App = () => null;\nexport { App as default };"
 
-  await compile_jsx(1, source, out_path=output)
+  await compile_jsx(source, out_path=output)
 
   assert output.is_file()
 
@@ -29,7 +29,7 @@ async def test_compile_inlines_dynamic_imports(tmp_path):
   entry.write_text(source)
   dependency.write_text("export const value = 'inlined-detail'")
 
-  await compile_jsx(1, source, out_path=output, source_path=entry)
+  await compile_jsx(source, out_path=output, source_path=entry)
 
   compiled = output.read_text()
   assert "inlined-detail" in compiled
@@ -47,7 +47,7 @@ async def test_compile_rejects_unresolved_import_matching_output_name(tmp_path):
   entry.write_text(source)
 
   with pytest.raises(CompileError, match="Compilation failed") as exc:
-    await compile_jsx(1, source, out_path=output, source_path=entry)
+    await compile_jsx(source, out_path=output, source_path=entry)
 
   assert "Could not resolve 'index.js'" in exc.value.stderr
   assert not output.exists()
@@ -61,7 +61,7 @@ async def test_compile_preserves_explicit_online_dynamic_import(tmp_path):
     "export default function App(){ return null }"
   )
 
-  await compile_jsx(1, source, out_path=output)
+  await compile_jsx(source, out_path=output)
 
   assert "https://esm.sh/example-package" in output.read_text()
 
@@ -81,7 +81,7 @@ async def test_compile_is_deterministic_across_snapshot_directories(tmp_path):
     (root / "detail.js").write_text("export const value = 'stable'")
     output = tmp_path / f"{name}.js"
 
-    await compile_jsx(1, source, out_path=output, source_path=entry)
+    await compile_jsx(source, out_path=output, source_path=entry)
     outputs.append(output.read_bytes())
 
   assert outputs[0] == outputs[1]
@@ -93,7 +93,7 @@ async def test_compile_rejects_comment_that_only_mentions_default_export(tmp_pat
   source = "// export default function Fake() {}\nexport const value = 1;"
 
   with pytest.raises(CompileError, match="Compilation failed") as exc:
-    await compile_jsx(1, source, out_path=output)
+    await compile_jsx(source, out_path=output)
 
   assert "no default export" in exc.value.stderr
   assert not output.exists()
@@ -109,7 +109,7 @@ async def test_compile_rejects_css_and_removes_side_output(tmp_path):
   css.write_text("body { color: red; }")
 
   with pytest.raises(CompileError, match="Compilation failed") as exc:
-    await compile_jsx(1, source, out_path=output, source_path=entry)
+    await compile_jsx(source, out_path=output, source_path=entry)
 
   assert "CSS imports are not supported" in exc.value.stderr
   assert not output.exists()

--- a/backend/tests/test_db_migrations.py
+++ b/backend/tests/test_db_migrations.py
@@ -265,7 +265,7 @@ def test_app_identity_migration_materializes_legacy_source_without_overwriting_d
 
   from app import compiler
 
-  async def fake_compile(_app_id, source, *, out_path, source_path):
+  async def fake_compile(source, *, out_path, source_path):
     assert source == stored
     assert Path(source_path) == source_dir / "index.jsx"
     Path(out_path).parent.mkdir(parents=True, exist_ok=True)

--- a/backend/tests/test_frame_etag.py
+++ b/backend/tests/test_frame_etag.py
@@ -30,7 +30,7 @@ def test_recompile_bumps_updated_at_so_etag_changes(monkeypatch, tmp_path):
   jsx_source = "export default function A(){}"
   source_path.write_text(jsx_source, encoding="utf-8")
 
-  async def fake_compile(app_id, jsx, *, out_path=None, source_path=None):
+  async def fake_compile(jsx, *, out_path=None, source_path=None):
     Path(out_path).write_text("// compiled")
 
   monkeypatch.setattr(compiler, "compile_jsx", fake_compile)


### PR DESCRIPTION
## Summary

- compile a new app before allocating its database identity
- keep bundle publication deterministic and bound to the final app id
- cover concurrent chat creation and first-create retry cleanup

## Why

A first `POST /api/apps/apply` inserted the App row before awaiting compilation. That held SQLite's only writer slot across the build, so unrelated chat creation could exhaust the five-second busy timeout and fail.

The compiler no longer accepts an unused app id. Explicit applies build under one lifecycle-serialized, non-servable staging name, then allocate the row, rename into the app-owned staging contract, and publish in the short final transaction.

This surfaced in the merge-queue e2e run for #996, where app apply held its database checkout for 5.46 seconds while two concurrent chat writes failed with `database is locked`.

## Validation

- exact-lock Ruff and mypy checks
- 94 focused app-apply, compiler, migration, and bundle tests
- full exact-lock backend suite: 4,290 passed, 18 skipped; 84.20% coverage