### PR TITLE
Keep provider credential checks off the event loop and gate the Möbius trial balance to the owner

### DIFF
--- a/backend/app/chat.py
+++ b/backend/app/chat.py
@@ -20,6 +20,7 @@ from pathlib import Path
 
 from sqlalchemy import func
 from sqlalchemy.orm import Session
+from starlette.concurrency import run_in_threadpool
 
 from app import (
   activity,
@@ -4547,7 +4548,11 @@ async def _run_chat_impl_with_db(
   # the SDK runner. Without this, the SDK fails with a cryptic error.
   auth_error = provider_requirement_errors.get(provider_id)
   if auth_error is None:
-    auth_error = provider.check_auth(settings.data_dir)
+    # check_auth may perform blocking I/O (e.g. MobiusProvider probes the
+    # local broker over a Unix socket). Run it off the event loop so a slow
+    # or hung broker cannot stall this single-worker ASGI loop and the other
+    # turns and SSE streams sharing it.
+    auth_error = await run_in_threadpool(provider.check_auth, settings.data_dir)
   if auth_error:
     # A fresh install may intentionally finish setup without connecting an
     # agent; a returning owner's sole credential can also expire. When no
@@ -4559,11 +4564,16 @@ async def _run_chat_impl_with_db(
     # disconnected. If another provider is connected, this chat's selected
     # provider genuinely failed and the existing error path below remains the
     # honest response.
-    runnable_provider = any(
-      provider_requirement_errors.get(candidate_id) is None
-      and candidate.check_auth(settings.data_dir) is None
-      for candidate_id, candidate in PROVIDERS.items()
-    )
+    def _has_runnable_provider() -> bool:
+      return any(
+        provider_requirement_errors.get(candidate_id) is None
+        and candidate.check_auth(settings.data_dir) is None
+        for candidate_id, candidate in PROVIDERS.items()
+      )
+
+    # The scan calls check_auth for each provider, so offload the whole loop
+    # off the event loop for the same broker-stall reason as the probe above.
+    runnable_provider = await run_in_threadpool(_has_runnable_provider)
     if not runnable_provider:
       await _record_run_metrics(
         chat_id=chat_id,

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -25,8 +25,11 @@ from app import auth, models, schemas
 from app.config import get_settings
 from app.database import get_db
 from app.deps import (
+  Principal,
+  get_chat_view_principal,
   get_current_owner, get_current_owner_or_app,
   get_owner_app_or_chat_embed_for_models, reject_cross_site,
+  require_chat_embed_operation,
 )
 from app.timeutil import now_naive_utc
 
@@ -864,7 +867,7 @@ async def provider_status(
 
 @router.get("/providers/status")
 async def providers_status(
-  _: models.Owner = Depends(get_owner_app_or_chat_embed_for_models),
+  principal: Principal = Depends(get_chat_view_principal),
   db: Session = Depends(get_db),
 ):
   """Returns local credential status for ALL registered providers.
@@ -874,7 +877,14 @@ async def providers_status(
   map, using app tokens, so their model pickers can disable disconnected
   providers instead of guessing. `configured` is the durable semantic field;
   `authenticated` is retained for compatibility with installed mini-apps.
+
+  Availability is safe to share across the app/embed boundary; the owner's
+  Möbius trial balance is not. `trial` is therefore attached only for a true
+  owner caller, so an app or chat-embed principal sees the same availability
+  fields without the owner's credit units and grant expiries.
   """
+  require_chat_embed_operation(principal, "models:read")
+  is_owner_caller = principal.app_id is None and principal.scope == "owner"
   from starlette.concurrency import run_in_threadpool
   from app.providers import PROVIDERS, provider_requirement_error
   data_dir = get_settings().data_dir
@@ -893,7 +903,7 @@ async def providers_status(
     }
     if provider.required_app_slug:
       out[pid]["available"] = requirement_error is None
-    if pid == "mobius" and requirement_error is None:
+    if pid == "mobius" and requirement_error is None and is_owner_caller:
       if error is None:
         try:
           out[pid]["trial"] = await run_in_threadpool(provider.trial_status)

--- a/backend/app/routes/chats.py
+++ b/backend/app/routes/chats.py
@@ -9,6 +9,7 @@ from typing import Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import PlainTextResponse, Response
+from starlette.concurrency import run_in_threadpool
 from pydantic import BaseModel, Field, field_validator
 from sqlalchemy import Text, case, cast, func
 from sqlalchemy.exc import IntegrityError
@@ -1200,8 +1201,8 @@ async def patch_chat(
       from app.providers import get_provider, provider_requirement_error
       candidate = get_provider(target_provider)
       requirement_error = provider_requirement_error(candidate, db)
-      auth_error = requirement_error or candidate.check_auth(
-        get_app_settings().data_dir
+      auth_error = requirement_error or await run_in_threadpool(
+        candidate.check_auth, get_app_settings().data_dir
       )
       if auth_error is not None:
         raise HTTPException(
@@ -2203,7 +2204,7 @@ async def _compact_chat_locked(
   candidate = providers.get_provider(body.provider)
   auth_error = providers.provider_requirement_error(candidate, db)
   if auth_error is None:
-    auth_error = candidate.check_auth(data_dir)
+    auth_error = await run_in_threadpool(candidate.check_auth, data_dir)
   if auth_error is not None:
     raise HTTPException(status_code=409, detail=auth_error)
 

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -404,6 +404,52 @@ def test_mobius_provider_is_available_only_with_identity_app_installed(
   assert installed["mobius"]["available"] is True
 
 
+def test_providers_status_hides_mobius_trial_from_app_principals(
+  client, auth, monkeypatch,
+):
+  """The owner's Möbius trial balance is owner-only. App/embed principals share
+  the endpoint for model-picker availability, so they must see the same
+  provider fields without the owner's credit units and grant expiries."""
+  from app import models
+  from app.database import SessionLocal
+  from app.providers import MobiusProvider
+
+  # Install the identity app so mobius reports as available.
+  app = create_local_app(
+    client, auth, name="Möbius · You", description="Account",
+  )
+  with SessionLocal() as session:
+    row = session.query(models.App).filter(models.App.id == app["id"]).one()
+    row.slug = "identity"
+    session.commit()
+
+  # Fake a linked subscription carrying a real trial balance.
+  balance = {
+    "spendable_units": 500,
+    "grants": [{"amount": 500, "expires_at": "2026-12-31"}],
+  }
+  monkeypatch.setattr(MobiusProvider, "check_auth", lambda self, data_dir: None)
+  monkeypatch.setattr(MobiusProvider, "trial_status", lambda self: balance)
+
+  # The owner sees the trial balance.
+  owner_body = client.get("/api/auth/providers/status", headers=auth).json()
+  assert owner_body["mobius"]["available"] is True
+  assert owner_body["mobius"]["trial"] == balance
+
+  # An app-scoped principal gets availability but never the balance.
+  from app.auth import create_access_token
+  app_token = create_access_token(
+    {"sub": "test", "scope": "app", "app_id": app["id"]},
+  )
+  app_body = client.get(
+    "/api/auth/providers/status",
+    headers={"Authorization": f"Bearer {app_token}"},
+  ).json()
+  assert app_body["mobius"]["available"] is True
+  assert app_body["mobius"]["configured"] is True
+  assert "trial" not in app_body["mobius"]
+
+
 def test_provider_status_exposes_configured_with_legacy_alias(client, auth):
   r = client.get("/api/auth/provider/status", headers=auth)
 


### PR DESCRIPTION
## Summary
- Run the Möbius provider's `check_auth` broker probe off the event loop at the remaining synchronous call sites — the chat-turn preflight, the runnable-provider fallback scan, and the two provider-switch paths in `routes/chats.py` — matching what `providers_status` already does.
- Restrict the Möbius trial balance in `GET /auth/providers/status` to a true owner caller, so app and chat-embed principals still get provider availability without the owner's credit units and grant expiries.

## Why
`MobiusProvider.check_auth` and `trial_status` make a synchronous Unix-socket round-trip to the local broker. On the single-worker deployment, calling them directly inside an async handler lets a slow or hung broker stall the event loop for other turns and SSE streams. `providers_status` already offloads these calls with `run_in_threadpool`; this brings the chat-turn preflight, the fallback scan, and the provider-switch / compaction paths in line.

Separately, `providers_status` is reachable by app and chat-embed principals so mini-app model pickers can show provider availability. It also attached the owner's raw Möbius trial balance — spendable/used units and grant expiries — to every caller. That balance is owner billing data and is not needed for availability, so it is now attached only when the caller is the actual owner; apps and embeds receive the same availability fields without it.

## Testing
- Added `test_providers_status_hides_mobius_trial_from_app_principals`, asserting the owner sees the balance and an app-scoped principal does not.
- `tests/test_auth.py`, `tests/test_chats.py`, `tests/test_chat_compact.py` — 100 passed.

## Context
Both issues were surfaced by review feedback on #901, in code that merged separately; this PR addresses them directly against `main`.