### PR TITLE
Keep replayed sends settled after reconnect

### DIFF
--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -1140,9 +1140,14 @@ export default function ChatView({
     if (reconciliation.status === 'none' || reconciliation.status === 'superseded') {
       return reconciliation.status
     }
+    // Coordinate can settle against the authoritative fetch passed into this
+    // call before that fetch is committed to messagesRef. Reconcile the
+    // composer against the exact evidence that produced the durable verdict;
+    // re-reading the older ref here would keep a delivered draft indefinitely.
+    const settledEvidence = reconciliation.evidence
     return reconcileFailedSendAttempt(
-      messagesRef.current,
-      pendingQueue.pendingMessagesRef.current,
+      settledEvidence?.visibleMessages ?? messagesRef.current,
+      settledEvidence?.pendingMessages ?? pendingQueue.pendingMessagesRef.current,
       {
         expectedAttempt,
         reportQueued: reconciliation.status === 'queued',

--- a/frontend/src/components/ChatView/__tests__/sendAttemptRecovery.test.js
+++ b/frontend/src/components/ChatView/__tests__/sendAttemptRecovery.test.js
@@ -185,8 +185,35 @@ test('transcript or pending evidence arriving during inspection outranks retaine
     )
     current = recoveryOwner(attempt, evidence)
     inspection.resolve('retained')
-    assert.deepEqual(await result, { status: 'durable', sendFailure: null })
+    assert.deepEqual(await result, {
+      status: 'durable',
+      sendFailure: null,
+      evidence: {
+        visibleMessages: current.visibleMessages,
+        pendingMessages: current.pendingMessages,
+      },
+    })
   }
+})
+
+test('authoritative fetch evidence remains the composer settlement owner before ref commit', async () => {
+  const attempt = { cid: 'cid-1', draftIdentity: 'draft-1' }
+  const visibleMessages = [{ role: 'user', cid: 'cid-1' }]
+  let inspected = false
+
+  const result = await coordinate(
+    attempt,
+    async () => { inspected = true; return 'absent' },
+    () => recoveryOwner(attempt),
+    { authoritative: true, visibleMessages },
+  )
+
+  assert.equal(inspected, false)
+  assert.deepEqual(result, {
+    status: 'durable',
+    sendFailure: null,
+    evidence: { visibleMessages, pendingMessages: [] },
+  })
 })
 
 test('a cached optimistic echo cannot retire a retained send during reload recovery', async () => {

--- a/frontend/src/components/ChatView/__tests__/sendFailure.test.js
+++ b/frontend/src/components/ChatView/__tests__/sendFailure.test.js
@@ -65,7 +65,7 @@ test('known offline state wins over the transport error shape', () => {
   )
 })
 
-test('the send attempt verdict outranks a connection snapshot that changed later', () => {
+test('either the send attempt or the current snapshot can prove the owner is offline', () => {
   const offline = new ChatTransportError(new TypeError('Failed to fetch'))
   offline.outboxRetained = true
   offline.sendReachability = 'offline'
@@ -79,7 +79,7 @@ test('the send attempt verdict outranks a connection snapshot that changed later
   online.sendReachability = 'online'
   assert.equal(
     sendFailureMessage(online, { online: false }),
-    'Möbius couldn’t confirm the send. Your message is queued and will retry automatically.',
+    'You’re offline. Your message is queued and will send when you reconnect.',
   )
 })
 

--- a/frontend/src/components/ChatView/sendAttemptRecovery.js
+++ b/frontend/src/components/ChatView/sendAttemptRecovery.js
@@ -171,7 +171,13 @@ export async function coordinateFailedSendRecovery({
     { expectedAttempt },
   )
   if (initial.status !== 'missing') {
-    return ownerMatches(readCurrent()) ? initial : { status: 'superseded' }
+    if (!ownerMatches(readCurrent())) return { status: 'superseded' }
+    return initial.status === 'durable'
+      ? {
+          ...initial,
+          evidence: { visibleMessages, pendingMessages },
+        }
+      : initial
   }
 
   let intentStatus = 'unknown'
@@ -191,7 +197,17 @@ export async function coordinateFailedSendRecovery({
     current.pendingMessages,
     { expectedAttempt },
   )
-  if (currentEvidence.status !== 'missing') return currentEvidence
+  if (currentEvidence.status !== 'missing') {
+    return currentEvidence.status === 'durable'
+      ? {
+          ...currentEvidence,
+          evidence: {
+            visibleMessages: current.visibleMessages,
+            pendingMessages: current.pendingMessages,
+          },
+        }
+      : currentEvidence
+  }
 
   const rememberedTerminal = sameSendAttempt(
     current.terminal?.attempt,

--- a/frontend/src/components/ChatView/sendFailure.js
+++ b/frontend/src/components/ChatView/sendFailure.js
@@ -18,11 +18,11 @@ export function shouldConfirmAmbiguousSend(error) {
 }
 
 export function sendFailureMessage(error, { online = true } = {}) {
-  const sendOnline = error?.sendReachability === 'offline'
-    ? false
-    : error?.sendReachability === 'online'
-      ? true
-      : online
+  // Either verdict can prove that the queued intent now needs offline copy.
+  // The attempt-local probe stays authoritative when a later shared snapshot
+  // has recovered, but a newer shared offline verdict must not be overwritten
+  // by an older in-flight probe that happened to finish successfully.
+  const sendOnline = online !== false && error?.sendReachability !== 'offline'
   if (!sendOnline) {
     return error?.outboxRetained
       ? 'You’re offline. Your message is queued and will send when you reconnect.'


### PR DESCRIPTION
## Summary
- carry the authoritative server evidence that resolved an ambiguous send through composer settlement
- clear a replayed offline draft once the accepted message appears after reconnect
- keep offline recovery copy accurate when connectivity changes during an in-flight reachability check

## Testing
- `npm test` (2,968 tests passed)
- focused send recovery tests (64 passed)
- production frontend build and generated-runtime guards
- privacy and patch-integrity checks