### PR TITLE
Keep completed Goal dismissal from interrupting chat

### DIFF
--- a/backend/app/chat.py
+++ b/backend/app/chat.py
@@ -2344,56 +2344,77 @@ async def stop_chat_for(
 
 
 async def clear_goal_for(chat_id: str, expected_goal_id: str) -> dict:
-  """Stop one Goal execution and dismiss its exact durable identity.
+  """Dismiss one exact Goal, stopping only work that remains unfinished.
 
-  Unlike ordinary Stop, this preserves the pending queue and does not bump the
-  chat generation. The interrupted runner therefore performs its normal
-  terminal handoff, including starting real owner follow-ups already queued
-  behind the Goal. The writer command then suppresses only the cleared Goal;
-  its transcript, plan, and metrics remain durable history.
+  A Goal that no longer owns live execution is presentation-only, as is a plan
+  whose tasks and delegations are settled while its physical turn composes the
+  final response. Only an unfinished Goal that still owns a nonterminal run is
+  stopped. Unlike ordinary Stop, that path preserves the pending queue and does
+  not bump the chat generation, so real owner follow-ups still hand off
+  normally. Every path retains transcript, plan, and metrics as history.
   """
   async with chat_queue.get_transition_lock(chat_id):
     # Fence a stale confirmation before touching any live runner. The writer
     # repeats this exact-id check when it commits the dismissal, so a newer Goal
     # that appears during interruption is also preserved rather than hidden.
     from app.database import SessionLocal
-    from app.goal_plans import presented_goal
+    from app.goal_plans import (
+      presented_goal_rows,
+      serialize_goal,
+      serialize_plan,
+    )
     with SessionLocal() as state_db:
-      current_goal = presented_goal(state_db, chat_id)
+      goal_rows = presented_goal_rows(state_db, chat_id)
+      current_goal = (
+        serialize_goal(state_db, *goal_rows) if goal_rows is not None else None
+      )
+      current_plan = (
+        serialize_plan(state_db, *goal_rows) if goal_rows is not None else None
+      )
+      goal_execution_active = bool(
+        goal_rows is not None
+        and goal_rows[0].status in models.NONTERMINAL_RUN_STATUSES
+      )
     if current_goal is None:
       return {"status": "missing", "goal_id": None}
     if current_goal["id"] != expected_goal_id:
       return {"status": "conflict", "goal_id": current_goal["id"]}
 
-    handles = registry.get_handles(chat_id)
-    all_stopped = True
-    for handle in handles:
-      clear_goal = getattr(handle, "clear_goal", None)
-      if callable(clear_goal):
-        try:
-          await clear_goal()
-          stopped = True
-        except asyncio.CancelledError:
-          raise
-        except Exception:
-          _get_logger().warning(
-            "direct Goal clear failed chat_id=%s kind=%s",
-            chat_id, getattr(handle, "kind", "?"), exc_info=True,
+    plan_complete = bool(
+      current_plan is not None and current_plan["summary"]["can_complete"]
+    )
+    stop_execution = goal_execution_active and not plan_complete
+    if stop_execution:
+      handles = registry.get_handles(chat_id)
+      all_stopped = True
+      for handle in handles:
+        clear_goal = getattr(handle, "clear_goal", None)
+        if callable(clear_goal):
+          try:
+            await clear_goal()
+            stopped = True
+          except asyncio.CancelledError:
+            raise
+          except Exception:
+            _get_logger().warning(
+              "direct Goal clear failed chat_id=%s kind=%s",
+              chat_id, getattr(handle, "kind", "?"), exc_info=True,
+            )
+            stopped = False
+        else:
+          stopped, _ = await _stop_handle_with_escalation(
+            chat_id, handle, source="clear_goal_for",
           )
-          stopped = False
-      else:
-        stopped, _ = await _stop_handle_with_escalation(
-          chat_id, handle, source="clear_goal_for",
-        )
-      all_stopped = all_stopped and stopped
-    if not all_stopped:
-      return {"status": "still_running", "goal_id": expected_goal_id}
-    questions.cancel(chat_id)
-    from app import secure_inputs
-    secure_inputs.cancel_chat(chat_id)
+        all_stopped = all_stopped and stopped
+      if not all_stopped:
+        return {"status": "still_running", "goal_id": expected_goal_id}
+      questions.cancel(chat_id)
+      from app import secure_inputs
+      secure_inputs.cancel_chat(chat_id)
     return await _await_ack(get_writer().submit(ClearPresentedGoal(
       chat_id=chat_id,
       expected_goal_id=expected_goal_id,
+      preserve_execution=not stop_execution,
     )))
 
 

--- a/backend/app/chat_writer.py
+++ b/backend/app/chat_writer.py
@@ -499,10 +499,17 @@ class PromoteRunToGoal(_Command):
 
 @dataclass
 class ClearPresentedGoal(_Command):
-  """Dismiss one exact Goal identity without fabricating a chat message."""
+  """Dismiss one exact Goal identity without fabricating a chat message.
+
+  A completed visible plan can be dismissed while its physical turn is still
+  writing the final response.  In that case the live execution remains the
+  owner of its ChatRun and closes itself normally; unfinished Goal clears still
+  retire nonterminal rows after their runner has stopped.
+  """
 
   chat_id: str = ""
   expected_goal_id: str = ""
+  preserve_execution: bool = False
 
 
 @dataclass
@@ -2682,15 +2689,16 @@ class ChatWriterActor:
       db.rollback()
       return {"status": "cleared", "goal_id": goal_id}
     chat.dismissed_goal_id = goal_id
-    cleared_at = datetime.now(UTC)
-    for run in db.query(models.ChatRun).filter(
-      models.ChatRun.chat_id == cmd.chat_id,
-      models.ChatRun.goal_id == goal_id,
-      models.ChatRun.status.in_(models.NONTERMINAL_RUN_STATUSES),
-    ).all():
-      run.status = "stopped"
-      run.ended_at = run.ended_at or cleared_at
-      run.restart_nonce = None
+    if not cmd.preserve_execution:
+      cleared_at = datetime.now(UTC)
+      for run in db.query(models.ChatRun).filter(
+        models.ChatRun.chat_id == cmd.chat_id,
+        models.ChatRun.goal_id == goal_id,
+        models.ChatRun.status.in_(models.NONTERMINAL_RUN_STATUSES),
+      ).all():
+        run.status = "stopped"
+        run.ended_at = run.ended_at or cleared_at
+        run.restart_nonce = None
     if not _commit_or_rollback(db):
       raise _PersistFailed("ClearPresentedGoal did not persist")
     return {"status": "cleared", "goal_id": goal_id}

--- a/backend/app/routes/goal_plans.py
+++ b/backend/app/routes/goal_plans.py
@@ -173,7 +173,7 @@ async def clear_presented_goal(
   principal: Principal = Depends(get_owner_or_chat_embed_principal),
   db: Session = Depends(get_db),
 ):
-  """Stop and dismiss one exact Goal without creating a chat message."""
+  """Dismiss one exact Goal; stop execution only while work is unfinished."""
   require_chat_embed_operation(principal, "chat:stop")
   get_active_chat_for_principal(db, chat_id, principal)
   from app.chat import clear_goal_for

--- a/backend/tests/test_goal_plans.py
+++ b/backend/tests/test_goal_plans.py
@@ -10,6 +10,7 @@ import pytest
 
 from app import auth as auth_mod, models
 from app import broadcast as broadcast_mod
+from app.runner_registry import RunnerKind, registry
 
 
 def _goal_plan_script():
@@ -309,6 +310,117 @@ def test_confirmed_goal_clear_is_exact_and_preserves_real_pending_work(
   assert chat.dismissed_goal_id == "clear-goal-id"
   assert [row["cid"] for row in chat.pending_messages] == ["real-follow-up"]
   assert run.status == "stopped"
+
+
+def test_completed_plan_clear_dismisses_without_interrupting_final_response(
+  client, owner_token, db,
+):
+  class FinishingGoal:
+    chat_id = ""
+    kind = RunnerKind.CODEX_SDK
+
+    def __init__(self, chat_id):
+      self.chat_id = chat_id
+      self.clear_calls = 0
+
+    async def clear_goal(self):
+      self.clear_calls += 1
+
+  auth = {"Authorization": f"Bearer {owner_token}"}
+  chat_id = client.post(
+    "/api/chats", json={"title": "Finishing goal"}, headers=auth,
+  ).json()["id"]
+  run = models.ChatRun(
+    id="finishing-goal-run", root_run_id="finishing-goal-run",
+    chat_id=chat_id, status="running", provider="codex",
+    goal_objective="Finish without interruption", goal_id="finishing-goal-id",
+    goal_plan_json={
+      "version": 1,
+      "tasks": [{
+        "id": "finish", "title": "Finish the work", "status": "completed",
+        "depends_on": [],
+      }],
+    },
+    goal_plan_revision=1,
+  )
+  db.add(run)
+  db.commit()
+  handle = FinishingGoal(chat_id)
+  registry.register(handle)
+
+  try:
+    cleared = client.request(
+      "DELETE", f"/api/chats/{chat_id}/goal",
+      json={"goal_id": "finishing-goal-id"}, headers=auth,
+    )
+  finally:
+    registry.unregister(chat_id, handle.kind)
+
+  assert cleared.status_code == 200, cleared.text
+  assert cleared.json() == {"cleared": True, "goal": None}
+  assert handle.clear_calls == 0
+  db.expire_all()
+  chat = db.query(models.Chat).filter(models.Chat.id == chat_id).one()
+  persisted_run = db.query(models.ChatRun).filter(
+    models.ChatRun.id == "finishing-goal-run",
+  ).one()
+  assert chat.dismissed_goal_id == "finishing-goal-id"
+  assert persisted_run.status == "running"
+  assert persisted_run.ended_at is None
+
+
+def test_paused_goal_clear_does_not_interrupt_a_later_ordinary_turn(
+  client, owner_token, db,
+):
+  class OrdinaryTurn:
+    chat_id = ""
+    kind = RunnerKind.CODEX_SDK
+
+    def __init__(self, chat_id):
+      self.chat_id = chat_id
+      self.clear_calls = 0
+
+    async def clear_goal(self):
+      self.clear_calls += 1
+
+  auth = {"Authorization": f"Bearer {owner_token}"}
+  chat_id = client.post(
+    "/api/chats", json={"title": "Retained goal"}, headers=auth,
+  ).json()["id"]
+  started_at = datetime.now(UTC)
+  db.add_all([
+    models.ChatRun(
+      id="paused-retained-goal", root_run_id="paused-retained-goal",
+      chat_id=chat_id, status="stopped", provider="codex",
+      goal_objective="Retained history", goal_id="retained-goal-id",
+      started_at=started_at,
+    ),
+    models.ChatRun(
+      id="later-ordinary-turn", root_run_id="later-ordinary-turn",
+      chat_id=chat_id, status="running", provider="codex",
+      started_at=started_at + timedelta(seconds=1),
+    ),
+  ])
+  db.commit()
+  handle = OrdinaryTurn(chat_id)
+  registry.register(handle)
+
+  try:
+    cleared = client.request(
+      "DELETE", f"/api/chats/{chat_id}/goal",
+      json={"goal_id": "retained-goal-id"}, headers=auth,
+    )
+  finally:
+    registry.unregister(chat_id, handle.kind)
+
+  assert cleared.status_code == 200, cleared.text
+  assert handle.clear_calls == 0
+  db.expire_all()
+  ordinary_run = db.query(models.ChatRun).filter(
+    models.ChatRun.id == "later-ordinary-turn",
+  ).one()
+  assert ordinary_run.status == "running"
+  assert ordinary_run.ended_at is None
 
 
 def test_legacy_queued_goal_clear_is_retired_without_opening_a_turn(db, chat):

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -3692,8 +3692,9 @@ export default function ChatView({
   }
 
   // Goal clearing is lifecycle control, never chat content. The rail confirms
-  // first, then this exact-id request stops active Goal execution and dismisses
-  // its presentation without entering the pending-message transport.
+  // first, then this exact-id request dismisses completed work without
+  // interrupting its final response; unfinished Goals still stop through the
+  // same control path without entering the pending-message transport.
   const handleClearGoal = useCallback(async (item) => {
     const goalId = item?.goalId
     if (!goalId || goalClearInFlightRef.current) return


### PR DESCRIPTION
## Summary
- dismiss a completed Goal without interrupting the final response still being written
- dismiss a retained paused Goal without stopping an unrelated later ordinary turn
- stop execution only when the exact presented Goal still owns unfinished live work
- preserve exact-id confirmation and durable dismissal semantics from the merged direct-clear layer

## Supersedes
- replaces #928, whose stacked base was superseded before it could reach `main`
- carries the same fully reviewed incremental change directly on top of #1016

## Testing
- `python -m pytest -q tests/test_goal_plans.py` (25 passed)
- canonical incremental diff is byte-identical to the reviewed #928 layer
- `python backend/scripts/check-schema-migrations.py --against 0f4771ee2329f93d0869bf66442e9fe211d55bc4` (24 immutable hashes matched)
- `scripts/check-private-paths.sh 0f4771ee2329f93d0869bf66442e9fe211d55bc4 d6040f4e77559b11d02b3eb49090b860f3c579d0` (passed)
- `git diff --check`, exact parent/tree, owner attribution, and commit-trailer guards (passed)