### PR TITLE
Keep pointer-opened drawer menus visually neutral

### DIFF
--- a/frontend/src/components/Drawer/Drawer.jsx
+++ b/frontend/src/components/Drawer/Drawer.jsx
@@ -1509,12 +1509,17 @@ const DrawerRow = memo(function DrawerRow({
     }
   }
 
-  function openItemMenuAt(point, trigger = itemButtonRef.current) {
+  function openItemMenuAt(
+    point,
+    trigger = itemButtonRef.current,
+    { focusFirstAction = false } = {},
+  ) {
     actions.openMenu({
       kind,
       id,
       surface,
       placement: itemMenuPlacement(point),
+      focusFirstAction,
       restoreFocusTarget: trigger,
     })
   }
@@ -1550,7 +1555,9 @@ const DrawerRow = memo(function DrawerRow({
     openItemMenuAt({
       x: event.clientX,
       y: event.clientY,
-    }, event.currentTarget)
+    }, event.currentTarget, {
+      focusFirstAction: event.type === 'keydown',
+    })
   }
 
   function recordItemMenuPointer(event) {
@@ -2004,6 +2011,7 @@ const DrawerItemMenu = memo(function DrawerItemMenu({
       canInstall={kind === 'app' && Boolean(item?.slug)}
       canShare={kind === 'app' && isDrawerAppShareEligible(item)}
       placement={menu?.placement}
+      focusFirstAction={menu?.focusFirstAction === true}
       restoreFocusRef={restoreFocusRef}
       onClose={actions.closeMenu}
       onPin={() => actions.pin(kind, id, !pinned)}

--- a/frontend/src/components/Drawer/DrawerItemActionMenu.jsx
+++ b/frontend/src/components/Drawer/DrawerItemActionMenu.jsx
@@ -26,6 +26,7 @@ export default function DrawerItemActionMenu({
   canInstall,
   canShare,
   placement,
+  focusFirstAction = false,
   restoreFocusRef,
   onClose,
   onPin,
@@ -110,11 +111,16 @@ export default function DrawerItemActionMenu({
 
   useLayoutEffect(() => {
     if (!open || !position || !menuRef.current) return
+    // Pointer-opened menus stay visually neutral: moving focus into the first
+    // action paints a keyboard ring even though the owner only held/right-
+    // clicked the row. Keyboard invocation still lands on the first action,
+    // and confirmation views always reclaim focus after replacing their trigger.
+    if (!focusFirstAction && confirmation === null) return
     const frame = requestAnimationFrame(() => {
       focusableMenuItems(menuRef.current)[0]?.focus()
     })
     return () => cancelAnimationFrame(frame)
-  }, [open, position, confirmation])
+  }, [open, position, confirmation, focusFirstAction])
 
   function run(action, { restoreFocus = true } = {}) {
     close({ restoreFocus })

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -974,6 +974,14 @@ test('drawer rows keep action and reorder chrome out of the list', () => {
   )
   assert.match(drawer, /if \(openMenu\) return[\s\S]*?onClose\?\.\(\)/,
     'Escape must close a row menu before dismissing the mobile drawer beneath it')
+  assert.match(drawer, /focusFirstAction: event\.type === 'keydown'/,
+    'only keyboard invocation should focus the first drawer action')
+  assert.match(drawer, /focusFirstAction=\{menu\?\.focusFirstAction === true\}/)
+  assert.match(
+    drawerItemActionMenu,
+    /if \(!focusFirstAction && confirmation === null\) return/,
+    'pointer-opened menus must not paint the first keyboard focus ring',
+  )
 })
 
 test('chat deletion is immediate while app deletion still requires confirmation', () => {
@@ -997,7 +1005,7 @@ test('drawer row actions have one opening path without a custom touch hold', () 
   assert.match(drawer, /open: openItemMenuHistory,[\s\S]*?close: closeItemMenu,[\s\S]*?useHistoryDismiss\(\(\) => setOpenMenu\(null\)\)/)
   assert.match(drawer, /function showItemMenu\(\{ restoreFocusTarget, \.\.\.menu \}\) \{[\s\S]*?openItemMenuHistory\(\)[\s\S]*?setOpenMenu\(menu\)/,
     'Back ownership must be registered before the portaled menu paints')
-  assert.match(drawer, /function openItemMenuAt\(point,[\s\S]*?actions\.openMenu\(\{[\s\S]*?restoreFocusTarget: trigger,/)
+  assert.match(drawer, /function openItemMenuAt\(\s*point,[\s\S]*?actions\.openMenu\(\{[\s\S]*?restoreFocusTarget: trigger,/)
   assert.equal((drawer.match(/onContextMenu=\{openItemMenu\}/g) || []).length, 2,
     'app cards and drawer rows must share one semantic opening function')
   assert.match(drawer, /if \(suppressTouchContextMenu\(event\)\) return/,


### PR DESCRIPTION
## Summary
- leave pointer-opened drawer menus visually neutral instead of focusing the first action
- preserve first-action focus for keyboard invocation and replacement confirmation views
- add a structural regression contract for both invocation paths

## Testing
- `node --loader=./src/lib/__tests__/vite-env-loader.mjs --test src/components/Shell/__tests__/workspaceUi.test.js`
- `eslint` on the changed files