### PR TITLE
Clear Goals directly without queueing control messages

### DIFF
--- a/backend/app/chat.py
+++ b/backend/app/chat.py
@@ -30,6 +30,7 @@ from app import (
   memory,
   models,
   questions,
+  run_state,
   schemas,
   skills as skills_platform,
 )
@@ -61,7 +62,6 @@ from app.chat_context import (
   _chat_has_goal_intent,
   _chat_settings_dict,
   _custom_system_prompt,
-  _goal_clear_requested,
   _goal_objective,
   _goal_resume_requested,
   _human_elapsed,
@@ -82,6 +82,7 @@ from app.chat_writer import (
   AppendPending,
   Barrier,
   CancelPending,
+  ClearPresentedGoal,
   ClearPending,
   FinishRun,
   Finalize,
@@ -93,6 +94,8 @@ from app.chat_writer import (
   RecoverWedgedRun,
   ResolvePark,
   RollbackAutoResume,
+  StartContinuation,
+  StartContinuationBlocked,
   alloc_run_token,
   await_ack as _await_ack,
   cid_of,
@@ -1729,53 +1732,80 @@ async def _auto_resume_chat(
               "restart" if restart_park else "usage_limit"
             )
             resume_app_id = (
-              park.initiated_by_app_id if restart_park else None
+              # A real owner follow-up already waiting behind an app-owned
+              # turn takes ownership of the resumed turn. This matches normal
+              # pending promotion, where the first queued row owns attribution.
+              park.initiated_by_app_id
+              if restart_park and not pending else None
             )
           if not mark_starting(chat_id):
             return False
           claimed = True
+          drain_token = alloc_run_token()
           continuation_cid = (
             f"restart-resume-{park_token or chat_id}"
             if resume_reason == "restart"
             else f"limit-resume-{park_token or chat_id}"
           )
-          ack = get_writer().submit(
-            AppendPending(
-              chat_id=chat_id,
-              run_token="",
-              user_msg={
-                "role": "user",
-                "content": "continue",
-                "ts": int(time.time() * 1000),
-                "kind": "continuation",
-                "continuation_reason": resume_reason,
-                # A retry after AppendPending succeeded but a later step failed
-                # must not enqueue a second synthetic continuation.
-                "cid": continuation_cid,
-              },
-              initiated_by_app_id=resume_app_id,
-            )
-          )
-          await _await_ack(ack)
-          drain_token = alloc_run_token()
-          try:
-            next_messages, next_user, next_session_id = (
-              await chat_queue.promote_pending_messages_locked(
-                None, chat_id, drain_token,
+          if restart_park:
+            promoted = await _await_ack(get_writer().submit(
+              StartContinuation(
+                chat_id=chat_id,
+                run_token=drain_token,
+                root_run_id=park.root_run_id or park.id,
+                content="continue",
+                cid=continuation_cid,
+                reason=resume_reason,
+                initiated_by_app_id=resume_app_id,
+                supersedes_run_token=park.id,
+                consume_pending=True,
               )
-            )
-          except chat_queue.PendingQuestionBlocksPromotion:
-            # A question committed between the locked preflight and the actor
-            # transition. Remove only this synthetic retry marker; real queued
-            # owner/product rows stay behind the question.
-            await _await_ack(get_writer().submit(CancelPending(
-              chat_id=chat_id,
-              run_token="",
-              cid=continuation_cid,
-            )))
-            discard_starting(chat_id)
-            claimed = False
-            return False
+            ))
+            if isinstance(promoted, StartContinuationBlocked):
+              discard_starting(chat_id)
+              claimed = False
+              return False
+            next_messages = promoted["history"]
+            next_user = promoted["promoted"]
+            next_session_id = promoted["session_id"]
+          else:
+            # Provider-limit recovery stays retryable if task creation fails.
+            # Its existing queue rollback owns that paid-usage policy; planned
+            # restarts use the atomic continuation above and never expose the
+            # synthetic control marker as pending UI.
+            await _await_ack(get_writer().submit(
+              AppendPending(
+                chat_id=chat_id,
+                run_token="",
+                user_msg={
+                  "role": "user",
+                  "content": "continue",
+                  "ts": int(time.time() * 1000),
+                  "kind": "continuation",
+                  "continuation_reason": resume_reason,
+                  "cid": continuation_cid,
+                },
+                initiated_by_app_id=resume_app_id,
+              )
+            ))
+            try:
+              next_messages, next_user, next_session_id = (
+                await chat_queue.promote_pending_messages_locked(
+                  None, chat_id, drain_token,
+                )
+              )
+            except chat_queue.PendingQuestionBlocksPromotion:
+              # A question committed between the locked preflight and the
+              # actor transition. Remove only this synthetic retry marker;
+              # real queued owner/product rows stay behind the question.
+              await _await_ack(get_writer().submit(CancelPending(
+                chat_id=chat_id,
+                run_token="",
+                cid=continuation_cid,
+              )))
+              discard_starting(chat_id)
+              claimed = False
+              return False
           if not next_user:
             discard_starting(chat_id)
             claimed = False
@@ -1793,23 +1823,22 @@ async def _auto_resume_chat(
             run_token=drain_token,
           )
           if scheduled is False:
-            # PromotePending committed before task creation. Reverse only this
-            # exact speculative handoff while the queue lock is still held.
-            # Provider-limit parks remain retryable; one-shot restart parks
-            # retire to manual recovery while preserving the queue.
-            rolled_back = await _await_ack(get_writer().submit(
-              RollbackAutoResume(
-                chat_id=chat_id,
-                run_token=park_token or "",
-                promoted_run_token=drain_token,
-                promoted_pending=list(
-                  next_user.get("_promoted_pending") or []
-                ),
-                retry_park=resume_reason != "restart",
-              )
-            ))
-            if rolled_back:
-              forget_chat(chat_id)
+            if not restart_park:
+              # PromotePending committed before task creation. Reverse only
+              # this paid-limit handoff so the later sweep can retry it.
+              rolled_back = await _await_ack(get_writer().submit(
+                RollbackAutoResume(
+                  chat_id=chat_id,
+                  run_token=park_token or "",
+                  promoted_run_token=drain_token,
+                  promoted_pending=list(
+                    next_user.get("_promoted_pending") or []
+                  ),
+                  retry_park=True,
+                )
+              ))
+              if rolled_back:
+                forget_chat(chat_id)
             claimed = False
             return False
           return True
@@ -2046,12 +2075,30 @@ async def sweep_reset_parks(
         else:
           limit_resume_started = True
       elif restart_auto_resume:
-        restart_deferred = True
-        log.warning(
-          "restart continuation remained pending after scheduling attempt "
-          "chat_id=%s run_token=%s; next event/fallback sweep will retry",
-          chat_id, run.id,
-        )
+        # The atomic restart handoff may already have opened a durable running
+        # continuation before task creation failed. It deliberately leaves no
+        # pending control row to retry; startup reconciliation (or the owner's
+        # next send) recovers that exact opened run. If the handoff was blocked
+        # before it committed, the original resume_pending park remains due and
+        # the supervisor should sweep it again.
+        db.expire_all()
+        still_parked = db.query(models.ChatRun.id).filter(
+          models.ChatRun.id == run.id,
+          models.ChatRun.status == "resume_pending",
+        ).first() is not None
+        if still_parked:
+          restart_deferred = True
+          log.warning(
+            "restart continuation remains durably parked after handoff "
+            "chat_id=%s run_token=%s; next event/fallback sweep will retry",
+            chat_id, run.id,
+          )
+        else:
+          log.warning(
+            "restart continuation opened durably but could not schedule "
+            "chat_id=%s run_token=%s; startup reconciliation will recover it",
+            chat_id, run.id,
+          )
       continue
 
     # Notify-only/app/deleted path: resolve before the best-effort push so a
@@ -2292,6 +2339,68 @@ async def stop_chat_for(
 
   Waits for the process to die with a bounded timeout.
   """
+  async with chat_queue.get_transition_lock(chat_id):
+    return await _stop_chat_for_locked(chat_id, db=db)
+
+
+async def clear_goal_for(chat_id: str, expected_goal_id: str) -> dict:
+  """Stop one Goal execution and dismiss its exact durable identity.
+
+  Unlike ordinary Stop, this preserves the pending queue and does not bump the
+  chat generation. The interrupted runner therefore performs its normal
+  terminal handoff, including starting real owner follow-ups already queued
+  behind the Goal. The writer command then suppresses only the cleared Goal;
+  its transcript, plan, and metrics remain durable history.
+  """
+  async with chat_queue.get_transition_lock(chat_id):
+    # Fence a stale confirmation before touching any live runner. The writer
+    # repeats this exact-id check when it commits the dismissal, so a newer Goal
+    # that appears during interruption is also preserved rather than hidden.
+    from app.database import SessionLocal
+    from app.goal_plans import presented_goal
+    with SessionLocal() as state_db:
+      current_goal = presented_goal(state_db, chat_id)
+    if current_goal is None:
+      return {"status": "missing", "goal_id": None}
+    if current_goal["id"] != expected_goal_id:
+      return {"status": "conflict", "goal_id": current_goal["id"]}
+
+    handles = registry.get_handles(chat_id)
+    all_stopped = True
+    for handle in handles:
+      clear_goal = getattr(handle, "clear_goal", None)
+      if callable(clear_goal):
+        try:
+          await clear_goal()
+          stopped = True
+        except asyncio.CancelledError:
+          raise
+        except Exception:
+          _get_logger().warning(
+            "direct Goal clear failed chat_id=%s kind=%s",
+            chat_id, getattr(handle, "kind", "?"), exc_info=True,
+          )
+          stopped = False
+      else:
+        stopped, _ = await _stop_handle_with_escalation(
+          chat_id, handle, source="clear_goal_for",
+        )
+      all_stopped = all_stopped and stopped
+    if not all_stopped:
+      return {"status": "still_running", "goal_id": expected_goal_id}
+    questions.cancel(chat_id)
+    from app import secure_inputs
+    secure_inputs.cancel_chat(chat_id)
+    return await _await_ack(get_writer().submit(ClearPresentedGoal(
+      chat_id=chat_id,
+      expected_goal_id=expected_goal_id,
+    )))
+
+
+async def _stop_chat_for_locked(
+  chat_id: str, db: Session = None,
+) -> tuple[bool, list[str]]:
+  """Stop one chat while its per-chat lifecycle transition is exclusive."""
   stopped_gen = current_run_generation(chat_id)
   bump_run_generation(chat_id)
   handles = registry.get_handles(chat_id)
@@ -4103,8 +4212,11 @@ async def _run_chat_impl_with_db(
   raw_user_message = messages[-1].content
   user_message = raw_user_message
   goal_objective = _goal_objective(raw_user_message)
-  goal_clear = _goal_clear_requested(raw_user_message)
   goal_mode = _chat_has_goal_intent(messages)
+  clear_dismissed_provider_goal = (
+    run_state.latest_provider_goal_is_dismissed(db, chat_id)
+    if chat_id else False
+  )
   goal_continue = is_goal_continue(raw_user_message or "")
   question_checkpoint = None
   if settings.ensure_chat_note and chat_id:
@@ -4178,7 +4290,7 @@ async def _run_chat_impl_with_db(
     # Delegation prompts are plain bounded tasks even if their text happens to
     # begin with an owner-only slash command.
     goal_objective = None
-    goal_clear = False
+    clear_dismissed_provider_goal = False
     goal_mode = False
     goal_continue = False
     is_slash_command = False
@@ -4753,7 +4865,7 @@ async def _run_chat_impl_with_db(
         resumed_context=resumed_context_fallback,
         should_abort=lambda: _run_generation_superseded(chat_id, run_gen),
         goal_objective=goal_objective,
-        goal_clear=goal_clear,
+        clear_dismissed_goal=clear_dismissed_provider_goal,
         goal_mode=goal_mode,
         goal_continue=goal_continue,
         fallback_goal_objective=fallback_goal_objective,

--- a/backend/app/chat_writer.py
+++ b/backend/app/chat_writer.py
@@ -447,10 +447,45 @@ class StartTurn(_Command):
 
 
 @dataclass(frozen=True)
+class StartContinuationAttached:
+  """The exact physical continuation run was already persisted."""
+
+
+@dataclass(frozen=True)
+class StartContinuationBlocked:
+  """Expected non-start because the controller chat is not idle."""
+
+  reason: str
+
+
+@dataclass(frozen=True)
 class GoalPromotionRejected:
   """Expected refusal when a run cannot accept the requested Goal."""
 
   reason: str
+
+
+@dataclass
+class StartContinuation(_Command):
+  """Atomically append and open one owner-authority continuation.
+
+  Durable coordinators reserve ``run_token`` and ``cid`` before asking the
+  writer to resume an already-settled logical root.  The transcript append,
+  pending-queue recovery, and ChatRun insert are one transaction so a crash
+  can never leave only the synthetic pending row behind.
+  """
+
+  chat_id: str = ""
+  run_token: str = ""
+  root_run_id: str = ""
+  content: str = ""
+  cid: str = ""
+  reason: str = ""
+  initiated_by_app_id: int | None = None
+  # A restart continuation atomically replaces its exact parked physical run.
+  # Other programmatic continuations require an already-idle logical root.
+  supersedes_run_token: str | None = None
+  consume_pending: bool = False
 
 
 @dataclass
@@ -460,6 +495,14 @@ class PromoteRunToGoal(_Command):
   chat_id: str = ""
   run_token: str = ""
   objective: str = ""
+
+
+@dataclass
+class ClearPresentedGoal(_Command):
+  """Dismiss one exact Goal identity without fabricating a chat message."""
+
+  chat_id: str = ""
+  expected_goal_id: str = ""
 
 
 @dataclass
@@ -825,6 +868,7 @@ _FENCE_COMMANDS = (
   QuestionCommit,
   AnswerQuestion,
   StartTurn,
+  StartContinuation,
   AppendPending,
   AppendSteeredUserMessage,
   PromotePending,
@@ -1321,7 +1365,7 @@ class ChatWriterActor:
         # post-abandon commit strands a turn. The `finally` still GCs the
         # key's fence epoch for the skipped command.
         if (
-          isinstance(cmd, (StartTurn, PromotePending))
+          isinstance(cmd, (StartTurn, StartContinuation, PromotePending))
           and cmd.ack is not None
           and cmd.ack.done()
         ):
@@ -1559,8 +1603,12 @@ class ChatWriterActor:
       return self._reconcile_startup_chat(db, cmd)
     if isinstance(cmd, StartTurn):
       return self._start_turn(db, cmd)
+    if isinstance(cmd, StartContinuation):
+      return self._start_continuation(db, cmd)
     if isinstance(cmd, PromoteRunToGoal):
       return self._promote_run_to_goal(db, cmd)
+    if isinstance(cmd, ClearPresentedGoal):
+      return self._clear_presented_goal(db, cmd)
     if isinstance(cmd, AppendPending):
       return self._append_pending(db, cmd)
     if isinstance(cmd, AppendSteeredUserMessage):
@@ -2349,6 +2397,212 @@ class ChatWriterActor:
       "provider": chat.provider,
     }
 
+  def _start_continuation(
+    self, db, cmd: StartContinuation,
+  ) -> dict | StartContinuationAttached | StartContinuationBlocked:
+    """Append and open an idle, same-root continuation in one commit.
+
+    A deterministic ``run_token`` makes a retry attach to an already-created
+    physical run.  A deterministic ``cid`` also lets this command repair the
+    one legacy crash shape produced by the former two-command implementation:
+    exactly the expected synthetic row was appended to ``pending_messages``
+    but never promoted. Ordinary coordinator calls reject foreign pending
+    work. Restart recovery may instead consume the current owner group while
+    preserving group order and every later group.
+    """
+    from datetime import UTC, datetime
+
+    from app.continuations import is_continuation_message
+    from app.models import ChatRun
+
+    chat = _active_chat(db, cmd.chat_id)
+    if chat is None:
+      raise _PersistFailed("StartContinuation: chat not found or deleted")
+
+    existing_run = db.query(ChatRun).filter(
+      ChatRun.id == cmd.run_token,
+      ChatRun.chat_id == cmd.chat_id,
+    ).first()
+    if existing_run is not None:
+      if (existing_run.root_run_id or existing_run.id) != cmd.root_run_id:
+        raise _PersistFailed(
+          "StartContinuation: run token belongs to a different logical root"
+        )
+      if existing_run.initiated_by_app_id != cmd.initiated_by_app_id:
+        raise _PersistFailed(
+          "StartContinuation: run token has different app attribution"
+        )
+      db.rollback()
+      return StartContinuationAttached()
+
+    root = db.query(ChatRun.id).filter(
+      ChatRun.id == cmd.root_run_id,
+      ChatRun.chat_id == cmd.chat_id,
+    ).first()
+    if root is None:
+      raise _PersistFailed(
+        "StartContinuation: logical root does not belong to chat"
+      )
+    if chat.pending_question_id is not None:
+      db.rollback()
+      return StartContinuationBlocked("pending_question")
+    other_run = db.query(ChatRun).filter(
+      ChatRun.chat_id == cmd.chat_id,
+      ChatRun.status.in_(models.NONTERMINAL_RUN_STATUSES),
+    ).first()
+    superseded = None
+    if cmd.supersedes_run_token is not None:
+      if (
+        other_run is None
+        or other_run.id != cmd.supersedes_run_token
+        or other_run.status != "resume_pending"
+      ):
+        db.rollback()
+        return StartContinuationBlocked("superseded_run_changed")
+      superseded = other_run
+    elif other_run is not None:
+      db.rollback()
+      return StartContinuationBlocked("active_run")
+
+    existing = list(chat.messages or [])
+    pending = list(chat.pending_messages or [])
+    for row in existing:
+      if row.get("role") == "user" and cid_of(row) == cmd.cid:
+        raise _PersistFailed(
+          "StartContinuation: continuation cid exists without its ChatRun"
+        )
+
+    source = {
+      "role": "user",
+      "content": cmd.content,
+      "ts": next_message_ts(existing + pending),
+      "cid": cmd.cid,
+      "kind": "continuation",
+      "continuation_reason": cmd.reason,
+    }
+    if cmd.initiated_by_app_id is not None:
+      source["_initiated_by_app_id"] = cmd.initiated_by_app_id
+
+    selected_pending: list[dict] = []
+    remaining_pending: list[dict] = []
+    if cmd.consume_pending and pending:
+      head_hidden = bool(pending[0].get("hidden"))
+      promote_count = 0
+      for row in pending:
+        if bool(row.get("hidden")) != head_hidden:
+          break
+        promote_count += 1
+      selected_pending = pending[:promote_count]
+      remaining_pending = pending[promote_count:]
+    elif pending:
+      # Recover only the exact row the retired AppendPending -> PromotePending
+      # sequence could have stranded.  Never consume a real owner queue or an
+      # app-attributed row in order to make coordinator progress.
+      if len(pending) != 1:
+        db.rollback()
+        return StartContinuationBlocked("foreign_pending")
+      queued = pending[0]
+      expected = (
+        queued.get("role") == "user"
+        and cid_of(queued) == cmd.cid
+        and queued.get("content") == cmd.content
+        and queued.get("kind") == "continuation"
+        and queued.get("continuation_reason") == cmd.reason
+        and queued.get("_initiated_by_app_id") == cmd.initiated_by_app_id
+      )
+      if not expected:
+        db.rollback()
+        return StartContinuationBlocked("foreign_pending")
+      source = dict(queued)
+
+    # Programmatic continuations have no browser request of their own. Carry
+    # the latest owner viewport/timezone forward so visual testing exercises
+    # the partner's real dimensions rather than provider defaults.
+    for key in ("viewport", "timezone"):
+      if source.get(key) is not None:
+        continue
+      for prior in reversed(existing):
+        if prior.get("role") == "user" and prior.get(key) is not None:
+          source[key] = copy.deepcopy(prior[key])
+          break
+
+    ensure_user_cid(source)
+    # Restart recovery consumes any already-queued owner group and writes its
+    # product continuation marker directly to history in the same commit. The
+    # marker is never a pending row. A hidden group stays hidden provider input;
+    # the visible restart marker remains transcript-only in that case.
+    provider_sources = list(selected_pending)
+    if not provider_sources or not bool(provider_sources[0].get("hidden")):
+      provider_sources.append(source)
+    agent_message = _combine_pending_messages(provider_sources)
+    stored_rows = _pending_messages_for_transcript(
+      [*selected_pending, source], existing,
+    )
+    try:
+      history = [
+        schemas.ChatMessage(
+          role=row.get("role", "user"),
+          content=row.get("content", "") or "",
+        )
+        for row in existing
+      ]
+      history.append(schemas.ChatMessage(
+        role="user", content=agent_message.get("content", "") or "",
+      ))
+    except Exception as exc:
+      raise _PersistFailed(
+        "StartContinuation: malformed controller transcript"
+      ) from exc
+
+    chat.messages = existing + stored_rows
+    chat.pending_messages = remaining_pending
+    chat.live_assistant = {
+      "role": "assistant",
+      "blocks": [],
+      "ts": next_message_ts(chat.messages),
+    }
+    started_at = datetime.now(UTC)
+    chat.updated_at = started_at
+    provider = chat.provider or "claude"
+    from app.run_state import goal_identity_for_run_start
+    goal_objective, goal_id = goal_identity_for_run_start(
+      db, cmd.chat_id, agent_message,
+    )
+    if superseded is not None:
+      superseded.status = "completed"
+      superseded.ended_at = started_at
+      superseded.restart_nonce = None
+    db.add(ChatRun(
+      id=cmd.run_token,
+      chat_id=cmd.chat_id,
+      status="running",
+      root_run_id=(
+        cmd.root_run_id
+        if is_continuation_message(agent_message)
+        else cmd.run_token
+      ),
+      provider=provider,
+      started_at=started_at,
+      initiated_by_app_id=cmd.initiated_by_app_id,
+      goal_objective=goal_objective,
+      goal_id=goal_id,
+    ))
+    if not _commit_or_rollback(db):
+      raise _PersistFailed("StartContinuation did not persist")
+    self._run_token_owner[cmd.chat_id] = cmd.run_token
+    return {
+      "history": history,
+      "promoted": {
+        **agent_message,
+        "_messages": stored_rows,
+        "_consumed_cids": [
+          cid_of(row) for row in selected_pending if cid_of(row) is not None
+        ],
+      },
+      "session_id": chat.session_id,
+      "provider": provider,
+    }
+
   def _promote_run_to_goal(
     self, db, cmd: PromoteRunToGoal,
   ) -> dict | GoalPromotionRejected:
@@ -2396,6 +2650,50 @@ class ChatWriterActor:
       "run_id": run.id,
       "state": "promoted" if changed else "active",
     }
+
+  def _clear_presented_goal(
+    self, db, cmd: ClearPresentedGoal,
+  ) -> dict:
+    """Record an exact Goal dismissal while preserving its run history."""
+    from datetime import UTC, datetime
+
+    chat = _active_chat(db, cmd.chat_id)
+    if chat is None:
+      raise _PersistFailed("ClearPresentedGoal: chat not found or deleted")
+    physical = (
+      db.query(models.ChatRun)
+      .filter(
+        models.ChatRun.chat_id == cmd.chat_id,
+        models.ChatRun.goal_objective.isnot(None),
+      )
+      .order_by(
+        models.ChatRun.started_at.desc(), models.ChatRun.id.desc(),
+      )
+      .first()
+    )
+    if physical is None:
+      db.rollback()
+      return {"status": "missing", "goal_id": None}
+    goal_id = physical.goal_id or physical.root_run_id or physical.id
+    if goal_id != cmd.expected_goal_id:
+      db.rollback()
+      return {"status": "conflict", "goal_id": goal_id}
+    if chat.dismissed_goal_id == goal_id:
+      db.rollback()
+      return {"status": "cleared", "goal_id": goal_id}
+    chat.dismissed_goal_id = goal_id
+    cleared_at = datetime.now(UTC)
+    for run in db.query(models.ChatRun).filter(
+      models.ChatRun.chat_id == cmd.chat_id,
+      models.ChatRun.goal_id == goal_id,
+      models.ChatRun.status.in_(models.NONTERMINAL_RUN_STATUSES),
+    ).all():
+      run.status = "stopped"
+      run.ended_at = run.ended_at or cleared_at
+      run.restart_nonce = None
+    if not _commit_or_rollback(db):
+      raise _PersistFailed("ClearPresentedGoal did not persist")
+    return {"status": "cleared", "goal_id": goal_id}
 
   def _append_pending(self, db, cmd: AppendPending) -> dict:
     """Queue `user_msg` behind the active turn; optionally apply answers.
@@ -2724,7 +3022,22 @@ class ChatWriterActor:
       db.rollback()
       return PromotePendingBlockedByPendingQuestion(question_id)
     pending = list(chat.pending_messages or [])
+    # `/goal clear` is no longer a runnable message. Retire any row queued by
+    # an older shell before it can reach a provider, while preserving every
+    # real follow-up around it. New sends are rejected at the HTTP boundary;
+    # this is the durable-upgrade path for already-stored queues.
+    from app.goal_commands import goal_clear_requested
+    without_retired_goal_clear = [
+      row for row in pending
+      if not goal_clear_requested(str(row.get("content") or ""))
+    ]
+    retired_goal_clear = len(without_retired_goal_clear) != len(pending)
+    if retired_goal_clear:
+      pending = without_retired_goal_clear
+      chat.pending_messages = pending
     if not pending:
+      if retired_goal_clear and not _commit_or_rollback(db):
+        raise _PersistFailed("PromotePending could not retire /goal clear")
       return {"history": [], "promoted": None, "session_id": chat.session_id}
     existing = list(chat.messages or [])
     head_hidden = bool(pending[0].get("hidden"))

--- a/backend/app/codex_sdk_runner.py
+++ b/backend/app/codex_sdk_runner.py
@@ -214,12 +214,12 @@ def _needs_native_goal_control(
   *,
   goal_mode: bool,
   goal_objective: str | None,
-  goal_clear: bool,
+  clear_dismissed_goal: bool,
   fallback_goal_objective: str | None,
 ) -> bool:
   """Whether this turn already belongs to Codex's explicit Goal lifecycle."""
   return bool(
-    goal_mode or goal_objective is not None or goal_clear
+    goal_mode or goal_objective is not None or clear_dismissed_goal
     or fallback_goal_objective is not None
   )
 
@@ -657,6 +657,27 @@ class ActiveCodexTurn:
       )
       return
 
+  async def clear_goal(self) -> None:
+    """Clear a native Goal when present, otherwise stop this Goal-owned turn."""
+    self._interrupt_requested = True
+    self._reject_pending_steer()
+    clear_goal = getattr(self.turn, "clear_goal", None)
+    try:
+      if callable(clear_goal):
+        await clear_goal()
+      else:
+        await self.turn.interrupt()
+    except Exception as exc:
+      log.warning("codex direct goal clear raised: %s", exc)
+      try:
+        await self.turn.interrupt()
+      except Exception as interrupt_exc:
+        log.warning("codex fallback interrupt raised: %s", interrupt_exc)
+    try:
+      await asyncio.wait_for(asyncio.shield(self._finished), timeout=5.0)
+    except asyncio.TimeoutError:
+      raise RuntimeError("Codex Goal did not stop after direct clear")
+
   async def stop(self, timeout: float = 2.0) -> bool:
     """Interrupts the active turn and waits up to `timeout` seconds."""
     try:
@@ -910,6 +931,13 @@ class _CodexGoalTurn:
     # its current physical turn.  A later thread/resume can therefore restore
     # the same objective and counters rather than starting a replacement chat.
     await self._client.cancel_goal_operation(self._state)
+
+  async def clear_goal(self) -> None:
+    """Remove the persisted objective, then interrupt its physical turn."""
+    try:
+      await self._client.thread_goal_clear(self._state.thread_id)
+    finally:
+      await self._client.cancel_goal_operation(self._state)
 
   async def steer(self, message: str) -> None:
     physical_turn_id = await asyncio.to_thread(self._state.active_turn)
@@ -1479,7 +1507,7 @@ async def run_codex_sdk_turn(
   resumed_context: str | None = None,
   should_abort: Callable[[], bool] | None = None,
   goal_objective: str | None = None,
-  goal_clear: bool = False,
+  clear_dismissed_goal: bool = False,
   goal_mode: bool = False,
   goal_continue: bool = False,
   fallback_goal_objective: str | None = None,
@@ -1598,7 +1626,7 @@ async def run_codex_sdk_turn(
   needs_goal_control = _needs_native_goal_control(
     goal_mode=goal_mode,
     goal_objective=goal_objective,
-    goal_clear=goal_clear,
+    clear_dismissed_goal=clear_dismissed_goal,
     fallback_goal_objective=fallback_goal_objective,
   )
   config_overrides = _codex_config_overrides(
@@ -1626,7 +1654,6 @@ async def run_codex_sdk_turn(
   thread = None
   turn = None
   goal_state = None
-  goal_cleared = False
   goal_steer_message: str | None = None
   active_turn: ActiveCodexTurn | None = None
   current_session_id = session_id
@@ -1779,7 +1806,7 @@ async def run_codex_sdk_turn(
       )
       persisted_goal = None
       goal_store_available = True
-      if session_id is not None and goal_mode:
+      if session_id is not None and (goal_mode or clear_dismissed_goal):
         try:
           persisted_goal = await _codex_thread_goal(
             goal_client, sdk, session_id,
@@ -1792,10 +1819,9 @@ async def run_codex_sdk_turn(
           # run before resume to register an active goal route in time, but a
           # stale session id should still be allowed to resume as a new thread.
           goal_store_available = False
-        if goal_clear:
+        if clear_dismissed_goal:
           if persisted_goal is not None:
-            cleared = await goal_client.thread_goal_clear(session_id)
-            goal_cleared = bool(getattr(cleared, "cleared", True))
+            await goal_client.thread_goal_clear(session_id)
           persisted_goal = None
         elif goal_objective is not None and persisted_goal is not None:
           # An explicit new /goal replaces the stored operation.  Clear it
@@ -1910,20 +1936,6 @@ async def run_codex_sdk_turn(
         "type": "session_init",
         "session_id": current_session_id,
       })
-
-      if goal_clear:
-        await _persist_session_id(db, chat_id, current_session_id)
-        bc.publish({
-          "type": "text",
-          "content": (
-            "Goal cleared." if goal_cleared else "No active goal to clear."
-          ),
-        })
-        return {
-          "session_id": current_session_id,
-          "cost_usd": None,
-          "error": None,
-        }
 
       native_goal_objective = (
         (goal_objective or fallback_goal_objective)

--- a/backend/app/goal_plans.py
+++ b/backend/app/goal_plans.py
@@ -255,6 +255,9 @@ def active_goal_rows(
     .order_by(models.ChatRun.started_at.desc(), models.ChatRun.id.desc())
     .first()
   )
+  dismissed_goal_id = db.query(models.Chat.dismissed_goal_id).filter(
+    models.Chat.id == chat_id,
+  ).scalar()
   if physical is None:
     # A parent provider turn may finish after launching durable background
     # children. Keep only the latest Goal actionable while its plan or
@@ -268,6 +271,8 @@ def active_goal_rows(
     )
     if physical is None or physical.goal_objective is None:
       return None
+  if physical.goal_id is not None and physical.goal_id == dismissed_goal_id:
+    return None
   rows = _goal_rows_for_physical(db, physical)
   if physical.status in models.NONTERMINAL_RUN_STATUSES:
     return rows
@@ -290,11 +295,10 @@ def presented_goal_rows(
 ) -> tuple[models.ChatRun, models.ChatRun] | None:
   """Return the latest Goal that remains visible until an explicit clear.
 
-  A ``/goal clear`` run carries the cleared Goal's identity with a null
-  objective. That row is a durable presentation tombstone: later ordinary
-  turns do not revive the Goal, while a genuinely new Goal has a newer identity
-  and naturally becomes visible. Execution liveness is deliberately absent
-  from this query so completed and paused Goals survive reloads.
+  ``Chat.dismissed_goal_id`` suppresses only the exact Goal the owner cleared;
+  later ordinary turns cannot revive it, while a genuinely new Goal has a new
+  identity and naturally becomes visible. Execution liveness is deliberately
+  absent from this query so completed and paused Goals survive reloads.
   """
   physical = (
     db.query(models.ChatRun)
@@ -309,6 +313,11 @@ def presented_goal_rows(
     .first()
   )
   if physical is None or physical.goal_objective is None:
+    return None
+  dismissed_goal_id = db.query(models.Chat.dismissed_goal_id).filter(
+    models.Chat.id == chat_id,
+  ).scalar()
+  if physical.goal_id is not None and physical.goal_id == dismissed_goal_id:
     return None
   return _goal_rows_for_physical(db, physical)
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -206,6 +206,11 @@ class Chat(Base):
   auto_resume_on_restart = Column(
     Boolean, nullable=False, default=True, server_default=true()
   )
+  # The latest Goal presentation the owner explicitly cleared. Goal history
+  # remains on ChatRun for summaries, metrics, and audit; this chat-owned
+  # pointer suppresses only that stable Goal identity. A later Goal receives a
+  # different id and therefore becomes visible without resetting this field.
+  dismissed_goal_id = Column(String(64), nullable=True, default=None)
   # Drawer pinning: NOT NULL = pinned, NULL = unpinned. Sort key for
   # the chats list — pinned rows render first, ordered by this
   # column DESC (newest pin at top of pinned group). PATCH

--- a/backend/app/routes/chats_stream.py
+++ b/backend/app/routes/chats_stream.py
@@ -47,6 +47,7 @@ from app.runner_registry import RunnerKind, registry
 from app.config import get_settings
 from app.database import get_db
 from app.memory_observability import record_memory_checkpoint_once
+from app.goal_commands import goal_clear_requested
 from app.owner_input import publish_owner_input_changed
 from app.deps import (
   Principal, get_chat_view_principal, get_owner_or_chat_embed_principal,
@@ -581,6 +582,14 @@ async def send_message(
   """
   require_chat_embed_operation(principal, "chat:send")
   chat = get_active_chat_for_principal(db, chat_id, principal)
+  if goal_clear_requested(body.content or ""):
+    raise HTTPException(
+      status_code=409,
+      detail={
+        "code": "goal_clear_retired",
+        "message": "Clear the Goal from its confirmed × control instead.",
+      },
+    )
   if _delegation_manages_chat(db, chat_id):
     raise HTTPException(
       status_code=409,

--- a/backend/app/routes/goal_plans.py
+++ b/backend/app/routes/goal_plans.py
@@ -53,6 +53,12 @@ class GoalPromotionRequest(BaseModel):
     return cleaned
 
 
+class GoalClearRequest(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+
+  goal_id: str = Field(min_length=1, max_length=64)
+
+
 class GoalTaskUpdate(BaseModel):
   model_config = ConfigDict(extra="forbid")
 
@@ -155,6 +161,43 @@ async def promote_current_run_to_goal(
         "run_id": result["run_id"],
       })
   return result
+
+
+@router.delete(
+  "/{chat_id}/goal",
+  dependencies=[Depends(reject_cross_site)],
+)
+async def clear_presented_goal(
+  chat_id: str,
+  body: GoalClearRequest,
+  principal: Principal = Depends(get_owner_or_chat_embed_principal),
+  db: Session = Depends(get_db),
+):
+  """Stop and dismiss one exact Goal without creating a chat message."""
+  require_chat_embed_operation(principal, "chat:stop")
+  get_active_chat_for_principal(db, chat_id, principal)
+  from app.chat import clear_goal_for
+
+  result = await clear_goal_for(chat_id, body.goal_id)
+  if result["status"] == "still_running":
+    raise HTTPException(
+      status_code=409,
+      detail="The Goal is still stopping; confirm again in a moment.",
+    )
+  if result["status"] == "conflict":
+    raise HTTPException(
+      status_code=409,
+      detail="A newer Goal replaced the one this confirmation targeted.",
+    )
+  if result["status"] == "missing":
+    return {"cleared": False, "goal": None}
+  broadcast = get_broadcast(chat_id)
+  if broadcast is not None and broadcast.running:
+    broadcast.publish({
+      "type": "goal_cleared",
+      "goal_id": result["goal_id"],
+    })
+  return {"cleared": True, "goal": None}
 
 
 @router.put(

--- a/backend/app/run_state.py
+++ b/backend/app/run_state.py
@@ -15,7 +15,6 @@ from sqlalchemy.orm import Session
 
 from app import models
 from app.goal_commands import (
-  goal_clear_requested,
   goal_objective,
   is_goal_continue,
 )
@@ -30,14 +29,6 @@ def goal_identity_for_run_start(
   from app.continuations import is_continuation_message
 
   content = message.get("content") if message is not None else ""
-  if goal_clear_requested(content if isinstance(content, str) else ""):
-    from app.goal_plans import presented_goal_rows
-
-    rows = presented_goal_rows(db, chat_id)
-    # A clear turn remains an ordinary non-Goal run, but references the Goal it
-    # dismissed. That null-objective identity is the durable presentation
-    # tombstone consumed by presented_goal_rows.
-    return None, rows[0].goal_id if rows is not None else None
   objective = goal_objective(content if isinstance(content, str) else "")
   if objective is not None:
     return objective, str(uuid.uuid4())
@@ -235,6 +226,26 @@ def running_goal_objective(db: Session, chat_id: str) -> str | None:
 
   rows = active_goal_rows(db, chat_id)
   return rows[0].goal_objective if rows is not None else None
+
+
+def latest_provider_goal_is_dismissed(db: Session, chat_id: str) -> bool:
+  """Whether the newest provider-backed Goal is hidden by direct clearing."""
+  dismissed_goal_id = db.query(models.Chat.dismissed_goal_id).filter(
+    models.Chat.id == chat_id,
+  ).scalar()
+  if not dismissed_goal_id:
+    return False
+  latest_goal_row = (
+    db.query(models.ChatRun.goal_id)
+    .filter(
+      models.ChatRun.chat_id == chat_id,
+      models.ChatRun.goal_id.isnot(None),
+    )
+    .order_by(models.ChatRun.started_at.desc(), models.ChatRun.id.desc())
+    .first()
+  )
+  latest_goal_id = latest_goal_row[0] if latest_goal_row is not None else None
+  return latest_goal_id == dismissed_goal_id
 
 
 def running_chat_ids(

--- a/backend/app/schema_migrations.py
+++ b/backend/app/schema_migrations.py
@@ -1937,7 +1937,6 @@ def _pin_established_legacy_chat_models(eng) -> None:
       })
 
 
-
 def _add_app_project_templates(eng) -> None:
   """Persist validated manifest project-template declarations on App rows."""
   from sqlalchemy import inspect as sa_inspect, text
@@ -2083,6 +2082,24 @@ def _add_project_color(eng) -> None:
       conn.execute(text(
         "ALTER TABLE projects ADD COLUMN color VARCHAR(7) NULL"
       ))
+
+
+def _add_chat_goal_dismissal(eng) -> None:
+  """Give Goal presentation a first-class chat-owned dismissal pointer."""
+  from sqlalchemy import inspect as sa_inspect, text
+
+  inspector = sa_inspect(eng)
+  if "chats" not in inspector.get_table_names():
+    return
+  columns = {column["name"] for column in inspector.get_columns("chats")}
+  if "dismissed_goal_id" in columns:
+    return
+  with eng.begin() as conn:
+    conn.execute(text(
+      "ALTER TABLE chats ADD COLUMN dismissed_goal_id VARCHAR(64) NULL"
+    ))
+
+
 _SCHEMA_MIGRATIONS = (
   ("0001_legacy_schema_convergence", _converge_legacy_schema),
   ("0002_chat_run_goal_objective", _add_chat_run_goal_objective),
@@ -2109,6 +2126,7 @@ _SCHEMA_MIGRATIONS = (
   ("0021_project_chat_collection", _add_project_chat_collection),
   ("0022_project_artifacts", _add_project_artifacts),
   ("0023_project_color", _add_project_color),
+  ("0024_chat_goal_dismissal", _add_chat_goal_dismissal),
 )
 
 

--- a/backend/tests/fixtures/migration_history.json
+++ b/backend/tests/fixtures/migration_history.json
@@ -24,6 +24,7 @@
     "0020_app_project_templates": "bdb43c8236d85fce265b6ad92ff5fb590c1a122030c496c888affa22b2f2c1d9",
     "0021_project_chat_collection": "03a5584764da2420f5cdda5256dd1e553fcedf51d488728f57f39278f49966ac",
     "0022_project_artifacts": "ba42d74e4b2795b08f37c2c75116c879dea1686ededb16b0eca0b5c4c79ab29e",
-    "0023_project_color": "aecbaff852f8640f86a9f0695bc26ff8b00e857b31d36a1d345440c301eca5ed"
+    "0023_project_color": "aecbaff852f8640f86a9f0695bc26ff8b00e857b31d36a1d345440c301eca5ed",
+    "0024_chat_goal_dismissal": "eb39716740f6dd2414db70b7d3d64443cc94583b778aca344398202adb591b96"
   }
 }

--- a/backend/tests/test_chats.py
+++ b/backend/tests/test_chats.py
@@ -732,6 +732,22 @@ def test_send_requires_explicit_model_before_any_durable_side_effect(
   ).count() == 0
 
 
+def test_goal_clear_text_command_is_retired_before_queueing(
+  client, auth, chat, db,
+):
+  response = client.post(
+    f"/api/chats/{chat.id}/messages",
+    json={"content": "/goal clear"},
+    headers=auth,
+  )
+
+  assert response.status_code == 409, response.text
+  assert response.json()["detail"]["code"] == "goal_clear_retired"
+  db.refresh(chat)
+  assert chat.messages == []
+  assert chat.pending_messages == []
+
+
 def test_fresh_send_response_includes_stored_user_message(
   client, auth, chat, db, monkeypatch,
 ):

--- a/backend/tests/test_codex_sdk_runner.py
+++ b/backend/tests/test_codex_sdk_runner.py
@@ -784,6 +784,32 @@ def test_active_codex_turn_interrupt_waits_for_runner_finish():
   asyncio.run(_scenario())
 
 
+def test_active_codex_turn_clear_uses_goal_control_and_waits_for_finish():
+  class GoalTurn(_FakeTurnHandle):
+    def __init__(self):
+      super().__init__()
+      self.clear_calls = 0
+
+    async def clear_goal(self):
+      self.clear_calls += 1
+
+  async def _scenario() -> None:
+    turn = GoalTurn()
+    active = codex_sdk_runner.ActiveCodexTurn(
+      object(), turn, chat_id="chat-goal-clear",
+    )
+    task = asyncio.create_task(active.clear_goal())
+    await asyncio.sleep(0)
+    assert turn.clear_calls == 1
+    assert turn.interrupt_calls == 0
+    assert active.interrupt_requested is True
+    assert task.done() is False
+    active.mark_finished()
+    await asyncio.wait_for(task, timeout=1)
+
+  asyncio.run(_scenario())
+
+
 def test_active_codex_turn_interrupt_logs_and_still_waits(caplog):
   async def _scenario() -> None:
     turn = _FakeTurnHandle(interrupt_exc=RuntimeError("interrupt failed"))
@@ -1255,6 +1281,23 @@ def test_goal_turn_interrupt_uses_sdk_pause_and_interrupt_operation():
   asyncio.run(scenario())
 
 
+def test_goal_turn_clear_removes_objective_then_interrupts_operation():
+  async def scenario():
+    client = _FakeGoalClient()
+    state = _FakeGoalState("thread-1", started=True)
+    turn = codex_sdk_runner._CodexGoalTurn(
+      client,
+      state,
+      _FakeAsyncGoalNotificationStream,
+      RuntimeError,
+    )
+    await turn.clear_goal()
+    assert client.clear_calls == ["thread-1"]
+    assert client.cancel_calls == [state]
+
+  asyncio.run(scenario())
+
+
 def test_goal_turn_steer_follows_physical_turn_rollover():
   async def scenario():
     sdk = _fake_sdk(object)
@@ -1287,7 +1330,7 @@ def test_goal_turn_steer_follows_physical_turn_rollover():
   asyncio.run(scenario())
 
 
-def test_goal_clear_uses_sdk_without_starting_an_ordinary_turn(monkeypatch):
+def test_dismissed_goal_is_cleared_before_the_next_ordinary_turn(monkeypatch):
   goal = SimpleNamespace(status=_FakeThreadGoalStatus.active)
   ordinary_turn = _FakeTurnHandle(_goal_completion_notifications())
   thread = _FakeThread("thread-1", ordinary_turn)
@@ -1315,7 +1358,7 @@ def test_goal_clear_uses_sdk_without_starting_an_ordinary_turn(monkeypatch):
 
   bc = _FakeBroadcast()
   result = asyncio.run(codex_sdk_runner.run_codex_sdk_turn(
-    user_message="/goal clear",
+    user_message="ordinary follow-up",
     session_id="thread-1",
     base_env={},
     cwd="/tmp",
@@ -1323,14 +1366,17 @@ def test_goal_clear_uses_sdk_without_starting_an_ordinary_turn(monkeypatch):
     bc=bc,
     pending_questions={},
     db=None,
-    goal_clear=True,
+    clear_dismissed_goal=True,
     goal_mode=True,
   ))
 
   assert result["error"] is None
   assert FakeAsyncCodex.last._client.clear_calls == ["thread-1"]
-  assert thread.turn_args is None
-  assert {"type": "text", "content": "Goal cleared."} in bc.events
+  assert thread.turn_args is not None
+  assert thread.turn_args[0] == "ordinary follow-up"
+  assert not any(
+    event.get("content") == "Goal cleared." for event in bc.events
+  )
 
 
 def test_run_codex_sdk_turn_reports_all_model_calls_in_turn(monkeypatch):
@@ -3280,7 +3326,7 @@ def test_ordinary_codex_turns_do_not_expose_provider_private_goal_tools():
   assert codex_sdk_runner._needs_native_goal_control(
     goal_mode=False,
     goal_objective=None,
-    goal_clear=False,
+    clear_dismissed_goal=False,
     fallback_goal_objective=None,
   ) is False
   assert "features.goals=true" not in codex_sdk_runner._codex_config_overrides(
@@ -3289,7 +3335,7 @@ def test_ordinary_codex_turns_do_not_expose_provider_private_goal_tools():
   assert codex_sdk_runner._needs_native_goal_control(
     goal_mode=True,
     goal_objective="Ship and verify",
-    goal_clear=False,
+    clear_dismissed_goal=False,
     fallback_goal_objective=None,
   ) is True
 

--- a/backend/tests/test_db_migrations.py
+++ b/backend/tests/test_db_migrations.py
@@ -1169,6 +1169,7 @@ def test_run_migrations_records_an_inspectable_append_only_history(tmp_path):
     "0021_project_chat_collection",
     "0022_project_artifacts",
     "0023_project_color",
+    "0024_chat_goal_dismissal",
   ]
   assert second == first
 
@@ -2189,6 +2190,31 @@ def test_published_schema_migration_history_is_unique_ordered_and_immutable():
   assert "migration hashes match migration_history.json" in (
     completed.stdout
   )
+
+
+def test_goal_dismissal_migration_adds_nullable_chat_pointer(tmp_path):
+  eng = create_engine(f"sqlite:///{tmp_path / 'goal-dismissal.db'}")
+  models.Base.metadata.create_all(eng)
+  with eng.begin() as conn:
+    conn.execute(text("ALTER TABLE chats DROP COLUMN dismissed_goal_id"))
+    conn.execute(text(
+      "CREATE TABLE IF NOT EXISTS schema_migrations ("
+      "version VARCHAR(128) PRIMARY KEY, applied_at TIMESTAMP NOT NULL)"
+    ))
+    for version in _migration_versions_before("0024_chat_goal_dismissal"):
+      conn.execute(text(
+        "INSERT INTO schema_migrations (version, applied_at) VALUES (:v, :at)"
+      ), {"v": version, "at": datetime(2026, 8, 22)})
+
+  run_migrations(eng)
+
+  columns = {column["name"] for column in inspect(eng).get_columns("chats")}
+  assert "dismissed_goal_id" in columns
+  with eng.connect() as conn:
+    assert conn.execute(text(
+      "SELECT COUNT(*) FROM schema_migrations "
+      "WHERE version = '0024_chat_goal_dismissal'"
+    )).scalar_one() == 1
 
 
 def test_failed_migration_is_not_recorded_and_can_retry(tmp_path, monkeypatch):

--- a/backend/tests/test_goal_identity.py
+++ b/backend/tests/test_goal_identity.py
@@ -3,7 +3,10 @@
 from app import models
 from app.chat_writer import AppendPending, Barrier, PromotePending, get_writer
 from app.goal_plans import presented_goal
-from app.run_state import goal_identity_for_run_start
+from app.run_state import (
+  goal_identity_for_run_start,
+  latest_provider_goal_is_dismissed,
+)
 
 
 def test_explicit_goals_mint_identity_and_continuations_inherit_it(db, chat):
@@ -153,27 +156,47 @@ def test_stopped_unplanned_goal_stays_resumable_after_ordinary_turns(db, chat):
   ) == ("Pause safely", "paused-id")
 
 
-def test_goal_clear_writes_an_identity_tombstone_that_prevents_resume(db, chat):
+def test_direct_goal_dismissal_prevents_resume_without_a_tombstone_run(db, chat):
   db.add(models.ChatRun(
     id="paused-goal", root_run_id="paused-goal", chat_id=chat.id,
     status="stopped", provider="codex", goal_objective="Pause safely",
     goal_id="paused-id",
   ))
-  db.commit()
-
-  assert goal_identity_for_run_start(
-    db, chat.id, {"content": "/goal clear"},
-  ) == (None, "paused-id")
-  db.add(models.ChatRun(
-    id="clear-run", root_run_id="clear-run", chat_id=chat.id,
-    status="completed", provider="codex", goal_id="paused-id",
-  ))
+  chat.dismissed_goal_id = "paused-id"
   db.commit()
 
   assert presented_goal(db, chat.id) is None
+  assert latest_provider_goal_is_dismissed(db, chat.id) is True
   assert goal_identity_for_run_start(
     db, chat.id, {"content": "continue"},
   ) == (None, None)
+
+
+def test_new_goal_remains_visible_after_the_previous_identity_was_dismissed(
+  db, chat,
+):
+  db.add_all([
+    models.ChatRun(
+      id="old-goal", root_run_id="old-goal", chat_id=chat.id,
+      status="stopped", provider="codex", goal_objective="Old",
+      goal_id="old-id",
+    ),
+    models.ChatRun(
+      id="new-goal", root_run_id="new-goal", chat_id=chat.id,
+      status="running", provider="codex", goal_objective="New",
+      goal_id="new-id",
+    ),
+  ])
+  chat.dismissed_goal_id = "old-id"
+  db.commit()
+
+  assert presented_goal(db, chat.id) == {
+    "id": "new-id",
+    "objective": "New",
+    "status": "active",
+    "resumable": False,
+  }
+  assert latest_provider_goal_is_dismissed(db, chat.id) is False
 
 
 def test_delegation_result_inherits_only_its_originating_goal(db, chat):

--- a/backend/tests/test_goal_plans.py
+++ b/backend/tests/test_goal_plans.py
@@ -262,6 +262,78 @@ def test_goal_promotion_rejects_browser_wrong_chat_and_terminal_run_tokens(
   assert "no longer active" in terminal.json()["detail"]
 
 
+def test_confirmed_goal_clear_is_exact_and_preserves_real_pending_work(
+  client, owner_token, db,
+):
+  auth = {"Authorization": f"Bearer {owner_token}"}
+  chat_id = client.post(
+    "/api/chats", json={"title": "Clear directly"}, headers=auth,
+  ).json()["id"]
+  chat = db.query(models.Chat).filter(models.Chat.id == chat_id).one()
+  chat.pending_messages = [{
+    "role": "user", "content": "keep this follow-up", "ts": 2,
+    "cid": "real-follow-up",
+  }]
+  db.add(models.ChatRun(
+    id="clear-goal-run", root_run_id="clear-goal-run", chat_id=chat_id,
+    status="running", provider="claude", goal_objective="Clear safely",
+    goal_id="clear-goal-id",
+  ))
+  db.commit()
+
+  stale = client.request(
+    "DELETE", f"/api/chats/{chat_id}/goal",
+    json={"goal_id": "stale-goal-id"}, headers=auth,
+  )
+  assert stale.status_code == 409, stale.text
+  db.expire_all()
+  chat = db.query(models.Chat).filter(models.Chat.id == chat_id).one()
+  run = db.query(models.ChatRun).filter(
+    models.ChatRun.id == "clear-goal-run",
+  ).one()
+  assert chat.dismissed_goal_id is None
+  assert [row["cid"] for row in chat.pending_messages] == ["real-follow-up"]
+  assert run.status == "running"
+
+  cleared = client.request(
+    "DELETE", f"/api/chats/{chat_id}/goal",
+    json={"goal_id": "clear-goal-id"}, headers=auth,
+  )
+  assert cleared.status_code == 200, cleared.text
+  assert cleared.json() == {"cleared": True, "goal": None}
+  db.expire_all()
+  chat = db.query(models.Chat).filter(models.Chat.id == chat_id).one()
+  run = db.query(models.ChatRun).filter(
+    models.ChatRun.id == "clear-goal-run",
+  ).one()
+  assert chat.dismissed_goal_id == "clear-goal-id"
+  assert [row["cid"] for row in chat.pending_messages] == ["real-follow-up"]
+  assert run.status == "stopped"
+
+
+def test_legacy_queued_goal_clear_is_retired_without_opening_a_turn(db, chat):
+  from app.chat_writer import PromotePending, get_writer
+
+  chat.pending_messages = [{
+    "role": "user", "content": "/goal clear", "ts": 1,
+    "cid": "legacy-goal-clear",
+  }]
+  db.commit()
+
+  result = get_writer().submit(PromotePending(
+    chat_id=chat.id, run_token="must-not-open",
+  )).result(timeout=5)
+
+  assert result["promoted"] is None
+  db.expire_all()
+  assert db.query(models.Chat).filter(
+    models.Chat.id == chat.id,
+  ).one().pending_messages == []
+  assert db.query(models.ChatRun).filter(
+    models.ChatRun.id == "must-not-open",
+  ).first() is None
+
+
 def test_goal_promotion_rejects_delegation_and_app_scope_tokens(
   client, owner_token, db,
 ):

--- a/backend/tests/test_limit_park.py
+++ b/backend/tests/test_limit_park.py
@@ -921,8 +921,59 @@ def test_restart_park_auto_continues_with_product_marker(
     assert marker["kind"] == "continuation"
     assert marker["continuation_reason"] == "restart"
     assert marker["cid"] == f"restart-resume-{token}"
+    state = _chat_row(cid)
+    assert state["pending"] == []
+    assert state["messages"][-1]["cid"] == f"restart-resume-{token}"
+    assert _run_row(token)["status"] == "completed"
     assert notifications[0]["title"] == "Möbius restarted"
     assert "limit" not in notifications[0]["body"].lower()
+  finally:
+    chat_mod.discard_starting(cid)
+
+
+def test_restart_consumes_a_hidden_owner_group_without_queueing_continue(
+  owner_token, monkeypatch,
+):
+  del owner_token
+  monkeypatch.setattr(
+    "app.push.notify_owner_async", _async_notify(lambda *args, **kwargs: "notif-id"),
+  )
+  scheduled = []
+  monkeypatch.setattr(
+    chat_mod, "_schedule_continuation",
+    lambda **kwargs: scheduled.append(kwargs),
+  )
+  cid = "restart-hidden-owner-group"
+  token = f"rt-{cid}"
+  nonce = "restart-nonce-hidden-owner-group"
+  monkeypatch.setattr(
+    "app.restart_ledger.authorized_restart_nonce", lambda: nonce,
+  )
+  _due_park(
+    cid,
+    token,
+    auto_restart=True,
+    park_reason="restart",
+    restart_nonce=nonce,
+    pending=[{
+      "role": "user",
+      "content": "hidden recovery payload",
+      "ts": 3,
+      "cid": "hidden-recovery",
+      "hidden": True,
+    }],
+  )
+
+  try:
+    assert _run_sweep() == [cid]
+    assert len(scheduled) == 1
+    assert scheduled[0]["next_user"]["content"] == "hidden recovery payload"
+    assert scheduled[0]["next_user"]["hidden"] is True
+    state = _chat_row(cid)
+    assert state["pending"] == []
+    assert [row["cid"] for row in state["messages"][-2:]] == [
+      "hidden-recovery", f"restart-resume-{token}",
+    ]
   finally:
     chat_mod.discard_starting(cid)
 
@@ -1289,18 +1340,28 @@ def test_restart_spawn_failure_retires_one_shot_authorization(
     )
 
   row = _run_row(token)
-  assert row["status"] == "interrupted"
+  assert row["status"] == "completed"
   assert row["restart_nonce"] is None
   state = _chat_row(cid)
-  assert state["running_status"] is None
-  assert state["pending"][-1]["cid"] == f"restart-resume-{token}"
+  assert state["running_status"] == "running"
+  assert state["pending"] == []
+  assert state["messages"][-1]["cid"] == f"restart-resume-{token}"
   assert _run_sweep() == []
+
+  # The promoted-but-unscheduled run is recoverable evidence, not a queued
+  # control message. The next startup turns it into the ordinary interrupted
+  # boundary rather than trying to replay an already-consumed restart nonce.
   db = SessionLocal()
   try:
-    assert chat_mod._restart_manual_hold_for_chat(db, cid) is True
-    assert asyncio.run(chat_mod.sweep_idle_pending_chats(db)) == []
+    recovered = chat_mod.reconcile_interrupted_chats(db)
   finally:
     db.close()
+  assert recovered == [cid]
+  assert _chat_row(cid)["pending"] == []
+  assert _chat_row(cid)["running_status"] is None
+  get_writer().submit(FinishRun(
+    chat_id=cid, run_token="",
+  )).result(timeout=5)
 
 
 def test_unacknowledged_restart_pending_cannot_bypass_via_idle_sweep(

--- a/frontend/src/components/ChatView/ChatView.css
+++ b/frontend/src/components/ChatView/ChatView.css
@@ -3470,8 +3470,8 @@
   color: var(--danger);
 }
 
-/* Goal step + its clear X. The wrapper stays a full-width row; the toggle takes
-   the remaining width so the X can sit flush at the right edge. */
+/* Goal step + its confirmed clear control. The wrapper stays a full-width row;
+   the toggle takes the remaining width so the icon sits flush at the right. */
 .chat__progress-step--clearable {
   flex: 1 0 100%;
   gap: 4px;
@@ -3557,6 +3557,17 @@
     margin: 0;
     border-radius: 10px;
   }
+}
+
+.chat__progress-clear--confirm {
+  color: var(--text);
+  background: color-mix(in srgb, var(--text) 10%, transparent);
+}
+
+.chat__progress-error {
+  flex: 1 0 100%;
+  color: var(--danger);
+  font-size: 11px;
 }
 
 /* Composer draft echo of the goal visual — same frosted card as the rail, shown

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -617,6 +617,8 @@ export default function ChatView({
   ))
   const goalPresentationRef = useRef(goalPresentation)
   goalPresentationRef.current = goalPresentation
+  const goalClearInFlightRef = useRef(false)
+  const [goalClearError, setGoalClearError] = useState('')
   const activeGoalObjective = goalPresentation?.objective || ''
   // Armed durable waits — the visible "agent is waiting for X" state. Server
   // truth arrives with every chat detail read; run start/finish already
@@ -673,6 +675,8 @@ export default function ChatView({
       goalPresentationRef.current,
     ))
   }, [setGoalState])
+
+  useEffect(() => setGoalClearError(''), [goalPresentation?.id])
 
   useEffect(() => () => {
     if (messageMetaTimerRef.current) clearTimeout(messageMetaTimerRef.current)
@@ -1687,6 +1691,14 @@ export default function ChatView({
       }
       if (event?.type === 'goal_plan_updated') {
         setActiveGoalPlan(current => newestGoalPlan(current, event.plan || null))
+        return
+      }
+      if (event?.type === 'goal_cleared') {
+        const current = goalPresentationRef.current
+        if (!event.goal_id || current?.id === String(event.goal_id)) {
+          setGoalState(null)
+          setActiveGoalPlan(null)
+        }
         return
       }
       // A build_phase is chat-local: it only feeds this chat's milestone rail,
@@ -3679,12 +3691,38 @@ export default function ChatView({
       .finally(() => { submitSteerInFlightRef.current = false })
   }
 
-  // The goal rail's X clears the active goal by sending the same `/goal clear`
-  // command typing it would — so the mid-run/idle behaviour stays identical to
-  // the documented command instead of a parallel clearing path.
-  const handleClearGoal = useCallback(() => {
-    void doSend('/goal clear', { pin: false })
-  }, [doSend])
+  // Goal clearing is lifecycle control, never chat content. The rail confirms
+  // first, then this exact-id request stops active Goal execution and dismisses
+  // its presentation without entering the pending-message transport.
+  const handleClearGoal = useCallback(async (item) => {
+    const goalId = item?.goalId
+    if (!goalId || goalClearInFlightRef.current) return
+    goalClearInFlightRef.current = true
+    setGoalClearError('')
+    try {
+      const res = await apiFetch(`/chats/${chatId}/goal`, {
+        method: 'DELETE',
+        body: JSON.stringify({ goal_id: goalId }),
+        timeoutMs: CHAT_FETCH_TIMEOUT_MS,
+      })
+      let data = null
+      try { data = await res.json() } catch { /* status remains authoritative */ }
+      if (!res.ok) {
+        const detail = typeof data?.detail === 'string'
+          ? data.detail
+          : data?.detail?.message
+        throw new Error(detail || 'Could not clear this Goal.')
+      }
+      if (goalPresentationRef.current?.id === String(goalId)) {
+        setGoalState(null)
+        setActiveGoalPlan(null)
+      }
+    } catch (err) {
+      setGoalClearError(err?.message || 'Could not clear this Goal.')
+    } finally {
+      goalClearInFlightRef.current = false
+    }
+  }, [chatId, setGoalState])
 
   const handleResumeGoal = useCallback(() => {
     if (goalPresentation?.status !== 'paused') return
@@ -4912,14 +4950,19 @@ export default function ChatView({
     activeGoalPlan,
   ).map(item => {
     if (item.key !== 'goal') return item
-    // The goal step carries a clear affordance (the X) in place of typing
-    // `/goal clear`, and the plan details when a plan exists.
+    // The Goal step owns a two-tap clear affordance and the plan details.
     return {
       ...item,
-      clearable: true,
+      clearable: !!goalPresentation?.id,
+      goalId: goalPresentation?.id,
+      clearConfirmationKey: goalPresentation?.id,
       clearLabel: visibleGoalObjective
         ? `Clear goal: ${visibleGoalObjective}`
         : 'Clear goal',
+      clearConfirmLabel: visibleGoalObjective
+        ? `Confirm clear goal: ${visibleGoalObjective}`
+        : 'Confirm clear goal',
+      ...(goalClearError ? { clearError: goalClearError } : {}),
       ...(goalPresentation?.status === 'paused'
         ? {
             actionLabel: 'Resume',

--- a/frontend/src/components/ChatView/ProgressRail.jsx
+++ b/frontend/src/components/ChatView/ProgressRail.jsx
@@ -1,11 +1,13 @@
 /* ProgressRail renders the shared compact status sequence above the composer. */
 
 import { useEffect, useState } from 'react'
-import { X } from '@openai/apps-sdk-ui/components/Icon'
+import { Check, X } from '@openai/apps-sdk-ui/components/Icon'
 
 function ProgressStep({ item, detailsExpanded, onDetailsToggle, onClear, onAction }) {
   const [labelExpanded, setLabelExpanded] = useState(false)
+  const [clearConfirmed, setClearConfirmed] = useState(false)
   useEffect(() => setLabelExpanded(false), [item.label])
+  useEffect(() => setClearConfirmed(false), [item.clearConfirmationKey])
 
   const hasDetails = !!item.details
   const expanded = hasDetails ? detailsExpanded : labelExpanded
@@ -79,15 +81,26 @@ function ProgressStep({ item, detailsExpanded, onDetailsToggle, onClear, onActio
       {clearable && (
         <button
           type="button"
-          className="chat__progress-clear"
+          className={`chat__progress-clear${clearConfirmed
+            ? ' chat__progress-clear--confirm'
+            : ''}`}
           // Keep composer focus (and the soft keyboard) put when clearing.
           onPointerDown={(event) => event.preventDefault()}
-          onClick={() => onClear()}
+          onClick={() => {
+            if (clearConfirmed) onClear(item)
+            else setClearConfirmed(true)
+          }}
           // Label text is item-supplied so the shared rail stays domain-neutral.
-          aria-label={item.clearLabel || 'Clear'}
-          title={item.clearLabel || 'Clear'}
+          aria-label={clearConfirmed
+            ? (item.clearConfirmLabel || 'Confirm clear')
+            : (item.clearLabel || 'Clear')}
+          title={clearConfirmed
+            ? (item.clearConfirmLabel || 'Confirm clear')
+            : (item.clearLabel || 'Clear')}
         >
-          <X width={14} height={14} aria-hidden="true" />
+          {clearConfirmed
+            ? <Check width={14} height={14} aria-hidden="true" />
+            : <X width={14} height={14} aria-hidden="true" />}
         </button>
       )}
     </span>
@@ -101,6 +114,7 @@ export default function ProgressRail({
   useEffect(() => setDetailsKey(null), [resetKey])
   if (!items.length) return null
   const detailItem = items.find(item => item.key === detailsKey && item.details)
+  const errorItem = items.find(item => item.clearError)
   return (
     <div className="chat__progress-rail" role="group" aria-label={ariaLabel}>
       {items.map(item => (
@@ -116,6 +130,11 @@ export default function ProgressRail({
         />
       ))}
       {detailItem && detailItem.details}
+      {errorItem && (
+        <div className="chat__progress-error" role="alert">
+          {errorItem.clearError}
+        </div>
+      )}
     </div>
   )
 }

--- a/frontend/src/components/ChatView/__tests__/goalProgress.behavior.test.js
+++ b/frontend/src/components/ChatView/__tests__/goalProgress.behavior.test.js
@@ -145,7 +145,11 @@ test('ordinary turns retain settled Goals while Resume reactivates a pause', () 
     goalPresentationAtRunStart('/goal Start another', [], paused),
     { id: null, objective: 'Start another', status: 'active', resumable: false },
   )
-  assert.equal(goalPresentationAtRunStart('/goal clear', [], paused), null)
+  assert.deepEqual(
+    goalPresentationAtRunStart('/goal clear', [], paused),
+    { ...paused, resumable: true },
+    'the retired text command must not optimistically hide a durable Goal',
+  )
 })
 
 test('a promoted continuation preserves the matching retained Goal identity', () => {

--- a/frontend/src/components/ChatView/__tests__/goalProgress.test.js
+++ b/frontend/src/components/ChatView/__tests__/goalProgress.test.js
@@ -412,20 +412,30 @@ test('draftGoalObjective keeps the goal visual open while typing the objective',
   assert.equal(draftGoalObjective(null), null)
 })
 
-test('the goal rail step carries a clear affordance, sourced domain-neutrally', () => {
-  // The X sends the same `/goal clear` typing it would, so behaviour matches
-  // the documented command instead of a parallel clearing path.
-  assert.match(chatView, /handleClearGoal\s*=\s*useCallback\(\(\)\s*=>\s*\{[\s\S]*?doSend\('\/goal clear'/,
-    'the clear handler must reuse the /goal clear command path')
-  assert.match(chatView, /clearable:\s*true/,
-    'the goal rail item must be marked clearable')
+test('the goal rail confirms and clears directly, sourced domain-neutrally', () => {
+  assert.match(
+    chatView,
+    /handleClearGoal\s*=\s*useCallback\(async \(item\)[\s\S]*?apiFetch\(`\/chats\/\$\{chatId\}\/goal`[\s\S]*?method:\s*'DELETE'[\s\S]*?goal_id:\s*goalId/,
+    'the confirmed clear must call the exact-id lifecycle route directly',
+  )
+  assert.doesNotMatch(
+    chatView,
+    /doSend\('\/goal clear'/,
+    'the Goal rail must never fabricate a /goal clear chat message',
+  )
+  assert.match(chatView, /clearable:\s*!!goalPresentation\?\.id/,
+    'only an identified durable Goal may expose clearing')
   assert.match(chatView, /onClearItem=\{handleClearGoal\}/,
     'ChatView must wire the clear handler into the rail')
   // The rail itself stays domain-neutral: the label text comes from item data.
-  assert.match(progressRail, /className="chat__progress-clear"/,
+  assert.match(progressRail, /className=\{`chat__progress-clear\$\{clearConfirmed/,
     'the rail must render the clear button')
-  assert.match(progressRail, /aria-label=\{item\.clearLabel \|\| 'Clear'\}/,
-    'the clear label must be item-supplied with a domain-neutral fallback')
+  assert.match(progressRail, /if \(clearConfirmed\) onClear\(item\)[\s\S]*?else setClearConfirmed\(true\)/,
+    'the first click must arm confirmation and only the second may clear')
+  assert.match(progressRail, /clearConfirmed[\s\S]*?<Check width=\{14\} height=\{14\}/,
+    'the armed clear control must turn into a confirm check')
+  assert.match(progressRail, /item\.clearConfirmLabel \|\| 'Confirm clear'/,
+    'the confirmation label must be item-supplied with a neutral fallback')
   assert.match(chatView, /actionLabel: 'Resume'/,
     'a paused Goal should expose the one-tap resume action')
   assert.match(chatView, /actionIcon: <Play width=\{13\} height=\{13\}/,

--- a/frontend/src/components/ChatView/goalProgress.js
+++ b/frontend/src/components/ChatView/goalProgress.js
@@ -70,13 +70,6 @@ function isContinue(text) {
   return typeof text === 'string' && text.trim().toLowerCase() === 'continue'
 }
 
-function isGoalClear(text) {
-  if (typeof text !== 'string') return false
-  const normalized = text.replace(/^\n+/, '')
-  const match = normalized.match(/^\/goal(?:\s+([\s\S]*))?$/)
-  return (match?.[1] || '').trim().toLowerCase() === 'clear'
-}
-
 const GOAL_PRESENTATION_STATUSES = new Set([
   'active', 'paused', 'completed', 'failed',
 ])
@@ -184,7 +177,6 @@ export function goalObjectiveForQueuedStart(message, messages) {
 
 /** Keep settled Goals visible across ordinary turns; reactivate only Resume. */
 export function goalPresentationAtRunStart(text, messages, current = null) {
-  if (isGoalClear(text)) return null
   const normalizedCurrent = normalizeGoalPresentation(current)
   if (isContinue(text) && normalizedCurrent?.status === 'paused') {
     return { ...normalizedCurrent, status: 'active', resumable: false }

--- a/frontend/src/components/ChatView/slashCommands.js
+++ b/frontend/src/components/ChatView/slashCommands.js
@@ -31,7 +31,7 @@ export const SLASH_COMMANDS = [
     name: 'goal',
     args: '<what to keep working toward>',
     summary: 'Keep pursuing a goal across turns',
-    detail: 'Runs until the goal holds. /goal clear stops it.',
+    detail: 'Runs until the goal holds. Clear it from the Goal rail.',
     providers: ['claude', 'codex', 'mobius'],
   },
 ]


### PR DESCRIPTION
## Summary
- replace queued /goal clear messages with an exact-id Goal lifecycle request and two-step confirmation
- preserve real pending owner follow-ups while stopping only the dismissed Goal identity
- retire legacy queued clear commands, integrate native provider clearing, and make planned restart continuations atomic
- persist Goal dismissal as chat-owned state through append-only migration 0024_chat_goal_dismissal

## Supersession
- supersedes #927 with the same reviewed semantic change targeted directly at main
- #927's successor branch was updated, but its base remained the already-merged parent branch, so that merge did not add the change to main

## Testing
- canonical diff and resulting tree are byte-identical to the fully reviewed #927 semantic layer
- 16 focused backend direct-clear and restart-continuation regressions passed
- 45 focused frontend Goal and slash-command regressions passed
- 24 append-only migration hashes match main
- privacy, owner attribution, single co-author trailer, exact-main ancestry, and git diff --check passed
- the merge queue remains the final full-suite gate