### PR TITLE
Complete trusted catalog adoption conflicts

### DIFF
--- a/backend/app/install.py
+++ b/backend/app/install.py
@@ -369,6 +369,43 @@ def _trusted_catalog_repo_base(url_or_base: str) -> str | None:
   return f"{parsed.scheme}://{parsed.hostname}/{org}/{repo}"
 
 
+def _trusted_catalog_origin_url(url_or_base: str) -> str | None:
+  """Return the one canonical Git origin proven by a trusted catalog URL."""
+  parsed = urlparse(url_or_base)
+  if (
+    parsed.scheme != "https"
+    or parsed.netloc != "raw.githubusercontent.com"
+    or parsed.username is not None
+    or parsed.password is not None
+  ):
+    return None
+  repo_base = _trusted_catalog_repo_base(url_or_base)
+  if repo_base is None:
+    return None
+  parts = [part for part in urlparse(repo_base).path.split("/") if part]
+  if len(parts) != 2:
+    return None
+  return f"https://github.com/{parts[0]}/{parts[1]}.git"
+
+
+def _trusted_origin_catalog_identity_matches(
+  app: models.App,
+  source_url: str,
+  manifest_id: str,
+) -> bool:
+  """Whether a local identity-free row has the catalog package's Git origin."""
+  if app.manifest_url is not None or app.slug != manifest_id:
+    return False
+  expected_origin = _trusted_catalog_origin_url(source_url)
+  if expected_origin is None:
+    return False
+  actual_origin = app_git.origin_url(app.source_dir)
+  return bool(
+    actual_origin
+    and actual_origin.rstrip("/") == expected_origin.rstrip("/")
+  )
+
+
 def _find_ref_independent_catalog_row(
   db: Session, canonical_manifest_url: str, manifest_id: str,
 ) -> models.App | None:
@@ -406,7 +443,6 @@ def _find_trusted_origin_catalog_row(
   db: Session,
   canonical_manifest_url: str,
   manifest_id: str,
-  manifest_url: str,
 ) -> models.App | None:
   """Adopt a legacy local row only when its Git origin proves identity.
 
@@ -416,12 +452,6 @@ def _find_trusted_origin_catalog_row(
   the same id as an unrelated local app. For the narrow trusted root-catalog
   shape, an exact canonical ``origin`` URL is the missing durable witness.
   """
