### PR TITLE
Keep drawer names stable and copyable

### DIFF
--- a/frontend/src/components/Drawer/Drawer.jsx
+++ b/frontend/src/components/Drawer/Drawer.jsx
@@ -59,6 +59,7 @@ import {
   DESKTOP_SIDEBAR_MIN_WIDTH,
 } from '../Shell/useDesktopSidebar.js'
 import { captureLayoutSpace, clientLengthToLayout } from '../../lib/layoutSpace.js'
+import { writeClipboardText } from '../../runtime/clipboard.js'
 import './Drawer.css'
 
 // Module-level constant so default Set props are stable across renders.
@@ -91,6 +92,7 @@ export default function Drawer({
   onDeleteChat,
   onDeleteApp,
   onDeleteAppData,
+  onNotice,
   onSettings,
   appsActive = false,
   onAppsOpen,
@@ -434,6 +436,15 @@ export default function Drawer({
       if (!next || next === previous) return
       if (kind === 'chat') current.renameChat(id, next)
       else current.renameApp(id, next)
+    },
+    copyName(name) {
+      const current = rowActionInputsRef.current
+      const value = typeof name === 'string' ? name : ''
+      void writeClipboardText(value).then(copied => {
+        if (!copied) {
+          current.onNotice?.("Couldn't copy the name.", { variant: 'error' })
+        }
+      })
     },
     pin(kind, id, next) {
       const current = rowActionInputsRef.current
@@ -993,6 +1004,7 @@ export default function Drawer({
     onDeleteChat,
     onDeleteApp,
     onDeleteAppData,
+    onNotice,
     showItemMenu,
     closeItemMenu,
     menuRestoreFocusRef,
@@ -2007,6 +2019,7 @@ const DrawerItemMenu = memo(function DrawerItemMenu({
       restoreFocusRef={restoreFocusRef}
       onClose={actions.closeMenu}
       onPin={() => actions.pin(kind, id, !pinned)}
+      onCopy={() => actions.copyName(label)}
       onRename={() => actions.startRename(kind, id, surface)}
       onInstall={() => actions.install(item)}
       onShare={() => actions.share(item)}

--- a/frontend/src/components/Drawer/DrawerItemActionMenu.jsx
+++ b/frontend/src/components/Drawer/DrawerItemActionMenu.jsx
@@ -29,6 +29,7 @@ export default function DrawerItemActionMenu({
   restoreFocusRef,
   onClose,
   onPin,
+  onCopy,
   onRename,
   onInstall,
   onShare,
@@ -283,6 +284,14 @@ export default function DrawerItemActionMenu({
                   ? <Pin width={15} height={15} aria-hidden="true" />
                   : <PinFilled width={15} height={15} aria-hidden="true" />}
                 <span>{pinned ? 'Unpin' : 'Pin'}</span>
+              </button>
+              <button
+                type="button"
+                role="menuitem"
+                className="drawer__item-action-item"
+                onClick={() => run(onCopy, { restoreFocus: false })}
+              >
+                Copy name
               </button>
               <button
                 type="button"

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -91,6 +91,7 @@ import {
 } from './confirmedDeletion.js'
 import {
   ownerInputChangeFromEvent,
+  reconcileChatRenameGuards,
   withChatOwnerActivity,
   withChatOwnerInput,
   withChatRename,
@@ -536,10 +537,17 @@ export default function Shell({ onInitialVisualReady }) {
   // the query function boundary so the protected row never disappears from
   // cache/render between fetch settlement and an after-the-fact patch.
   const recentlyCreatedChatsRef = useRef(new Map())
+  // A committed rename event can overtake a list request that began before the
+  // commit. Keep that exact row revision until a list read confirms it, just as
+  // newly-created rows stay protected from an older in-flight snapshot.
+  const chatRenameGuardsRef = useRef(new Map())
   const reconcileCreatedChats = useCallback(
     rows => withoutConfirmedDeletions(
-      mergeChatListWithCreatedGuards(
-        rows, recentlyCreatedChatsRef.current,
+      reconcileChatRenameGuards(
+        mergeChatListWithCreatedGuards(
+          rows, recentlyCreatedChatsRef.current,
+        ),
+        chatRenameGuardsRef.current,
       ),
       deletedChatIdsRef.current,
     ),
@@ -2019,6 +2027,10 @@ export default function Shell({ onInitialVisualReady }) {
     projectChatList(rows => withChatOwnerInput(rows, chatId, change))
   }, [projectChatList])
   const applyChatRenameEvent = useCallback((event) => {
+    chatRenameGuardsRef.current.set(String(event.chatId), {
+      title: event.title,
+      updatedAt: event.updatedAt,
+    })
     projectChatList(rows => withChatRename(rows, event.chatId, {
       title: event.title,
       updatedAt: event.updatedAt,
@@ -2027,6 +2039,7 @@ export default function Shell({ onInitialVisualReady }) {
 
   const confirmChatDeleted = useCallback((id) => {
     const sid = String(id)
+    chatRenameGuardsRef.current.delete(sid)
     rememberConfirmedDeletion(deletedChatIdsRef.current, sid)
     recentlyCreatedChatsRef.current.delete(sid)
     queryClient.setQueryData(chatQueries.keys.all, current => {
@@ -3971,6 +3984,7 @@ export default function Shell({ onInitialVisualReady }) {
         onDeleteChat={deleteChat}
         onDeleteApp={deleteApp}
         onDeleteAppData={deleteAppData}
+        onNotice={showToast}
         onSettings={() => {
           setSettingsFocusTarget(null)
           navTo('settings')

--- a/frontend/src/components/Shell/__tests__/chatListProjection.test.js
+++ b/frontend/src/components/Shell/__tests__/chatListProjection.test.js
@@ -2,6 +2,7 @@ import test from 'node:test'
 import assert from 'node:assert/strict'
 import {
   ownerInputChangeFromEvent,
+  reconcileChatRenameGuards,
   withChatListRowPatch,
   withChatOwnerActivity,
   withChatOwnerInput,
@@ -44,6 +45,44 @@ test('run and rename events project only the committed fields they carry', () =>
   })
   assert.equal(renamed[0].title, 'Current topic')
   assert.equal(renamed[0].updated_at, '2026-08-01T12:30:00Z')
+})
+
+test('a committed rename survives an older in-flight drawer snapshot', () => {
+  const guards = new Map([['a', {
+    title: 'Current topic',
+    updatedAt: '2026-08-01T12:30:00Z',
+  }]])
+  const stale = reconcileChatRenameGuards([{
+    id: 'a',
+    title: 'First message preview',
+    updated_at: '2026-08-01T12:00:00Z',
+  }], guards)
+
+  assert.equal(stale[0].title, 'Current topic')
+  assert.equal(stale[0].updated_at, '2026-08-01T12:30:00Z')
+  assert.equal(guards.has('a'), true, 'an older list read must not retire the guard')
+
+  const confirmedRow = {
+    id: 'a',
+    title: 'Current topic',
+    updated_at: '2026-08-01T12:30:00Z',
+  }
+  const confirmed = reconcileChatRenameGuards([confirmedRow], guards)
+  assert.equal(confirmed[0], confirmedRow)
+  assert.equal(guards.has('a'), false, 'matching server truth retires the guard')
+
+  const supersededGuards = new Map([['a', {
+    title: 'Current topic',
+    updatedAt: '2026-08-01T12:30:00Z',
+  }]])
+  const newerRow = {
+    id: 'a',
+    title: 'Owner-chosen name',
+    updated_at: '2026-08-01T12:31:00Z',
+  }
+  const newer = reconcileChatRenameGuards([newerRow], supersededGuards)
+  assert.equal(newer[0], newerRow, 'a later rename must win over the old guard')
+  assert.equal(supersededGuards.has('a'), false)
 })
 
 test('visible and owner-input turns survive temporarily false compact rows', () => {

--- a/frontend/src/components/Shell/__tests__/chatRenameEvent.test.js
+++ b/frontend/src/components/Shell/__tests__/chatRenameEvent.test.js
@@ -18,5 +18,7 @@ test('a committed summary rename projects exact fields without a list refetch', 
     shell.indexOf("ev.type === 'app_deleted'"),
   )
   assert.doesNotMatch(renamePath, /refreshChats/)
+  assert.match(shell, /chatRenameGuardsRef\.current\.set\(String\(event\.chatId\)/)
+  assert.match(shell, /reconcileChatRenameGuards\([\s\S]*?chatRenameGuardsRef\.current/)
   assert.match(shell, /title: event\.title[\s\S]*?updatedAt: event\.updatedAt/)
 })

--- a/frontend/src/components/Shell/chatListProjection.js
+++ b/frontend/src/components/Shell/chatListProjection.js
@@ -116,3 +116,36 @@ export function withChatRename(rows, chatId, { title, updatedAt } = {}) {
     ...(typeof updatedAt === 'string' ? { updated_at: updatedAt } : {}),
   })
 }
+
+/**
+ * Keep a committed rename ahead of drawer-list reads that began before it.
+ * The guard retires only when a row carries the same committed revision (or a
+ * newer one), so an older in-flight response cannot briefly resurrect the
+ * first-message title after the live rename event already reached the shell.
+ */
+export function reconcileChatRenameGuards(rows, guards) {
+  if (!Array.isArray(rows) || !(guards instanceof Map) || guards.size === 0) {
+    return rows
+  }
+
+  let next = rows
+  for (const [chatId, rename] of guards) {
+    const row = next.find(item => String(item?.id) === String(chatId))
+    if (!row) continue
+
+    const rowUpdatedAt = typeof row.updated_at === 'string' ? row.updated_at : ''
+    const renameUpdatedAt = typeof rename?.updatedAt === 'string'
+      ? rename.updatedAt
+      : ''
+    const sameCommittedRename = row.title === rename?.title
+      && (!renameUpdatedAt || rowUpdatedAt === renameUpdatedAt)
+    const rowIsNewer = Boolean(renameUpdatedAt && rowUpdatedAt > renameUpdatedAt)
+    if (sameCommittedRename || rowIsNewer) {
+      guards.delete(chatId)
+      continue
+    }
+
+    next = withChatRename(next, chatId, rename)
+  }
+  return next
+}

--- a/frontend/src/lib/__tests__/appsDirectoryContract.test.js
+++ b/frontend/src/lib/__tests__/appsDirectoryContract.test.js
@@ -28,7 +28,7 @@ test('Apps is a single drawer destination and the old full app list is gone', ()
 test('directory cards preserve app management through shared row actions', () => {
   assert.match(drawer, /variant="card"[\s\S]*?actions=\{rowActions\}/,
     'app cards must keep the shared row action surface')
-  for (const action of ['Install to home screen', 'Share app', 'Delete data', 'Rename']) {
+  for (const action of ['Install to home screen', 'Share app', 'Delete data', 'Copy name', 'Rename']) {
     assert.match(itemActionMenu, new RegExp(action))
   }
 })
@@ -68,6 +68,12 @@ test('chat and app rows share one placed action menu contract', () => {
   assert.doesNotMatch(itemActionMenu, /drawer__item-action-header|drawer__item-action-handle/)
   assert.match(itemActionMenu, /itemKind === 'app' && \(/,
     'Delete data must stay app-only')
+  assert.match(drawer, /onCopy=\{\(\) => actions\.copyName\(label\)\}/)
+  assert.match(drawer, /writeClipboardText\(value\)/)
+  assert.doesNotMatch(drawer, /Name copied/,
+    'successful name copies should not create a routine confirmation notice')
+  assert.match(drawer, /if \(!copied\)[\s\S]*?Couldn't copy the name\./,
+    'clipboard failures must remain visible')
 })
 
 test('the app directory distinguishes loading, errors, and confirmed emptiness', () => {


### PR DESCRIPTION
## Summary
- keep a committed chat rename ahead of older in-flight drawer snapshots until server truth catches up
- add a shared **Copy name** action for chat and app rows that stays quiet on success and surfaces clipboard failures
- cover rename reconciliation and the drawer action contract with focused tests

## Testing
- `node --loader=./src/lib/__tests__/vite-env-loader.mjs --test src/components/Shell/__tests__/chatListProjection.test.js src/components/Shell/__tests__/chatRenameEvent.test.js src/lib/__tests__/appsDirectoryContract.test.js`
- `eslint` on the changed files (no errors; existing Shell hook warnings remain)