-  if _trusted_catalog_repo_base(canonical_manifest_url) is None:
-    return None
-  repo_ref = _derive_repo_ref(manifest_url)
-  if repo_ref is None:
-    return None
-  expected_origin, _ref = repo_ref
   candidate = (
     db.query(models.App)
     .filter(
@@ -432,10 +462,9 @@ def _find_trusted_origin_catalog_row(
   )
   if candidate is None:
     return None
-  actual_origin = app_git.origin_url(candidate.source_dir)
-  if actual_origin is None:
-    return None
-  return candidate if actual_origin.rstrip("/") == expected_origin.rstrip("/") else None
+  return candidate if _trusted_origin_catalog_identity_matches(
+    candidate, canonical_manifest_url, manifest_id,
+  ) else None
 
 
 def _find_install_identity_row(
@@ -455,7 +484,7 @@ def _find_install_identity_row(
     existing = _find_ref_independent_catalog_row(db, canonical, manifest_id)
   if existing is None:
     existing = _find_trusted_origin_catalog_row(
-      db, canonical, manifest_id, source_url,
+      db, canonical, manifest_id,
     )
   return existing
 
@@ -477,6 +506,36 @@ def _catalog_identity_matches(
     existing_identity.endswith(suffix)
     and existing_repo
     and existing_repo == _trusted_catalog_repo_base(candidate_identity)
+  )
+
+
+def pending_conflict_update_matches_app(
+  app: models.App,
+  receipt: dict,
+) -> bool:
+  """Bind a pending receipt to the app identity it is allowed to promote.
+
+  A normal Store app is bound by its persisted package identity. During the
+  first adoption of a local app, that identity intentionally remains unset
+  until source and capabilities are accepted together; the exact trusted Git
+  origin is the temporary witness for that one pending package.
+  """
+  manifest = receipt.get("manifest")
+  raw_base = receipt.get("raw_base")
+  if (
+    receipt.get("app_id") != app.id
+    or not app.upstream_commit
+    or receipt.get("upstream_commit") != app.upstream_commit
+    or not isinstance(manifest, dict)
+    or not isinstance(manifest.get("id"), str)
+    or not isinstance(raw_base, str)
+  ):
+    return False
+  manifest_id = manifest["id"]
+  if app.manifest_url is not None:
+    return _catalog_identity_matches(app.manifest_url, raw_base, manifest_id)
+  return _trusted_origin_catalog_identity_matches(
+    app, raw_base, manifest_id,
   )
 
 

--- a/backend/app/routes/apps.py
+++ b/backend/app/routes/apps.py
@@ -1663,14 +1663,6 @@ def _pending_store_update_app(
         "message": "The app source identity changed; retry resolution.",
       },
     )
-  if app.manifest_url is None:
-    raise HTTPException(
-      status_code=409,
-      detail={
-        "code": "not_store_app",
-        "message": "Only a Store app can have a pending update resolution.",
-      },
-    )
   return app
 
 
@@ -1683,12 +1675,30 @@ def _pending_store_update_receipt(app: models.App, source_dir: str) -> dict:
     upstream_commit=app.upstream_commit,
   )
   if receipt is None:
+    if app.manifest_url is None:
+      raise HTTPException(
+        status_code=409,
+        detail={
+          "code": "not_store_app",
+          "message": "Only a Store app can have a pending update resolution.",
+        },
+      )
     raise HTTPException(
       status_code=409,
       detail={
         "code": "pending_update_missing",
         "message": (
           "The pending update receipt is missing or no longer matches this app."
+        ),
+      },
+    )
+  if not install.pending_conflict_update_matches_app(app, receipt):
+    raise HTTPException(
+      status_code=409,
+      detail={
+        "code": "pending_update_identity_changed",
+        "message": (
+          "The pending update no longer matches this app's Store identity."
         ),
       },
     )

--- a/backend/tests/test_apps_install.py
+++ b/backend/tests/test_apps_install.py
@@ -1888,6 +1888,218 @@ def test_trusted_origin_adoption_is_always_reconciled_as_local_source(
   assert target.adopting_trusted_origin is True
 
 
+def test_trusted_origin_first_adoption_conflict_reviews_and_finalizes(
+  client, auth, db, bypass_url_validation,
+):
+  """A proven local app stays unprivileged until its conflict is accepted."""
+  from app import install
+
+  original = (
+    'const title = "ORIGINAL";\n'
+    'export default function App() { return <div>{title}</div> }\n'
+  )
+  local = original.replace("ORIGINAL", "LOCAL")
+  incoming = original.replace("ORIGINAL", "STORE")
+  resolved = original.replace("ORIGINAL", "RESOLVED")
+  manifest_id = "trusted-adoption"
+  manifest_url = (
+    "https://raw.githubusercontent.com/mobius-os/"
+    "app-trusted-adoption/main/mobius.json"
+  )
+  raw_base = manifest_url.rsplit("/", 1)[0] + "/"
+  manifest = {
+    "id": manifest_id,
+    "name": "Trusted Adoption",
+    "version": "1.0.0",
+    "description": "Published package",
+    "entry": "index.jsx",
+    "permissions": {"manage_apps": True, "connect_manage": True},
+  }
+  legacy = create_local_app(
+    client,
+    auth,
+    name="Trusted Adoption",
+    description="Local source",
+    jsx_source=original,
+  )
+  app_id = legacy["id"]
+  repo = Path(legacy["source_dir"])
+  (repo / "index.jsx").write_text(local, encoding="utf-8")
+  subprocess.run(
+    [
+      "git", "-C", str(repo), "remote", "add", "origin",
+      "https://github.com/mobius-os/app-trusted-adoption.git",
+    ],
+    check=True,
+  )
+  responses = {
+    manifest_url: (200, json.dumps(manifest).encode()),
+    raw_base + "index.jsx": (200, incoming.encode()),
+  }
+
+  # The origin is an identity witness, not a live dependency of this test.
+  # Falling back to the fetched package mirrors an unavailable private/offline
+  # origin while preserving the same installer path.
+  with patch(
+    "app.install.httpx.AsyncClient",
+    side_effect=_fake_async_client(responses),
+  ), patch(
+    "app.install.app_git.fetch_upstream",
+    side_effect=RuntimeError("offline origin"),
+  ):
+    conflicted = client.post(
+      "/api/apps/install",
+      headers=auth,
+      json={"manifest_url": manifest_url},
+    )
+
+  assert conflicted.status_code == 201, conflicted.text
+  assert conflicted.json()["mode"] == "conflict"
+  assert conflicted.json()["id"] == app_id
+  assert (repo / "index.jsx").read_text(encoding="utf-8") == local
+  db.expire_all()
+  row = db.query(models.App).filter(models.App.id == app_id).one()
+  assert row.manifest_url is None
+  assert row.manage_apps is False
+  assert row.connect_manage is False
+
+  selected = client.post(
+    "/api/apps/resolve-update/policy",
+    headers=auth,
+    json={"source_dir": str(repo), "policy": "preserve_local"},
+  )
+  assert selected.status_code == 200, selected.text
+  assert (repo / ".git" / "MERGE_HEAD").is_file()
+  (repo / "index.jsx").write_text(resolved, encoding="utf-8")
+
+  reviewed = client.post(
+    "/api/apps/resolve-update/review",
+    headers=auth,
+    json={"source_dir": str(repo)},
+  )
+  assert reviewed.status_code == 200, reviewed.text
+  assert "RESOLVED" in reviewed.json()["diff"]
+
+  db.expire_all()
+  row = db.query(models.App).filter(models.App.id == app_id).one()
+  assert row.manifest_url is None
+  assert row.manage_apps is False
+  assert row.connect_manage is False
+
+  with patch(
+    "app.install.httpx.AsyncClient",
+    side_effect=_fake_async_client({raw_base + "index.jsx": (200, incoming.encode())}),
+  ):
+    finalized = client.post(
+      "/api/apps/resolve-update",
+      headers=auth,
+      json={
+        "source_dir": str(repo),
+        "reviewed_tree_oid": reviewed.json()["tree_oid"],
+      },
+    )
+
+  assert finalized.status_code == 200, finalized.text
+  assert finalized.json()["mode"] == "updated"
+  assert finalized.json()["app"]["id"] == app_id
+  assert (repo / "index.jsx").read_text(encoding="utf-8") == resolved
+  db.expire_all()
+  row = db.query(models.App).filter(models.App.id == app_id).one()
+  assert row.manifest_url == (
+    raw_base.rstrip("/") + f"#manifest-id={manifest_id}"
+  )
+  assert row.manage_apps is True
+  assert row.connect_manage is True
+  assert install.read_pending_conflict_update_receipt(
+    repo,
+    app_id=app_id,
+    upstream_commit=row.upstream_commit,
+  ) is None
+
+
+def test_trusted_origin_pending_adoption_rejects_mismatched_and_stale_receipts(
+  client, auth, db,
+):
+  """A receipt cannot attach another package or outlive its upstream proof."""
+  from app import install
+
+  legacy = create_local_app(
+    client,
+    auth,
+    name="Receipt Guard",
+    description="Local source",
+    jsx_source="export default function App(){return <div>local</div>}\n",
+  )
+  app_id = legacy["id"]
+  repo = Path(legacy["source_dir"])
+  subprocess.run(
+    [
+      "git", "-C", str(repo), "remote", "add", "origin",
+      "https://github.com/mobius-os/app-receipt-guard.git",
+    ],
+    check=True,
+  )
+  row = db.query(models.App).filter(models.App.id == app_id).one()
+  assert row.manifest_url is None
+  row.upstream_commit = app_git.head_sha(repo, app_git.UPSTREAM_BRANCH)
+  db.commit()
+  assert row.upstream_commit
+  upstream_commit = row.upstream_commit
+  manifest = {
+    "id": "receipt-guard",
+    "name": "Receipt Guard",
+    "version": "1.0.0",
+    "description": "Published package",
+    "entry": "index.jsx",
+    "permissions": {"manage_apps": True},
+  }
+
+  install.stage_pending_conflict_update(
+    repo,
+    app_id=app_id,
+    upstream_commit=upstream_commit,
+    manifest=manifest,
+    raw_base=(
+      "https://raw.githubusercontent.com/mobius-os/"
+      "app-another-package/main/"
+    ),
+    capability_digest="a" * 64,
+    candidate_digest="b" * 64,
+  )
+  mismatched = client.post(
+    "/api/apps/resolve-update/policy",
+    headers=auth,
+    json={"source_dir": str(repo), "policy": "preserve_local"},
+  )
+  assert mismatched.status_code == 409, mismatched.text
+  assert mismatched.json()["detail"]["code"] == "pending_update_identity_changed"
+  assert not (repo / ".git" / "MERGE_HEAD").exists()
+
+  install.stage_pending_conflict_update(
+    repo,
+    app_id=app_id,
+    upstream_commit="0" * 40,
+    manifest=manifest,
+    raw_base=(
+      "https://raw.githubusercontent.com/mobius-os/"
+      "app-receipt-guard/main/"
+    ),
+    capability_digest="a" * 64,
+    candidate_digest="b" * 64,
+  )
+  stale = client.post(
+    "/api/apps/resolve-update/policy",
+    headers=auth,
+    json={"source_dir": str(repo), "policy": "preserve_local"},
+  )
+  assert stale.status_code == 409, stale.text
+  assert not (repo / ".git" / "MERGE_HEAD").exists()
+  db.expire_all()
+  row = db.query(models.App).filter(models.App.id == app_id).one()
+  assert row.manifest_url is None
+  assert row.manage_apps is False
+
+
 def test_trusted_origin_adoption_accepts_equal_tree_with_unrelated_history(
   client, auth, db, bypass_url_validation, tmp_path,
 ):


### PR DESCRIPTION
## Summary
- let a local app with an exact trusted catalog origin complete its first Store adoption through the existing conflict policy, whole-tree review, and finalize flow
- reuse the same origin proof when the saved receipt is replayed, so finalization updates the original app row instead of losing its target
- bind every pending receipt to the app id, recorded upstream revision, and either its persisted Store identity or exact canonical Git origin
- keep Store identity and requested permissions unchanged until reviewed source promotion succeeds

## Prior work
This is a focused follow-up to #583, which introduced trusted-origin adoption but did not carry an identity-free app through a deferred conflict replay. It complements #974's reviewed publication handoff by preserving the same rule: conflicting source never gains Store identity or permissions before explicit reviewed promotion.

## Testing
- complete installer and update-resolution module: 156 passed
- focused trusted-origin and resolution regressions: 5 passed
- Ruff, Python bytecode compilation, canonical diff, and whitespace checks passed