### PR TITLE
Add personal previews and shared Creations

### DIFF
--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -172,6 +172,29 @@ def create_project_collaborator_token(
   )
 
 
+def create_shared_app_collaborator_token(
+  *,
+  owner_username: str,
+  owner_epoch: int,
+  instance_id: str,
+  member_id: str,
+  member_epoch: int,
+  expires_delta: timedelta = timedelta(days=30),
+) -> str:
+  """Mint a bearer confined to one revocable shared-app membership."""
+  return create_access_token(
+    {
+      "sub": owner_username,
+      "scope": "shared_app_collaborator",
+      "shared_app_instance": instance_id,
+      "shared_app_member": member_id,
+      "member_epoch": member_epoch,
+    },
+    expires_delta=expires_delta,
+    token_epoch=owner_epoch,
+  )
+
+
 def create_delegation_token(
   delegation_id: str,
   app_id: int,

--- a/backend/app/deps.py
+++ b/backend/app/deps.py
@@ -116,6 +116,21 @@ class ProjectPrincipal:
 
 
 @dataclass(frozen=True)
+class SharedAppPrincipal:
+  """Owner or a revocable identity confined to one shared app instance."""
+
+  owner: models.Owner
+  role: str
+  instance_id: str | None = None
+  member_id: str | None = None
+  display_name: str | None = None
+
+  @property
+  def is_owner(self) -> bool:
+    return self.member_id is None
+
+
+@dataclass(frozen=True)
 class PublicAppAccess:
   """One live, anonymous, exact-app capability."""
 
@@ -358,6 +373,45 @@ def get_project_principal(
   db: Session = Depends(get_db),
 ) -> ProjectPrincipal:
   return resolve_project_principal(token, db)
+
+
+def resolve_shared_app_principal(token: str, db: Session) -> SharedAppPrincipal:
+  """Resolve owner authority or one exact live shared-app membership."""
+  owner, payload = _resolve_owner(token, db)
+  scope = payload.get("scope")
+  if scope is None:
+    return SharedAppPrincipal(owner=owner, role="owner", display_name=owner.username)
+  if scope != "shared_app_collaborator":
+    raise HTTPException(403, "Token scope is not valid for shared apps.")
+  member_id = payload.get("shared_app_member")
+  instance_id = payload.get("shared_app_instance")
+  member_epoch = payload.get("member_epoch")
+  if (
+    not isinstance(member_id, str)
+    or not isinstance(instance_id, str)
+    or type(member_epoch) is not int
+  ):
+    raise HTTPException(401, "Invalid shared app session.")
+  member = db.query(models.SharedAppMember).filter(
+    models.SharedAppMember.id == member_id,
+    models.SharedAppMember.instance_id == instance_id,
+    models.SharedAppMember.revoked_at.is_(None),
+  ).first()
+  if member is None or member.token_epoch != member_epoch:
+    raise HTTPException(401, "Shared app access has been revoked.")
+  return SharedAppPrincipal(
+    owner=owner,
+    role=str(member.role),
+    instance_id=str(member.instance_id),
+    member_id=str(member.id),
+    display_name=str(member.display_name),
+  )
+
+
+def get_shared_app_principal(
+  token: str = Depends(_oauth2), db: Session = Depends(get_db),
+) -> SharedAppPrincipal:
+  return resolve_shared_app_principal(token, db)
 
 
 def _enforce_delegation_claims(

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -82,6 +82,7 @@ from app.routes import (
   published_router,
   connect_router,
   projects_router,
+  shared_apps_router,
 )
 
 _BOOT_ID = os.environ.get("MOBIUS_BOOT_ID") or f"{os.getpid()}-{time.time_ns()}"
@@ -781,6 +782,7 @@ app.include_router(apps_router)
 app.include_router(storage_router)
 app.include_router(fs_router)
 app.include_router(projects_router)
+app.include_router(shared_apps_router)
 app.include_router(chat_router)
 app.include_router(chat_embed_router)
 app.include_router(chats_router)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -980,6 +980,18 @@ class ProjectDrawerState(Base):
   pinned_at = Column(DateTime, nullable=True, default=None)
 
 
+class ProjectArtifactDrawerState(Base):
+  """Open recency for one built Project result, separate from content dates."""
+
+  __tablename__ = "project_artifact_drawer_state"
+
+  project_id = Column(
+    String(64), ForeignKey("projects.id", ondelete="CASCADE"), primary_key=True,
+  )
+  artifact_id = Column(String(64), primary_key=True)
+  last_opened_at = Column(DateTime, nullable=False, default=now_naive_utc)
+
+
 class ProjectAgentMessage(Base):
   """A bounded project-local mailbox between project chat agents.
 
@@ -1045,6 +1057,83 @@ class ProjectInvite(Base):
     String(64), ForeignKey("project_members.id", ondelete="SET NULL"),
     nullable=True,
   )
+
+
+class SharedAppInstance(Base):
+  """A pinned project build with its own members and shared runtime data."""
+
+  __tablename__ = "shared_app_instances"
+
+  id = Column(String(64), primary_key=True)
+  project_id = Column(String(64), ForeignKey("projects.id"), nullable=False, index=True)
+  artifact_id = Column(String(64), nullable=False)
+  name = Column(String(256), nullable=False)
+  entry_path = Column(String(2048), nullable=False)
+  snapshot_path = Column(String(2048), nullable=False, unique=True)
+  previous_snapshot_path = Column(
+    String(2048), nullable=True, unique=True, index=True,
+  )
+  created_at = Column(DateTime, nullable=False, default=now_naive_utc)
+  updated_at = Column(DateTime, nullable=False, default=now_naive_utc)
+  deleted_at = Column(DateTime, nullable=True, default=None, index=True)
+
+
+class SharedAppMember(Base):
+  """One revocable person confined to one shared app instance."""
+
+  __tablename__ = "shared_app_members"
+
+  id = Column(String(64), primary_key=True)
+  instance_id = Column(
+    String(64), ForeignKey("shared_app_instances.id", ondelete="CASCADE"),
+    nullable=False, index=True,
+  )
+  display_name = Column(String(128), nullable=False)
+  role = Column(String(16), nullable=False, default="editor")
+  token_epoch = Column(Integer, nullable=False, default=0, server_default="0")
+  joined_at = Column(DateTime, nullable=False, default=now_naive_utc)
+  revoked_at = Column(DateTime, nullable=True, default=None, index=True)
+
+
+class SharedAppInvite(Base):
+  """A one-use invitation to an app instance, never to its source Project."""
+
+  __tablename__ = "shared_app_invites"
+
+  id = Column(String(64), primary_key=True)
+  instance_id = Column(
+    String(64), ForeignKey("shared_app_instances.id", ondelete="CASCADE"),
+    nullable=False, index=True,
+  )
+  token_hash = Column(String(64), nullable=False, unique=True, index=True)
+  invitee_name = Column(String(128), nullable=True)
+  role = Column(String(16), nullable=False, default="editor")
+  created_at = Column(DateTime, nullable=False, default=now_naive_utc)
+  expires_at = Column(DateTime, nullable=False, index=True)
+  consumed_at = Column(DateTime, nullable=True, default=None)
+  revoked_at = Column(DateTime, nullable=True, default=None)
+  accepted_member_id = Column(
+    String(64), ForeignKey("shared_app_members.id", ondelete="SET NULL"), nullable=True,
+  )
+
+
+class SharedAppChange(Base):
+  """Bounded path-change cursor for one shared app's data namespace."""
+
+  __tablename__ = "shared_app_changes"
+
+  id = Column(Integer, primary_key=True, autoincrement=True)
+  operation_id = Column(String(64), nullable=True, unique=True, index=True)
+  instance_id = Column(
+    String(64), ForeignKey("shared_app_instances.id", ondelete="CASCADE"),
+    nullable=False, index=True,
+  )
+  kind = Column(String(16), nullable=False)
+  path = Column(String(200), nullable=False)
+  version = Column(String(128), nullable=True)
+  actor_key = Column(String(72), nullable=False)
+  display_name = Column(String(256), nullable=False)
+  created_at = Column(DateTime, nullable=False, default=now_naive_utc, index=True)
 
 
 class ProjectPresence(Base):

--- a/backend/app/project_drawer.py
+++ b/backend/app/project_drawer.py
@@ -49,6 +49,31 @@ def mark_opened(db: Session, project_id: str) -> datetime:
   return opened_at
 
 
+def mark_artifact_opened(db: Session, project_id: str, artifact_id: str) -> datetime:
+  """Advance one built result's open marker inside the caller's transaction."""
+  opened_at = now_naive_utc()
+  key = (project_id, artifact_id)
+  state = db.get(models.ProjectArtifactDrawerState, key)
+  if state is None:
+    try:
+      with db.begin_nested():
+        state = models.ProjectArtifactDrawerState(
+          project_id=project_id,
+          artifact_id=artifact_id,
+          last_opened_at=opened_at,
+        )
+        db.add(state)
+        db.flush()
+        return opened_at
+    except IntegrityError:
+      state = db.get(models.ProjectArtifactDrawerState, key)
+      if state is None:
+        raise
+  if state.last_opened_at < opened_at:
+    state.last_opened_at = opened_at
+  return opened_at
+
+
 def set_pinned(db: Session, project_id: str, pinned: bool) -> datetime | None:
   """Set project pin state without advancing project ``updated_at``."""
   pinned_at = now_naive_utc() if pinned else None
@@ -74,4 +99,12 @@ def annotate_projects(
     state = states.get(project.id)
     project.last_opened_at = state.last_opened_at if state else None
     project.pinned_at = state.pinned_at if state else None
+  artifact_states = db.query(models.ProjectArtifactDrawerState).filter(
+    models.ProjectArtifactDrawerState.project_id.in_(ids),
+  ).all() if ids else []
+  opened_by_project: dict[str, dict[str, datetime]] = {}
+  for state in artifact_states:
+    opened_by_project.setdefault(state.project_id, {})[state.artifact_id] = state.last_opened_at
+  for project in projects:
+    project.artifact_last_opened_at = opened_by_project.get(project.id, {})
   return projects

--- a/backend/app/project_retention.py
+++ b/backend/app/project_retention.py
@@ -85,6 +85,12 @@ def purge_expired_project_tombstones(db: Session) -> list[str]:
   """
   cutoff = now_naive_utc() - SOFT_DELETE_TTL
   with PROJECT_LIFECYCLE_LOCK:
+    from app.shared_app_retention import (
+      delete_project_shared_apps,
+      purge_expired_shared_apps,
+      remove_snapshot_root,
+    )
+    purge_expired_shared_apps(db)
     rows = db.query(models.Project).filter(
       models.Project.deleted_at.isnot(None),
       models.Project.deleted_at < cutoff,
@@ -96,6 +102,7 @@ def purge_expired_project_tombstones(db: Session) -> list[str]:
         str(project.id), project.root_path, project.legacy_source_json,
       )) is not None
     ]
+    shared_app_roots = delete_project_shared_apps(db, project_ids)
     if project_ids:
       # ProjectAgentMessage predates cascade ownership on some local builds.
       # Clear it explicitly so an upgraded database and a fresh database have
@@ -117,5 +124,10 @@ def purge_expired_project_tombstones(db: Session) -> list[str]:
         except OSError:
           # The row is already gone, so the UUID orphan sweep can retry safely.
           log.exception("Could not remove expired native project root %s", root)
+      for root in shared_app_roots:
+        try:
+          remove_snapshot_root(root)
+        except OSError:
+          log.exception("Could not remove project-owned shared-app snapshot %s", root)
     _sweep_orphaned_native_roots(db)
     return project_ids

--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -95,6 +95,7 @@ platform_router = _load("platform")
 published_router = _load("published")
 connect_router = _load("connect")
 projects_router = _load("projects")
+shared_apps_router = _load("shared_apps")
 
 __all__ = [
   "admin_router",
@@ -139,4 +140,5 @@ __all__ = [
   "published_router",
   "connect_router",
   "projects_router",
+  "shared_apps_router",
 ]

--- a/backend/app/routes/projects.py
+++ b/backend/app/routes/projects.py
@@ -704,6 +704,7 @@ def _artifact_view(
     "log_rel": log_rel,
     "status": project_builders.effective_status(project.id, entry),
     "updated_at": entry.get("updated_at"),
+    "last_opened_at": getattr(project, "artifact_last_opened_at", {}).get(str(artifact_id)),
     "duration_ms": entry.get("duration_ms"),
     "has_output": has_output,
     "source_missing": not source_exists,
@@ -1907,6 +1908,8 @@ async def delete_project(
   with PROJECT_LIFECYCLE_LOCK:
     deleted_at = now_naive_utc()
     project.deleted_at = deleted_at
+    from app.shared_app_retention import stage_project_shared_app_delete
+    stage_project_shared_app_delete(db, str(project.id), deleted_at)
     from app.chat_waits import stage_cancel_waits_for_chat
     for chat in chats:
       stage_cancel_waits_for_chat(db, chat.id)
@@ -1951,6 +1954,8 @@ def recover_project(
     if not _project_root(project).is_dir():
       raise HTTPException(409, "Project files are unavailable.")
     deleted_at = project.deleted_at
+    from app.shared_app_retention import stage_project_shared_app_recovery
+    stage_project_shared_app_recovery(db, str(project.id), deleted_at)
     chats = db.query(models.Chat).filter(
       models.Chat.project_id == project.id,
       models.Chat.deleted_at == deleted_at,
@@ -2467,6 +2472,8 @@ def list_project_artifacts(
 ):
   """List a project's artifacts, reconciling live/stale build status."""
   project = _project_for(db, project_id, principal, "viewer")
+  if principal.is_owner:
+    project_drawer.annotate_projects(db, [project])
   root = _project_root(project)
   return {
     "artifacts": [
@@ -2474,6 +2481,27 @@ def list_project_artifacts(
       for entry in project_builders.read_artifacts(project)
     ],
   }
+
+
+@router.post(
+  "/{project_id}/artifacts/{artifact_id}/opened", status_code=204,
+  dependencies=[Depends(reject_cross_site)],
+)
+def mark_project_artifact_opened(
+  project_id: str,
+  artifact_id: str,
+  _: models.Owner = Depends(get_current_owner),
+  db: Session = Depends(get_db),
+):
+  project = _live_project(db, project_id)
+  if not any(
+    str(entry.get("id")) == artifact_id
+    for entry in project_builders.read_artifacts(project)
+  ):
+    raise HTTPException(404, "Creation not found.")
+  project_drawer.mark_artifact_opened(db, project.id, artifact_id)
+  db.commit()
+  return Response(status_code=204)
 
 
 @router.post(

--- a/backend/app/routes/projects.py
+++ b/backend/app/routes/projects.py
@@ -2575,6 +2575,10 @@ async def delete_project_artifact(
   project.artifacts_json = remaining or None
   flag_modified(project, "artifacts_json")
   project.updated_at = now_naive_utc()
+  db.query(models.ProjectArtifactDrawerState).filter(
+    models.ProjectArtifactDrawerState.project_id == project.id,
+    models.ProjectArtifactDrawerState.artifact_id == artifact_id,
+  ).delete(synchronize_session=False)
   db.commit()
   return Response(status_code=204)
 

--- a/backend/app/routes/shared_apps.py
+++ b/backend/app/routes/shared_apps.py
@@ -14,9 +14,11 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 from starlette.background import BackgroundTask
+from starlette.concurrency import run_in_threadpool
 
 from app import (
   auth,
+  fs_locks,
   models,
   project_builders,
   shared_app_releases,
@@ -104,6 +106,8 @@ def _instance_for(
 
 
 def _built_artifact(project: models.Project, artifact_id: str) -> tuple[dict, Path, str]:
+  if project_builders.ARTIFACT_ID_RE.fullmatch(artifact_id) is None:
+    raise HTTPException(422, "Artifact output is invalid.")
   artifact = next(
     (item for item in project_builders.read_artifacts(project) if item.get("id") == artifact_id),
     None,
@@ -116,13 +120,32 @@ def _built_artifact(project: models.Project, artifact_id: str) -> tuple[dict, Pa
     output_rel = project_builders.default_output_rel(
       artifact_id, str(artifact.get("builder")), str(artifact.get("source") or ""), artifact_type,
     )
-  project_root = (Path(get_settings().data_dir) / project.root_path).resolve()
-  output_root = (project_root / "artifacts" / artifact_id / "output").resolve()
+  data_root = Path(get_settings().data_dir).resolve()
+  stored_root = Path(project.root_path)
+  project_root = (
+    stored_root if stored_root.is_absolute() else data_root / stored_root
+  ).absolute()
+  output_root = project_root / "artifacts" / artifact_id / "output"
   try:
+    output_root.relative_to(data_root)
+    relative_output = output_root.relative_to(data_root)
+    current = data_root
+    for part in relative_output.parts:
+      current = current / part
+      # Check the lexical path before resolving it. Resolving first would hide
+      # an output root (or ancestor) redirected into owner-private storage.
+      if current.is_symlink():
+        raise ValueError("artifact output traverses a symbolic link")
+    project_root = project_root.resolve()
+    project_root.relative_to(data_root)
+    output_root = output_root.resolve()
+    output_root.relative_to(project_root)
     entry = (project_root / output_rel.lstrip("/")).resolve()
     entry_rel = entry.relative_to(output_root).as_posix()
   except (ValueError, OSError) as exc:
     raise HTTPException(422, "Artifact output is invalid.") from exc
+  if not output_root.is_dir():
+    raise HTTPException(409, "Build the artifact before sharing it.")
   if not entry.is_file():
     raise HTTPException(409, "Build the artifact before sharing it.")
   total = 0
@@ -157,11 +180,26 @@ def _view(
 
 
 @router.post("", status_code=201, dependencies=[Depends(reject_cross_site)])
-def create_shared_app(
+async def create_shared_app(
   body: SharedAppCreate,
   response: Response,
   owner: models.Owner = Depends(get_current_owner),
   db: Session = Depends(get_db),
+):
+  # A release is one immutable observation of a build. The builder owns this
+  # same per-project lock for its entire output rewrite, so validation and copy
+  # can never capture files from two build revisions.
+  async with fs_locks.project_build_lock(body.project_id):
+    return await run_in_threadpool(
+      _create_shared_app_with_lifecycle, body, response, owner, db,
+    )
+
+
+def _create_shared_app_with_lifecycle(
+  body: SharedAppCreate,
+  response: Response,
+  owner: models.Owner,
+  db: Session,
 ):
   with PROJECT_LIFECYCLE_LOCK:
     return _create_shared_app(body, response, owner, db)
@@ -322,10 +360,31 @@ def get_shared_app(
 
 
 @router.put("/{instance_id}/release", dependencies=[Depends(reject_cross_site)])
-def publish_shared_app_release(
+async def publish_shared_app_release(
   instance_id: str,
   principal: SharedAppPrincipal = Depends(get_shared_app_principal),
   db: Session = Depends(get_db),
+):
+  project_id = await run_in_threadpool(
+    _shared_app_project_id, instance_id, principal, db,
+  )
+  async with fs_locks.project_build_lock(project_id):
+    return await run_in_threadpool(
+      _publish_shared_app_release_with_lifecycle,
+      instance_id,
+      principal,
+      db,
+    )
+
+
+def _shared_app_project_id(
+  instance_id: str, principal: SharedAppPrincipal, db: Session,
+) -> str:
+  return str(_instance_for(db, instance_id, principal, "owner").project_id)
+
+
+def _publish_shared_app_release_with_lifecycle(
+  instance_id: str, principal: SharedAppPrincipal, db: Session,
 ):
   with PROJECT_LIFECYCLE_LOCK:
     return _publish_shared_app_release(instance_id, principal, db)

--- a/backend/app/routes/shared_apps.py
+++ b/backend/app/routes/shared_apps.py
@@ -1,0 +1,616 @@
+"""Pinned project builds that people can use together without source access."""
+
+from __future__ import annotations
+
+import hashlib
+import secrets
+import uuid
+from datetime import timedelta
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Response
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+from starlette.background import BackgroundTask
+
+from app import (
+  auth,
+  models,
+  project_builders,
+  shared_app_releases,
+  shared_app_retention,
+  shared_app_state,
+)
+from app.config import get_settings
+from app.database import get_db
+from app.deps import SharedAppPrincipal, get_current_owner, get_shared_app_principal, reject_cross_site
+from app.project_retention import PROJECT_LIFECYCLE_LOCK
+from app.timeutil import SOFT_DELETE_TTL, now_naive_utc
+
+
+router = APIRouter(prefix="/api/shared-apps", tags=["shared-apps"])
+_INVITE_TTL = timedelta(days=7)
+_ROLES = {"viewer": 0, "editor": 1, "owner": 2}
+
+
+class SharedAppCreate(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+  project_id: str = Field(min_length=1, max_length=64)
+  artifact_id: str = Field(min_length=1, max_length=64)
+  name: str | None = Field(default=None, max_length=256)
+
+
+class SharedAppInviteCreate(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+  invitee_name: str | None = Field(default=None, max_length=128)
+  role: str = "editor"
+
+  @field_validator("role")
+  @classmethod
+  def validate_role(cls, value: str) -> str:
+    if value not in {"viewer", "editor"}:
+      raise ValueError("role must be viewer or editor")
+    return value
+
+
+class SharedAppInviteRedeem(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+  invite: str = Field(min_length=20, max_length=256)
+  display_name: str = Field(min_length=1, max_length=128)
+
+
+class SharedStateWrite(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+  expected_version: str | None = Field(default=None, max_length=128)
+  value: object | None = None
+  delete: bool = False
+
+
+class SharedAppMemberUpdate(BaseModel):
+  model_config = ConfigDict(extra="forbid")
+  role: str
+
+  @field_validator("role")
+  @classmethod
+  def validate_role(cls, value: str) -> str:
+    if value not in {"viewer", "editor"}:
+      raise ValueError("role must be viewer or editor")
+    return value
+
+
+def _invite_hash(secret: str) -> str:
+  return hashlib.sha256(secret.encode("utf-8")).hexdigest()
+
+
+def _instance_for(
+  db: Session, instance_id: str, principal: SharedAppPrincipal, role: str = "viewer",
+) -> models.SharedAppInstance:
+  if not principal.is_owner and principal.instance_id != instance_id:
+    raise HTTPException(404, "Shared app not found.")
+  if _ROLES.get(principal.role, -1) < _ROLES[role]:
+    raise HTTPException(403, "This shared app role cannot do that.")
+  row = db.query(models.SharedAppInstance).filter(models.SharedAppInstance.id == instance_id).first()
+  if row is None or row.deleted_at is not None:
+    raise HTTPException(404, "Shared app not found.")
+  project = db.query(models.Project.id).filter(
+    models.Project.id == row.project_id,
+    models.Project.deleted_at.is_(None),
+  ).first()
+  if project is None:
+    raise HTTPException(404, "Shared app not found.")
+  return row
+
+
+def _built_artifact(project: models.Project, artifact_id: str) -> tuple[dict, Path, str]:
+  artifact = next(
+    (item for item in project_builders.read_artifacts(project) if item.get("id") == artifact_id),
+    None,
+  )
+  if artifact is None:
+    raise HTTPException(404, "Artifact not found.")
+  output_rel = artifact.get("output_rel")
+  if not isinstance(output_rel, str) or not output_rel:
+    artifact_type = project_builders.resolve_artifact_type(project, str(artifact.get("builder")))
+    output_rel = project_builders.default_output_rel(
+      artifact_id, str(artifact.get("builder")), str(artifact.get("source") or ""), artifact_type,
+    )
+  project_root = (Path(get_settings().data_dir) / project.root_path).resolve()
+  output_root = (project_root / "artifacts" / artifact_id / "output").resolve()
+  try:
+    entry = (project_root / output_rel.lstrip("/")).resolve()
+    entry_rel = entry.relative_to(output_root).as_posix()
+  except (ValueError, OSError) as exc:
+    raise HTTPException(422, "Artifact output is invalid.") from exc
+  if not entry.is_file():
+    raise HTTPException(409, "Build the artifact before sharing it.")
+  total = 0
+  for candidate in output_root.rglob("*"):
+    if candidate.is_symlink():
+      raise HTTPException(422, "Shared builds cannot contain symbolic links.")
+    if candidate.is_file():
+      total += candidate.stat().st_size
+      if total > shared_app_releases.SNAPSHOT_BYTES_MAX:
+        raise HTTPException(413, "This build is too large to share as an app.")
+  return artifact, output_root, entry_rel
+
+
+def _view(
+  row: models.SharedAppInstance,
+  principal: SharedAppPrincipal,
+  release: shared_app_releases.SharedAppRelease | None = None,
+) -> dict:
+  release = release or shared_app_releases.current_release(row)
+  return {
+    "id": row.id,
+    "name": release.name,
+    "project_id": row.project_id if principal.is_owner else None,
+    "artifact_id": row.artifact_id if principal.is_owner else None,
+    "entry_path": release.entry_path,
+    "release_id": release.release_id,
+    "role": principal.role,
+    "member_id": principal.member_id,
+    "created_at": row.created_at,
+    "updated_at": release.published_at,
+  }
+
+
+@router.post("", status_code=201, dependencies=[Depends(reject_cross_site)])
+def create_shared_app(
+  body: SharedAppCreate,
+  response: Response,
+  owner: models.Owner = Depends(get_current_owner),
+  db: Session = Depends(get_db),
+):
+  with PROJECT_LIFECYCLE_LOCK:
+    return _create_shared_app(body, response, owner, db)
+
+
+def _create_shared_app(
+  body: SharedAppCreate,
+  response: Response,
+  owner: models.Owner,
+  db: Session,
+):
+  project = db.query(models.Project).filter(
+    models.Project.id == body.project_id, models.Project.deleted_at.is_(None),
+  ).first()
+  if project is None:
+    raise HTTPException(404, "Project not found.")
+  existing = db.query(models.SharedAppInstance).filter(
+    models.SharedAppInstance.project_id == project.id,
+    models.SharedAppInstance.artifact_id == body.artifact_id,
+    models.SharedAppInstance.deleted_at.is_(None),
+  ).order_by(models.SharedAppInstance.updated_at.desc()).first()
+  principal = SharedAppPrincipal(owner=owner, role="owner", display_name=owner.username)
+  if existing is not None:
+    response.status_code = 200
+    return _view(existing, principal)
+  artifact, output_root, entry_rel = _built_artifact(project, body.artifact_id)
+  instance_id = str(uuid.uuid4())
+  name = str(body.name or artifact.get("name") or project.name)[:256]
+  release = None
+  try:
+    release = shared_app_releases.create_initial_release(
+      instance_id=instance_id,
+      output_root=output_root,
+      entry_path=entry_rel,
+      name=name,
+    )
+    row = models.SharedAppInstance(
+      id=instance_id,
+      project_id=project.id,
+      artifact_id=body.artifact_id,
+      name=name,
+      entry_path=entry_rel,
+      snapshot_path=release.snapshot_path,
+    )
+    db.add(row)
+    db.commit()
+  except Exception:
+    db.rollback()
+    try:
+      persisted_snapshot = db.query(models.SharedAppInstance.snapshot_path).filter(
+        models.SharedAppInstance.id == instance_id,
+      ).scalar()
+    except Exception:
+      # The commit outcome cannot be established while the database is down.
+      # Leave the fsynced tree for startup's canonical-pointer reconciliation.
+      raise
+    if persisted_snapshot is None:
+      cleanup_path = (
+        release.snapshot_path
+        if release is not None
+        else (Path("shared") / "app-instances" / instance_id / "build").as_posix()
+      )
+      cleanup_root = shared_app_retention.owned_snapshot_root(instance_id, cleanup_path)
+      if cleanup_root is not None:
+        shared_app_retention.remove_snapshot_root(cleanup_root)
+    raise
+  return _view(row, principal, release)
+
+
+@router.get("")
+def list_shared_apps(
+  owner: models.Owner = Depends(get_current_owner),
+  db: Session = Depends(get_db),
+):
+  principal = SharedAppPrincipal(owner=owner, role="owner", display_name=owner.username)
+  rows = db.query(models.SharedAppInstance).join(
+    models.Project, models.Project.id == models.SharedAppInstance.project_id,
+  ).filter(
+    models.SharedAppInstance.deleted_at.is_(None),
+    models.Project.deleted_at.is_(None),
+  ).order_by(models.SharedAppInstance.updated_at.desc()).all()
+  return [_view(row, principal) for row in rows]
+
+
+@router.post("/invites/redeem", dependencies=[Depends(reject_cross_site)])
+def redeem_shared_app_invite(body: SharedAppInviteRedeem, db: Session = Depends(get_db)):
+  with PROJECT_LIFECYCLE_LOCK:
+    return _redeem_shared_app_invite(body, db)
+
+
+def _redeem_shared_app_invite(body: SharedAppInviteRedeem, db: Session):
+  now = now_naive_utc()
+  invite = db.query(models.SharedAppInvite).filter(
+    models.SharedAppInvite.token_hash == _invite_hash(body.invite),
+    models.SharedAppInvite.revoked_at.is_(None),
+    models.SharedAppInvite.consumed_at.is_(None),
+    models.SharedAppInvite.expires_at > now,
+  ).first()
+  if invite is None:
+    raise HTTPException(410, "This app invitation is invalid or has expired.")
+  instance = db.query(models.SharedAppInstance).filter(
+    models.SharedAppInstance.id == invite.instance_id,
+    models.SharedAppInstance.deleted_at.is_(None),
+  ).first()
+  if instance is None:
+    raise HTTPException(410, "This shared app is no longer available.")
+  if db.query(models.Project.id).filter(
+    models.Project.id == instance.project_id,
+    models.Project.deleted_at.is_(None),
+  ).first() is None:
+    raise HTTPException(410, "This shared app is no longer available.")
+  owner = db.query(models.Owner).first()
+  if owner is None:
+    raise HTTPException(503, "The app owner is unavailable.")
+  member_id = str(uuid.uuid4())
+  member = models.SharedAppMember(
+    id=member_id, instance_id=instance.id, display_name=body.display_name,
+    role=invite.role, token_epoch=0, joined_at=now,
+  )
+  db.add(member)
+  db.flush()
+  claimed = db.query(models.SharedAppInvite).filter(
+    models.SharedAppInvite.id == invite.id,
+    models.SharedAppInvite.consumed_at.is_(None),
+    models.SharedAppInvite.revoked_at.is_(None),
+  ).update({
+    models.SharedAppInvite.consumed_at: now,
+    models.SharedAppInvite.accepted_member_id: member_id,
+  }, synchronize_session=False)
+  if claimed != 1:
+    db.rollback()
+    raise HTTPException(410, "This app invitation has already been used.")
+  try:
+    db.commit()
+  except IntegrityError as exc:
+    db.rollback()
+    raise HTTPException(409, "Shared app access could not be created.") from exc
+  token = auth.create_shared_app_collaborator_token(
+    owner_username=owner.username, owner_epoch=owner.token_epoch,
+    instance_id=instance.id, member_id=member_id, member_epoch=0,
+  )
+  return {
+    "access_token": token, "token_type": "bearer",
+    "instance": _view(instance, SharedAppPrincipal(
+      owner=owner, role=member.role, instance_id=instance.id,
+      member_id=member.id, display_name=member.display_name,
+    )),
+  }
+
+
+@router.get("/{instance_id}")
+def get_shared_app(
+  instance_id: str,
+  principal: SharedAppPrincipal = Depends(get_shared_app_principal),
+  db: Session = Depends(get_db),
+):
+  return _view(_instance_for(db, instance_id, principal), principal)
+
+
+@router.put("/{instance_id}/release", dependencies=[Depends(reject_cross_site)])
+def publish_shared_app_release(
+  instance_id: str,
+  principal: SharedAppPrincipal = Depends(get_shared_app_principal),
+  db: Session = Depends(get_db),
+):
+  with PROJECT_LIFECYCLE_LOCK:
+    return _publish_shared_app_release(instance_id, principal, db)
+
+
+def _publish_shared_app_release(
+  instance_id: str, principal: SharedAppPrincipal, db: Session,
+):
+  row = _instance_for(db, instance_id, principal, "owner")
+  project = db.query(models.Project).filter(
+    models.Project.id == row.project_id,
+    models.Project.deleted_at.is_(None),
+  ).first()
+  if project is None:
+    raise HTTPException(409, "The source project is no longer available.")
+  artifact, output_root, entry_rel = _built_artifact(project, row.artifact_id)
+  name = str(artifact.get("name") or row.name)[:256]
+  release = shared_app_releases.publish_release(
+    db,
+    row,
+    output_root=output_root,
+    entry_path=entry_rel,
+    name=name,
+  )
+  return _view(row, principal, release)
+
+
+@router.delete("/{instance_id}", status_code=204, dependencies=[Depends(reject_cross_site)])
+def delete_shared_app(
+  instance_id: str,
+  principal: SharedAppPrincipal = Depends(get_shared_app_principal),
+  db: Session = Depends(get_db),
+):
+  with PROJECT_LIFECYCLE_LOCK:
+    row = _instance_for(db, instance_id, principal, "owner")
+    now = now_naive_utc()
+    row.deleted_at = now
+    db.query(models.SharedAppInvite).filter(
+      models.SharedAppInvite.instance_id == row.id,
+      models.SharedAppInvite.revoked_at.is_(None),
+    ).update({models.SharedAppInvite.revoked_at: now}, synchronize_session=False)
+    db.query(models.SharedAppMember).filter(
+      models.SharedAppMember.instance_id == row.id,
+      models.SharedAppMember.revoked_at.is_(None),
+    ).update({
+      models.SharedAppMember.revoked_at: now,
+      models.SharedAppMember.token_epoch: models.SharedAppMember.token_epoch + 1,
+    }, synchronize_session=False)
+    db.commit()
+
+
+@router.post("/{instance_id}/recover", dependencies=[Depends(reject_cross_site)])
+def recover_shared_app(
+  instance_id: str,
+  owner: models.Owner = Depends(get_current_owner),
+  db: Session = Depends(get_db),
+):
+  with PROJECT_LIFECYCLE_LOCK:
+    cutoff = now_naive_utc() - SOFT_DELETE_TTL
+    row = db.query(models.SharedAppInstance).filter(
+      models.SharedAppInstance.id == instance_id,
+      models.SharedAppInstance.deleted_at.isnot(None),
+      models.SharedAppInstance.deleted_at >= cutoff,
+    ).first()
+    if row is None:
+      raise HTTPException(404, "Shared app not found or recovery expired.")
+    project = db.query(models.Project.id).filter(
+      models.Project.id == row.project_id,
+      models.Project.deleted_at.is_(None),
+    ).first()
+    if project is None:
+      raise HTTPException(409, "Recover the source project before this shared app.")
+    active = db.query(models.SharedAppInstance.id).filter(
+      models.SharedAppInstance.project_id == row.project_id,
+      models.SharedAppInstance.artifact_id == row.artifact_id,
+      models.SharedAppInstance.deleted_at.is_(None),
+    ).first()
+    if active is not None:
+      raise HTTPException(409, "A newer shared app already exists for this creation.")
+    row.deleted_at = None
+    row.updated_at = now_naive_utc()
+    db.commit()
+    return _view(row, SharedAppPrincipal(
+      owner=owner, role="owner", display_name=owner.username,
+    ))
+
+
+@router.get("/{instance_id}/output/{release_id}/{path:path}")
+def get_shared_app_output(
+  instance_id: str,
+  release_id: str,
+  path: str,
+  principal: SharedAppPrincipal = Depends(get_shared_app_principal),
+  db: Session = Depends(get_db),
+):
+  with shared_app_releases.release_lock(instance_id):
+    row = _instance_for(db, instance_id, principal)
+    handle, media_type = shared_app_releases.open_release_file(row, release_id, path)
+
+  def stream_body():
+    with handle:
+      while chunk := handle.read(64 * 1024):
+        yield chunk
+
+  return StreamingResponse(
+    stream_body(),
+    media_type=media_type,
+    background=BackgroundTask(handle.close),
+  )
+
+
+@router.get("/{instance_id}/state")
+def get_shared_app_state(
+  instance_id: str,
+  principal: SharedAppPrincipal = Depends(get_shared_app_principal),
+  db: Session = Depends(get_db),
+):
+  row = _instance_for(db, instance_id, principal)
+  return shared_app_state.read_state_snapshot(db, row)
+
+
+@router.get("/{instance_id}/changes")
+def get_shared_app_changes(
+  instance_id: str,
+  after: int | None = Query(default=None, ge=0),
+  principal: SharedAppPrincipal = Depends(get_shared_app_principal),
+  db: Session = Depends(get_db),
+):
+  return shared_app_state.list_changes(
+    db, _instance_for(db, instance_id, principal), after,
+  )
+
+
+@router.put("/{instance_id}/state/{path:path}", dependencies=[Depends(reject_cross_site)])
+def put_shared_app_state(
+  instance_id: str,
+  path: str,
+  body: SharedStateWrite,
+  principal: SharedAppPrincipal = Depends(get_shared_app_principal),
+  db: Session = Depends(get_db),
+):
+  row = _instance_for(db, instance_id, principal, "editor")
+  return shared_app_state.write_state(
+    db, row, principal,
+    path=path, value=body.value, delete=body.delete,
+    expected_version=body.expected_version,
+  )
+
+
+@router.get("/{instance_id}/collaboration")
+def get_shared_app_collaboration(
+  instance_id: str,
+  principal: SharedAppPrincipal = Depends(get_shared_app_principal),
+  db: Session = Depends(get_db),
+):
+  row = _instance_for(db, instance_id, principal)
+  members = db.query(models.SharedAppMember).filter(
+    models.SharedAppMember.instance_id == row.id,
+    models.SharedAppMember.revoked_at.is_(None),
+  ).order_by(models.SharedAppMember.joined_at.asc()).all()
+  payload = {
+    "role": principal.role,
+    "members": [
+      {"id": "owner", "display_name": principal.owner.username, "role": "owner", "you": principal.is_owner},
+      *[
+        {"id": item.id, "display_name": item.display_name, "role": item.role, "you": item.id == principal.member_id}
+        for item in members
+      ],
+    ],
+  }
+  if principal.is_owner:
+    payload["invites"] = [{
+      "id": item.id,
+      "invitee_name": item.invitee_name,
+      "role": item.role,
+      "expires_at": item.expires_at,
+    } for item in db.query(models.SharedAppInvite).filter(
+      models.SharedAppInvite.instance_id == row.id,
+      models.SharedAppInvite.revoked_at.is_(None),
+      models.SharedAppInvite.consumed_at.is_(None),
+      models.SharedAppInvite.expires_at > now_naive_utc(),
+    ).order_by(models.SharedAppInvite.created_at.desc()).all()]
+  return payload
+
+
+@router.post("/{instance_id}/invites", dependencies=[Depends(reject_cross_site)])
+def create_shared_app_invite(
+  instance_id: str,
+  body: SharedAppInviteCreate,
+  principal: SharedAppPrincipal = Depends(get_shared_app_principal),
+  db: Session = Depends(get_db),
+):
+  with PROJECT_LIFECYCLE_LOCK:
+    return _create_shared_app_invite(instance_id, body, principal, db)
+
+
+def _create_shared_app_invite(
+  instance_id: str,
+  body: SharedAppInviteCreate,
+  principal: SharedAppPrincipal,
+  db: Session,
+):
+  row = _instance_for(db, instance_id, principal, "owner")
+  secret = secrets.token_urlsafe(32)
+  now = now_naive_utc()
+  invite = models.SharedAppInvite(
+    id=str(uuid.uuid4()), instance_id=row.id, token_hash=_invite_hash(secret),
+    invitee_name=body.invitee_name, role=body.role,
+    created_at=now, expires_at=now + _INVITE_TTL,
+  )
+  db.add(invite)
+  db.commit()
+  return {
+    "id": invite.id,
+    "invitee_name": invite.invitee_name,
+    "role": invite.role,
+    "expires_at": invite.expires_at,
+    "join_url": get_settings().frontend_origin.rstrip("/") + "/app-invite#" + secret,
+  }
+
+
+@router.delete(
+  "/{instance_id}/invites/{invite_id}", status_code=204,
+  dependencies=[Depends(reject_cross_site)],
+)
+def revoke_shared_app_invite(
+  instance_id: str,
+  invite_id: str,
+  principal: SharedAppPrincipal = Depends(get_shared_app_principal),
+  db: Session = Depends(get_db),
+):
+  row = _instance_for(db, instance_id, principal, "owner")
+  invite = db.query(models.SharedAppInvite).filter(
+    models.SharedAppInvite.id == invite_id,
+    models.SharedAppInvite.instance_id == row.id,
+    models.SharedAppInvite.revoked_at.is_(None),
+    models.SharedAppInvite.consumed_at.is_(None),
+  ).first()
+  if invite is None:
+    raise HTTPException(404, "Invitation not found.")
+  invite.revoked_at = now_naive_utc()
+  db.commit()
+
+
+@router.patch(
+  "/{instance_id}/members/{member_id}", dependencies=[Depends(reject_cross_site)],
+)
+def update_shared_app_member(
+  instance_id: str,
+  member_id: str,
+  body: SharedAppMemberUpdate,
+  principal: SharedAppPrincipal = Depends(get_shared_app_principal),
+  db: Session = Depends(get_db),
+):
+  row = _instance_for(db, instance_id, principal, "owner")
+  member = db.query(models.SharedAppMember).filter(
+    models.SharedAppMember.id == member_id,
+    models.SharedAppMember.instance_id == row.id,
+    models.SharedAppMember.revoked_at.is_(None),
+  ).first()
+  if member is None:
+    raise HTTPException(404, "Member not found.")
+  member.role = body.role
+  db.commit()
+  return {"id": member.id, "display_name": member.display_name, "role": member.role}
+
+
+@router.delete(
+  "/{instance_id}/members/{member_id}", status_code=204,
+  dependencies=[Depends(reject_cross_site)],
+)
+def revoke_shared_app_member(
+  instance_id: str,
+  member_id: str,
+  principal: SharedAppPrincipal = Depends(get_shared_app_principal),
+  db: Session = Depends(get_db),
+):
+  row = _instance_for(db, instance_id, principal, "owner")
+  member = db.query(models.SharedAppMember).filter(
+    models.SharedAppMember.id == member_id,
+    models.SharedAppMember.instance_id == row.id,
+    models.SharedAppMember.revoked_at.is_(None),
+  ).first()
+  if member is None:
+    raise HTTPException(404, "Member not found.")
+  member.revoked_at = now_naive_utc()
+  member.token_epoch += 1
+  db.commit()

--- a/backend/app/schema_migrations.py
+++ b/backend/app/schema_migrations.py
@@ -1937,6 +1937,7 @@ def _pin_established_legacy_chat_models(eng) -> None:
       })
 
 
+
 def _add_app_project_templates(eng) -> None:
   """Persist validated manifest project-template declarations on App rows."""
   from sqlalchemy import inspect as sa_inspect, text
@@ -2100,6 +2101,253 @@ def _add_chat_goal_dismissal(eng) -> None:
     ))
 
 
+
+def _add_shared_app_retention(eng) -> None:
+  """Make shared app removal reversible on existing installations."""
+  from sqlalchemy import inspect as sa_inspect, text
+
+  inspector = sa_inspect(eng)
+  if "shared_app_instances" not in inspector.get_table_names():
+    return
+  columns = {
+    column["name"]
+    for column in inspector.get_columns("shared_app_instances")
+  }
+  with eng.begin() as conn:
+    if "deleted_at" not in columns:
+      conn.execute(text(
+        "ALTER TABLE shared_app_instances ADD COLUMN deleted_at DATETIME NULL"
+      ))
+    conn.execute(text(
+      "CREATE INDEX IF NOT EXISTS ix_shared_app_instances_deleted_at "
+      "ON shared_app_instances (deleted_at)"
+    ))
+
+
+def _migrate_shared_app_state_files(eng) -> None:
+  """Move prototype JSON blobs into path-based shared storage.
+
+  Historical migrations own their behavior permanently, so this conversion
+  carries its validation, path ownership, and atomic-write logic instead of
+  importing mutable runtime helpers.
+  """
+  import re
+  import tempfile
+
+  from sqlalchemy import (
+    JSON as SAJSON,
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    MetaData,
+    String,
+    Table,
+    bindparam,
+    inspect as sa_inspect,
+    text,
+  )
+
+  inspector = sa_inspect(eng)
+  if "shared_app_instances" not in inspector.get_table_names():
+    return
+  # Fresh installations use path storage directly and never create the
+  # prototype blob columns. Existing installations keep this one-way data
+  # migration, but the compatibility shape is not part of normal runtime.
+  columns = {
+    column["name"]
+    for column in inspector.get_columns("shared_app_instances")
+  }
+  if not {"state_json", "revision"}.issubset(columns):
+    return
+
+  metadata = MetaData()
+  Table("shared_app_instances", metadata, autoload_with=eng)
+  changes = Table(
+    "shared_app_changes",
+    metadata,
+    Column("id", Integer, primary_key=True, autoincrement=True),
+    Column(
+      "instance_id",
+      String(64),
+      ForeignKey("shared_app_instances.id", ondelete="CASCADE"),
+      nullable=False,
+      index=True,
+    ),
+    Column("kind", String(16), nullable=False),
+    Column("path", String(200), nullable=False),
+    Column("version", String(128), nullable=True),
+    Column("actor_key", String(72), nullable=False),
+    Column("display_name", String(256), nullable=False),
+    Column("created_at", DateTime, nullable=False, index=True),
+    extend_existing=True,
+  )
+  changes.create(bind=eng, checkfirst=True)
+
+  safe_path = re.compile(r"^[\w._/@+ -]+$")
+
+  def validate_path(value: str) -> Path:
+    path = str(value)
+    relative = Path(path)
+    if (
+      not path
+      or len(path) > 200
+      or path.startswith("/")
+      or "\\" in path
+      or ".." in relative.parts
+      or safe_path.fullmatch(path) is None
+    ):
+      raise RuntimeError("shared app state has an invalid path")
+    return relative
+
+  data_root = Path(os.environ.get("DATA_DIR", "/data")).resolve()
+  instances_root = data_root / "shared" / "app-instances"
+
+  def owned_root(instance_id: str, snapshot_path: str) -> Path:
+    root = instances_root / str(instance_id)
+    stored = Path(snapshot_path)
+    lexical = stored if stored.is_absolute() else data_root / stored
+    try:
+      if lexical.absolute() != (root / "build").absolute():
+        raise RuntimeError("shared app state has an invalid snapshot path")
+      instances_root.resolve().relative_to(data_root)
+    except (OSError, ValueError) as exc:
+      raise RuntimeError("shared app state has an invalid snapshot path") from exc
+    if root.is_symlink() or (root / "data").is_symlink():
+      raise RuntimeError("shared app state has an unsafe snapshot path")
+    return root
+
+  def atomic_write(target: Path, content: bytes) -> None:
+    target.parent.mkdir(parents=True, exist_ok=True)
+    current = target.parent
+    while current != instances_root:
+      if current.is_symlink():
+        raise RuntimeError("shared app state has an unsafe path")
+      current = current.parent
+    fd, temporary = tempfile.mkstemp(
+      dir=target.parent,
+      prefix=f".{target.name}.",
+      suffix=".tmp",
+    )
+    try:
+      with os.fdopen(fd, "wb") as handle:
+        handle.write(content)
+        handle.flush()
+        os.fsync(handle.fileno())
+      os.chmod(temporary, 0o644)
+      os.replace(temporary, target)
+    except BaseException:
+      try:
+        os.unlink(temporary)
+      except OSError:
+        pass
+      raise
+
+  clear = text(
+    "UPDATE shared_app_instances "
+    "SET state_json = :empty, revision = 0 WHERE id = :id"
+  ).bindparams(bindparam("empty", type_=SAJSON))
+  with eng.begin() as conn:
+    rows = conn.execute(text(
+      "SELECT id, snapshot_path, state_json FROM shared_app_instances"
+    )).mappings().all()
+    for row in rows:
+      values = row["state_json"]
+      if isinstance(values, str):
+        values = json.loads(values)
+      if not isinstance(values, dict) or not values:
+        continue
+      root = owned_root(str(row["id"]), str(row["snapshot_path"]))
+      for path, value in values.items():
+        target = root / "data" / validate_path(str(path))
+        atomic_write(
+          target,
+          json.dumps(
+            value,
+            ensure_ascii=False,
+            separators=(",", ":"),
+          ).encode("utf-8"),
+        )
+      conn.execute(clear, {"empty": {}, "id": row["id"]})
+
+
+def _add_project_artifact_drawer_state(eng) -> None:
+  """Track built-result opens without treating navigation as a content edit."""
+  from sqlalchemy import (
+    Column,
+    DateTime,
+    ForeignKey,
+    MetaData,
+    String,
+    Table,
+    inspect as sa_inspect,
+  )
+
+  if "projects" not in sa_inspect(eng).get_table_names():
+    return
+  metadata = MetaData()
+  Table("projects", metadata, autoload_with=eng)
+  drawer_state = Table(
+    "project_artifact_drawer_state",
+    metadata,
+    Column(
+      "project_id",
+      String(64),
+      ForeignKey("projects.id", ondelete="CASCADE"),
+      primary_key=True,
+    ),
+    Column("artifact_id", String(64), primary_key=True),
+    Column("last_opened_at", DateTime, nullable=False),
+    extend_existing=True,
+  )
+  drawer_state.create(bind=eng, checkfirst=True)
+
+
+def _add_shared_app_change_operation_id(eng) -> None:
+  """Give filesystem journals one durable, idempotent change identity."""
+  from sqlalchemy import inspect as sa_inspect, text
+
+  inspector = sa_inspect(eng)
+  if "shared_app_changes" not in inspector.get_table_names():
+    return
+  columns = {
+    column["name"]
+    for column in inspector.get_columns("shared_app_changes")
+  }
+  with eng.begin() as conn:
+    if "operation_id" not in columns:
+      conn.execute(text(
+        "ALTER TABLE shared_app_changes ADD COLUMN operation_id VARCHAR(64) NULL"
+      ))
+    conn.execute(text(
+      "CREATE UNIQUE INDEX IF NOT EXISTS ix_shared_app_changes_operation_id "
+      "ON shared_app_changes (operation_id)"
+    ))
+
+
+def _add_shared_app_previous_snapshot_path(eng) -> None:
+  """Retain one immutable predecessor while clients finish a pinned load."""
+  from sqlalchemy import inspect as sa_inspect, text
+
+  inspector = sa_inspect(eng)
+  if "shared_app_instances" not in inspector.get_table_names():
+    return
+  columns = {
+    column["name"]
+    for column in inspector.get_columns("shared_app_instances")
+  }
+  with eng.begin() as conn:
+    if "previous_snapshot_path" not in columns:
+      conn.execute(text(
+        "ALTER TABLE shared_app_instances "
+        "ADD COLUMN previous_snapshot_path VARCHAR(2048) NULL"
+      ))
+    conn.execute(text(
+      "CREATE UNIQUE INDEX IF NOT EXISTS ix_shared_app_instances_previous_snapshot_path "
+      "ON shared_app_instances (previous_snapshot_path)"
+    ))
+
+
 _SCHEMA_MIGRATIONS = (
   ("0001_legacy_schema_convergence", _converge_legacy_schema),
   ("0002_chat_run_goal_objective", _add_chat_run_goal_objective),
@@ -2127,6 +2375,11 @@ _SCHEMA_MIGRATIONS = (
   ("0022_project_artifacts", _add_project_artifacts),
   ("0023_project_color", _add_project_color),
   ("0024_chat_goal_dismissal", _add_chat_goal_dismissal),
+  ("0025_shared_app_retention", _add_shared_app_retention),
+  ("0026_shared_app_path_state", _migrate_shared_app_state_files),
+  ("0027_project_artifact_drawer_state", _add_project_artifact_drawer_state),
+  ("0028_shared_app_change_operation_id", _add_shared_app_change_operation_id),
+  ("0029_shared_app_previous_snapshot_path", _add_shared_app_previous_snapshot_path),
 )
 
 

--- a/backend/app/schema_migrations.py
+++ b/backend/app/schema_migrations.py
@@ -2132,7 +2132,6 @@ def _migrate_shared_app_state_files(eng) -> None:
   importing mutable runtime helpers.
   """
   import re
-  import tempfile
   import uuid
 
   from sqlalchemy import (
@@ -2243,29 +2242,66 @@ def _migrate_shared_app_state_files(eng) -> None:
     finally:
       os.close(descriptor)
 
-  def atomic_write(target: Path, content: bytes) -> None:
-    target.parent.mkdir(parents=True, exist_ok=True)
-    current = target.parent
-    while current != instances_root:
-      if current.is_symlink():
-        raise RuntimeError("shared app state has an unsafe path")
-      current = current.parent
-    fd, temporary = tempfile.mkstemp(
-      dir=target.parent,
-      prefix=f".{target.name}.",
-      suffix=".tmp",
-    )
+  def open_parent(target: Path) -> int:
+    """Open/create ``target.parent`` without following path symlinks."""
+    relative = target.relative_to(instances_root)
+    instance_root = instances_root / relative.parts[0]
+    flags = os.O_RDONLY
+    if hasattr(os, "O_DIRECTORY"):
+      flags |= os.O_DIRECTORY
+    if hasattr(os, "O_NOFOLLOW"):
+      flags |= os.O_NOFOLLOW
     try:
+      descriptor = os.open(instance_root, flags)
+      for part in relative.parent.parts[1:]:
+        try:
+          child = os.open(part, flags, dir_fd=descriptor)
+        except FileNotFoundError:
+          # Create exactly one component below the already-open owning
+          # directory. Never ``parents=True``: a later symlink in the chain
+          # must be rejected before it can redirect any descendant creation.
+          os.mkdir(part, 0o755, dir_fd=descriptor)
+          os.fsync(descriptor)
+          child = os.open(part, flags, dir_fd=descriptor)
+        os.close(descriptor)
+        descriptor = child
+      return descriptor
+    except OSError as exc:
+      try:
+        os.close(descriptor)
+      except (OSError, UnboundLocalError):
+        pass
+      raise RuntimeError("shared app state has an unsafe path") from exc
+
+  def atomic_write(target: Path, content: bytes) -> None:
+    parent_descriptor = open_parent(target)
+    temporary = f".{target.name}.{uuid.uuid4().hex}.tmp"
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    if hasattr(os, "O_NOFOLLOW"):
+      flags |= os.O_NOFOLLOW
+    try:
+      fd = os.open(
+        temporary,
+        flags,
+        0o644,
+        dir_fd=parent_descriptor,
+      )
       with os.fdopen(fd, "wb") as handle:
         os.fchmod(handle.fileno(), 0o644)
         handle.write(content)
         handle.flush()
         os.fsync(handle.fileno())
-      os.replace(temporary, target)
+      os.replace(
+        temporary,
+        target.name,
+        src_dir_fd=parent_descriptor,
+        dst_dir_fd=parent_descriptor,
+      )
       # The file fsync above preserves its bytes. Directory fsyncs, from the
       # new leaf back to the already-owned instance root, preserve the rename
       # and every newly-created directory entry before the DB blob is cleared.
-      current = target.parent
+      os.fsync(parent_descriptor)
+      current = target.parent.parent
       while True:
         sync_directory(current)
         if current == instances_root / target.relative_to(instances_root).parts[0]:
@@ -2273,10 +2309,12 @@ def _migrate_shared_app_state_files(eng) -> None:
         current = current.parent
     except BaseException:
       try:
-        os.unlink(temporary)
+        os.unlink(temporary, dir_fd=parent_descriptor)
       except OSError:
         pass
       raise
+    finally:
+      os.close(parent_descriptor)
 
   clear = text(
     "UPDATE shared_app_instances "

--- a/backend/app/schema_migrations.py
+++ b/backend/app/schema_migrations.py
@@ -2133,6 +2133,7 @@ def _migrate_shared_app_state_files(eng) -> None:
   """
   import re
   import tempfile
+  import uuid
 
   from sqlalchemy import (
     JSON as SAJSON,
@@ -2204,18 +2205,43 @@ def _migrate_shared_app_state_files(eng) -> None:
   instances_root = data_root / "shared" / "app-instances"
 
   def owned_root(instance_id: str, snapshot_path: str) -> Path:
-    root = instances_root / str(instance_id)
+    try:
+      canonical_id = str(uuid.UUID(str(instance_id)))
+    except (ValueError, AttributeError) as exc:
+      raise RuntimeError("shared app state has an invalid instance id") from exc
+    if canonical_id != str(instance_id):
+      raise RuntimeError("shared app state has an invalid instance id")
+    root = instances_root / canonical_id
     stored = Path(snapshot_path)
     lexical = stored if stored.is_absolute() else data_root / stored
     try:
       if lexical.absolute() != (root / "build").absolute():
         raise RuntimeError("shared app state has an invalid snapshot path")
-      instances_root.resolve().relative_to(data_root)
+      resolved_instances = instances_root.resolve()
+      resolved_instances.relative_to(data_root)
+      resolved_root = root.resolve()
+      if resolved_root.relative_to(resolved_instances).parts != (canonical_id,):
+        raise RuntimeError("shared app state has an invalid snapshot path")
     except (OSError, ValueError) as exc:
       raise RuntimeError("shared app state has an invalid snapshot path") from exc
-    if root.is_symlink() or (root / "data").is_symlink():
-      raise RuntimeError("shared app state has an unsafe snapshot path")
+    current = data_root
+    for part in (root / "data").relative_to(data_root).parts:
+      current = current / part
+      if current.is_symlink():
+        raise RuntimeError("shared app state has an unsafe snapshot path")
     return root
+
+  def sync_directory(path: Path) -> None:
+    flags = os.O_RDONLY
+    if hasattr(os, "O_DIRECTORY"):
+      flags |= os.O_DIRECTORY
+    if hasattr(os, "O_NOFOLLOW"):
+      flags |= os.O_NOFOLLOW
+    descriptor = os.open(path, flags)
+    try:
+      os.fsync(descriptor)
+    finally:
+      os.close(descriptor)
 
   def atomic_write(target: Path, content: bytes) -> None:
     target.parent.mkdir(parents=True, exist_ok=True)
@@ -2231,11 +2257,20 @@ def _migrate_shared_app_state_files(eng) -> None:
     )
     try:
       with os.fdopen(fd, "wb") as handle:
+        os.fchmod(handle.fileno(), 0o644)
         handle.write(content)
         handle.flush()
         os.fsync(handle.fileno())
-      os.chmod(temporary, 0o644)
       os.replace(temporary, target)
+      # The file fsync above preserves its bytes. Directory fsyncs, from the
+      # new leaf back to the already-owned instance root, preserve the rename
+      # and every newly-created directory entry before the DB blob is cleared.
+      current = target.parent
+      while True:
+        sync_directory(current)
+        if current == instances_root / target.relative_to(instances_root).parts[0]:
+          break
+        current = current.parent
     except BaseException:
       try:
         os.unlink(temporary)

--- a/backend/app/shared_app_releases.py
+++ b/backend/app/shared_app_releases.py
@@ -1,0 +1,331 @@
+"""Immutable, fsynced build releases owned by shared-app database pointers."""
+
+from __future__ import annotations
+
+import mimetypes
+import os
+import shutil
+import threading
+import uuid
+from dataclasses import dataclass
+from io import BufferedReader
+from pathlib import Path
+from weakref import WeakValueDictionary
+
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+from app import models
+from app.config import get_settings
+from app.path_utils import validate_path_within_base
+from app.shared_app_retention import owned_snapshot_root, remove_snapshot_root
+from app.storage_io import sync_directory, sync_file_tree
+from app.timeutil import now_naive_utc
+
+
+_RELEASES_DIR = "releases"
+_STAGING_PREFIX = ".release-staging-"
+SNAPSHOT_BYTES_MAX = 100 * 1024 * 1024
+_locks: "WeakValueDictionary[str, threading.RLock]" = WeakValueDictionary()
+_locks_guard = threading.Lock()
+
+
+@dataclass(frozen=True)
+class SharedAppRelease:
+  release_id: str
+  snapshot_path: str
+  entry_path: str
+  name: str
+  published_at: str
+
+
+def release_lock(instance_id: str) -> threading.RLock:
+  with _locks_guard:
+    lock = _locks.get(instance_id)
+    if lock is None:
+      lock = threading.RLock()
+      _locks[instance_id] = lock
+    return lock
+
+
+def _instance_root(instance_id: str, snapshot_path: str) -> Path:
+  root = owned_snapshot_root(instance_id, snapshot_path)
+  if root is None or root.is_symlink():
+    raise HTTPException(500, "Shared app storage is misconfigured.")
+  return root
+
+
+def _snapshot_release_id(instance_id: str, snapshot_path: str) -> str:
+  root = _instance_root(instance_id, snapshot_path)
+  data_root = Path(get_settings().data_dir).resolve()
+  stored = Path(snapshot_path)
+  target = stored if stored.is_absolute() else data_root / stored
+  try:
+    relative = target.absolute().relative_to(root.absolute())
+  except ValueError as exc:
+    raise HTTPException(500, "Shared app release metadata is invalid.") from exc
+  if relative.parts == ("build",):
+    return "legacy"
+  if len(relative.parts) != 2 or relative.parts[0] != _RELEASES_DIR:
+    raise HTTPException(500, "Shared app release metadata is invalid.")
+  try:
+    release_id = str(uuid.UUID(relative.parts[1]))
+  except (ValueError, AttributeError) as exc:
+    raise HTTPException(500, "Shared app release metadata is invalid.") from exc
+  if release_id != relative.parts[1]:
+    raise HTTPException(500, "Shared app release metadata is invalid.")
+  return release_id
+
+
+def _release_root(instance_id: str, snapshot_path: str) -> Path:
+  root = _instance_root(instance_id, snapshot_path)
+  data_root = Path(get_settings().data_dir).resolve()
+  stored = Path(snapshot_path)
+  target = stored if stored.is_absolute() else data_root / stored
+  target = target.absolute()
+  _snapshot_release_id(instance_id, snapshot_path)
+  try:
+    relative = target.relative_to(root.absolute())
+  except ValueError as exc:
+    raise HTTPException(500, "Shared app release storage is unavailable.") from exc
+  current = root
+  for part in relative.parts:
+    current = current / part
+    if current.is_symlink():
+      raise HTTPException(500, "Shared app release storage is unavailable.")
+  if not target.is_dir():
+    raise HTTPException(500, "Shared app release storage is unavailable.")
+  return target
+
+
+def current_release(row: models.SharedAppInstance) -> SharedAppRelease:
+  release_id = _snapshot_release_id(str(row.id), str(row.snapshot_path))
+  root = _release_root(str(row.id), str(row.snapshot_path))
+  try:
+    entry = validate_path_within_base(str(row.entry_path), root)
+  except HTTPException as exc:
+    raise HTTPException(500, "Shared app release metadata is invalid.") from exc
+  if entry.is_symlink() or not entry.is_file():
+    raise HTTPException(500, "Shared app release entry is unavailable.")
+  updated_at = row.updated_at or row.created_at or now_naive_utc()
+  return SharedAppRelease(
+    release_id=release_id,
+    snapshot_path=str(row.snapshot_path),
+    entry_path=str(row.entry_path),
+    name=str(row.name),
+    published_at=updated_at.isoformat() + "Z",
+  )
+
+
+def _remove_owned_path(path: Path) -> None:
+  if path.is_symlink():
+    path.unlink(missing_ok=True)
+  elif path.exists():
+    remove_snapshot_root(path)
+  if path.parent.is_dir():
+    sync_directory(path.parent)
+
+
+def _ensure_durable_directory(path: Path) -> None:
+  """Create one directory and durably link it from its existing parent."""
+  if path.is_symlink():
+    raise HTTPException(500, "Shared app release storage is misconfigured.")
+  if path.exists():
+    if not path.is_dir():
+      raise HTTPException(500, "Shared app release storage is misconfigured.")
+    return
+  if not path.parent.is_dir() or path.parent.is_symlink():
+    raise HTTPException(500, "Shared app release storage is misconfigured.")
+  path.mkdir()
+  sync_directory(path.parent)
+
+
+def _install_immutable_release(instance_id: str, output_root: Path) -> SharedAppRelease:
+  data_root = Path(get_settings().data_dir).resolve()
+  shared = data_root / "shared"
+  instances = shared / "app-instances"
+  root = instances / instance_id
+  release_id = str(uuid.uuid4())
+  staging = root / f"{_STAGING_PREFIX}{release_id}"
+  releases = root / _RELEASES_DIR
+  target = releases / release_id
+  for directory in (shared, instances, root, releases):
+    _ensure_durable_directory(directory)
+  if root.is_symlink() or releases.is_symlink() or staging.is_symlink() or target.exists():
+    raise HTTPException(500, "Shared app release storage is misconfigured.")
+  try:
+    # Preserve source symlinks as symlinks so ``sync_file_tree`` rejects them;
+    # never follow a path that appeared after the artifact's validation walk.
+    shutil.copytree(output_root, staging, symlinks=True)
+    total = 0
+    for candidate in staging.rglob("*"):
+      if candidate.is_symlink():
+        raise HTTPException(422, "Shared builds cannot contain symbolic links.")
+      if candidate.is_file():
+        total += candidate.stat().st_size
+        if total > SNAPSHOT_BYTES_MAX:
+          raise HTTPException(413, "This build is too large to share as an app.")
+    sync_file_tree(staging)
+    staging.rename(target)
+    sync_directory(releases)
+  except BaseException:
+    if staging.exists() or staging.is_symlink():
+      _remove_owned_path(staging)
+    raise
+  snapshot_path = target.relative_to(data_root).as_posix()
+  return SharedAppRelease(
+    release_id=release_id,
+    snapshot_path=snapshot_path,
+    entry_path="",
+    name="",
+    published_at=now_naive_utc().isoformat() + "Z",
+  )
+
+
+def create_initial_release(
+  *,
+  instance_id: str,
+  output_root: Path,
+  entry_path: str,
+  name: str,
+) -> SharedAppRelease:
+  with release_lock(instance_id):
+    installed = _install_immutable_release(instance_id, output_root)
+    release = SharedAppRelease(
+      release_id=installed.release_id,
+      snapshot_path=installed.snapshot_path,
+      entry_path=entry_path,
+      name=name,
+      published_at=installed.published_at,
+    )
+    root = _release_root(instance_id, release.snapshot_path)
+    try:
+      entry = validate_path_within_base(entry_path, root)
+    except HTTPException as exc:
+      _remove_owned_path(root)
+      raise HTTPException(500, "Shared app release metadata is invalid.") from exc
+    if entry.is_symlink() or not entry.is_file():
+      _remove_owned_path(root)
+      raise HTTPException(500, "Shared app release entry is unavailable.")
+    return release
+
+
+def _cleanup_instance_releases_locked(row: models.SharedAppInstance) -> None:
+  root = _instance_root(str(row.id), str(row.snapshot_path))
+  keep = {str(row.snapshot_path)}
+  if row.previous_snapshot_path:
+    _snapshot_release_id(str(row.id), str(row.previous_snapshot_path))
+    keep.add(str(row.previous_snapshot_path))
+  data_root = Path(get_settings().data_dir).resolve()
+  keep_paths = {
+    (Path(path) if Path(path).is_absolute() else data_root / path).absolute()
+    for path in keep
+  }
+  for child in root.iterdir() if root.is_dir() else ():
+    if (
+      child.name.startswith(_STAGING_PREFIX)
+      or child.name.startswith(".build.next-")
+      or child.name.startswith(".build.previous-")
+    ):
+      _remove_owned_path(child)
+  legacy = root / "build"
+  if legacy.absolute() not in keep_paths and (legacy.exists() or legacy.is_symlink()):
+    _remove_owned_path(legacy)
+  releases = root / _RELEASES_DIR
+  if releases.is_dir() and not releases.is_symlink():
+    for child in releases.iterdir():
+      if child.absolute() not in keep_paths:
+        _remove_owned_path(child)
+
+
+def cleanup_instance_releases(row: models.SharedAppInstance) -> None:
+  with release_lock(str(row.id)):
+    _cleanup_instance_releases_locked(row)
+
+
+def publish_release(
+  db: Session,
+  row: models.SharedAppInstance,
+  *,
+  output_root: Path,
+  entry_path: str,
+  name: str,
+) -> SharedAppRelease:
+  """Install, fsync, and transactionally point at one immutable release."""
+  with release_lock(str(row.id)):
+    old_snapshot = str(row.snapshot_path)
+    installed = _install_immutable_release(str(row.id), output_root)
+    row.previous_snapshot_path = old_snapshot
+    row.snapshot_path = installed.snapshot_path
+    row.entry_path = entry_path
+    row.name = name
+    row.updated_at = now_naive_utc()
+    try:
+      # ``current_release`` validates the new tree before its pointer commits.
+      release = current_release(row)
+      db.commit()
+    except Exception:
+      db.rollback()
+      try:
+        persisted_snapshot = db.query(models.SharedAppInstance.snapshot_path).filter(
+          models.SharedAppInstance.id == row.id,
+        ).scalar()
+      except Exception:
+        # The commit outcome is unknowable while the database is unavailable.
+        # Keep the fsynced immutable tree; startup reconciliation removes it
+        # only if no durable pointer references it.
+        raise
+      if persisted_snapshot != installed.snapshot_path:
+        data_root = Path(get_settings().data_dir).resolve()
+        target = Path(installed.snapshot_path)
+        target = target if target.is_absolute() else data_root / target
+        _remove_owned_path(target)
+      raise
+    _cleanup_instance_releases_locked(row)
+    return release
+
+
+def _snapshot_for_token(row: models.SharedAppInstance, release_id: str) -> str:
+  current_id = _snapshot_release_id(str(row.id), str(row.snapshot_path))
+  if release_id == current_id:
+    return str(row.snapshot_path)
+  if row.previous_snapshot_path:
+    previous_id = _snapshot_release_id(str(row.id), str(row.previous_snapshot_path))
+    if release_id == previous_id:
+      return str(row.previous_snapshot_path)
+  raise HTTPException(404, "Shared app release not found.")
+
+
+def open_release_file(
+  row: models.SharedAppInstance, release_id: str, path: str,
+) -> tuple[BufferedReader, str]:
+  """Open one authorized release body before publication ownership is released."""
+  with release_lock(str(row.id)):
+    snapshot_path = _snapshot_for_token(row, release_id)
+    root = _release_root(str(row.id), snapshot_path)
+    rel = (path or "").lstrip("/")
+    target = validate_path_within_base(rel, root)
+    if target.is_symlink() or not target.is_file():
+      raise HTTPException(404, "Shared app file not found.")
+    fd = os.open(target, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+    return open(fd, "rb", closefd=True), (
+      mimetypes.guess_type(target.name)[0] or "application/octet-stream"
+    )
+
+
+def reconcile_release_storage(db: Session) -> None:
+  """Remove only release paths that no durable instance pointer can reach."""
+  rows = db.query(models.SharedAppInstance).all()
+  live_ids = {str(row.id) for row in rows}
+  for row in rows:
+    cleanup_instance_releases(row)
+  instances = Path(get_settings().data_dir).resolve() / "shared" / "app-instances"
+  if not instances.is_dir() or instances.is_symlink():
+    return
+  for child in instances.iterdir():
+    try:
+      instance_id = str(uuid.UUID(child.name))
+    except (ValueError, AttributeError):
+      continue
+    if instance_id not in live_ids:
+      _remove_owned_path(child)

--- a/backend/app/shared_app_retention.py
+++ b/backend/app/shared_app_retention.py
@@ -1,0 +1,158 @@
+"""Retention and filesystem ownership for pinned shared-app builds."""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import uuid
+from pathlib import Path
+
+from sqlalchemy.orm import Session
+
+from app import models
+from app.config import get_settings
+from app.project_retention import PROJECT_LIFECYCLE_LOCK
+from app.storage_io import sync_directory
+from app.timeutil import SOFT_DELETE_TTL, now_naive_utc
+
+
+log = logging.getLogger(__name__)
+
+
+def stage_project_shared_app_delete(db: Session, project_id: str, deleted_at) -> None:
+  """Make a Project and only its currently-live shared apps one recovery unit."""
+  instance_ids = [
+    str(instance_id) for (instance_id,) in db.query(models.SharedAppInstance.id).filter(
+      models.SharedAppInstance.project_id == project_id,
+      models.SharedAppInstance.deleted_at.is_(None),
+    ).all()
+  ]
+  if not instance_ids:
+    return
+  db.query(models.SharedAppInstance).filter(
+    models.SharedAppInstance.id.in_(instance_ids),
+  ).update({models.SharedAppInstance.deleted_at: deleted_at}, synchronize_session=False)
+  db.query(models.SharedAppInvite).filter(
+    models.SharedAppInvite.instance_id.in_(instance_ids),
+    models.SharedAppInvite.revoked_at.is_(None),
+  ).update({models.SharedAppInvite.revoked_at: deleted_at}, synchronize_session=False)
+  db.query(models.SharedAppMember).filter(
+    models.SharedAppMember.instance_id.in_(instance_ids),
+    models.SharedAppMember.revoked_at.is_(None),
+  ).update({
+    models.SharedAppMember.revoked_at: deleted_at,
+    models.SharedAppMember.token_epoch: models.SharedAppMember.token_epoch + 1,
+  }, synchronize_session=False)
+
+
+def stage_project_shared_app_recovery(db: Session, project_id: str, deleted_at) -> None:
+  """Recover instances deleted with a Project; revoked access stays revoked."""
+  db.query(models.SharedAppInstance).filter(
+    models.SharedAppInstance.project_id == project_id,
+    models.SharedAppInstance.deleted_at == deleted_at,
+  ).update({models.SharedAppInstance.deleted_at: None}, synchronize_session=False)
+
+
+def owned_snapshot_root(instance_id: str, snapshot_path: str) -> Path | None:
+  data_root = Path(get_settings().data_dir).resolve()
+  shared_root = data_root / "shared"
+  instances_root = data_root / "shared" / "app-instances"
+  try:
+    canonical_instance_id = str(uuid.UUID(str(instance_id)))
+  except (ValueError, AttributeError):
+    return None
+  if canonical_instance_id != str(instance_id):
+    return None
+  expected = instances_root / canonical_instance_id
+  stored = Path(snapshot_path)
+  lexical = stored if stored.is_absolute() else data_root / stored
+  try:
+    relative = lexical.absolute().relative_to(expected.absolute())
+    valid_legacy = relative.parts == ("build",)
+    valid_release = (
+      len(relative.parts) == 2
+      and relative.parts[0] == "releases"
+      and str(uuid.UUID(relative.parts[1])) == relative.parts[1]
+    )
+    if not valid_legacy and not valid_release:
+      return None
+    instances_root.resolve().relative_to(data_root)
+    if any(path.is_symlink() for path in (shared_root, instances_root, expected)):
+      return None
+  except (OSError, ValueError, AttributeError):
+    return None
+  return expected
+
+
+def remove_snapshot_root(root: Path) -> None:
+  if root.is_symlink():
+    root.unlink(missing_ok=True)
+  elif root.exists():
+    shutil.rmtree(root)
+  if root.parent.is_dir():
+    sync_directory(root.parent)
+
+
+def _sweep_orphaned_snapshot_roots(db: Session) -> None:
+  instances_root = Path(get_settings().data_dir).resolve() / "shared" / "app-instances"
+  if not instances_root.is_dir() or instances_root.is_symlink():
+    return
+  live_ids = {str(instance_id) for (instance_id,) in db.query(models.SharedAppInstance.id).all()}
+  for child in instances_root.iterdir():
+    try:
+      uuid.UUID(child.name)
+    except (ValueError, AttributeError):
+      continue
+    if child.name in live_ids:
+      continue
+    try:
+      remove_snapshot_root(child)
+    except OSError:
+      log.exception("Could not remove orphaned shared-app snapshot %s", child)
+
+
+def purge_expired_shared_apps(db: Session) -> list[str]:
+  cutoff = now_naive_utc() - SOFT_DELETE_TTL
+  with PROJECT_LIFECYCLE_LOCK:
+    rows = db.query(models.SharedAppInstance).filter(
+      models.SharedAppInstance.deleted_at.isnot(None),
+      models.SharedAppInstance.deleted_at < cutoff,
+    ).all()
+    ids = [str(row.id) for row in rows]
+    roots = [
+      root for row in rows
+      if (root := owned_snapshot_root(str(row.id), row.snapshot_path)) is not None
+    ]
+    if ids:
+      db.query(models.SharedAppInstance).filter(
+        models.SharedAppInstance.id.in_(ids),
+        models.SharedAppInstance.deleted_at.isnot(None),
+        models.SharedAppInstance.deleted_at < cutoff,
+      ).delete(synchronize_session=False)
+      db.commit()
+      db.expire_all()
+      for root in roots:
+        try:
+          remove_snapshot_root(root)
+        except OSError:
+          log.exception("Could not remove expired shared-app snapshot %s", root)
+    _sweep_orphaned_snapshot_roots(db)
+    return ids
+
+
+def delete_project_shared_apps(db: Session, project_ids: list[str]) -> list[Path]:
+  """Delete instance rows in the caller's transaction and return owned roots."""
+  if not project_ids:
+    return []
+  rows = db.query(models.SharedAppInstance).filter(
+    models.SharedAppInstance.project_id.in_(project_ids),
+  ).all()
+  roots = [
+    root for row in rows
+    if (root := owned_snapshot_root(str(row.id), row.snapshot_path)) is not None
+  ]
+  if rows:
+    db.query(models.SharedAppInstance).filter(
+      models.SharedAppInstance.id.in_([row.id for row in rows]),
+    ).delete(synchronize_session=False)
+  return roots

--- a/backend/app/shared_app_state.py
+++ b/backend/app/shared_app_state.py
@@ -1,0 +1,398 @@
+"""Path-based JSON storage and reconnect cursors for shared app instances."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import threading
+import uuid
+from pathlib import Path
+from weakref import WeakValueDictionary
+
+from fastapi import HTTPException
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from app import models
+from app.deps import SharedAppPrincipal
+from app.shared_app_retention import owned_snapshot_root
+from app.storage_io import (
+  app_dir_usage,
+  atomic_write,
+  file_version_token,
+  is_atomic_write_temp_name,
+  sync_directory,
+  sync_file_tree,
+)
+from app.timeutil import now_naive_utc
+
+
+STATE_BYTES_MAX = 512 * 1024
+CHANGE_LIMIT = 1000
+_SAFE_PATH = re.compile(r"^[\w._/@+ -]+$")
+_JOURNAL_NAME = "state-journal.json"
+# Each image is already JSON text. Encoding it inside the journal can escape
+# every quote/backslash once more, so reserve twice each image's byte bound.
+_JOURNAL_BYTES_MAX = (STATE_BYTES_MAX * 4) + (16 * 1024)
+_JOURNAL_FIELDS = {
+  "operation_id", "instance_id", "actor_key", "display_name", "kind", "path",
+  "before_present", "before_encoded", "before_mtime_ns",
+  "after_present", "after_encoded",
+}
+_locks: "WeakValueDictionary[str, threading.RLock]" = WeakValueDictionary()
+_locks_guard = threading.Lock()
+
+
+def state_lock(instance_id: str) -> threading.RLock:
+  with _locks_guard:
+    lock = _locks.get(instance_id)
+    if lock is None:
+      lock = threading.RLock()
+      _locks[instance_id] = lock
+    return lock
+
+
+def validate_state_path(path: str) -> str:
+  parts = Path(path).parts
+  if (
+    not path or len(path) > 200 or path.startswith("/") or "\\" in path
+    or ".." in parts or not _SAFE_PATH.fullmatch(path)
+    or any(is_atomic_write_temp_name(part) for part in parts)
+  ):
+    raise HTTPException(400, "Invalid shared app data path.")
+  return path
+
+
+def state_root(row: models.SharedAppInstance) -> Path:
+  root = owned_snapshot_root(str(row.id), row.snapshot_path)
+  if root is None:
+    raise HTTPException(500, "Shared app storage is misconfigured.")
+  data = root / "data"
+  if root.is_symlink() or data.is_symlink():
+    raise HTTPException(500, "Shared app storage is misconfigured.")
+  return data
+
+
+def _journal_path(row: models.SharedAppInstance) -> Path:
+  data = state_root(row)
+  journal = data.parent / _JOURNAL_NAME
+  if journal.is_symlink():
+    raise HTTPException(500, "Shared app state journal is misconfigured.")
+  return journal
+
+
+def _target(row: models.SharedAppInstance, path: str) -> Path:
+  base = state_root(row)
+  target = base.joinpath(*Path(validate_state_path(path)).parts)
+  current = base
+  for part in target.relative_to(base).parts:
+    current = current / part
+    if current.is_symlink():
+      raise HTTPException(400, "Shared app data cannot use symbolic links.")
+  return target
+
+
+def read_state(row: models.SharedAppInstance) -> dict:
+  with state_lock(str(row.id)):
+    root = state_root(row)
+    values = {}
+    versions = {}
+    if root.is_dir() and not root.is_symlink():
+      for target in root.rglob("*"):
+        if not target.is_file() or target.is_symlink():
+          continue
+        # A process crash can strand ``atomic_write``'s same-directory temp
+        # file. Its exact namespace is reserved by ``validate_state_path``;
+        # never expose partial internal bytes as app state after restart.
+        if is_atomic_write_temp_name(target.name):
+          continue
+        path = target.relative_to(root).as_posix()
+        validate_state_path(path)
+        try:
+          values[path] = json.loads(target.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+          raise HTTPException(500, "Shared app data could not be read.") from exc
+        versions[path] = file_version_token(target)
+    return {"values": values, "versions": versions}
+
+
+def read_state_snapshot(db: Session, row: models.SharedAppInstance) -> dict:
+  """Read files and their durable change cursor as one ordered snapshot."""
+  with state_lock(str(row.id)):
+    _reconcile_journal(db, row)
+    state = read_state(row)
+    state["cursor"] = _latest_change_cursor(db, row)
+    return state
+
+
+def _append_change(
+  db: Session,
+  row: models.SharedAppInstance,
+  *,
+  operation_id: str,
+  actor_key: str,
+  display_name: str,
+  kind: str,
+  path: str,
+  version: str | None,
+) -> models.SharedAppChange:
+  change = models.SharedAppChange(
+    operation_id=operation_id,
+    instance_id=row.id,
+    kind=kind,
+    path=path,
+    version=version,
+    actor_key=actor_key,
+    display_name=display_name,
+  )
+  db.add(change)
+  db.flush()
+  cutoff = db.query(models.SharedAppChange.id).filter(
+    models.SharedAppChange.instance_id == row.id,
+  ).order_by(models.SharedAppChange.id.desc()).offset(CHANGE_LIMIT - 1).limit(1).scalar()
+  if cutoff is not None:
+    db.query(models.SharedAppChange).filter(
+      models.SharedAppChange.instance_id == row.id,
+      models.SharedAppChange.id < cutoff,
+    ).delete(synchronize_session=False)
+  return change
+
+
+def _load_journal(row: models.SharedAppInstance) -> dict | None:
+  journal_path = _journal_path(row)
+  try:
+    if journal_path.stat().st_size > _JOURNAL_BYTES_MAX:
+      raise HTTPException(500, "Shared app state recovery journal is invalid.")
+    journal = json.loads(journal_path.read_text(encoding="utf-8"))
+  except FileNotFoundError:
+    return None
+  except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+    raise HTTPException(500, "Shared app state recovery journal is invalid.") from exc
+  if not isinstance(journal, dict):
+    raise HTTPException(500, "Shared app state recovery journal is invalid.")
+  try:
+    operation_id = str(uuid.UUID(str(journal.get("operation_id"))))
+  except (ValueError, AttributeError, TypeError) as exc:
+    raise HTTPException(500, "Shared app state recovery journal is invalid.") from exc
+  if operation_id != journal.get("operation_id"):
+    raise HTTPException(500, "Shared app state recovery journal is invalid.")
+  if (
+    set(journal) != _JOURNAL_FIELDS
+    or journal.get("instance_id") != str(row.id)
+    or journal.get("kind") not in {"set", "delete"}
+    or not isinstance(journal.get("path"), str)
+    or not isinstance(journal.get("actor_key"), str)
+    or not isinstance(journal.get("display_name"), str)
+    or type(journal.get("before_present")) is not bool
+    or type(journal.get("after_present")) is not bool
+    or journal.get("before_present") != isinstance(journal.get("before_encoded"), str)
+    or journal.get("after_present") != isinstance(journal.get("after_encoded"), str)
+    or (not journal.get("before_present") and journal.get("before_encoded") is not None)
+    or (not journal.get("after_present") and journal.get("after_encoded") is not None)
+    or journal.get("before_present") != (type(journal.get("before_mtime_ns")) is int)
+    or journal.get("after_present") != (journal.get("kind") == "set")
+  ):
+    raise HTTPException(500, "Shared app state recovery journal is invalid.")
+  try:
+    validate_state_path(journal["path"])
+    for key in ("before_encoded", "after_encoded"):
+      encoded = journal.get(key)
+      if isinstance(encoded, str):
+        if len(encoded.encode("utf-8")) > STATE_BYTES_MAX:
+          raise ValueError("journal image exceeds the state bound")
+        json.loads(encoded)
+  except (HTTPException, UnicodeError, ValueError) as exc:
+    raise HTTPException(500, "Shared app state recovery journal is invalid.") from exc
+  return journal
+
+
+def _write_journal(row: models.SharedAppInstance, journal: dict) -> None:
+  encoded = json.dumps(journal, ensure_ascii=False, separators=(",", ":"))
+  if len(encoded.encode("utf-8")) > _JOURNAL_BYTES_MAX:
+    raise HTTPException(500, "Shared app state recovery journal is too large.")
+  atomic_write(_journal_path(row), encoded)
+  sync_directory(_journal_path(row).parent)
+
+
+def _remove_journal(row: models.SharedAppInstance) -> None:
+  journal_path = _journal_path(row)
+  journal_path.unlink(missing_ok=True)
+  sync_directory(journal_path.parent)
+
+
+def _apply_journal_image(
+  row: models.SharedAppInstance, journal: dict, image: str,
+) -> str | None:
+  target = _target(row, journal["path"])
+  if target.exists() and not target.is_file():
+    raise HTTPException(400, "Shared app data paths must identify files.")
+  present = journal[f"{image}_present"]
+  if not present:
+    target.unlink(missing_ok=True)
+    root = state_root(row)
+    if root.is_dir():
+      sync_file_tree(root)
+    return None
+  encoded = journal[f"{image}_encoded"].encode("utf-8")
+  if not target.is_file() or target.read_bytes() != encoded:
+    atomic_write(target, encoded)
+  if image == "before" and journal.get("before_mtime_ns") is not None:
+    mtime_ns = journal["before_mtime_ns"]
+    os.utime(target, ns=(mtime_ns, mtime_ns))
+  sync_file_tree(state_root(row))
+  return file_version_token(target)
+
+
+def _reconcile_journal(
+  db: Session, row: models.SharedAppInstance,
+) -> models.SharedAppChange | None:
+  """Commit only a recorded operation; otherwise restore its exact before image."""
+  journal = _load_journal(row)
+  if journal is None:
+    return None
+  change = db.query(models.SharedAppChange).filter(
+    models.SharedAppChange.operation_id == journal["operation_id"],
+    models.SharedAppChange.instance_id == row.id,
+  ).first()
+  if change is None:
+    _apply_journal_image(row, journal, "before")
+  else:
+    if (
+      change.kind != journal["kind"]
+      or change.path != journal["path"]
+      or change.actor_key != journal["actor_key"]
+      or change.display_name != journal["display_name"]
+    ):
+      raise HTTPException(500, "Shared app state recovery journal is invalid.")
+    version = _apply_journal_image(row, journal, "after")
+    if change.version != version:
+      change.version = version
+      try:
+        db.commit()
+      except Exception:
+        db.rollback()
+        raise
+  _remove_journal(row)
+  return change
+
+
+def reconcile_all_journals(db: Session) -> None:
+  """Resolve every interrupted state operation before the server accepts work."""
+  rows = db.query(models.SharedAppInstance).all()
+  for row in rows:
+    with state_lock(str(row.id)):
+      _reconcile_journal(db, row)
+
+
+def _latest_change_cursor(db: Session, row: models.SharedAppInstance) -> int:
+  return db.query(func.max(models.SharedAppChange.id)).filter(
+    models.SharedAppChange.instance_id == row.id,
+  ).scalar() or 0
+
+
+def write_state(
+  db: Session,
+  row: models.SharedAppInstance,
+  principal: SharedAppPrincipal,
+  *,
+  path: str,
+  value,
+  delete: bool,
+  expected_version: str | None,
+) -> dict:
+  with state_lock(str(row.id)):
+    _reconcile_journal(db, row)
+    target = _target(row, path)
+    if target.exists() and not target.is_file():
+      raise HTTPException(400, "Shared app data paths must identify files.")
+    current_version = file_version_token(target) if target.is_file() else None
+    if current_version != expected_version:
+      raise HTTPException(409, {"version": current_version})
+    encoded = None if delete else json.dumps(
+      value, ensure_ascii=False, separators=(",", ":"),
+    ).encode("utf-8")
+    root = state_root(row)
+    previous = target.read_bytes() if target.is_file() else None
+    previous_stat = target.stat() if target.is_file() else None
+    previous_size = len(previous) if previous is not None else 0
+    projected = app_dir_usage(root) - previous_size
+    projected += len(encoded) if encoded is not None else 0
+    if projected > STATE_BYTES_MAX:
+      raise HTTPException(413, "Shared app data is full.")
+    journal = {
+      "operation_id": str(uuid.uuid4()),
+      "instance_id": str(row.id),
+      "actor_key": "owner" if principal.is_owner else f"member:{principal.member_id}",
+      "display_name": principal.display_name or principal.owner.username or "Collaborator",
+      "kind": "delete" if delete else "set",
+      "path": path,
+      "before_present": previous is not None,
+      "before_encoded": None if previous is None else previous.decode("utf-8"),
+      "before_mtime_ns": previous_stat.st_mtime_ns if previous_stat is not None else None,
+      "after_present": encoded is not None,
+      "after_encoded": None if encoded is None else encoded.decode("utf-8"),
+    }
+    _write_journal(row, journal)
+    try:
+      version = _apply_journal_image(row, journal, "after")
+      change = _append_change(
+        db,
+        row,
+        operation_id=journal["operation_id"],
+        actor_key=journal["actor_key"],
+        display_name=journal["display_name"],
+        kind=journal["kind"],
+        path=journal["path"],
+        version=version,
+      )
+      row.updated_at = now_naive_utc()
+      db.commit()
+    except Exception:
+      db.rollback()
+      # A database driver can report an ambiguous commit outcome. Re-read the
+      # operation identity after rollback: committed means keep ``after``;
+      # absent means restore the exact before image.
+      _reconcile_journal(db, row)
+      raise
+    _remove_journal(row)
+    return {
+      "version": change.version,
+      "change_id": change.id,
+      "value": None if delete else value,
+    }
+
+
+def list_changes(db: Session, row: models.SharedAppInstance, after: int | None) -> dict:
+  with state_lock(str(row.id)):
+    _reconcile_journal(db, row)
+    oldest, latest, retained = db.query(
+      func.min(models.SharedAppChange.id),
+      func.max(models.SharedAppChange.id),
+      func.count(models.SharedAppChange.id),
+    ).filter(models.SharedAppChange.instance_id == row.id).one()
+    latest = latest or 0
+    if after is None:
+      return {"cursor": latest, "changes": [], "truncated": False}
+    rows = db.query(models.SharedAppChange).filter(
+      models.SharedAppChange.instance_id == row.id,
+      models.SharedAppChange.id > after,
+    ).order_by(models.SharedAppChange.id.asc()).limit(101).all()
+    truncated = len(rows) > 100 or (
+      retained >= CHANGE_LIMIT and oldest is not None and after < oldest
+    )
+    rows = rows[:100]
+    cursor = rows[-1].id if rows else max(after, latest)
+    return {
+      "cursor": cursor,
+      "truncated": truncated,
+      "changes": [{
+        "id": change.id,
+        "kind": change.kind,
+        "path": change.path,
+        "version": change.version,
+        "actor_key": change.actor_key,
+        "display_name": change.display_name,
+        "created_at": change.created_at.isoformat() if change.created_at else None,
+      } for change in rows],
+    }

--- a/backend/app/startup.py
+++ b/backend/app/startup.py
@@ -207,6 +207,15 @@ def _fix_forward_chat_media(context: StartupContext) -> None:
     raise
 
 
+def _reconcile_shared_app_storage(_context: StartupContext) -> None:
+  from app.shared_app_releases import reconcile_release_storage
+  from app.shared_app_state import reconcile_all_journals
+
+  with SessionLocal() as db:
+    reconcile_all_journals(db)
+    reconcile_release_storage(db)
+
+
 def _read_restart_authorization(context: StartupContext) -> None:
   from app.restart_ledger import authorized_restart_nonce
 
@@ -414,6 +423,7 @@ DATABASE_STARTUP_TASKS = (
   StartupTask("backfill session links", _backfill_session_links),
   StartupTask("backfill prompt snapshots", _backfill_prompt_snapshots),
   StartupTask("fix forward chat media", _fix_forward_chat_media),
+  StartupTask("reconcile shared app storage", _reconcile_shared_app_storage),
   StartupTask("read restart authorization", _read_restart_authorization),
   StartupTask(
     "reconcile startup chats",

--- a/backend/app/storage_io.py
+++ b/backend/app/storage_io.py
@@ -8,6 +8,7 @@ could observe it torn.
 
 import json
 import os
+import re
 import shutil
 import stat
 import tempfile
@@ -31,6 +32,17 @@ MAX_STORAGE_BYTES = 50 * 1024 * 1024
 # a backstop, not a wall: the owner's agent can raise it in code if a real app
 # needs more headroom.
 MAX_APP_STORAGE_BYTES = 1024 * 1024 * 1024
+
+# ``tempfile.mkstemp`` uses eight characters from this alphabet for the random
+# portion of names created by ``atomic_write``. Keep recognition beside the
+# writer so readers can reserve only its exact crash-artifact namespace rather
+# than broadly hiding dotfiles or every ``*.tmp`` owner path.
+_ATOMIC_WRITE_TEMP_RE = re.compile(r"^\..+\.[a-z0-9_]{8}\.tmp$")
+
+
+def is_atomic_write_temp_name(name: str) -> bool:
+  """Whether ``name`` is an internal same-directory atomic-write artifact."""
+  return _ATOMIC_WRITE_TEMP_RE.fullmatch(name) is not None
 
 
 def rmtree_strict(path: Path) -> None:
@@ -125,6 +137,39 @@ def atomic_write(file_path: Path, content: str | bytes) -> None:
     except OSError:
       pass
     raise
+
+
+def sync_directory(path: Path) -> None:
+  """Flush directory entries that make an atomic filesystem change durable."""
+  fd = os.open(path, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+  try:
+    os.fsync(fd)
+  finally:
+    os.close(fd)
+
+
+def sync_file_tree(root: Path) -> None:
+  """Flush every regular file and directory in one newly published tree."""
+  directories = []
+  for current, child_dirs, files in os.walk(root):
+    current_path = Path(current)
+    if current_path.is_symlink():
+      raise OSError(f"cannot sync symbolic-link directory {current_path}")
+    directories.append(current_path)
+    for name in child_dirs:
+      if (current_path / name).is_symlink():
+        raise OSError(f"cannot sync symbolic-link directory {current_path / name}")
+    for name in files:
+      target = current_path / name
+      if target.is_symlink():
+        raise OSError(f"cannot sync symbolic-link file {target}")
+      fd = os.open(target, os.O_RDONLY)
+      try:
+        os.fsync(fd)
+      finally:
+        os.close(fd)
+  for directory in reversed(directories):
+    sync_directory(directory)
 
 
 async def read_capped_body(request: Request, cap: int = MAX_STORAGE_BYTES) -> bytes:

--- a/backend/scripts/agent-screenshot.sh
+++ b/backend/scripts/agent-screenshot.sh
@@ -679,7 +679,7 @@ PY
     # publishes one stable visual-readiness contract; automation must not learn
     # its private handoff classes or compositor attributes. Once the owner says
     # settled, give style/layout two frames to commit.
-    SHELL_SETTLED_EXPR="document.querySelector('.shell[data-workspace-visual-state=\"settled\"]') !== null && performance.getEntriesByName('first-contentful-paint').length > 0"
+    SHELL_SETTLED_EXPR="(document.querySelector('.shell[data-workspace-visual-state=\"settled\"]') !== null || document.querySelector('[data-mobius-visual-state=\"settled\"]') !== null) && performance.getEntriesByName('first-contentful-paint').length > 0"
     BROWSER_PHASE="shell visual readiness"
     if ! browser_wait --fn "$SHELL_SETTLED_EXPR" >/dev/null; then
       die "shell did not reach a settled visual state before capture"

--- a/backend/tests/fixtures/migration_history.json
+++ b/backend/tests/fixtures/migration_history.json
@@ -27,7 +27,7 @@
     "0023_project_color": "aecbaff852f8640f86a9f0695bc26ff8b00e857b31d36a1d345440c301eca5ed",
     "0024_chat_goal_dismissal": "eb39716740f6dd2414db70b7d3d64443cc94583b778aca344398202adb591b96",
     "0025_shared_app_retention": "44d4501813e2c71e654ae3301f8f6fdd5ff588664196e3e82f2c89e27d12731f",
-    "0026_shared_app_path_state": "fe3fac236f48c4a85097c6cc6c25b04ed6fb6f0a1819c6cb59455819fbd69c67",
+    "0026_shared_app_path_state": "31f90979d741af9447311e811e99715ae5e1826d076be950ee4ff7bd839b5c4b",
     "0027_project_artifact_drawer_state": "af397bc4236ca3a27776d89759075fe51c359cfb501b52f11c139b89eb6f7e61",
     "0028_shared_app_change_operation_id": "847ec995de34278f5951353831982146dfbc4ed7239e12b3536e67f9e5f5faea",
     "0029_shared_app_previous_snapshot_path": "3ff76dcd2a8766392210628ee5aad312547c002f6d72ea06db4a4c756eadaeef"

--- a/backend/tests/fixtures/migration_history.json
+++ b/backend/tests/fixtures/migration_history.json
@@ -25,6 +25,11 @@
     "0021_project_chat_collection": "03a5584764da2420f5cdda5256dd1e553fcedf51d488728f57f39278f49966ac",
     "0022_project_artifacts": "ba42d74e4b2795b08f37c2c75116c879dea1686ededb16b0eca0b5c4c79ab29e",
     "0023_project_color": "aecbaff852f8640f86a9f0695bc26ff8b00e857b31d36a1d345440c301eca5ed",
-    "0024_chat_goal_dismissal": "eb39716740f6dd2414db70b7d3d64443cc94583b778aca344398202adb591b96"
+    "0024_chat_goal_dismissal": "eb39716740f6dd2414db70b7d3d64443cc94583b778aca344398202adb591b96",
+    "0025_shared_app_retention": "44d4501813e2c71e654ae3301f8f6fdd5ff588664196e3e82f2c89e27d12731f",
+    "0026_shared_app_path_state": "26224aac401b8c4ceb27772b675581ec42455a7c38abebf5f4f71f0f6dc29bf2",
+    "0027_project_artifact_drawer_state": "af397bc4236ca3a27776d89759075fe51c359cfb501b52f11c139b89eb6f7e61",
+    "0028_shared_app_change_operation_id": "847ec995de34278f5951353831982146dfbc4ed7239e12b3536e67f9e5f5faea",
+    "0029_shared_app_previous_snapshot_path": "3ff76dcd2a8766392210628ee5aad312547c002f6d72ea06db4a4c756eadaeef"
   }
 }

--- a/backend/tests/fixtures/migration_history.json
+++ b/backend/tests/fixtures/migration_history.json
@@ -27,7 +27,7 @@
     "0023_project_color": "aecbaff852f8640f86a9f0695bc26ff8b00e857b31d36a1d345440c301eca5ed",
     "0024_chat_goal_dismissal": "eb39716740f6dd2414db70b7d3d64443cc94583b778aca344398202adb591b96",
     "0025_shared_app_retention": "44d4501813e2c71e654ae3301f8f6fdd5ff588664196e3e82f2c89e27d12731f",
-    "0026_shared_app_path_state": "26224aac401b8c4ceb27772b675581ec42455a7c38abebf5f4f71f0f6dc29bf2",
+    "0026_shared_app_path_state": "fe3fac236f48c4a85097c6cc6c25b04ed6fb6f0a1819c6cb59455819fbd69c67",
     "0027_project_artifact_drawer_state": "af397bc4236ca3a27776d89759075fe51c359cfb501b52f11c139b89eb6f7e61",
     "0028_shared_app_change_operation_id": "847ec995de34278f5951353831982146dfbc4ed7239e12b3536e67f9e5f5faea",
     "0029_shared_app_previous_snapshot_path": "3ff76dcd2a8766392210628ee5aad312547c002f6d72ea06db4a4c756eadaeef"

--- a/backend/tests/test_agent_screenshot_auth.py
+++ b/backend/tests/test_agent_screenshot_auth.py
@@ -923,6 +923,7 @@ def test_shell_capture_waits_for_visual_ownership_and_rendered_fonts(tmp_path: P
     and "first-contentful-paint" in command
   )
   settle_command = commands[settle_index]
+  assert "data-mobius-visual-state" in settle_command
   assert "shell__chat-view--staging" not in settle_command
   assert "shell__chat-view--held" not in settle_command
   assert "data-mode-motion" not in settle_command

--- a/backend/tests/test_db_migrations.py
+++ b/backend/tests/test_db_migrations.py
@@ -5,6 +5,7 @@ import sqlite3
 import subprocess
 import sys
 import importlib.util
+import os
 from datetime import UTC, datetime
 from pathlib import Path
 from types import SimpleNamespace
@@ -1427,6 +1428,205 @@ def test_shared_app_path_state_migrates_prototype_data_without_runtime_columns(
   assert migrated["revision"] == 0
   assert "state_json" not in models.SharedAppInstance.__table__.columns
   assert "revision" not in models.SharedAppInstance.__table__.columns
+
+
+def test_shared_app_path_state_rejects_a_traversing_legacy_instance_id(
+  tmp_path, monkeypatch,
+):
+  data_dir = tmp_path / "data"
+  monkeypatch.setenv("DATA_DIR", str(data_dir))
+  instance_id = "../escape"
+  snapshot_path = "shared/escape/build"
+  (data_dir / snapshot_path).mkdir(parents=True)
+  eng = create_engine(f"sqlite:///{tmp_path / 'shared-state-traversal.db'}")
+  with eng.begin() as conn:
+    conn.execute(text(
+      "CREATE TABLE shared_app_instances ("
+      "id VARCHAR(64) PRIMARY KEY, snapshot_path VARCHAR(2048) NOT NULL, "
+      "state_json JSON NOT NULL, revision INTEGER NOT NULL)"
+    ))
+    conn.execute(text(
+      "INSERT INTO shared_app_instances (id, snapshot_path, state_json, revision) "
+      "VALUES (:id, :snapshot_path, :state_json, 7)"
+    ), {
+      "id": instance_id,
+      "snapshot_path": snapshot_path,
+      "state_json": json.dumps({"board.json": {"secret": "must stay in DB"}}),
+    })
+
+  with pytest.raises(RuntimeError, match="invalid instance id"):
+    migrations._migrate_shared_app_state_files(eng)
+
+  assert not (data_dir / "shared" / "escape" / "data" / "board.json").exists()
+  with eng.connect() as conn:
+    retained = conn.execute(text(
+      "SELECT state_json, revision FROM shared_app_instances WHERE id = :id"
+    ), {"id": instance_id}).mappings().one()
+  assert json.loads(retained["state_json"]) == {
+    "board.json": {"secret": "must stay in DB"},
+  }
+  assert retained["revision"] == 7
+
+
+def test_shared_app_path_state_rejects_a_noncanonical_legacy_instance_id(
+  tmp_path, monkeypatch,
+):
+  data_dir = tmp_path / "data"
+  monkeypatch.setenv("DATA_DIR", str(data_dir))
+  canonical_id = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+  instance_id = canonical_id.upper()
+  snapshot_path = f"shared/app-instances/{instance_id}/build"
+  (data_dir / snapshot_path).mkdir(parents=True)
+  eng = create_engine(f"sqlite:///{tmp_path / 'shared-state-noncanonical.db'}")
+  with eng.begin() as conn:
+    conn.execute(text(
+      "CREATE TABLE shared_app_instances ("
+      "id VARCHAR(64) PRIMARY KEY, snapshot_path VARCHAR(2048) NOT NULL, "
+      "state_json JSON NOT NULL, revision INTEGER NOT NULL)"
+    ))
+    conn.execute(text(
+      "INSERT INTO shared_app_instances (id, snapshot_path, state_json, revision) "
+      "VALUES (:id, :snapshot_path, :state_json, 7)"
+    ), {
+      "id": instance_id,
+      "snapshot_path": snapshot_path,
+      "state_json": json.dumps({"board.json": {"secret": "must stay in DB"}}),
+    })
+
+  with pytest.raises(RuntimeError, match="invalid instance id"):
+    migrations._migrate_shared_app_state_files(eng)
+
+  assert not (
+    data_dir / "shared" / "app-instances" / canonical_id / "data" / "board.json"
+  ).exists()
+  with eng.connect() as conn:
+    retained = conn.execute(text(
+      "SELECT state_json, revision FROM shared_app_instances WHERE id = :id"
+    ), {"id": instance_id}).mappings().one()
+  assert json.loads(retained["state_json"]) == {
+    "board.json": {"secret": "must stay in DB"},
+  }
+  assert retained["revision"] == 7
+
+
+def test_shared_app_path_state_rejects_a_symlinked_instance_root(
+  tmp_path, monkeypatch,
+):
+  data_dir = tmp_path / "data"
+  monkeypatch.setenv("DATA_DIR", str(data_dir))
+  instance_id = "11111111-1111-4111-8111-111111111111"
+  snapshot_path = f"shared/app-instances/{instance_id}/build"
+  instances_root = data_dir / "shared" / "app-instances"
+  instances_root.mkdir(parents=True)
+  outside = data_dir / "owner-private" / instance_id
+  (outside / "build").mkdir(parents=True)
+  (instances_root / instance_id).symlink_to(outside, target_is_directory=True)
+  eng = create_engine(f"sqlite:///{tmp_path / 'shared-state-symlink.db'}")
+  with eng.begin() as conn:
+    conn.execute(text(
+      "CREATE TABLE shared_app_instances ("
+      "id VARCHAR(64) PRIMARY KEY, snapshot_path VARCHAR(2048) NOT NULL, "
+      "state_json JSON NOT NULL, revision INTEGER NOT NULL)"
+    ))
+    conn.execute(text(
+      "INSERT INTO shared_app_instances (id, snapshot_path, state_json, revision) "
+      "VALUES (:id, :snapshot_path, :state_json, 7)"
+    ), {
+      "id": instance_id,
+      "snapshot_path": snapshot_path,
+      "state_json": json.dumps({"board.json": {"secret": "must stay in DB"}}),
+    })
+
+  with pytest.raises(RuntimeError, match="invalid snapshot path"):
+    migrations._migrate_shared_app_state_files(eng)
+
+  assert not (outside / "data" / "board.json").exists()
+  with eng.connect() as conn:
+    retained = conn.execute(text(
+      "SELECT state_json, revision FROM shared_app_instances WHERE id = :id"
+    ), {"id": instance_id}).mappings().one()
+  assert json.loads(retained["state_json"]) == {
+    "board.json": {"secret": "must stay in DB"},
+  }
+  assert retained["revision"] == 7
+
+
+def test_shared_app_path_state_fsyncs_renamed_file_and_directory_chain(
+  tmp_path, monkeypatch,
+):
+  data_dir = tmp_path / "data"
+  monkeypatch.setenv("DATA_DIR", str(data_dir))
+  instance_id = "11111111-1111-4111-8111-111111111111"
+  snapshot_path = f"shared/app-instances/{instance_id}/build"
+  (data_dir / snapshot_path).mkdir(parents=True)
+  eng = create_engine(f"sqlite:///{tmp_path / 'shared-state-fsync.db'}")
+  with eng.begin() as conn:
+    conn.execute(text(
+      "CREATE TABLE shared_app_instances ("
+      "id VARCHAR(64) PRIMARY KEY, snapshot_path VARCHAR(2048) NOT NULL, "
+      "state_json JSON NOT NULL, revision INTEGER NOT NULL)"
+    ))
+    conn.execute(text(
+      "INSERT INTO shared_app_instances (id, snapshot_path, state_json, revision) "
+      "VALUES (:id, :snapshot_path, :state_json, 1)"
+    ), {
+      "id": instance_id,
+      "snapshot_path": snapshot_path,
+      "state_json": json.dumps({"nested/board.json": {"cards": ["durable"]}}),
+    })
+
+  events = []
+  original_replace = os.replace
+  original_fsync = os.fsync
+
+  def tracked_replace(source, target):
+    original_replace(source, target)
+    events.append(("replace", Path(target)))
+
+  def tracked_fsync(descriptor):
+    link = Path(f"/proc/self/fd/{descriptor}")
+    try:
+      target = Path(os.readlink(link))
+    except OSError:
+      target = None
+    original_fsync(descriptor)
+    events.append(("fsync", target))
+
+  def tracked_sql(_conn, _cursor, statement, _parameters, _context, _many):
+    if statement.startswith("UPDATE shared_app_instances SET state_json"):
+      events.append(("clear", None))
+
+  monkeypatch.setattr(os, "replace", tracked_replace)
+  monkeypatch.setattr(os, "fsync", tracked_fsync)
+  event.listen(eng, "before_cursor_execute", tracked_sql)
+  try:
+    migrations._migrate_shared_app_state_files(eng)
+  finally:
+    event.remove(eng, "before_cursor_execute", tracked_sql)
+
+  target = (
+    data_dir / "shared" / "app-instances" / instance_id
+    / "data" / "nested" / "board.json"
+  )
+  replace_index = events.index(("replace", target))
+  synced_after_replace = {
+    path for kind, path in events[replace_index + 1:] if kind == "fsync"
+  }
+  required_directories = {
+    target.parent,
+    target.parent.parent,
+    target.parent.parent.parent,
+  }
+  assert required_directories <= synced_after_replace
+  clear_index = events.index(("clear", None))
+  for directory in required_directories:
+    assert events.index(("fsync", directory), replace_index + 1) < clear_index
+  with eng.connect() as conn:
+    cleared = conn.execute(text(
+      "SELECT state_json, revision FROM shared_app_instances WHERE id = :id"
+    ), {"id": instance_id}).mappings().one()
+  assert json.loads(cleared["state_json"]) == {}
+  assert cleared["revision"] == 0
 
 
 def test_shared_app_change_operation_identity_is_added_idempotently(tmp_path):

--- a/backend/tests/test_db_migrations.py
+++ b/backend/tests/test_db_migrations.py
@@ -1170,6 +1170,11 @@ def test_run_migrations_records_an_inspectable_append_only_history(tmp_path):
     "0022_project_artifacts",
     "0023_project_color",
     "0024_chat_goal_dismissal",
+    "0025_shared_app_retention",
+    "0026_shared_app_path_state",
+    "0027_project_artifact_drawer_state",
+    "0028_shared_app_change_operation_id",
+    "0029_shared_app_previous_snapshot_path",
   ]
   assert second == first
 
@@ -1383,6 +1388,83 @@ def test_legacy_chat_models_preserve_malformed_settings(tmp_path, monkeypatch):
     assert conn.execute(text(
       "SELECT agent_settings_json FROM chats WHERE id = 'malformed-settings'"
     )).scalar_one() == "{malformed"
+
+
+def test_shared_app_path_state_migrates_prototype_data_without_runtime_columns(
+  tmp_path, monkeypatch,
+):
+  data_dir = tmp_path / "data"
+  monkeypatch.setenv("DATA_DIR", str(data_dir))
+  instance_id = "11111111-1111-4111-8111-111111111111"
+  snapshot_path = f"shared/app-instances/{instance_id}/build"
+  (data_dir / snapshot_path).mkdir(parents=True)
+  eng = create_engine(f"sqlite:///{tmp_path / 'shared-state.db'}")
+  with eng.begin() as conn:
+    conn.execute(text(
+      "CREATE TABLE shared_app_instances ("
+      "id VARCHAR(64) PRIMARY KEY, snapshot_path VARCHAR(2048) NOT NULL, "
+      "state_json JSON NOT NULL, revision INTEGER NOT NULL)"
+    ))
+    conn.execute(text(
+      "INSERT INTO shared_app_instances (id, snapshot_path, state_json, revision) "
+      "VALUES (:id, :snapshot_path, :state_json, 7)"
+    ), {
+      "id": instance_id,
+      "snapshot_path": snapshot_path,
+      "state_json": json.dumps({"board.json": {"cards": ["kept"]}}),
+    })
+
+  migrations._migrate_shared_app_state_files(eng)
+
+  assert json.loads((
+    data_dir / "shared" / "app-instances" / instance_id / "data" / "board.json"
+  ).read_text(encoding="utf-8")) == {"cards": ["kept"]}
+  with eng.connect() as conn:
+    migrated = conn.execute(text(
+      "SELECT state_json, revision FROM shared_app_instances WHERE id = :id"
+    ), {"id": instance_id}).mappings().one()
+  assert json.loads(migrated["state_json"]) == {}
+  assert migrated["revision"] == 0
+  assert "state_json" not in models.SharedAppInstance.__table__.columns
+  assert "revision" not in models.SharedAppInstance.__table__.columns
+
+
+def test_shared_app_change_operation_identity_is_added_idempotently(tmp_path):
+  eng = create_engine(f"sqlite:///{tmp_path / 'shared-change.db'}")
+  with eng.begin() as conn:
+    conn.execute(text(
+      "CREATE TABLE shared_app_changes ("
+      "id INTEGER PRIMARY KEY, instance_id VARCHAR(64) NOT NULL)"
+    ))
+
+  migrations._add_shared_app_change_operation_id(eng)
+  migrations._add_shared_app_change_operation_id(eng)
+
+  inspector = inspect(eng)
+  assert "operation_id" in {
+    column["name"] for column in inspector.get_columns("shared_app_changes")
+  }
+  indexes = {index["name"]: index for index in inspector.get_indexes("shared_app_changes")}
+  assert indexes["ix_shared_app_changes_operation_id"]["unique"] == 1
+
+
+def test_shared_app_previous_snapshot_pointer_is_added_idempotently(tmp_path):
+  eng = create_engine(f"sqlite:///{tmp_path / 'shared-release.db'}")
+  with eng.begin() as conn:
+    conn.execute(text(
+      "CREATE TABLE shared_app_instances ("
+      "id VARCHAR(64) PRIMARY KEY, snapshot_path VARCHAR(2048) NOT NULL)"
+    ))
+
+  migrations._add_shared_app_previous_snapshot_path(eng)
+  migrations._add_shared_app_previous_snapshot_path(eng)
+
+  inspector = inspect(eng)
+  assert "previous_snapshot_path" in {
+    column["name"] for column in inspector.get_columns("shared_app_instances")
+  }
+  indexes = {index["name"]: index for index in inspector.get_indexes("shared_app_instances")}
+  assert indexes["ix_shared_app_instances_previous_snapshot_path"]["unique"] == 1
 
 
 def test_pending_question_migration_backfills_only_active_latest_question(
@@ -2190,31 +2272,6 @@ def test_published_schema_migration_history_is_unique_ordered_and_immutable():
   assert "migration hashes match migration_history.json" in (
     completed.stdout
   )
-
-
-def test_goal_dismissal_migration_adds_nullable_chat_pointer(tmp_path):
-  eng = create_engine(f"sqlite:///{tmp_path / 'goal-dismissal.db'}")
-  models.Base.metadata.create_all(eng)
-  with eng.begin() as conn:
-    conn.execute(text("ALTER TABLE chats DROP COLUMN dismissed_goal_id"))
-    conn.execute(text(
-      "CREATE TABLE IF NOT EXISTS schema_migrations ("
-      "version VARCHAR(128) PRIMARY KEY, applied_at TIMESTAMP NOT NULL)"
-    ))
-    for version in _migration_versions_before("0024_chat_goal_dismissal"):
-      conn.execute(text(
-        "INSERT INTO schema_migrations (version, applied_at) VALUES (:v, :at)"
-      ), {"v": version, "at": datetime(2026, 8, 22)})
-
-  run_migrations(eng)
-
-  columns = {column["name"] for column in inspect(eng).get_columns("chats")}
-  assert "dismissed_goal_id" in columns
-  with eng.connect() as conn:
-    assert conn.execute(text(
-      "SELECT COUNT(*) FROM schema_migrations "
-      "WHERE version = '0024_chat_goal_dismissal'"
-    )).scalar_one() == 1
 
 
 def test_failed_migration_is_not_recorded_and_can_retry(tmp_path, monkeypatch):

--- a/backend/tests/test_db_migrations.py
+++ b/backend/tests/test_db_migrations.py
@@ -1551,6 +1551,52 @@ def test_shared_app_path_state_rejects_a_symlinked_instance_root(
   assert retained["revision"] == 7
 
 
+def test_shared_app_path_state_rejects_a_symlink_before_creating_descendants(
+  tmp_path, monkeypatch,
+):
+  data_dir = tmp_path / "data"
+  monkeypatch.setenv("DATA_DIR", str(data_dir))
+  instance_id = "11111111-1111-4111-8111-111111111111"
+  snapshot_path = f"shared/app-instances/{instance_id}/build"
+  root = data_dir / "shared" / "app-instances" / instance_id
+  (root / "build").mkdir(parents=True)
+  (root / "data").mkdir()
+  outside = data_dir / "owner-private"
+  outside.mkdir()
+  (root / "data" / "linked").symlink_to(outside, target_is_directory=True)
+  eng = create_engine(f"sqlite:///{tmp_path / 'shared-state-child-link.db'}")
+  with eng.begin() as conn:
+    conn.execute(text(
+      "CREATE TABLE shared_app_instances ("
+      "id VARCHAR(64) PRIMARY KEY, snapshot_path VARCHAR(2048) NOT NULL, "
+      "state_json JSON NOT NULL, revision INTEGER NOT NULL)"
+    ))
+    conn.execute(text(
+      "INSERT INTO shared_app_instances (id, snapshot_path, state_json, revision) "
+      "VALUES (:id, :snapshot_path, :state_json, 7)"
+    ), {
+      "id": instance_id,
+      "snapshot_path": snapshot_path,
+      "state_json": json.dumps({
+        "linked/newdir/board.json": {"secret": "must stay in DB"},
+      }),
+    })
+
+  with pytest.raises(RuntimeError, match="unsafe path"):
+    migrations._migrate_shared_app_state_files(eng)
+
+  assert not (outside / "newdir").exists()
+  assert not (outside / "newdir" / "board.json").exists()
+  with eng.connect() as conn:
+    retained = conn.execute(text(
+      "SELECT state_json, revision FROM shared_app_instances WHERE id = :id"
+    ), {"id": instance_id}).mappings().one()
+  assert json.loads(retained["state_json"]) == {
+    "linked/newdir/board.json": {"secret": "must stay in DB"},
+  }
+  assert retained["revision"] == 7
+
+
 def test_shared_app_path_state_fsyncs_renamed_file_and_directory_chain(
   tmp_path, monkeypatch,
 ):
@@ -1579,9 +1625,14 @@ def test_shared_app_path_state_fsyncs_renamed_file_and_directory_chain(
   original_replace = os.replace
   original_fsync = os.fsync
 
-  def tracked_replace(source, target):
-    original_replace(source, target)
-    events.append(("replace", Path(target)))
+  def tracked_replace(source, target, *args, **kwargs):
+    original_replace(source, target, *args, **kwargs)
+    target_dir_fd = kwargs.get("dst_dir_fd")
+    if target_dir_fd is None:
+      replaced = Path(target)
+    else:
+      replaced = Path(os.readlink(f"/proc/self/fd/{target_dir_fd}")) / target
+    events.append(("replace", replaced))
 
   def tracked_fsync(descriptor):
     link = Path(f"/proc/self/fd/{descriptor}")
@@ -2472,6 +2523,78 @@ def test_published_schema_migration_history_is_unique_ordered_and_immutable():
   assert "migration hashes match migration_history.json" in (
     completed.stdout
   )
+
+
+def test_goal_dismissal_migration_adds_nullable_chat_pointer(tmp_path):
+  eng = create_engine(f"sqlite:///{tmp_path / 'goal-dismissal.db'}")
+  models.Base.metadata.create_all(eng)
+  with eng.begin() as conn:
+    conn.execute(text("ALTER TABLE chats DROP COLUMN dismissed_goal_id"))
+    conn.execute(text(
+      "CREATE TABLE IF NOT EXISTS schema_migrations ("
+      "version VARCHAR(128) PRIMARY KEY, applied_at TIMESTAMP NOT NULL)"
+    ))
+    for version in _migration_versions_before("0024_chat_goal_dismissal"):
+      conn.execute(text(
+        "INSERT INTO schema_migrations (version, applied_at) VALUES (:v, :at)"
+      ), {"v": version, "at": datetime(2026, 8, 22)})
+
+  run_migrations(eng)
+
+  columns = {column["name"] for column in inspect(eng).get_columns("chats")}
+  assert "dismissed_goal_id" in columns
+  with eng.connect() as conn:
+    assert conn.execute(text(
+      "SELECT COUNT(*) FROM schema_migrations "
+      "WHERE version = '0024_chat_goal_dismissal'"
+    )).scalar_one() == 1
+
+
+def test_current_history_survives_unmerged_local_migration_names(tmp_path):
+  """A local review may have run before upstream claimed the same number.
+
+  The durable ledger keys the complete semantic name, not only its numeric
+  prefix. Keep the landed Goal migration and the renumbered sharing migrations
+  runnable when an installation already recorded the five names from the
+  earlier unmerged sharing review.
+  """
+  eng = create_engine(f"sqlite:///{tmp_path / 'local-review-history.db'}")
+  models.Base.metadata.create_all(eng)
+  old_local_names = [
+    "0024_shared_app_retention",
+    "0025_shared_app_path_state",
+    "0026_project_artifact_drawer_state",
+    "0027_shared_app_change_operation_id",
+    "0028_shared_app_previous_snapshot_path",
+  ]
+  with eng.begin() as conn:
+    conn.execute(text("ALTER TABLE chats DROP COLUMN dismissed_goal_id"))
+    conn.execute(text(
+      "CREATE TABLE IF NOT EXISTS schema_migrations ("
+      "version VARCHAR(128) PRIMARY KEY, applied_at TIMESTAMP NOT NULL)"
+    ))
+    for version in [
+      *_migration_versions_before("0024_chat_goal_dismissal"),
+      *old_local_names,
+    ]:
+      conn.execute(text(
+        "INSERT INTO schema_migrations (version, applied_at) VALUES (:v, :at)"
+      ), {"v": version, "at": datetime(2026, 8, 22)})
+
+  run_migrations(eng)
+
+  history = {row["version"] for row in schema_migration_history(eng)}
+  assert set(old_local_names) <= history
+  assert {
+    "0024_chat_goal_dismissal",
+    "0025_shared_app_retention",
+    "0026_shared_app_path_state",
+    "0027_project_artifact_drawer_state",
+    "0028_shared_app_change_operation_id",
+    "0029_shared_app_previous_snapshot_path",
+  } <= history
+  columns = {column["name"] for column in inspect(eng).get_columns("chats")}
+  assert "dismissed_goal_id" in columns
 
 
 def test_failed_migration_is_not_recorded_and_can_retry(tmp_path, monkeypatch):

--- a/backend/tests/test_project_artifacts.py
+++ b/backend/tests/test_project_artifacts.py
@@ -154,6 +154,38 @@ def test_creation_open_recency_is_navigation_state(client, auth, db):
   ).status_code == 404
 
 
+def test_deleted_creation_does_not_transfer_recency_to_a_reused_id(
+  client, auth, db,
+):
+  project = _make_project(client, auth)
+  _write_file(client, auth, project, "index.html", "<h1>Hi</h1>")
+  artifact_url = f"/api/projects/{project['id']}/artifacts"
+  body = {
+    "name": "Website",
+    "builder": "website",
+    "source": "index.html",
+  }
+  assert client.post(artifact_url, headers=auth, json=body).status_code == 201
+  assert client.post(
+    f"{artifact_url}/website/opened", headers=auth,
+  ).status_code == 204
+  assert _artifact(client, auth, project["id"], "website")[
+    "last_opened_at"
+  ] is not None
+
+  assert client.delete(
+    f"{artifact_url}/website", headers=auth,
+  ).status_code == 204
+  assert db.get(
+    models.ProjectArtifactDrawerState,
+    {"project_id": project["id"], "artifact_id": "website"},
+  ) is None
+
+  assert client.post(artifact_url, headers=auth, json=body).status_code == 201
+  recreated = _artifact(client, auth, project["id"], "website")
+  assert recreated["last_opened_at"] is None
+
+
 def test_website_build_copies_tree_and_serves_entry_with_csp(client, auth):
   project = _make_project(client, auth)
   _write_file(client, auth, project, "index.html", "<h1>Hello site</h1>")

--- a/backend/tests/test_project_artifacts.py
+++ b/backend/tests/test_project_artifacts.py
@@ -130,6 +130,30 @@ def test_artifact_crud_validates_and_confines(client, auth):
   ).status_code == 404
 
 
+def test_creation_open_recency_is_navigation_state(client, auth, db):
+  project = _make_project(client, auth)
+  _write_file(client, auth, project, "index.html", "<h1>Hi</h1>")
+  client.post(
+    f"/api/projects/{project['id']}/artifacts", headers=auth,
+    json={"name": "Website", "builder": "website", "source": "index.html"},
+  )
+  row = db.get(models.Project, project["id"])
+  original_updated_at = row.updated_at
+
+  opened = client.post(
+    f"/api/projects/{project['id']}/artifacts/website/opened", headers=auth,
+  )
+
+  assert opened.status_code == 204, opened.text
+  artifact = _artifact(client, auth, project["id"], "website")
+  assert artifact["last_opened_at"] is not None
+  db.refresh(row)
+  assert row.updated_at == original_updated_at
+  assert client.post(
+    f"/api/projects/{project['id']}/artifacts/missing/opened", headers=auth,
+  ).status_code == 404
+
+
 def test_website_build_copies_tree_and_serves_entry_with_csp(client, auth):
   project = _make_project(client, auth)
   _write_file(client, auth, project, "index.html", "<h1>Hello site</h1>")

--- a/backend/tests/test_shared_apps.py
+++ b/backend/tests/test_shared_apps.py
@@ -1,5 +1,6 @@
 """Shared app instances pin builds and keep membership separate from source."""
 
+import asyncio
 from concurrent.futures import ThreadPoolExecutor
 from threading import Barrier, Event
 from pathlib import Path
@@ -9,7 +10,7 @@ import pytest
 from fastapi import HTTPException, Response
 from sqlalchemy.orm.attributes import flag_modified
 
-from app import models, shared_app_releases, shared_app_state
+from app import models, project_builders, shared_app_releases, shared_app_state
 from app.config import get_settings
 from app.deps import SharedAppPrincipal
 from app.routes import shared_apps as shared_app_routes
@@ -81,6 +82,136 @@ def test_shared_app_pins_build_and_confines_member_to_runtime(client, auth, db):
     "/api/shared-apps/invites/redeem",
     json={"invite": secret, "display_name": "Replay"},
   ).status_code == 410
+
+
+def test_shared_app_rejects_an_output_root_symlink_to_owner_private_data(
+  client, auth, db, tmp_path,
+):
+  project, output = _built_project(client, auth, db)
+  private = tmp_path / "owner-private"
+  private.mkdir()
+  (private / "index.html").write_text("PRIVATE SENTINEL", encoding="utf-8")
+  (output / "index.html").unlink()
+  output.rmdir()
+  output.symlink_to(private, target_is_directory=True)
+
+  response = client.post(
+    "/api/shared-apps",
+    headers=auth,
+    json={"project_id": project.id, "artifact_id": "website"},
+  )
+
+  assert response.status_code == 422, response.text
+  assert db.query(models.SharedAppInstance).filter(
+    models.SharedAppInstance.project_id == project.id,
+  ).count() == 0
+  instances_root = Path(get_settings().data_dir) / "shared" / "app-instances"
+  assert not instances_root.exists() or not any(instances_root.iterdir())
+
+
+def test_shared_app_rejects_an_output_ancestor_symlink_to_owner_private_data(
+  client, auth, db, tmp_path,
+):
+  project, output = _built_project(client, auth, db)
+  project_root = output.parents[2]
+  private = tmp_path / "owner-private"
+  private_output = private / "website" / "output"
+  private_output.mkdir(parents=True)
+  (private_output / "index.html").write_text(
+    "PRIVATE SENTINEL", encoding="utf-8",
+  )
+  (output / "index.html").unlink()
+  output.rmdir()
+  output.parent.rmdir()
+  output.parent.parent.rmdir()
+  (project_root / "artifacts").symlink_to(private, target_is_directory=True)
+
+  response = client.post(
+    "/api/shared-apps",
+    headers=auth,
+    json={"project_id": project.id, "artifact_id": "website"},
+  )
+
+  assert response.status_code == 422, response.text
+  assert db.query(models.SharedAppInstance).filter(
+    models.SharedAppInstance.project_id == project.id,
+  ).count() == 0
+  instances_root = Path(get_settings().data_dir) / "shared" / "app-instances"
+  assert not instances_root.exists() or not any(instances_root.iterdir())
+
+
+def test_shared_app_keeps_an_unbuilt_artifact_as_a_retryable_conflict(
+  client, auth, db,
+):
+  project, output = _built_project(client, auth, db)
+  (output / "index.html").unlink()
+  output.rmdir()
+
+  response = client.post(
+    "/api/shared-apps",
+    headers=auth,
+    json={"project_id": project.id, "artifact_id": "website"},
+  )
+
+  assert response.status_code == 409, response.text
+  assert response.json()["detail"] == "Build the artifact before sharing it."
+
+
+def test_shared_app_publish_waits_for_one_coherent_project_build(
+  client, auth, db, monkeypatch,
+):
+  project, output = _built_project(client, auth, db)
+  (output.parents[2] / "index.html").write_text(
+    "<h1>source</h1>", encoding="utf-8",
+  )
+  (output / "app.js").write_text("window.release = 'old'", encoding="utf-8")
+  instance = _create_instance(client, auth, project.id)
+  half_written = Event()
+  finish_build = Event()
+
+  async def staged_builder(*, root, source, output_dir, log_path):
+    del root, source, log_path
+    (output_dir / "index.html").write_text(
+      "<script src='app.js'></script><p>new</p>", encoding="utf-8",
+    )
+    half_written.set()
+    assert await asyncio.to_thread(finish_build.wait, 5)
+    (output_dir / "app.js").write_text(
+      "window.release = 'new'", encoding="utf-8",
+    )
+
+  monkeypatch.setitem(project_builders.BUILDERS, "website", staged_builder)
+  owner = db.query(models.Owner).one()
+  principal = SharedAppPrincipal(
+    owner=owner, role="owner", display_name=owner.username,
+  )
+
+  async def build_and_publish():
+    building = asyncio.create_task(
+      project_builders.run_build(str(project.id), "website"),
+    )
+    assert await asyncio.to_thread(half_written.wait, 5)
+    publishing = asyncio.create_task(
+      shared_app_routes.publish_shared_app_release(
+        instance["id"], principal, db,
+      ),
+    )
+    await asyncio.sleep(0.05)
+    assert not publishing.done()
+    finish_build.set()
+    await building
+    return await publishing
+
+  published = asyncio.run(build_and_publish())
+  release_id = published["release_id"]
+  assert client.get(
+    f"/api/shared-apps/{instance['id']}/output/{release_id}/index.html",
+    headers=auth,
+  ).text == "<script src='app.js'></script><p>new</p>"
+  assert client.get(
+    f"/api/shared-apps/{instance['id']}/output/{release_id}/app.js",
+    headers=auth,
+  ).text == "window.release = 'new'"
 
 
 def test_shared_state_is_path_version_checked_and_visible_to_members(client, auth, db):

--- a/backend/tests/test_shared_apps.py
+++ b/backend/tests/test_shared_apps.py
@@ -1,0 +1,823 @@
+"""Shared app instances pin builds and keep membership separate from source."""
+
+from concurrent.futures import ThreadPoolExecutor
+from threading import Barrier, Event
+from pathlib import Path
+from urllib.parse import urlsplit
+
+import pytest
+from fastapi import HTTPException, Response
+from sqlalchemy.orm.attributes import flag_modified
+
+from app import models, shared_app_releases, shared_app_state
+from app.config import get_settings
+from app.deps import SharedAppPrincipal
+from app.routes import shared_apps as shared_app_routes
+from app.shared_app_retention import purge_expired_shared_apps
+from app.timeutil import SOFT_DELETE_TTL, now_naive_utc
+
+
+def _built_project(client, auth, db):
+  response = client.post(
+    "/api/projects", headers=auth,
+    json={"name": "Together Board", "template_id": "blank"},
+  )
+  assert response.status_code == 200, response.text
+  project_id = response.json()["id"]
+  project = db.get(models.Project, project_id)
+  root = Path(get_settings().data_dir) / project.root_path
+  output = root / "artifacts" / "website" / "output"
+  output.mkdir(parents=True)
+  (output / "index.html").write_text("<h1>Pinned board</h1>")
+  project.artifacts_json = [{
+    "id": "website", "name": "Website", "builder": "website",
+    "source": "index.html", "output_rel": "artifacts/website/output/index.html",
+    "status": "ok",
+  }]
+  flag_modified(project, "artifacts_json")
+  db.commit()
+  return project, output
+
+
+def _create_instance(client, auth, project_id):
+  response = client.post(
+    "/api/shared-apps", headers=auth,
+    json={"project_id": project_id, "artifact_id": "website", "name": "Together Board"},
+  )
+  assert response.status_code == 201, response.text
+  return response.json()
+
+
+def test_shared_app_pins_build_and_confines_member_to_runtime(client, auth, db):
+  project, output = _built_project(client, auth, db)
+  instance = _create_instance(client, auth, project.id)
+  (output / "index.html").write_text("<h1>Changed source build</h1>")
+
+  invite = client.post(
+    f"/api/shared-apps/{instance['id']}/invites", headers=auth,
+    json={"invitee_name": "Morgan", "role": "editor"},
+  )
+  assert invite.status_code == 200, invite.text
+  secret = urlsplit(invite.json()["join_url"]).fragment
+  redeemed = client.post(
+    "/api/shared-apps/invites/redeem",
+    json={"invite": secret, "display_name": "Morgan"},
+  )
+  assert redeemed.status_code == 200, redeemed.text
+  guest = {"Authorization": f"Bearer {redeemed.json()['access_token']}"}
+
+  pinned = client.get(
+    f"/api/shared-apps/{instance['id']}/output/{instance['release_id']}/index.html",
+    headers=guest,
+  )
+  assert pinned.status_code == 200
+  assert pinned.text == "<h1>Pinned board</h1>"
+  assert client.get(f"/api/projects/{project.id}", headers=guest).status_code == 403
+
+  other_project, _other_output = _built_project(client, auth, db)
+  other = _create_instance(client, auth, other_project.id)
+  assert client.get(f"/api/shared-apps/{other['id']}", headers=guest).status_code == 404
+  assert client.post(
+    "/api/shared-apps/invites/redeem",
+    json={"invite": secret, "display_name": "Replay"},
+  ).status_code == 410
+
+
+def test_shared_state_is_path_version_checked_and_visible_to_members(client, auth, db):
+  project, _output = _built_project(client, auth, db)
+  instance = _create_instance(client, auth, project.id)
+  invite = client.post(
+    f"/api/shared-apps/{instance['id']}/invites", headers=auth,
+    json={"role": "editor"},
+  ).json()
+  redeemed = client.post(
+    "/api/shared-apps/invites/redeem",
+    json={"invite": urlsplit(invite["join_url"]).fragment, "display_name": "Morgan"},
+  ).json()
+  guest = {"Authorization": f"Bearer {redeemed['access_token']}"}
+
+  first = client.put(
+    f"/api/shared-apps/{instance['id']}/state/board.json", headers=auth,
+    json={"expected_version": None, "value": [{"title": "Owner card"}]},
+  )
+  assert first.status_code == 200, first.text
+  first_version = first.json()["version"]
+  member_state = client.get(
+    f"/api/shared-apps/{instance['id']}/state", headers=guest,
+  ).json()
+  assert member_state["values"]["board.json"][0]["title"] == "Owner card"
+  assert member_state["versions"]["board.json"] == first_version
+
+  second = client.put(
+    f"/api/shared-apps/{instance['id']}/state/board.json", headers=guest,
+    json={"expected_version": first_version, "value": [{"title": "Together"}]},
+  )
+  assert second.status_code == 200, second.text
+  stale = client.put(
+    f"/api/shared-apps/{instance['id']}/state/board.json", headers=auth,
+    json={"expected_version": first_version, "value": []},
+  )
+  assert stale.status_code == 409
+  assert stale.json()["detail"]["version"] == second.json()["version"]
+
+  changes = client.get(
+    f"/api/shared-apps/{instance['id']}/changes?after=0", headers=guest,
+  ).json()
+  assert changes["truncated"] is False
+  assert [(item["kind"], item["path"]) for item in changes["changes"]] == [
+    ("set", "board.json"), ("set", "board.json"),
+  ]
+  assert changes["cursor"] == second.json()["change_id"]
+
+
+def test_shared_state_snapshot_reads_files_and_cursor_under_one_lock(
+  client, auth, db, monkeypatch,
+):
+  project, _output = _built_project(client, auth, db)
+  instance = _create_instance(client, auth, project.id)
+  row = db.get(models.SharedAppInstance, instance["id"])
+  original = shared_app_state._latest_change_cursor
+
+  class ReentrantSpy:
+    depth = 0
+
+    def __enter__(self):
+      self.depth += 1
+      return self
+
+    def __exit__(self, *_args):
+      self.depth -= 1
+
+  lock = ReentrantSpy()
+  monkeypatch.setattr(shared_app_state, "state_lock", lambda _instance_id: lock)
+
+  def assert_locked(*args, **kwargs):
+    assert lock.depth == 1
+    return original(*args, **kwargs)
+
+  monkeypatch.setattr(shared_app_state, "_latest_change_cursor", assert_locked)
+
+  snapshot = shared_app_state.read_state_snapshot(db, row)
+
+  assert snapshot == {"values": {}, "versions": {}, "cursor": 0}
+
+
+def test_shared_state_accepts_only_one_writer_for_one_path_version(client, auth, db):
+  project, _output = _built_project(client, auth, db)
+  instance = _create_instance(client, auth, project.id)
+  barrier = Barrier(2)
+
+  def write(title):
+    barrier.wait()
+    return client.put(
+      f"/api/shared-apps/{instance['id']}/state/board.json", headers=auth,
+      json={"expected_version": None, "value": [{"title": title}]},
+    )
+
+  with ThreadPoolExecutor(max_workers=2) as pool:
+    responses = list(pool.map(write, ["First", "Second"]))
+
+  assert sorted(response.status_code for response in responses) == [200, 409]
+  state = client.get(f"/api/shared-apps/{instance['id']}/state", headers=auth).json()
+  assert state["values"]["board.json"][0]["title"] in {"First", "Second"}
+
+
+def test_shared_state_startup_recovery_rolls_back_an_uncommitted_file_change(
+  client, auth, db, monkeypatch,
+):
+  project, _output = _built_project(client, auth, db)
+  instance = _create_instance(client, auth, project.id)
+  row = db.get(models.SharedAppInstance, instance["id"])
+  owner = db.query(models.Owner).one()
+  principal = SharedAppPrincipal(owner=owner, role="owner", display_name=owner.username)
+  original = shared_app_state.write_state(
+    db, row, principal,
+    path="board.json", value={"cards": ["before"]}, delete=False,
+    expected_version=None,
+  )
+  before = shared_app_state.read_state_snapshot(db, row)
+  original_append = shared_app_state._append_change
+
+  def interrupt_before_event(*_args, **_kwargs):
+    raise KeyboardInterrupt("simulated process death")
+
+  monkeypatch.setattr(shared_app_state, "_append_change", interrupt_before_event)
+  with pytest.raises(KeyboardInterrupt):
+    shared_app_state.write_state(
+      db, row, principal,
+      path="board.json", value={"cards": ["uncommitted"]}, delete=False,
+      expected_version=original["version"],
+    )
+  db.rollback()
+  assert (shared_app_state.state_root(row).parent / "state-journal.json").is_file()
+
+  monkeypatch.setattr(shared_app_state, "_append_change", original_append)
+  shared_app_state.reconcile_all_journals(db)
+  snapshot = shared_app_state.read_state_snapshot(db, row)
+  changes = shared_app_state.list_changes(db, row, before["cursor"])
+
+  assert snapshot["values"] == {"board.json": {"cards": ["before"]}}
+  assert snapshot["versions"] == before["versions"]
+  assert snapshot["cursor"] == before["cursor"]
+  assert changes["changes"] == []
+  assert not (shared_app_state.state_root(row).parent / "state-journal.json").exists()
+
+
+def test_shared_state_startup_recovery_keeps_a_committed_change_once(
+  client, auth, db, monkeypatch,
+):
+  project, _output = _built_project(client, auth, db)
+  instance = _create_instance(client, auth, project.id)
+  row = db.get(models.SharedAppInstance, instance["id"])
+  owner = db.query(models.Owner).one()
+  principal = SharedAppPrincipal(owner=owner, role="owner", display_name=owner.username)
+  original_remove = shared_app_state._remove_journal
+
+  monkeypatch.setattr(
+    shared_app_state,
+    "_remove_journal",
+    lambda *_args, **_kwargs: (_ for _ in ()).throw(
+      KeyboardInterrupt("after database commit"),
+    ),
+  )
+  with pytest.raises(KeyboardInterrupt):
+    shared_app_state.write_state(
+      db, row, principal,
+      path="board.json", value={"cards": ["committed"]}, delete=False,
+      expected_version=None,
+    )
+  db.rollback()
+  monkeypatch.setattr(shared_app_state, "_remove_journal", original_remove)
+
+  shared_app_state.reconcile_all_journals(db)
+  snapshot = shared_app_state.read_state_snapshot(db, row)
+  changes = shared_app_state.list_changes(db, row, 0)
+
+  assert snapshot["values"] == {"board.json": {"cards": ["committed"]}}
+  assert len(changes["changes"]) == 1
+  assert changes["changes"][0]["version"] == snapshot["versions"]["board.json"]
+
+
+def test_shared_state_ambiguous_commit_error_reconciles_from_operation_identity(
+  client, auth, db, monkeypatch,
+):
+  project, _output = _built_project(client, auth, db)
+  instance = _create_instance(client, auth, project.id)
+  row = db.get(models.SharedAppInstance, instance["id"])
+  owner = db.query(models.Owner).one()
+  principal = SharedAppPrincipal(owner=owner, role="owner", display_name=owner.username)
+  original_commit = db.commit
+
+  def committed_then_errored():
+    original_commit()
+    raise RuntimeError("database acknowledgement was lost")
+
+  monkeypatch.setattr(db, "commit", committed_then_errored)
+  with pytest.raises(RuntimeError, match="acknowledgement"):
+    shared_app_state.write_state(
+      db, row, principal,
+      path="board.json", value={"cards": ["durable"]}, delete=False,
+      expected_version=None,
+    )
+  monkeypatch.setattr(db, "commit", original_commit)
+  db.expire_all()
+
+  snapshot = shared_app_state.read_state_snapshot(db, row)
+  changes = shared_app_state.list_changes(db, row, 0)
+  assert snapshot["values"] == {"board.json": {"cards": ["durable"]}}
+  assert len(changes["changes"]) == 1
+  assert changes["changes"][0]["version"] == snapshot["versions"]["board.json"]
+  assert not (shared_app_state.state_root(row).parent / "state-journal.json").exists()
+
+
+def test_shared_state_malformed_recovery_journal_fails_closed(client, auth, db):
+  project, _output = _built_project(client, auth, db)
+  instance = _create_instance(client, auth, project.id)
+  row = db.get(models.SharedAppInstance, instance["id"])
+  journal = shared_app_state.state_root(row).parent / "state-journal.json"
+  journal.write_text("{malformed", encoding="utf-8")
+
+  with pytest.raises(HTTPException):
+    shared_app_state.reconcile_all_journals(db)
+  response = client.get(f"/api/shared-apps/{instance['id']}/state", headers=auth)
+
+  assert response.status_code == 500
+  assert journal.read_text(encoding="utf-8") == "{malformed"
+
+
+def test_shared_state_allows_independent_paths_without_global_conflicts(client, auth, db):
+  project, _output = _built_project(client, auth, db)
+  instance = _create_instance(client, auth, project.id)
+
+  first = client.put(
+    f"/api/shared-apps/{instance['id']}/state/board.json", headers=auth,
+    json={"expected_version": None, "value": ["card"]},
+  )
+  second = client.put(
+    f"/api/shared-apps/{instance['id']}/state/settings.json", headers=auth,
+    json={"expected_version": None, "value": {"compact": True}},
+  )
+
+  assert first.status_code == second.status_code == 200
+  state = client.get(f"/api/shared-apps/{instance['id']}/state", headers=auth).json()
+  assert state["values"] == {
+    "board.json": ["card"], "settings.json": {"compact": True},
+  }
+  assert set(state["versions"]) == {"board.json", "settings.json"}
+
+
+def test_shared_state_ignores_only_atomic_write_crash_artifacts(client, auth, db):
+  project, _output = _built_project(client, auth, db)
+  instance = _create_instance(client, auth, project.id)
+  row = db.get(models.SharedAppInstance, instance["id"])
+  root = shared_app_state.state_root(row)
+  root.mkdir(parents=True, exist_ok=True)
+  (root / ".board.json.deadbeef.tmp").write_bytes(b"{partial")
+  (root / ".settings.json.abc12345.tmp").write_text(
+    '{"phantom":true}', encoding="utf-8",
+  )
+  # Similar ordinary owner paths remain visible: only mkstemp's exact
+  # eight-character atomic-write namespace is reserved.
+  (root / ".board.json.owner.tmp").write_text(
+    '{"kept":true}', encoding="utf-8",
+  )
+
+  state = client.get(
+    f"/api/shared-apps/{instance['id']}/state", headers=auth,
+  )
+
+  assert state.status_code == 200, state.text
+  assert state.json()["values"] == {
+    ".board.json.owner.tmp": {"kept": True},
+  }
+  reserved_write = client.put(
+    f"/api/shared-apps/{instance['id']}/state/.board.json.deadbeef.tmp",
+    headers=auth,
+    json={"expected_version": None, "value": {"not": "owner state"}},
+  )
+  assert reserved_write.status_code == 400
+  assert reserved_write.json()["detail"] == "Invalid shared app data path."
+
+
+def test_shared_app_reuses_identity_and_publishes_a_new_pinned_release(client, auth, db):
+  project, output = _built_project(client, auth, db)
+  instance = _create_instance(client, auth, project.id)
+  repeated = client.post(
+    "/api/shared-apps", headers=auth,
+    json={"project_id": project.id, "artifact_id": "website"},
+  )
+  assert repeated.status_code == 200
+  assert repeated.json()["id"] == instance["id"]
+
+  client.put(
+    f"/api/shared-apps/{instance['id']}/state/board.json", headers=auth,
+    json={"expected_version": None, "value": ["kept"]},
+  )
+  (output / "index.html").write_text("<h1>Published again</h1>")
+  published = client.put(f"/api/shared-apps/{instance['id']}/release", headers=auth)
+  assert published.status_code == 200, published.text
+  assert client.get(
+    f"/api/shared-apps/{instance['id']}/output/{published.json()['release_id']}/index.html",
+    headers=auth,
+  ).text == "<h1>Published again</h1>"
+  assert client.get(
+    f"/api/shared-apps/{instance['id']}/state", headers=auth,
+  ).json()["values"]["board.json"] == ["kept"]
+
+
+def test_shared_app_create_ambiguous_commit_keeps_the_durable_snapshot(
+  client, auth, db, monkeypatch,
+):
+  project, _output = _built_project(client, auth, db)
+  owner = db.query(models.Owner).one()
+  original_commit = db.commit
+
+  def committed_then_errored():
+    original_commit()
+    raise RuntimeError("database acknowledgement was lost")
+
+  monkeypatch.setattr(db, "commit", committed_then_errored)
+  with pytest.raises(RuntimeError, match="acknowledgement"):
+    shared_app_routes._create_shared_app(
+      shared_app_routes.SharedAppCreate(
+        project_id=project.id,
+        artifact_id="website",
+        name="Together Board",
+      ),
+      Response(),
+      owner,
+      db,
+    )
+  monkeypatch.setattr(db, "commit", original_commit)
+  db.expire_all()
+
+  row = db.query(models.SharedAppInstance).filter(
+    models.SharedAppInstance.project_id == project.id,
+  ).one()
+  release = shared_app_releases.current_release(row)
+  assert (Path(get_settings().data_dir) / release.snapshot_path).is_dir()
+
+
+def test_shared_app_owner_controls_access_and_can_recover_removal(client, auth, db):
+  project, _output = _built_project(client, auth, db)
+  instance = _create_instance(client, auth, project.id)
+  invitation = client.post(
+    f"/api/shared-apps/{instance['id']}/invites", headers=auth,
+    json={"invitee_name": "Morgan", "role": "editor"},
+  ).json()
+  redeemed = client.post(
+    "/api/shared-apps/invites/redeem",
+    json={"invite": urlsplit(invitation["join_url"]).fragment, "display_name": "Morgan"},
+  ).json()
+  guest = {"Authorization": f"Bearer {redeemed['access_token']}"}
+  member_id = redeemed["instance"]["member_id"]
+
+  assert client.patch(
+    f"/api/shared-apps/{instance['id']}/members/{member_id}", headers=auth,
+    json={"role": "viewer"},
+  ).status_code == 200
+  assert client.put(
+    f"/api/shared-apps/{instance['id']}/state/board.json", headers=guest,
+    json={"expected_version": None, "value": []},
+  ).status_code == 403
+  assert client.delete(
+    f"/api/shared-apps/{instance['id']}/members/{member_id}", headers=auth,
+  ).status_code == 204
+  assert client.get(f"/api/shared-apps/{instance['id']}", headers=guest).status_code == 401
+
+  assert client.delete(f"/api/shared-apps/{instance['id']}", headers=auth).status_code == 204
+  assert client.get(f"/api/shared-apps/{instance['id']}", headers=auth).status_code == 404
+  recovered = client.post(f"/api/shared-apps/{instance['id']}/recover", headers=auth)
+  assert recovered.status_code == 200
+  assert recovered.json()["id"] == instance["id"]
+
+
+def test_shared_app_recovery_does_not_duplicate_a_newer_instance(client, auth, db):
+  project, _output = _built_project(client, auth, db)
+  original = _create_instance(client, auth, project.id)
+  assert client.delete(
+    f"/api/shared-apps/{original['id']}", headers=auth,
+  ).status_code == 204
+
+  replacement = _create_instance(client, auth, project.id)
+  assert replacement["id"] != original["id"]
+  blocked = client.post(
+    f"/api/shared-apps/{original['id']}/recover", headers=auth,
+  )
+  assert blocked.status_code == 409
+  assert client.get(
+    f"/api/shared-apps/{replacement['id']}", headers=auth,
+  ).status_code == 200
+
+
+def test_shared_app_requires_its_source_project_before_recovery(client, auth, db):
+  project, _output = _built_project(client, auth, db)
+  instance = _create_instance(client, auth, project.id)
+  assert client.delete(
+    f"/api/shared-apps/{instance['id']}", headers=auth,
+  ).status_code == 204
+  assert client.delete(f"/api/projects/{project.id}", headers=auth).status_code == 204
+
+  blocked = client.post(f"/api/shared-apps/{instance['id']}/recover", headers=auth)
+
+  assert blocked.status_code == 409
+  assert blocked.json()["detail"] == "Recover the source project before this shared app."
+
+
+def test_shared_app_output_rejects_a_snapshot_outside_its_owned_root(
+  client, auth, db, tmp_path,
+):
+  project, _output = _built_project(client, auth, db)
+  instance = _create_instance(client, auth, project.id)
+  outside = tmp_path / "outside"
+  outside.mkdir()
+  (outside / "index.html").write_text("not shared", encoding="utf-8")
+  row = db.get(models.SharedAppInstance, instance["id"])
+  row.snapshot_path = str(outside)
+  db.commit()
+
+  response = client.get(
+    f"/api/shared-apps/{instance['id']}/output/{instance['release_id']}/index.html",
+    headers=auth,
+  )
+  assert response.status_code == 500
+  assert response.json()["detail"] == "Shared app storage is misconfigured."
+
+
+def test_expired_shared_app_removal_deletes_its_owned_snapshot(client, auth, db):
+  project, _output = _built_project(client, auth, db)
+  instance = _create_instance(client, auth, project.id)
+  row = db.get(models.SharedAppInstance, instance["id"])
+  snapshot_root = Path(get_settings().data_dir) / row.snapshot_path
+  row.deleted_at = now_naive_utc() - (SOFT_DELETE_TTL * 2)
+  db.commit()
+
+  assert purge_expired_shared_apps(db) == [instance["id"]]
+  assert db.get(models.SharedAppInstance, instance["id"]) is None
+  assert not snapshot_root.parent.exists()
+
+
+def test_shared_app_releases_are_immutable_across_multi_request_loads(client, auth, db):
+  project, output = _built_project(client, auth, db)
+  (output / "app.js").write_text("window.release = 'old'", encoding="utf-8")
+  instance = _create_instance(client, auth, project.id)
+  old_release = instance["release_id"]
+  (output / "index.html").write_text("<script src='app.js'></script><p>new</p>")
+  (output / "app.js").write_text("window.release = 'new'", encoding="utf-8")
+
+  published = client.put(
+    f"/api/shared-apps/{instance['id']}/release", headers=auth,
+  )
+  assert published.status_code == 200, published.text
+  new_release = published.json()["release_id"]
+  assert new_release != old_release
+
+  def output_text(release_id, path):
+    response = client.get(
+      f"/api/shared-apps/{instance['id']}/output/{release_id}/{path}", headers=auth,
+    )
+    assert response.status_code == 200, response.text
+    return response.text
+
+  assert output_text(old_release, "index.html") == "<h1>Pinned board</h1>"
+  assert output_text(old_release, "app.js") == "window.release = 'old'"
+  assert output_text(new_release, "index.html") == "<script src='app.js'></script><p>new</p>"
+  assert output_text(new_release, "app.js") == "window.release = 'new'"
+
+
+def test_legacy_build_snapshot_remains_valid_through_one_pinned_publish(
+  client, auth, db,
+):
+  project, output = _built_project(client, auth, db)
+  instance = _create_instance(client, auth, project.id)
+  row = db.get(models.SharedAppInstance, instance["id"])
+  data_root = Path(get_settings().data_dir)
+  release_root = data_root / row.snapshot_path
+  instance_root = release_root.parent.parent
+  release_root.rename(instance_root / "build")
+  release_root.parent.rmdir()
+  row.snapshot_path = (
+    Path("shared") / "app-instances" / instance["id"] / "build"
+  ).as_posix()
+  row.previous_snapshot_path = None
+  db.commit()
+
+  detail = client.get(f"/api/shared-apps/{instance['id']}", headers=auth)
+  assert detail.status_code == 200, detail.text
+  assert detail.json()["release_id"] == "legacy"
+  assert client.get(
+    f"/api/shared-apps/{instance['id']}/output/legacy/index.html", headers=auth,
+  ).text == "<h1>Pinned board</h1>"
+
+  (output / "index.html").write_text("<h1>first immutable</h1>", encoding="utf-8")
+  first = client.put(f"/api/shared-apps/{instance['id']}/release", headers=auth)
+  assert first.status_code == 200, first.text
+  assert client.get(
+    f"/api/shared-apps/{instance['id']}/output/legacy/index.html", headers=auth,
+  ).status_code == 200
+
+  (output / "index.html").write_text("<h1>second immutable</h1>", encoding="utf-8")
+  second = client.put(f"/api/shared-apps/{instance['id']}/release", headers=auth)
+  assert second.status_code == 200, second.text
+  assert client.get(
+    f"/api/shared-apps/{instance['id']}/output/legacy/index.html", headers=auth,
+  ).status_code == 404
+  assert client.get(
+    f"/api/shared-apps/{instance['id']}/output/{first.json()['release_id']}/index.html",
+    headers=auth,
+  ).text == "<h1>first immutable</h1>"
+
+
+def test_shared_app_database_pointer_recovers_both_publish_crash_boundaries(
+  client, auth, db, monkeypatch,
+):
+  project, output = _built_project(client, auth, db)
+  instance = _create_instance(client, auth, project.id)
+  row = db.get(models.SharedAppInstance, instance["id"])
+  original = shared_app_releases.current_release(row)
+  original_commit = db.commit
+  original_cleanup = shared_app_releases._cleanup_instance_releases_locked
+
+  (output / "index.html").write_text("<h1>not active</h1>", encoding="utf-8")
+  monkeypatch.setattr(db, "commit", lambda: (_ for _ in ()).throw(
+    KeyboardInterrupt("before database pointer commit"),
+  ))
+  with pytest.raises(KeyboardInterrupt):
+    shared_app_releases.publish_release(
+      db,
+      row,
+      output_root=output,
+      entry_path="index.html",
+      name="Together Board",
+    )
+  monkeypatch.setattr(db, "commit", original_commit)
+  db.rollback()
+  db.refresh(row)
+  shared_app_releases.reconcile_release_storage(db)
+  recovered_old = shared_app_releases.current_release(row)
+  assert recovered_old.release_id == original.release_id
+  instance_root = (Path(get_settings().data_dir) / row.snapshot_path).parent.parent
+  assert {child.name for child in (instance_root / "releases").iterdir()} == {
+    original.release_id,
+  }
+
+  (output / "index.html").write_text("<h1>active after restart</h1>", encoding="utf-8")
+  monkeypatch.setattr(
+    shared_app_releases,
+    "_cleanup_instance_releases_locked",
+    lambda *_args, **_kwargs: (_ for _ in ()).throw(
+      KeyboardInterrupt("after database pointer commit"),
+    ),
+  )
+  with pytest.raises(KeyboardInterrupt):
+    shared_app_releases.publish_release(
+      db,
+      row,
+      output_root=output,
+      entry_path="index.html",
+      name="Together Board",
+    )
+  monkeypatch.setattr(
+    shared_app_releases, "_cleanup_instance_releases_locked", original_cleanup,
+  )
+  db.rollback()
+  db.refresh(row)
+  shared_app_releases.reconcile_release_storage(db)
+  recovered_new = shared_app_releases.current_release(row)
+  assert recovered_new.release_id != original.release_id
+  assert {child.name for child in (instance_root / "releases").iterdir()} == {
+    original.release_id,
+    recovered_new.release_id,
+  }
+  handle, _media_type = shared_app_releases.open_release_file(
+    row, recovered_new.release_id, "index.html",
+  )
+  with handle:
+    assert handle.read().decode() == "<h1>active after restart</h1>"
+
+
+def test_shared_app_publish_ambiguous_commit_keeps_only_the_durable_pointer(
+  client, auth, db, monkeypatch,
+):
+  project, output = _built_project(client, auth, db)
+  instance = _create_instance(client, auth, project.id)
+  row = db.get(models.SharedAppInstance, instance["id"])
+  old_release = shared_app_releases.current_release(row)
+  original_commit = db.commit
+
+  (output / "index.html").write_text("<h1>durably active</h1>", encoding="utf-8")
+
+  def committed_then_errored():
+    original_commit()
+    raise RuntimeError("database acknowledgement was lost")
+
+  monkeypatch.setattr(db, "commit", committed_then_errored)
+  with pytest.raises(RuntimeError, match="acknowledgement"):
+    shared_app_releases.publish_release(
+      db,
+      row,
+      output_root=output,
+      entry_path="index.html",
+      name="Together Board",
+    )
+  monkeypatch.setattr(db, "commit", original_commit)
+  db.expire_all()
+  row = db.get(models.SharedAppInstance, instance["id"])
+  durable = shared_app_releases.current_release(row)
+  assert durable.release_id != old_release.release_id
+  shared_app_releases.reconcile_release_storage(db)
+  handle, _media_type = shared_app_releases.open_release_file(
+    row, durable.release_id, "index.html",
+  )
+  with handle:
+    assert handle.read().decode() == "<h1>durably active</h1>"
+
+
+def test_shared_app_release_open_waits_for_publish_and_keeps_its_descriptor(
+  client, auth, db, monkeypatch,
+):
+  project, output = _built_project(client, auth, db)
+  instance = _create_instance(client, auth, project.id)
+  old_release = instance["release_id"]
+  (output / "index.html").write_text("<h1>second</h1>", encoding="utf-8")
+  installed = Event()
+  continue_publish = Event()
+  original_install = shared_app_releases._install_immutable_release
+
+  def blocking_install(instance_id, output_root):
+    release = original_install(instance_id, output_root)
+    installed.set()
+    assert continue_publish.wait(5)
+    return release
+
+  monkeypatch.setattr(shared_app_releases, "_install_immutable_release", blocking_install)
+  with ThreadPoolExecutor(max_workers=2) as pool:
+    publish = pool.submit(
+      client.put, f"/api/shared-apps/{instance['id']}/release", headers=auth,
+    )
+    assert installed.wait(5)
+    opened = pool.submit(
+      client.get,
+      f"/api/shared-apps/{instance['id']}/output/{old_release}/index.html",
+      headers=auth,
+    )
+    assert not opened.done()
+    continue_publish.set()
+    published = publish.result(timeout=10)
+    old_response = opened.result(timeout=10)
+  assert published.status_code == 200, published.text
+  assert old_response.status_code == 200
+  assert old_response.text == "<h1>Pinned board</h1>"
+
+  monkeypatch.setattr(shared_app_releases, "_install_immutable_release", original_install)
+  db.expire_all()
+  row = db.get(models.SharedAppInstance, instance["id"])
+  handle, _media_type = shared_app_releases.open_release_file(
+    row, old_release, "index.html",
+  )
+  (output / "index.html").write_text("<h1>third</h1>", encoding="utf-8")
+  third = client.put(f"/api/shared-apps/{instance['id']}/release", headers=auth)
+  assert third.status_code == 200, third.text
+  with handle:
+    assert handle.read().decode() == "<h1>Pinned board</h1>"
+
+
+def test_project_removal_recovers_its_shared_app_but_not_old_guest_access(client, auth, db):
+  project, _output = _built_project(client, auth, db)
+  instance = _create_instance(client, auth, project.id)
+  invitation = client.post(
+    f"/api/shared-apps/{instance['id']}/invites", headers=auth,
+    json={"role": "editor"},
+  ).json()
+  redeemed = client.post(
+    "/api/shared-apps/invites/redeem",
+    json={"invite": urlsplit(invitation["join_url"]).fragment, "display_name": "Morgan"},
+  ).json()
+  guest = {"Authorization": f"Bearer {redeemed['access_token']}"}
+
+  assert client.delete(f"/api/projects/{project.id}", headers=auth).status_code == 204
+  assert client.get(f"/api/shared-apps/{instance['id']}", headers=auth).status_code == 404
+  assert client.get(f"/api/shared-apps/{instance['id']}", headers=guest).status_code == 401
+  assert client.post(f"/api/projects/{project.id}/recover", headers=auth).status_code == 200
+  assert client.get(f"/api/shared-apps/{instance['id']}", headers=auth).status_code == 200
+  assert client.get(f"/api/shared-apps/{instance['id']}", headers=guest).status_code == 401
+
+
+def test_shared_app_routes_hide_an_inconsistent_live_row_when_its_project_is_deleted(
+  client, auth, db,
+):
+  project, _output = _built_project(client, auth, db)
+  instance = _create_instance(client, auth, project.id)
+  accepted_invite = client.post(
+    f"/api/shared-apps/{instance['id']}/invites", headers=auth,
+    json={"role": "editor"},
+  ).json()
+  accepted = client.post(
+    "/api/shared-apps/invites/redeem",
+    json={
+      "invite": urlsplit(accepted_invite["join_url"]).fragment,
+      "display_name": "Morgan",
+    },
+  ).json()
+  guest = {"Authorization": f"Bearer {accepted['access_token']}"}
+  pending = client.post(
+    f"/api/shared-apps/{instance['id']}/invites", headers=auth,
+    json={"role": "viewer"},
+  ).json()
+  db.get(models.Project, project.id).deleted_at = now_naive_utc()
+  db.commit()
+
+  assert client.get("/api/shared-apps", headers=auth).json() == []
+  assert client.get(f"/api/shared-apps/{instance['id']}", headers=auth).status_code == 404
+  assert client.get(f"/api/shared-apps/{instance['id']}/state", headers=guest).status_code == 404
+  assert client.get(
+    f"/api/shared-apps/{instance['id']}/output/{instance['release_id']}/index.html",
+    headers=auth,
+  ).status_code == 404
+  redeemed = client.post(
+    "/api/shared-apps/invites/redeem",
+    json={
+      "invite": urlsplit(pending["join_url"]).fragment,
+      "display_name": "Taylor",
+    },
+  )
+  assert redeemed.status_code == 410
+
+
+def test_expired_project_removal_purges_its_shared_app_snapshot(client, auth, db):
+  from app.project_retention import purge_expired_project_tombstones
+
+  project, _output = _built_project(client, auth, db)
+  project_id = str(project.id)
+  instance = _create_instance(client, auth, project.id)
+  shared = db.get(models.SharedAppInstance, instance["id"])
+  snapshot_root = Path(get_settings().data_dir) / shared.snapshot_path
+  assert client.delete(f"/api/projects/{project.id}", headers=auth).status_code == 204
+  expired_at = now_naive_utc() - (SOFT_DELETE_TTL * 2)
+  db.get(models.Project, project.id).deleted_at = expired_at
+  db.get(models.SharedAppInstance, instance["id"]).deleted_at = expired_at
+  db.commit()
+
+  assert purge_expired_project_tombstones(db) == [project_id]
+  assert db.get(models.SharedAppInstance, instance["id"]) is None
+  assert not snapshot_root.parent.exists()

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -24,6 +24,7 @@ const Shell = lazy(() => import('./components/Shell/Shell.jsx'))
 const ChatEmbed = lazy(() => import('./components/ChatEmbed/ChatEmbed.jsx'))
 const StandaloneApp = lazy(() => import('./components/StandaloneApp/StandaloneApp.jsx'))
 const ProjectShare = lazy(() => import('./components/Projects/ProjectShare.jsx'))
+const SharedApp = lazy(() => import('./components/Projects/SharedApp.jsx'))
 
 // True when this SPA load is the stripped-chrome chat embed
 // (capability A). The SPA catch-all serves index.html for any non-API
@@ -52,11 +53,23 @@ const PROJECT_SHARE_ROUTE = (() => {
     return false
   }
 })()
+const SHARED_APP_ROUTE = (() => {
+  try {
+    const path = window.location.pathname
+    return path === `${BASE}/app-invite` || path.startsWith(`${BASE}/shared/app/`)
+  } catch {
+    return false
+  }
+})()
+const SHARED_APP_INVITE_ROUTE = (() => {
+  try { return window.location.pathname === `${BASE}/app-invite` }
+  catch { return false }
+})()
 const STANDALONE_APP = readStandaloneBoot()
 if (EMBED_ROUTE) {
   beginEphemeralAuth()
   beginEmbedBootstrap()
-} else if (PROJECT_SHARE_ROUTE) {
+} else if (PROJECT_SHARE_ROUTE || SHARED_APP_INVITE_ROUTE) {
   beginEphemeralAuth()
 } else {
   // Capture Chromium's one-shot install event before setup or sign-in can keep
@@ -91,6 +104,15 @@ export default function App() {
       <QueryClientProvider client={queryClient}>
         <ErrorBoundary label="project-share" recoveryKey="project-share:root" canAskAgent={false}>
           <Suspense fallback={<RouteLoading />}><ProjectShare /></Suspense>
+        </ErrorBoundary>
+      </QueryClientProvider>
+    )
+  }
+  if (SHARED_APP_ROUTE) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <ErrorBoundary label="shared-app" recoveryKey="shared-app:root" canAskAgent={false}>
+          <Suspense fallback={<RouteLoading />}><SharedApp /></Suspense>
         </ErrorBoundary>
       </QueryClientProvider>
     )

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -621,6 +621,10 @@ export const api = {
     markOpened: (projectId) => apiFetch(
       `/projects/${encodeURIComponent(projectId)}/opened`, { method: 'POST' },
     ),
+    markArtifactOpened: (projectId, artifactId) => apiFetch(
+      `/projects/${encodeURIComponent(projectId)}/artifacts/${encodeURIComponent(artifactId)}/opened`,
+      { method: 'POST' },
+    ),
     create: (payload) => apiFetch('/projects', {
       method: 'POST',
       body: JSON.stringify(payload),
@@ -819,6 +823,50 @@ export const api = {
     artifactOutput: (projectId, artifactId, path, { signal } = {}) => apiFetch(
       `/projects/${encodeURIComponent(projectId)}/artifacts/${encodeURIComponent(artifactId)}/output/${path.split('/').map(encodeURIComponent).join('/')}`,
       { signal },
+    ),
+  },
+  sharedApps: {
+    list: () => apiFetch('/shared-apps'),
+    create: payload => apiFetch('/shared-apps', { method: 'POST', body: JSON.stringify(payload) }),
+    detail: instanceId => apiFetch(`/shared-apps/${encodeURIComponent(instanceId)}`),
+    publishRelease: instanceId => apiFetch(
+      `/shared-apps/${encodeURIComponent(instanceId)}/release`, { method: 'PUT' },
+    ),
+    remove: instanceId => apiFetch(`/shared-apps/${encodeURIComponent(instanceId)}`, { method: 'DELETE' }),
+    recover: instanceId => apiFetch(
+      `/shared-apps/${encodeURIComponent(instanceId)}/recover`, { method: 'POST' },
+    ),
+    redeemInvite: payload => apiFetch('/shared-apps/invites/redeem', {
+      method: 'POST', body: JSON.stringify(payload),
+    }),
+    collaboration: instanceId => apiFetch(`/shared-apps/${encodeURIComponent(instanceId)}/collaboration`),
+    createInvite: (instanceId, payload) => apiFetch(
+      `/shared-apps/${encodeURIComponent(instanceId)}/invites`,
+      { method: 'POST', body: JSON.stringify(payload) },
+    ),
+    revokeInvite: (instanceId, inviteId) => apiFetch(
+      `/shared-apps/${encodeURIComponent(instanceId)}/invites/${encodeURIComponent(inviteId)}`,
+      { method: 'DELETE' },
+    ),
+    updateMember: (instanceId, memberId, payload) => apiFetch(
+      `/shared-apps/${encodeURIComponent(instanceId)}/members/${encodeURIComponent(memberId)}`,
+      { method: 'PATCH', body: JSON.stringify(payload) },
+    ),
+    removeMember: (instanceId, memberId) => apiFetch(
+      `/shared-apps/${encodeURIComponent(instanceId)}/members/${encodeURIComponent(memberId)}`,
+      { method: 'DELETE' },
+    ),
+    state: instanceId => apiFetch(`/shared-apps/${encodeURIComponent(instanceId)}/state`),
+    changes: (instanceId, after) => apiFetch(
+      `/shared-apps/${encodeURIComponent(instanceId)}/changes?after=${encodeURIComponent(after)}`,
+    ),
+    writeState: (instanceId, path, payload) => apiFetch(
+      `/shared-apps/${encodeURIComponent(instanceId)}/state/${encodeURIComponent(path)}`,
+      { method: 'PUT', body: JSON.stringify(payload) },
+    ),
+    output: (instanceId, releaseId, path, options) => apiFetch(
+      `/shared-apps/${encodeURIComponent(instanceId)}/output/${encodeURIComponent(releaseId)}/${String(path || '').split('/').map(encodeURIComponent).join('/')}`,
+      options,
     ),
   },
   services: {

--- a/frontend/src/components/Drawer/Drawer.jsx
+++ b/frontend/src/components/Drawer/Drawer.jsx
@@ -1463,7 +1463,7 @@ const DrawerArtifactRow = memo(function DrawerArtifactRow({ item, active, action
         type="button"
         className={`drawer__item${active ? ' drawer__item--active' : ''}`}
         aria-current={active ? 'page' : undefined}
-        aria-label={`Open artifact ${item.name || item.artifact_id}`}
+        aria-label={`Open Creation ${item.name || item.artifact_id}`}
         onClick={() => actions.select('artifact', item.id)}
       >
         <span className="drawer__item-icon drawer__artifact-icon" aria-hidden="true">

--- a/frontend/src/components/Drawer/drawerInformationArchitecture.js
+++ b/frontend/src/components/Drawer/drawerInformationArchitecture.js
@@ -18,6 +18,7 @@ function recentAt({ kind, item }) {
   if (kind === 'chat') {
     return item?.activity_at || item?.updated_at || item?.created_at || ''
   }
+  if (kind === 'artifact') return item?.last_opened_at || ''
   return item?.last_opened_at || item?.updated_at || item?.created_at || ''
 }
 
@@ -82,14 +83,15 @@ export function buildDrawerSections(chats = [], apps = [], projects = []) {
     ...projects.flatMap(project => (
       Array.isArray(project?.artifacts) ? project.artifacts : []
     )
-      .filter(artifact => artifact?.status === 'ok' && artifact?.has_output)
+      .filter(artifact => (
+        artifact?.status === 'ok' && artifact?.has_output && artifact?.last_opened_at
+      ))
       .map(artifact => ({
         kind: 'artifact',
         item: {
           ...artifact,
           id: `${project.id}:${artifact.id}`,
           artifact_id: artifact.id,
-          activity_at: artifact.updated_at || project.updated_at || '',
           project: { id: project.id, name: project.name, color: project.color },
         },
       }))),

--- a/frontend/src/components/Projects/ArtifactWorkspace.jsx
+++ b/frontend/src/components/Projects/ArtifactWorkspace.jsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import ArrowLeft from 'lucide-react/dist/esm/icons/arrow-left.mjs'
 import Hammer from 'lucide-react/dist/esm/icons/hammer.mjs'
-import { api, jsonOrThrow } from '../../api/client.js'
+import { api, BASE, jsonOrThrow } from '../../api/client.js'
 import { projectQueries } from '../../hooks/queries.js'
 import {
   artifactEntryPath,
@@ -24,12 +24,12 @@ import './Projects.css'
 // HTML renders in a sandboxed iframe with NO
 // allow-same-origin (its JS can never read the parent token); PDFs render
 // through pdfjs; images use a private object URL. The preview hot-swaps.
-export default function ArtifactWorkspace({ projectId, artifactId, projectName, onOpenProject, readOnly = false }) {
+export default function ArtifactWorkspace({ projectId, artifactId, projectName, onOpenProject, readOnly = false, canShareApp = !readOnly }) {
   const artifactsQuery = useQuery({
     queryKey: projectQueries.keys.artifacts(projectId),
     queryFn: async ({ signal }) => normalizeArtifacts(await jsonOrThrow(
       await api.projects.artifacts(projectId, { signal }),
-      'Project artifacts failed:',
+      'Project Creations failed:',
     )),
     // The owner shell also forwards build-status events, but an invited
     // collaborator runs in an isolated route without that stream. Poll only
@@ -53,6 +53,7 @@ export default function ArtifactWorkspace({ projectId, artifactId, projectName, 
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState('')
   const [previewVersion, setPreviewVersion] = useState(0)
+  const [sharing, setSharing] = useState(false)
 
   // Hot-swap the preview when a build finishes (building -> ok, or a fresh ok
   // first seen). The status is owned by the query, refreshed by the build-status
@@ -77,16 +78,42 @@ export default function ArtifactWorkspace({ projectId, artifactId, projectName, 
     } finally { setBusy(false) }
   }
 
+  async function useTogether() {
+    if (sharing || !artifact) return
+    const sharedWindow = window.open('', '_blank')
+    if (sharedWindow) {
+      sharedWindow.opener = null
+      sharedWindow.document.title = 'Opening shared app…'
+      sharedWindow.document.body.textContent = 'Opening shared app…'
+    }
+    setSharing(true); setError('')
+    try {
+      const instance = await jsonOrThrow(await api.sharedApps.create({
+        project_id: projectId,
+        artifact_id: artifactId,
+        name: artifact.name || projectName || 'Shared app',
+      }), 'Could not share app:')
+      const url = `${BASE}/shared/app/${encodeURIComponent(instance.id)}`
+      if (sharedWindow) sharedWindow.location.assign(url)
+      else window.location.assign(url)
+      setSharing(false)
+    } catch (cause) {
+      sharedWindow?.close()
+      setError(cause?.message || 'Could not create a shared app.')
+      setSharing(false)
+    }
+  }
+
   const entryPath = artifact ? artifactEntryPath(artifact) : null
 
   if (artifactsQuery.isLoading) {
-    return <section className="artifact-workspace" aria-busy="true"><p className="projects-empty" role="status">Loading artifact…</p></section>
+    return <section className="artifact-workspace" aria-busy="true"><p className="projects-empty" role="status">Loading Creation…</p></section>
   }
   if (!artifact) {
     return (
       <section className="artifact-workspace">
         <div className="projects-empty" role="alert">
-          <p>This artifact is no longer available.</p>
+          <p>This Creation is no longer available.</p>
           {onOpenProject && <button type="button" onClick={onOpenProject}>Back to project</button>}
         </div>
       </section>
@@ -94,7 +121,7 @@ export default function ArtifactWorkspace({ projectId, artifactId, projectName, 
   }
 
   return (
-    <section className="artifact-workspace" aria-label={`${artifact.name || artifactId} artifact`}>
+    <section className="artifact-workspace" aria-label={`${artifact.name || artifactId} Creation`}>
       <header className="artifact-workspace__header">
         {onOpenProject && (
           <button type="button" className="project-icon-button" aria-label="Back to project" title={projectName ? `Back to ${projectName}` : 'Back to project'} onClick={onOpenProject}><ArrowLeft size={18} /></button>
@@ -114,6 +141,12 @@ export default function ArtifactWorkspace({ projectId, artifactId, projectName, 
           <Hammer size={16} aria-hidden="true" />
           <span>{isBuilding(artifact) ? 'Building…' : hasOutput ? 'Rebuild' : 'Build'}</span>
         </button>}
+        {canShareApp && hasOutput && preview === 'html' && <button
+          type="button"
+          className="project-use-together-button"
+          disabled={sharing}
+          onClick={useTogether}
+        >{sharing ? 'Opening…' : 'Open shared version'}</button>}
       </header>
 
       {error && <p className="projects-error" role="alert">{error}</p>}
@@ -123,7 +156,7 @@ export default function ArtifactWorkspace({ projectId, artifactId, projectName, 
           <div className="project-document__empty" role="status">
             <Hammer size={42} strokeWidth={1.3} aria-hidden="true" />
             <h2>Nothing built yet</h2>
-            <p>{status === 'error' ? 'The last build failed. Fix the source and build again.' : 'Build this artifact to preview it here.'}</p>
+            <p>{status === 'error' ? 'The last build failed. Fix the source and build again.' : 'Build this Creation to preview it here.'}</p>
             {!readOnly && <button type="button" className="project-build-button" disabled={busy} onClick={build}><Hammer size={16} aria-hidden="true" /><span>Build</span></button>}
           </div>
         ) : preview === 'pdf' ? (
@@ -235,7 +268,7 @@ function PdfPreview({ projectId, artifactId, entryPath, version }) {
 
   if (error) return <div className="project-document__empty" role="alert"><h2>Couldn’t load the document</h2><p>{error}</p></div>
   if (loading && !data) return <div className="project-document__empty" role="status"><p>Rendering document…</p></div>
-  return <ProjectPdfPreview data={data} title="Artifact document" />
+  return <ProjectPdfPreview data={data} title="Creation document" />
 }
 
 function ImagePreview({ projectId, artifactId, entryPath, version, name }) {

--- a/frontend/src/components/Projects/ProjectArtifacts.jsx
+++ b/frontend/src/components/Projects/ProjectArtifacts.jsx
@@ -10,8 +10,8 @@ import {
 import ArtifactIdentityIcon from './ArtifactIdentityIcon.jsx'
 import './Projects.css'
 
-// The Artifacts zone: a simple list of a project's buildable outputs, each
-// opening in its own tab. Artifacts are created for you — a
+// The Creations zone: a simple list of a project's buildable outputs, each
+// opening in its own tab. Creations are created for you — a
 // templated project comes with one predefined, and any file can be built into
 // one from its ⋯ menu in the finder — so this panel deliberately has no manual
 // "new artifact" form. Kept as plain as possible.
@@ -20,7 +20,7 @@ export default function ProjectArtifacts({ projectId, onOpen }) {
     queryKey: projectQueries.keys.artifacts(projectId),
     queryFn: async ({ signal }) => normalizeArtifacts(await jsonOrThrow(
       await api.projects.artifacts(projectId, { signal }),
-      'Project artifacts failed:',
+      'Project Creations failed:',
     )),
   })
   const artifacts = artifactsQuery.data || []
@@ -28,11 +28,11 @@ export default function ProjectArtifacts({ projectId, onOpen }) {
   return (
     <div className="project-artifacts">
       {artifactsQuery.isLoading ? (
-        <p className="projects-empty" role="status">Loading artifacts…</p>
+        <p className="projects-empty" role="status">Loading Creations…</p>
       ) : artifactsQuery.isError ? (
-        <div className="projects-empty" role="alert"><p>Artifacts are unavailable.</p><button type="button" onClick={() => artifactsQuery.refetch()}>Try again</button></div>
+        <div className="projects-empty" role="alert"><p>Creations are unavailable.</p><button type="button" onClick={() => artifactsQuery.refetch()}>Try again</button></div>
       ) : artifacts.length === 0 ? (
-        <p className="projects-empty project-artifacts__empty">No artifacts yet.</p>
+        <p className="projects-empty project-artifacts__empty">No Creations yet.</p>
       ) : (
         <div className="project-artifacts__list">
           {artifacts.map(artifact => {

--- a/frontend/src/components/Projects/ProjectFinder.jsx
+++ b/frontend/src/components/Projects/ProjectFinder.jsx
@@ -632,7 +632,7 @@ export default function ProjectFinder({
         try {
           await onSourceSaved(selected)
         } catch (cause) {
-          setError(cause?.message || 'The file was saved, but its live artifact could not rebuild.')
+          setError(cause?.message || 'The file was saved, but its Creation could not rebuild.')
         }
       }
     } catch (cause) {

--- a/frontend/src/components/Projects/ProjectGitPanel.jsx
+++ b/frontend/src/components/Projects/ProjectGitPanel.jsx
@@ -134,7 +134,7 @@ export default function ProjectGitPanel({ project, onClose }) {
                   <button type="button" className="is-primary" disabled={!!busy || !actions.push} aria-expanded={pushReview} onClick={() => setPushReview(true)}><ArrowUp size={14} />{busy === 'push' ? 'Pushing…' : 'Review & push'}</button>
                 </div>
                 {pushReview && <div className="project-git__push-review" role="group" aria-label="Confirm GitHub push">
-                  <div><strong>Publish {status.ahead} {status.ahead === 1 ? 'commit' : 'commits'}?</strong><p>Destination: <code>{status.repository}:{status.branch}</code>. Uncommitted files and generated artifacts stay local.</p></div>
+                  <div><strong>Publish {status.ahead} {status.ahead === 1 ? 'commit' : 'commits'}?</strong><p>Destination: <code>{status.repository}:{status.branch}</code>. Uncommitted files and generated build output stay local.</p></div>
                   <div><button type="button" disabled={!!busy} onClick={() => setPushReview(false)}>Cancel</button><button type="button" className="is-primary" disabled={!!busy} onClick={() => void run('push')}>{busy === 'push' ? 'Pushing…' : `Push ${status.ahead}`}</button></div>
                 </div>}
               </section>
@@ -142,7 +142,7 @@ export default function ProjectGitPanel({ project, onClose }) {
               {status.commits?.length > 0 && <section>
                 <div className="project-git__section-head"><h3>Outgoing commits</h3><span>{status.commits.length}{status.ahead > status.commits.length ? ` of ${status.ahead}` : ''}</span></div>
                 <div className="project-git__commits">{status.commits.map(commit => <div key={commit.id}><code>{commit.id}</code><span>{commit.subject}</span></div>)}</div>
-                <p className="project-git__review-note">Only these committed snapshots are published. Uncommitted files and generated artifacts are never included.</p>
+                <p className="project-git__review-note">Only these committed snapshots are published. Uncommitted files and generated build output are never included.</p>
               </section>}
             </>}
           </>}

--- a/frontend/src/components/Projects/ProjectPreviewFrame.jsx
+++ b/frontend/src/components/Projects/ProjectPreviewFrame.jsx
@@ -51,7 +51,7 @@ export default function ProjectPreviewFrame({ projectId, sourcePath, title, clas
       try {
         previous = event.oldValue ? JSON.parse(event.oldValue) : {}
       } catch {
-        // A malformed old browser value should not break the live bridge.
+        // A malformed old browser value should not break the live preview bridge.
       }
       const next = readProjectPreviewStore(localStorage, storageKey)
       for (const path of new Set([...Object.keys(previous), ...Object.keys(next)])) {

--- a/frontend/src/components/Projects/ProjectShare.jsx
+++ b/frontend/src/components/Projects/ProjectShare.jsx
@@ -237,7 +237,7 @@ export default function ProjectShare() {
     if (!canEdit) return
     const artifacts = await jsonOrThrow(
       await api.projects.artifacts(projectId),
-      'Artifact refresh failed:',
+      'Creation refresh failed:',
     )
     const outcomes = await queueArtifactBuildsAfterSourceSave(
       artifacts,
@@ -261,7 +261,7 @@ export default function ProjectShare() {
         <button type="button" onClick={leave}><LogOut size={16} /><span>Leave</span></button>
       </header>
       <div className="project-share__workspace">
-        {artifactId ? <ArtifactWorkspace projectId={projectId} artifactId={artifactId} projectName={project.name} readOnly={!canEdit} onOpenProject={() => setArtifactId('')} /> : <ProjectFinder
+        {artifactId ? <ArtifactWorkspace projectId={projectId} artifactId={artifactId} projectName={project.name} readOnly={!canEdit} canShareApp={false} onOpenProject={() => setArtifactId('')} /> : <ProjectFinder
           projectId={projectId}
           projectName={project.name}
           artifactTypes={project.template?.artifact_types}
@@ -269,7 +269,7 @@ export default function ProjectShare() {
           onBuildFile={canEdit ? buildFileAsArtifact : undefined}
           onSourceSaved={canEdit ? rebuildRegisteredArtifacts : undefined}
           overview={<div className="project-share__overview">
-            <section><div className="project-share__section-head"><h2>Artifacts</h2></div><ProjectArtifacts projectId={projectId} onOpen={setArtifactId} /></section>
+            <section><div className="project-share__section-head"><h2>Creations</h2></div><ProjectArtifacts projectId={projectId} onOpen={setArtifactId} /></section>
             <section><div className="project-share__section-head"><h2>People</h2><span>{online} online</span></div><div className="project-share__people">{members.map(member => { const claim = claimsByActor.get(member.id === 'owner' ? 'owner' : `member:${member.id}`); return <div key={member.id}><span>{initials(member.display_name)}</span><strong>{member.you ? `${member.display_name} · You` : member.display_name}</strong><small>{claim?.summary || `${member.role}${member.online ? ' · online' : ''}`}</small></div> })}{claims.filter(claim => claim.actor_kind === 'agent').map(claim => <div key={claim.id}><span>AI</span><strong>{claim.display_name}</strong><small>{claim.summary}</small></div>)}</div></section>
           </div>}
         />}

--- a/frontend/src/components/Projects/ProjectWorkspace.jsx
+++ b/frontend/src/components/Projects/ProjectWorkspace.jsx
@@ -140,7 +140,7 @@ export default function ProjectWorkspace({
   async function rebuildRegisteredArtifacts() {
     const artifacts = await jsonOrThrow(
       await api.projects.artifacts(project.id),
-      'Artifact refresh failed:',
+      'Creation refresh failed:',
     )
     const outcomes = await queueArtifactBuildsAfterSourceSave(
       artifacts,
@@ -210,7 +210,7 @@ export default function ProjectWorkspace({
             <div className="project-overview" aria-label="Project overview">
               <section className="project-overview__section" aria-labelledby={`project-artifacts-heading-${project.id}`}>
                 <header className="project-overview__heading">
-                  <h2 id={`project-artifacts-heading-${project.id}`}>Artifacts</h2>
+                  <h2 id={`project-artifacts-heading-${project.id}`}>Creations</h2>
                 </header>
                 <ProjectArtifacts projectId={project.id} onOpen={onOpenArtifact} />
               </section>

--- a/frontend/src/components/Projects/Projects.css
+++ b/frontend/src/components/Projects/Projects.css
@@ -21,8 +21,7 @@
 .project-workspace input,
 .project-workspace textarea { font: inherit; }
 
-.projects-directory__header,
-.project-document__header {
+.projects-directory__header {
   min-height: 58px;
   flex: 0 0 auto;
   display: flex;
@@ -45,16 +44,14 @@
   letter-spacing: -0.03em;
 }
 
-.projects-directory__header p,
-.projects-section-heading p {
+.projects-directory__header p {
   margin: 3px 0 0;
   color: var(--muted);
   font-size: 13px;
   line-height: 1.4;
 }
 
-.projects-directory__actions,
-.project-document__actions {
+.projects-directory__actions {
   display: flex;
   align-items: center;
   gap: 7px;
@@ -197,31 +194,6 @@
 }
 .project-actions__confirm .project-actions__delete { font-weight: 650; }
 
-.projects-view-toggle {
-  height: 36px;
-  display: flex;
-  align-items: center;
-  padding: 3px;
-  border: 1px solid var(--border-light);
-  border-radius: 10px;
-  background: var(--surface);
-}
-
-.projects-view-toggle button {
-  width: 29px;
-  height: 28px;
-  display: grid;
-  place-items: center;
-  padding: 0;
-  border: 0;
-  border-radius: 7px;
-  color: var(--muted);
-  background: transparent;
-  cursor: pointer;
-}
-
-.projects-view-toggle button[aria-pressed="true"] { color: var(--text); background: var(--bg); }
-
 .projects-directory__scroll {
   flex: 1;
   min-height: 0;
@@ -231,7 +203,6 @@
 }
 
 .projects-empty button,
-.project-document__actions button,
 .project-document__empty button {
   min-height: 38px;
   padding: 0 13px;
@@ -242,8 +213,6 @@
   font-weight: 600;
   cursor: pointer;
 }
-.project-document textarea:focus { box-shadow: 0 0 0 2px var(--accent-dim); border-color: var(--accent); }
-
 .projects-error { margin: 10px clamp(12px, 2vw, 20px); color: var(--danger, #c43d3d); font-size: 13px; }
 .projects-directory__scroll > .projects-error { margin-left: 0; }
 .projects-empty {
@@ -267,35 +236,7 @@
 }
 .projects-collection__row:hover { background: var(--surface); }
 .projects-collection__main:focus-visible,
-.project-items > button:focus-visible,
-.project-icon-button:focus-visible,
-.projects-view-toggle button:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
-
-.projects-collection--icons {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(148px, 1fr));
-  gap: 12px 8px;
-}
-.projects-collection--icons > button {
-  min-height: 124px;
-  display: grid;
-  place-items: center;
-  align-content: center;
-  gap: 7px;
-  padding: 12px 8px;
-  border-radius: 12px;
-  text-align: center;
-}
-.projects-collection--icons .projects-collection__icon {
-  width: 42px;
-  height: 42px;
-  display: grid;
-  place-items: center;
-  border-radius: 14px;
-  color: var(--accent);
-  background: var(--accent-dim);
-}
-.projects-collection--icons .projects-collection__copy { max-width: 100%; display: grid; gap: 2px; }
+.project-icon-button:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 
 .projects-collection--list { display: grid; gap: 1px; }
 .projects-collection__row {
@@ -327,21 +268,9 @@
 .projects-collection__row .project-actions > .project-icon-button[aria-expanded="true"] {
   opacity: 1;
 }
-.projects-collection--list .projects-collection__icon,
-.projects-collection__rename .projects-collection__icon {
-  width: 22px;
-  height: 22px;
-  display: grid;
-  place-items: center;
-  flex: 0 0 auto;
-  border-radius: 6px;
-  color: var(--accent);
-  background: var(--accent-dim);
-}
 .projects-collection--list .projects-collection__copy { flex: 1; min-width: 0; display: grid; gap: 2px; }
 .projects-collection__copy strong { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 14px; font-weight: 600; }
-.projects-collection__copy small,
-.projects-collection__verb { color: var(--muted); font-size: 11px; }
+.projects-collection__copy small { color: var(--muted); font-size: 11px; }
 .projects-collection__rename {
   flex: 1;
   min-width: 0;
@@ -378,9 +307,6 @@
   color: var(--accent-fg, white);
   background: var(--accent);
 }
-.projects-legacy { max-width: 760px; margin-top: 34px; padding-top: 20px; border-top: 1px solid var(--border-light); }
-.projects-section-heading h2 { font-size: 16px; font-weight: 620; letter-spacing: -0.02em; }
-
 .project-workspace__bar {
   flex: 0 0 auto;
   min-height: 48px;
@@ -396,14 +322,6 @@
   display: flex;
   align-items: center;
   gap: 7px;
-}
-.project-workspace__mark {
-  width: 20px;
-  height: 20px;
-  display: grid;
-  place-items: center;
-  flex: 0 0 auto;
-  color: var(--muted);
 }
 .project-workspace__title {
   min-width: 0;
@@ -505,27 +423,22 @@
 }
 .project-build-button:hover { filter: brightness(1.08); }
 .project-build-button:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
-.project-breadcrumb {
-  min-height: 40px;
-  flex: 0 0 auto;
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  padding: 4px clamp(14px, 3vw, 30px);
-  overflow-x: auto;
-  border-bottom: 1px solid var(--border-light);
-  scrollbar-width: none;
-}
-.project-breadcrumb button {
-  flex: 0 0 auto;
-  padding: 5px 2px;
-  border: 0;
-  color: var(--muted);
-  background: transparent;
+.project-use-together-button {
+  min-height: 38px;
+  padding: 0 14px;
+  border: 1px solid color-mix(in srgb, var(--accent) 45%, var(--border));
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--accent) 13%, var(--surface));
+  color: var(--text);
+  font: inherit;
+  font-size: 12px;
+  font-weight: 750;
+  white-space: nowrap;
   cursor: pointer;
 }
-.project-breadcrumb button:first-child { color: var(--text); font-weight: 600; }
-
+.project-use-together-button:hover { background: color-mix(in srgb, var(--accent) 20%, var(--surface)); }
+.project-use-together-button:disabled { opacity: .6; cursor: wait; }
+.project-use-together-button:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 .project-inline-create {
   min-height: 54px;
   flex: 0 0 auto;
@@ -562,86 +475,7 @@
 }
 .project-inline-create button[type="submit"] { border-color: var(--accent); color: var(--accent-fg, white); background: var(--accent); }
 
-.project-browser { flex: 1; min-height: 0; overflow-y: auto; padding: 16px clamp(14px, 3vw, 30px) 26px; }
-.project-browser__back {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  min-height: 34px;
-  margin-bottom: 8px;
-  padding: 0 8px;
-  border: 0;
-  border-radius: 8px;
-  color: var(--muted);
-  background: transparent;
-  cursor: pointer;
-}
-.project-browser__back:hover { color: var(--text); background: var(--surface); }
-
-.project-items--icons {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(108px, 1fr));
-  gap: 9px 7px;
-}
-.project-items > button {
-  min-width: 0;
-  border: 0;
-  color: var(--text);
-  background: transparent;
-  cursor: pointer;
-}
-.project-items > button:hover { background: var(--surface); }
-.project-items--icons > button {
-  min-height: 110px;
-  display: grid;
-  place-items: center;
-  align-content: center;
-  gap: 7px;
-  padding: 10px 7px;
-  border-radius: 11px;
-  text-align: center;
-}
-.project-items--icons > button > span:last-child { min-width: 0; max-width: 100%; display: grid; gap: 2px; }
-.project-items--list { display: grid; gap: 1px; }
-.project-items--list > button {
-  min-height: 46px;
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 6px 8px;
-  border-radius: 8px;
-  text-align: left;
-}
-.project-items--list > button > span:last-child { flex: 1; min-width: 0; display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 14px; align-items: center; }
-.project-items strong { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 13px; font-weight: 600; }
-.project-items small { color: var(--muted); font-size: 10px; }
-.project-items__icon { color: var(--muted); }
-.project-items__icon--chat { color: var(--accent); }
-.project-items__chat--new { color: var(--accent) !important; }
-.project-items__chat--new small { color: var(--muted); }
-.project-items > button:disabled { cursor: wait; opacity: .62; }
 .project-actions--context-only { position: absolute; inset: 0 auto auto 0; width: 0; height: 0; }
-
-.project-document__header { justify-content: flex-start; }
-.project-document__header > div:nth-child(2) { flex: 1; min-width: 0; display: grid; gap: 2px; }
-.project-document__header strong,
-.project-document__header small { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.project-document__header strong { font-size: 14px; }
-.project-document__header small { color: var(--muted); font-size: 11px; }
-.project-document__surface { flex: 1; min-height: 0; display: flex; }
-.project-document textarea {
-  flex: 1;
-  min-height: 0;
-  width: 100%;
-  resize: none;
-  padding: clamp(16px, 3vw, 28px);
-  border: 0;
-  outline: 0;
-  color: var(--text);
-  background: var(--bg);
-  font: 13px/1.65 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-  tab-size: 2;
-}
 .project-preview { flex: 1; min-width: 0; min-height: 0; display: flex; flex-direction: column; background: var(--surface); }
 .project-preview > p { margin: 0; padding: 7px 12px; border-bottom: 1px solid var(--border-light); color: var(--muted); font-size: 11px; }
 .project-preview iframe { flex: 1; width: 100%; min-height: 0; border: 0; background: white; }
@@ -657,17 +491,6 @@
 .project-document__empty { flex: 1; display: grid; place-content: center; justify-items: center; gap: 8px; padding: 28px; color: var(--muted); text-align: center; }
 .project-document__empty h2 { font-size: 18px; }
 .project-document__empty p { max-width: 46ch; margin: 0; line-height: 1.5; }
-.project-document__actions .project-document__delete {
-  width: 36px;
-  min-height: 36px;
-  display: grid;
-  place-items: center;
-  padding: 0;
-  border: 1px solid var(--border-light);
-  color: var(--danger, #c43d3d);
-  background: var(--bg);
-}
-
 .projects-directory button:disabled,
 .project-workspace button:disabled { cursor: default; opacity: .5; }
 
@@ -1277,7 +1100,6 @@ button.project-finder__change:hover { color: var(--text); background: var(--surf
 }
 .project-artifacts__row:hover { background: var(--surface); }
 .project-artifacts__row:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
-.project-artifacts__icon { flex: 0 0 auto; color: var(--muted); display: grid; place-items: center; }
 .project-artifacts__copy { flex: 1; min-width: 0; display: grid; gap: 1px; }
 .project-artifacts__copy strong { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 12px; font-weight: 600; }
 .project-artifacts__copy small { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--muted); font-size: 10px; }
@@ -1360,12 +1182,19 @@ button.project-finder__change:hover { color: var(--text); background: var(--surf
   .projects-collection__rename > label { flex-basis: calc(100% - 42px); }
   .projects-collection__rename > button { flex: 1; }
   .projects-directory__header p { display: none; }
-  .project-items--icons,
-  .projects-collection--icons { grid-template-columns: repeat(auto-fill, minmax(104px, 1fr)); }
-  .project-document__header small { display: none; }
   .project-inline-create { flex-wrap: wrap; }
   .project-inline-create label { width: 100%; }
   .project-workspace__rename { max-width: min(150px, 38vw); }
+  .artifact-workspace__header {
+    display: grid;
+    grid-template-columns: auto auto minmax(0, 1fr) auto auto;
+    gap: 8px;
+    padding-inline: 10px;
+  }
+  .artifact-workspace__header .project-use-together-button {
+    grid-column: 1 / -1;
+    width: 100%;
+  }
   .project-build-button span { display: none; }
   .project-build-button { width: 38px; padding: 0; justify-content: center; }
 }

--- a/frontend/src/components/Projects/ProjectsDirectory.jsx
+++ b/frontend/src/components/Projects/ProjectsDirectory.jsx
@@ -5,10 +5,7 @@ import ProjectIdentityIcon from './ProjectIdentityIcon.jsx'
 import ProjectTypeIcon from './ProjectTypeIcon.jsx'
 import './Projects.css'
 
-// The Projects launcher: one clean list of the owner's projects plus the create
-// menu. The icon/list view toggle and the legacy "Existing app projects" import
-// section were removed — a single readable list is the one good default, and
-// legacy app-projects are no longer surfaced here.
+// The Projects launcher: one readable list plus the focused creation menu.
 export default function ProjectsDirectory({
   projects,
   templates,

--- a/frontend/src/components/Projects/SharedApp.css
+++ b/frontend/src/components/Projects/SharedApp.css
@@ -1,0 +1,210 @@
+.shared-app {
+  --shared-accent: #8b5cf6;
+  min-height: 100dvh;
+  background: #0b0b0d;
+  color: #f7f5fb;
+  display: flex;
+  flex-direction: column;
+}
+
+.shared-app--center {
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+}
+
+.shared-app__header {
+  min-height: 68px;
+  padding: max(12px, env(safe-area-inset-top)) 18px 12px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  border-bottom: 1px solid #25242a;
+  background: rgb(15 15 18 / 94%);
+}
+
+.shared-app__identity { min-width: 0; flex: 1; }
+.shared-app__identity span {
+  display: block;
+  margin-bottom: 2px;
+  color: #a78bfa;
+  font-size: 10px;
+  font-weight: 850;
+  letter-spacing: .12em;
+  text-transform: uppercase;
+}
+.shared-app__identity h1 {
+  margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 19px;
+  letter-spacing: -.02em;
+}
+
+.shared-app__people {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 7px 9px;
+  border: 1px solid #302e38;
+  border-radius: 999px;
+  color: #cbc5d8;
+  font-size: 12px;
+  font-weight: 750;
+}
+
+.shared-app__icon-button {
+  width: 38px;
+  height: 38px;
+  border: 1px solid #302e38;
+  border-radius: 12px;
+  background: #19181d;
+  color: #eeeaf5;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+}
+
+.shared-app__icon-button:focus-visible,
+.shared-app button:focus-visible,
+.shared-app input:focus-visible,
+.shared-app select:focus-visible {
+  outline: 2px solid var(--shared-accent);
+  outline-offset: 2px;
+}
+
+.shared-app__invite {
+  padding: 10px 18px;
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  border-bottom: 1px solid #25242a;
+  background: #111114;
+}
+.shared-app__invite > input { flex: 1 1 220px; }
+.shared-app input,
+.shared-app select {
+  min-height: 40px;
+  padding: 0 12px;
+  border: 1px solid #34313b;
+  border-radius: 11px;
+  background: #19181e;
+  color: #f6f3fa;
+  font: inherit;
+  font-size: 13px;
+}
+.shared-app button {
+  min-height: 40px;
+  padding: 0 14px;
+  border: 0;
+  border-radius: 11px;
+  background: var(--shared-accent);
+  color: white;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 800;
+  cursor: pointer;
+}
+.shared-app button:disabled { opacity: .55; cursor: not-allowed; }
+.shared-app__publish { display: inline-flex; align-items: center; gap: 6px; }
+
+.shared-app__invite-link {
+  flex: 1 0 100%;
+  display: flex;
+  gap: 8px;
+}
+.shared-app__invite-link input { flex: 1; min-width: 0; }
+.shared-app__invite-link button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: #26232e;
+}
+
+.shared-app__access {
+  flex: 1 0 100%;
+  margin-top: 4px;
+  padding-top: 10px;
+  border-top: 1px solid #29272f;
+}
+.shared-app__access > summary {
+  color: #d8d3df;
+  font-size: 12px;
+  font-weight: 750;
+  cursor: pointer;
+}
+.shared-app__access-row {
+  display: grid;
+  grid-template-columns: minmax(120px, 1fr) minmax(105px, auto) auto;
+  align-items: center;
+  gap: 8px;
+  margin-top: 6px;
+  color: #bdb7c7;
+  font-size: 12px;
+}
+.shared-app__access-row select { min-height: 34px; padding-inline: 9px; }
+.shared-app__access-row button { min-height: 34px; padding-inline: 10px; }
+.shared-app button.shared-app__quiet { background: #26232e; }
+.shared-app button.shared-app__danger { background: #7f1d1d; }
+
+.shared-app__surface { position: relative; flex: 1; min-height: 0; background: white; }
+.shared-app__frame { position: absolute; inset: 0; width: 100%; height: 100%; border: 0; background: white; }
+.shared-app__empty { display: grid; place-items: center; height: 100%; padding: 24px; color: #433f4b; }
+.shared-app__error,
+.shared-app__notice { margin: 0; padding: 10px 18px; font-size: 13px; }
+.shared-app__error { background: #35191d; color: #fecaca; }
+.shared-app__notice { background: #123322; color: #bbf7d0; }
+
+.shared-app__join {
+  width: min(100%, 430px);
+  padding: 28px;
+  border: 1px solid #2d2a33;
+  border-radius: 24px;
+  background: #151519;
+  box-shadow: 0 24px 70px rgb(0 0 0 / 35%);
+}
+.shared-app__join-mark {
+  width: 48px;
+  height: 48px;
+  display: grid;
+  place-items: center;
+  border-radius: 15px;
+  background: rgb(139 92 246 / 16%);
+  color: #a78bfa;
+}
+.shared-app__join > p {
+  margin: 20px 0 5px;
+  color: #a78bfa;
+  font-size: 11px;
+  font-weight: 850;
+  letter-spacing: .1em;
+  text-transform: uppercase;
+}
+.shared-app__join h1 { margin: 0 0 10px; font-size: 28px; letter-spacing: -.04em; }
+.shared-app__join > span:not(.shared-app__join-mark) { color: #aaa5b2; line-height: 1.55; }
+.shared-app__join form { margin-top: 24px; display: grid; gap: 9px; }
+.shared-app__join label { font-size: 12px; font-weight: 750; color: #d4cfda; }
+.shared-app__join button { margin-top: 4px; }
+.shared-app__join .shared-app__error { margin-top: 12px; border-radius: 10px; }
+
+@media (max-width: 700px) {
+  .shared-app__header { min-height: 62px; padding-inline: 12px; }
+  .shared-app__publish { width: 40px; padding: 0; justify-content: center; font-size: 0; }
+  .shared-app__invite { padding-inline: 12px; }
+  .shared-app__access-row { grid-template-columns: minmax(0, 1fr) auto; }
+  .shared-app__access-row select { grid-row: 2; grid-column: 1; }
+  .shared-app__access-row button { grid-row: 2; grid-column: 2; }
+  .shared-app__join { padding: 24px; border-radius: 20px; }
+}
+
+@media (max-width: 1000px) {
+  .shared-app__publish {
+    width: 40px;
+    padding: 0;
+    flex: 0 0 40px;
+    justify-content: center;
+    gap: 0;
+    font-size: 0;
+  }
+}

--- a/frontend/src/components/Projects/SharedApp.jsx
+++ b/frontend/src/components/Projects/SharedApp.jsx
@@ -1,0 +1,289 @@
+import { useEffect, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import ArrowLeft from 'lucide-react/dist/esm/icons/arrow-left.mjs'
+import Copy from 'lucide-react/dist/esm/icons/copy.mjs'
+import LogOut from 'lucide-react/dist/esm/icons/log-out.mjs'
+import RefreshCw from 'lucide-react/dist/esm/icons/refresh-cw.mjs'
+import Trash2 from 'lucide-react/dist/esm/icons/trash-2.mjs'
+import Users from 'lucide-react/dist/esm/icons/users.mjs'
+import {
+  api, BASE, beginEphemeralAuth, clearEphemeralAuthSession, getToken, jsonOrThrow,
+  setEphemeralAuthSession,
+} from '../../api/client.js'
+import { assembleProjectHtmlPreview } from '../../lib/projectPreview.js'
+import SharedAppFrame from './SharedAppFrame.jsx'
+import './SharedApp.css'
+
+
+function routeInstanceId() {
+  try {
+    const prefix = `${BASE}/shared/app/`
+    return window.location.pathname.startsWith(prefix)
+      ? decodeURIComponent(window.location.pathname.slice(prefix.length).split('/')[0])
+      : ''
+  } catch { return '' }
+}
+
+function sessionKey(instanceId) {
+  return `mobius:shared-app-session:${instanceId}`
+}
+
+function releaseSplash() {
+  const splash = document.getElementById('splash')
+  if (!splash) return
+  splash.style.pointerEvents = 'none'
+  splash.style.opacity = '0'
+  window.setTimeout(() => splash.remove(), 400)
+}
+
+export default function SharedApp() {
+  const initialId = routeInstanceId()
+  const [phase, setPhase] = useState('boot')
+  const [instanceId, setInstanceId] = useState(initialId)
+  const [seed, setSeed] = useState(null)
+  const [displayName, setDisplayName] = useState('')
+  const [error, setError] = useState('')
+  const [joining, setJoining] = useState(false)
+  const [doc, setDoc] = useState('')
+  const [docError, setDocError] = useState('')
+  const [inviteName, setInviteName] = useState('')
+  const [invite, setInvite] = useState(null)
+  const [copyState, setCopyState] = useState('')
+  const [notice, setNotice] = useState('')
+  const [publishing, setPublishing] = useState(false)
+  const [confirmMemberId, setConfirmMemberId] = useState(null)
+
+  useEffect(() => {
+    if (!initialId) {
+      setPhase('invite')
+    } else {
+      let guestToken = ''
+      try { guestToken = sessionStorage.getItem(sessionKey(initialId)) || '' } catch { /* ignore */ }
+      if (guestToken) {
+        beginEphemeralAuth()
+        setEphemeralAuthSession(guestToken, null)
+      }
+      setPhase(guestToken || getToken() ? 'workspace' : 'expired')
+    }
+    releaseSplash()
+  }, [initialId])
+
+  useEffect(() => {
+    const expired = () => {
+      if (instanceId) {
+        try { sessionStorage.removeItem(sessionKey(instanceId)) } catch { /* ignore */ }
+      }
+      setPhase('expired')
+    }
+    window.addEventListener('mobius:ephemeral-auth-expired', expired)
+    return () => window.removeEventListener('mobius:ephemeral-auth-expired', expired)
+  }, [instanceId])
+
+  const instanceQuery = useQuery({
+    queryKey: ['shared-app', instanceId],
+    queryFn: async () => jsonOrThrow(await api.sharedApps.detail(instanceId), 'Shared app failed:'),
+    enabled: phase === 'workspace' && !!instanceId,
+    initialData: seed || undefined,
+  })
+  const stateQuery = useQuery({
+    queryKey: ['shared-app', instanceId, 'state'],
+    queryFn: async () => jsonOrThrow(await api.sharedApps.state(instanceId), 'Shared data failed:'),
+    enabled: phase === 'workspace' && !!instanceId,
+  })
+  const peopleQuery = useQuery({
+    queryKey: ['shared-app', instanceId, 'people'],
+    queryFn: async () => jsonOrThrow(await api.sharedApps.collaboration(instanceId), 'People failed:'),
+    enabled: phase === 'workspace' && !!instanceId,
+    refetchInterval: 5_000,
+  })
+
+  useEffect(() => {
+    if (
+      !instanceQuery.data?.entry_path
+      || !instanceQuery.data?.release_id
+      || phase !== 'workspace'
+    ) return undefined
+    const controller = new AbortController()
+    let active = true
+    setDocError('')
+    ;(async () => {
+      try {
+        const entry = instanceQuery.data.entry_path
+        const releaseId = instanceQuery.data.release_id
+        const response = await api.sharedApps.output(
+          instanceId, releaseId, entry, { signal: controller.signal },
+        )
+        if (!response.ok) throw new Error(`The shared build could not be loaded (${response.status}).`)
+        const html = await response.text()
+        const loadText = async path => {
+          const dep = await api.sharedApps.output(
+            instanceId, releaseId, path, { signal: controller.signal },
+          )
+          if (!dep.ok) throw new Error(`dependency ${path} failed (${dep.status})`)
+          return dep.text()
+        }
+        const loadDataUri = async path => {
+          const dep = await api.sharedApps.output(
+            instanceId, releaseId, path, { signal: controller.signal },
+          )
+          if (!dep.ok) throw new Error(`asset ${path} failed (${dep.status})`)
+          const blob = await dep.blob()
+          return await new Promise((resolve, reject) => {
+            const reader = new FileReader()
+            reader.onload = () => resolve(reader.result)
+            reader.onerror = () => reject(reader.error)
+            reader.readAsDataURL(blob)
+          })
+        }
+        const assembled = await assembleProjectHtmlPreview(html, entry, loadText, loadDataUri, 'shared')
+        if (active) setDoc(assembled)
+      } catch (cause) {
+        if (active && cause?.name !== 'AbortError') setDocError(cause?.message || 'The shared build could not be loaded.')
+      }
+    })()
+    return () => { active = false; controller.abort() }
+  }, [
+    instanceId,
+    instanceQuery.data?.entry_path,
+    instanceQuery.data?.release_id,
+    phase,
+  ])
+
+  async function join(event) {
+    event.preventDefault()
+    const secret = window.location.hash.replace(/^#/, '').split('?')[0]
+    if (!displayName.trim() || !secret || joining) return
+    setJoining(true); setError('')
+    try {
+      const payload = await jsonOrThrow(await api.sharedApps.redeemInvite({
+        invite: secret, display_name: displayName.trim(),
+      }), 'Invitation failed:')
+      setEphemeralAuthSession(payload.access_token, null)
+      try { sessionStorage.setItem(sessionKey(payload.instance.id), payload.access_token) } catch { /* tab remains usable */ }
+      setInstanceId(payload.instance.id)
+      setSeed(payload.instance)
+      window.history.replaceState(null, '', `${BASE}/shared/app/${encodeURIComponent(payload.instance.id)}`)
+      setPhase('workspace')
+    } catch (cause) {
+      setError(cause?.message || 'This invitation could not be accepted.')
+    } finally { setJoining(false) }
+  }
+
+  async function createInvite() {
+    try {
+      setError('')
+      setCopyState('')
+      setInvite(await jsonOrThrow(await api.sharedApps.createInvite(instanceId, {
+        invitee_name: inviteName.trim() || null, role: 'editor',
+      }), 'Invitation failed:'))
+      await peopleQuery.refetch()
+    } catch (cause) { setError(cause?.message || 'Could not create an invitation.') }
+  }
+
+  async function publishLatest() {
+    if (publishing) return
+    setPublishing(true); setError(''); setNotice('')
+    try {
+      await jsonOrThrow(await api.sharedApps.publishRelease(instanceId), 'Publish failed:')
+      await instanceQuery.refetch()
+      setNotice('Latest build published. Shared data was kept.')
+    } catch (cause) {
+      setError(cause?.message || 'Could not publish the latest build.')
+    } finally { setPublishing(false) }
+  }
+
+  async function revokeInvite(inviteId) {
+    setError('')
+    try {
+      const response = await api.sharedApps.revokeInvite(instanceId, inviteId)
+      if (!response.ok) throw new Error(`Invitation update failed (${response.status}).`)
+      await peopleQuery.refetch()
+    } catch (cause) { setError(cause?.message || 'Could not revoke the invitation.') }
+  }
+
+  async function changeMemberRole(memberId, role) {
+    setError('')
+    try {
+      await jsonOrThrow(
+        await api.sharedApps.updateMember(instanceId, memberId, { role }),
+        'Role update failed:',
+      )
+      await peopleQuery.refetch()
+    } catch (cause) { setError(cause?.message || 'Could not update this person.') }
+  }
+
+  async function removeMember(memberId) {
+    if (confirmMemberId !== memberId) {
+      setConfirmMemberId(memberId)
+      return
+    }
+    setError('')
+    try {
+      const response = await api.sharedApps.removeMember(instanceId, memberId)
+      if (!response.ok) throw new Error(`Remove failed (${response.status}).`)
+      setConfirmMemberId(null)
+      await peopleQuery.refetch()
+    } catch (cause) { setError(cause?.message || 'Could not remove this person.') }
+  }
+
+  async function copyInvite() {
+    if (!invite?.join_url) return
+    try { await navigator.clipboard.writeText(invite.join_url); setCopyState('Copied') }
+    catch { setCopyState('Select the link') }
+  }
+
+  function leave() {
+    try { sessionStorage.removeItem(sessionKey(instanceId)) } catch { /* ignore */ }
+    clearEphemeralAuthSession()
+    setPhase('expired')
+  }
+
+  if (phase === 'boot') return <main className="shared-app shared-app--center" aria-busy="true" />
+  if (phase === 'invite') return <main className="shared-app shared-app--center" data-mobius-visual-state="settled"><section className="shared-app__join">
+    <span className="shared-app__join-mark"><Users size={22} /></span>
+    <p>Private app invitation</p><h1>Use this app together</h1>
+    <span>You can use the shared app and its live data. Its source project stays private.</span>
+    <form onSubmit={join}><label htmlFor="shared-app-name">Your name</label><input id="shared-app-name" autoFocus maxLength="128" value={displayName} onChange={event => setDisplayName(event.target.value)} /><button type="submit" disabled={joining || !displayName.trim()}>{joining ? 'Joining…' : 'Join app'}</button></form>
+    {error && <div className="shared-app__error" role="alert">{error}</div>}
+  </section></main>
+  if (phase === 'expired') return <main className="shared-app shared-app--center" data-mobius-visual-state="settled"><section className="shared-app__join" role="alert"><h1>This app session has ended</h1><span>Ask the app owner for a new invitation.</span></section></main>
+
+  const instance = instanceQuery.data
+  if (instanceQuery.isLoading || stateQuery.isLoading) return <main className="shared-app shared-app--center"><p role="status">Opening shared app…</p></main>
+  if (!instance || instanceQuery.isError || stateQuery.isError) return <main className="shared-app shared-app--center" data-mobius-visual-state="settled"><section className="shared-app__join" role="alert"><h1>Couldn’t open this app</h1><span>{instanceQuery.error?.message || stateQuery.error?.message}</span></section></main>
+  const people = peopleQuery.data?.members || []
+  const isOwner = instance.role === 'owner'
+  return <main className="shared-app" data-mobius-visual-state="settled">
+    <header className="shared-app__header">
+      {isOwner && instance.project_id && <button type="button" className="shared-app__icon-button" aria-label="Back to project" onClick={() => window.location.assign(`${BASE}/shell/?project=${encodeURIComponent(instance.project_id)}`)}><ArrowLeft size={19} /></button>}
+      <div className="shared-app__identity"><span>Live shared app</span><h1>{instance.name}</h1></div>
+      <span className="shared-app__people"><Users size={15} />{people.length || 1}</span>
+      {isOwner && <button type="button" className="shared-app__publish" disabled={publishing} onClick={publishLatest}><RefreshCw size={15} />{publishing ? 'Publishing…' : 'Publish latest'}</button>}
+      {!isOwner && <button type="button" className="shared-app__icon-button" aria-label="Leave app" onClick={leave}><LogOut size={18} /></button>}
+    </header>
+    {isOwner && <section className="shared-app__invite" aria-label="Invite someone to this app">
+      <input value={inviteName} maxLength="128" placeholder="Collaborator name (optional)" aria-label="Collaborator name" onChange={event => setInviteName(event.target.value)} />
+      <button type="button" onClick={createInvite}>Invite</button>
+      {invite?.join_url && <div className="shared-app__invite-link"><input readOnly value={invite.join_url} aria-label="App invitation link" onFocus={event => event.currentTarget.select()} /><button type="button" onClick={copyInvite}><Copy size={14} />{copyState || 'Copy'}</button></div>}
+      <details className="shared-app__access">
+        <summary>Access · {Math.max(0, people.length - 1)} {people.length === 2 ? 'person' : 'people'}</summary>
+        {people.filter(person => person.id !== 'owner').map(person => <div key={person.id} className="shared-app__access-row">
+          <span>{person.display_name}{person.you ? ' · you' : ''}</span>
+          <select value={person.role} aria-label={`Role for ${person.display_name}`} onChange={event => changeMemberRole(person.id, event.target.value)}>
+            <option value="editor">Can edit</option><option value="viewer">Can view</option>
+          </select>
+          <button type="button" className={confirmMemberId === person.id ? 'shared-app__danger' : 'shared-app__quiet'} onClick={() => removeMember(person.id)}><Trash2 size={14} />{confirmMemberId === person.id ? 'Confirm remove' : 'Remove'}</button>
+        </div>)}
+        {(peopleQuery.data?.invites || []).map(pending => <div key={pending.id} className="shared-app__access-row">
+          <span>{pending.invitee_name || 'Invitation'} · pending</span>
+          <button type="button" className="shared-app__quiet" onClick={() => revokeInvite(pending.id)}>Revoke</button>
+        </div>)}
+      </details>
+    </section>}
+    {notice && <p className="shared-app__notice" role="status">{notice}</p>}
+    {error && <p className="shared-app__error" role="alert">{error}</p>}
+    <section className="shared-app__surface">
+      {docError ? <div className="shared-app__empty" role="alert">{docError}</div> : doc ? <SharedAppFrame instanceId={instanceId} srcDoc={doc} initialState={stateQuery.data} title={`${instance.name} shared app`} /> : <div className="shared-app__empty" role="status">Preparing shared app…</div>}
+    </section>
+  </main>
+}

--- a/frontend/src/components/Projects/SharedAppFrame.jsx
+++ b/frontend/src/components/Projects/SharedAppFrame.jsx
@@ -1,0 +1,159 @@
+import { useEffect, useRef } from 'react'
+import { api, jsonOrThrow } from '../../api/client.js'
+import { projectPreviewSandbox } from '../../lib/projectPreview.js'
+import {
+  applySharedAppMutation,
+  normalizeSharedAppSnapshot,
+} from '../../lib/sharedAppState.js'
+
+
+function changedPaths(previous, next) {
+  return [...new Set([...Object.keys(previous || {}), ...Object.keys(next || {})])]
+    .filter(path => JSON.stringify(previous?.[path]) !== JSON.stringify(next?.[path]))
+}
+
+
+export default function SharedAppFrame({ instanceId, srcDoc, initialState, title }) {
+  const frameRef = useRef(null)
+  const stateRef = useRef(initialState || { cursor: 0, values: {}, versions: {} })
+
+  useEffect(() => {
+    stateRef.current = initialState || { cursor: 0, values: {}, versions: {} }
+  }, [instanceId, initialState])
+
+  useEffect(() => {
+    let active = true
+    let syncing = false
+    let mutating = false
+    let pollTimer = 0
+    let pollDelay = 2_500
+    let mutationQueue = Promise.resolve()
+    const requests = new Map()
+    const notify = (path, value) => frameRef.current?.contentWindow?.postMessage({
+      type: 'mobius:project-preview-storage-changed', path, value,
+    }, '*')
+    const adopt = next => {
+      const normalized = normalizeSharedAppSnapshot(stateRef.current, next)
+      if (!normalized) return false
+      const previous = stateRef.current?.values || {}
+      const values = normalized.values
+      stateRef.current = normalized
+      for (const path of changedPaths(previous, values)) {
+        notify(path, Object.hasOwn(values, path) ? values[path] : null)
+      }
+      return true
+    }
+    const refresh = async () => {
+      if (!active || syncing || mutating) return false
+      syncing = true
+      try {
+        adopt(await jsonOrThrow(await api.sharedApps.state(instanceId), 'Shared data failed:'))
+        return true
+      }
+      catch { /* the next explicit interaction owns user-facing feedback */ }
+      finally { syncing = false }
+      return false
+    }
+    const handleRequest = async message => {
+      const response = {
+        type: 'mobius:project-preview-storage-result',
+        requestId: message.requestId,
+      }
+      try {
+        const values = stateRef.current?.values || {}
+        if (message.method === 'get') {
+          response.value = Object.hasOwn(values, message.path) ? values[message.path] : null
+        } else if (message.method === 'list') {
+          response.value = Object.keys(values).filter(path => path.startsWith(message.path || '')).sort()
+        } else if (message.method === 'set' || message.method === 'delete') {
+          mutating = true
+          try {
+            const result = await jsonOrThrow(await api.sharedApps.writeState(instanceId, message.path, {
+              expected_version: stateRef.current.versions?.[message.path] ?? null,
+              value: message.value,
+              delete: message.method === 'delete',
+            }), 'Shared data changed:')
+            adopt(applySharedAppMutation(
+              stateRef.current,
+              message.path,
+              message.value,
+              result.version,
+              message.method === 'delete',
+            ))
+            response.value = message.method === 'delete' ? null : message.value
+          } finally {
+            mutating = false
+          }
+        } else {
+          throw new Error('Unsupported shared data operation.')
+        }
+      } catch (cause) {
+        await refresh()
+        response.error = cause?.message || 'Shared data could not be saved.'
+      }
+      return response
+    }
+    const onMessage = event => {
+      if (event.source !== frameRef.current?.contentWindow) return
+      const message = event.data
+      if (!message || message.type !== 'mobius:project-preview-storage') return
+      let task = requests.get(message.requestId)
+      if (!task) {
+        task = mutationQueue.then(() => handleRequest(message))
+        mutationQueue = task.catch(() => {})
+        requests.set(message.requestId, task)
+        if (requests.size > 256) requests.delete(requests.keys().next().value)
+      }
+      void task.then(response => event.source.postMessage(response, '*'))
+    }
+    const schedulePoll = delay => {
+      window.clearTimeout(pollTimer)
+      pollTimer = window.setTimeout(poll, delay)
+    }
+    const poll = async () => {
+      if (!active) return
+      if (document.hidden || syncing || mutating) {
+        schedulePoll(pollDelay)
+        return
+      }
+      try {
+        const result = await jsonOrThrow(
+          await api.sharedApps.changes(instanceId, stateRef.current.cursor || 0),
+          'Shared changes failed:',
+        )
+        if (result.truncated || result.changes?.length) {
+          await refresh()
+        } else {
+          stateRef.current = { ...stateRef.current, cursor: Number(result.cursor || 0) }
+        }
+        pollDelay = 2_500
+      } catch {
+        pollDelay = Math.min(pollDelay * 2, 10_000)
+      }
+      schedulePoll(pollDelay)
+    }
+    const onVisibilityChange = () => {
+      if (!document.hidden) schedulePoll(0)
+    }
+    window.addEventListener('message', onMessage)
+    document.addEventListener('visibilitychange', onVisibilityChange)
+    schedulePoll(pollDelay)
+    return () => {
+      active = false
+      window.clearTimeout(pollTimer)
+      window.removeEventListener('message', onMessage)
+      document.removeEventListener('visibilitychange', onVisibilityChange)
+    }
+  }, [instanceId, srcDoc])
+
+  return <iframe
+    ref={frameRef}
+    title={title}
+    className="shared-app__frame"
+    sandbox={projectPreviewSandbox()}
+    srcDoc={srcDoc}
+    onLoad={() => frameRef.current?.contentWindow?.postMessage({
+      type: 'mobius:project-preview-storage-connected',
+    }, '*')}
+  />
+}

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -560,6 +560,38 @@ export default function Shell({ onInitialVisualReady }) {
       })
       .catch(() => {})
   }, [activeProjectId, activeView, queryClient])
+  const recencyMarkedArtifactRef = useRef(null)
+  useEffect(() => {
+    if (activeView !== 'artifact' || !activeArtifactRef) {
+      recencyMarkedArtifactRef.current = null
+      return
+    }
+    const parsed = tabModel.parseArtifactTabId(activeArtifactRef)
+    if (!parsed || recencyMarkedArtifactRef.current === activeArtifactRef) return
+    recencyMarkedArtifactRef.current = activeArtifactRef
+    const lastOpenedAt = new Date().toISOString()
+    const promoteCachedArtifact = () => {
+      queryClient.setQueryData(projectQueries.keys.all, rows => (
+        Array.isArray(rows) ? rows.map(project => (
+          String(project.id) !== parsed.projectId ? project : {
+            ...project,
+            artifacts: (project.artifacts || []).map(artifact => (
+              String(artifact.id) === parsed.artifactId
+                ? { ...artifact, last_opened_at: lastOpenedAt }
+                : artifact
+            )),
+          }
+        )) : rows
+      ))
+    }
+    promoteCachedArtifact()
+    void api.projects.markArtifactOpened(parsed.projectId, parsed.artifactId)
+      .then(response => {
+        if (response.ok) promoteCachedArtifact()
+        else projectQueries.list.invalidate(queryClient)
+      })
+      .catch(() => {})
+  }, [activeArtifactRef, activeView, queryClient])
   const notificationCenterActionsRef = useRef(null)
   const reconcileNotifications = useCallback(() => {
     notificationCenterActionsRef.current?.reconcile()

--- a/frontend/src/components/Shell/__tests__/drawerInformationArchitecture.test.js
+++ b/frontend/src/components/Shell/__tests__/drawerInformationArchitecture.test.js
@@ -22,6 +22,25 @@ test('projects join Recents only after they have been opened', () => {
   ])
 })
 
+test('Creations join Recents only after they have been opened', () => {
+  const project = {
+    id: 'project-1', name: 'Album', updated_at: '2026-08-26T08:00:00',
+    artifacts: [
+      { id: 'unopened', name: 'Unopened', status: 'ok', has_output: true },
+      {
+        id: 'opened', name: 'Opened', status: 'ok', has_output: true,
+        last_opened_at: '2026-08-26T10:00:00',
+      },
+    ],
+  }
+
+  const result = buildDrawerSections([], [], [project])
+
+  assert.deepEqual(result.recents.map(row => `${row.kind}:${row.item.id}`), [
+    'artifact:project-1:opened',
+  ])
+})
+
 test('a pinned project shares the combined pinned order and leaves Recents', () => {
   const project = {
     id: 'pinned-project',

--- a/frontend/src/lib/__tests__/drawerInformationArchitecture.test.js
+++ b/frontend/src/lib/__tests__/drawerInformationArchitecture.test.js
@@ -72,6 +72,39 @@ test('app opens outrank bundle updates without changing catalogue order', () => 
   assert.deepEqual(sections.apps.map(app => app.id), [1, 2])
 })
 
+test('opened project Creations join Recents once and rebuilds do not manufacture recency', () => {
+  const project = {
+    id: 12,
+    name: 'Portfolio',
+    color: '#3b82f6',
+    artifacts: [
+      {
+        id: 'site', name: 'Website', status: 'ok', has_output: true,
+        updated_at: '2026-08-25T11:30:00Z',
+        last_opened_at: '2026-08-25T11:30:00Z',
+      },
+      { id: 'draft', name: 'Draft', status: 'idle', has_output: false, updated_at: '2026-08-25T12:00:00Z' },
+    ],
+  }
+  const before = buildDrawerSections([
+    { id: 'chat', has_messages: true, activity_at: '2026-08-25T11:45:00Z' },
+  ], [], [project])
+  assert.deepEqual(before.recents.map(entry => [entry.kind, entry.item.id]), [
+    ['chat', 'chat'],
+    ['artifact', '12:site'],
+  ])
+  assert.deepEqual(before.recents[1].item.project, { id: 12, name: 'Portfolio', color: '#3b82f6' })
+
+  project.artifacts[0].updated_at = '2026-08-25T12:10:00Z'
+  const after = buildDrawerSections([
+    { id: 'chat', has_messages: true, activity_at: '2026-08-25T11:45:00Z' },
+  ], [], [project])
+  assert.deepEqual(after.recents.map(entry => [entry.kind, entry.item.id]), [
+    ['chat', 'chat'],
+    ['artifact', '12:site'],
+  ])
+})
+
 test('pinned order is stable across mixed timestamp formats (Z vs naive UTC)', () => {
   // After a drag, optimistic chat stamps carry a trailing Z while a refetched
   // app carries the server's naive-UTC form. Same instants must still interleave

--- a/frontend/src/lib/__tests__/projectPreview.test.js
+++ b/frontend/src/lib/__tests__/projectPreview.test.js
@@ -16,6 +16,9 @@ test('project HTML preview injects a deny-by-default CSP into the document head'
   assert.match(result, /script-src 'unsafe-inline'/)
   assert.match(result, /data-mobius-project-preview-runtime/)
   assert.match(result, /dataScope: 'personal'/)
+  assert.match(result, /mobius:project-preview-storage-connected/)
+  assert.doesNotMatch(result, /setInterval\(post, 100\)/)
+  assert.match(result, /Personal preview data did not connect/)
 })
 
 test('project preview policy precedes resources placed before a malformed head', () => {
@@ -36,6 +39,14 @@ test('preview storage waits for the parent handshake and has a bounded failure',
 
 test('project HTML preview runs scripts without granting origin or navigation access', () => {
   assert.equal(projectPreviewSandbox(), 'allow-scripts')
+})
+
+test('shared app preview exposes the same storage surface with a truthful scope', () => {
+  const result = safeProjectHtmlDocument('<main>Shared</main>', 'shared')
+  assert.match(result, /dataScope: 'shared'/)
+  assert.doesNotMatch(result, /dataScope: 'personal'/)
+  assert.match(result, /Shared app data did not connect/)
+  assert.doesNotMatch(result, /Personal preview data did not connect/)
 })
 
 test('project HTML preview inlines local CSS and JavaScript into its isolated document', async () => {

--- a/frontend/src/lib/__tests__/projectWorkspaceSurface.test.js
+++ b/frontend/src/lib/__tests__/projectWorkspaceSurface.test.js
@@ -45,11 +45,11 @@ function renderWorkspace() {
   )
 }
 
-test('Artifacts, Chats, and Files form one ordered project workspace without tabs', () => {
+test('Creations, Chats, and Files form one ordered project workspace without tabs', () => {
   const markup = renderWorkspace()
   assert.doesNotMatch(markup, /role="tablist"|role="tab"|role="tabpanel"/)
   assert.match(markup, /aria-label="Project overview"/)
-  const artifacts = markup.indexOf('>Artifacts</h2>')
+  const artifacts = markup.indexOf('>Creations</h2>')
   const chats = markup.indexOf('>Chats</h2>')
   const files = markup.indexOf('aria-label="Folder location"')
   assert.ok(artifacts >= 0 && artifacts < chats)

--- a/frontend/src/lib/__tests__/sharedAppState.test.js
+++ b/frontend/src/lib/__tests__/sharedAppState.test.js
@@ -1,0 +1,53 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  applySharedAppMutation,
+  normalizeSharedAppSnapshot,
+} from '../sharedAppState.js'
+
+
+test('a late shared-state refresh cannot replace a newer mutation', () => {
+  const current = {
+    cursor: 12,
+    values: { 'board.json': ['new'] },
+    versions: { 'board.json': 'new-version' },
+  }
+
+  assert.equal(normalizeSharedAppSnapshot(current, {
+    cursor: 11,
+    values: { 'board.json': ['old'] },
+    versions: { 'board.json': 'old-version' },
+  }), null)
+})
+
+
+test('an equal or newer shared-state snapshot is normalized for adoption', () => {
+  assert.deepEqual(normalizeSharedAppSnapshot({ cursor: 2 }, {
+    cursor: 3,
+    values: { 'board.json': ['current'] },
+    versions: { 'board.json': 'v3' },
+  }), {
+    cursor: 3,
+    values: { 'board.json': ['current'] },
+    versions: { 'board.json': 'v3' },
+  })
+})
+
+
+test('a local mutation retains the last fully observed collaborator cursor', () => {
+  const current = {
+    cursor: 7,
+    values: { 'existing.json': true },
+    versions: { 'existing.json': 'v7' },
+  }
+
+  assert.deepEqual(
+    applySharedAppMutation(current, 'board.json', ['mine'], 'v9'),
+    {
+      cursor: 7,
+      values: { 'existing.json': true, 'board.json': ['mine'] },
+      versions: { 'existing.json': 'v7', 'board.json': 'v9' },
+    },
+  )
+})

--- a/frontend/src/lib/projectPreview.js
+++ b/frontend/src/lib/projectPreview.js
@@ -13,7 +13,9 @@ const SAFE_PROJECT_PREVIEW_CSP = [
 // truthful place for disposable test data. The opaque frame delegates this
 // tiny storage surface to its parent; ProjectPreviewFrame owns the browser-
 // private namespace and never hands the frame a shell or project credential.
-const PROJECT_PREVIEW_RUNTIME = `<script data-mobius-project-preview-runtime>
+function projectPreviewRuntime(dataScope = 'personal') {
+  const scope = dataScope === 'shared' ? 'shared' : 'personal'
+  return `<script data-mobius-project-preview-runtime>
 (() => {
   const pending = new Map();
   const listeners = new Map();
@@ -24,7 +26,7 @@ const PROJECT_PREVIEW_RUNTIME = `<script data-mobius-project-preview-runtime>
     const message = { type: 'mobius:project-preview-storage', requestId, method, path, value };
     const timeout = setTimeout(() => {
       pending.delete(requestId);
-      reject(new Error('Personal preview data did not connect. Reload the preview and try again.'));
+      reject(new Error('${scope === 'shared' ? 'Shared app data' : 'Personal preview data'} did not connect. Reload the preview and try again.'));
     }, 5000);
     pending.set(requestId, { resolve, reject, timeout, message });
     if (connected) parent.postMessage(message, '*');
@@ -62,18 +64,19 @@ const PROJECT_PREVIEW_RUNTIME = `<script data-mobius-project-preview-runtime>
       return () => { group.delete(listener); if (!group.size) listeners.delete(path); };
     },
   };
-  window.mobius = Object.freeze({ ...(window.mobius || {}), storage, preview: Object.freeze({ dataScope: 'personal' }) });
+  window.mobius = Object.freeze({ ...(window.mobius || {}), storage, preview: Object.freeze({ dataScope: '${scope}' }) });
   dispatchEvent(new CustomEvent('mobius:preview-ready'));
 })();
 </script>`
+}
 
-export function safeProjectHtmlDocument(source) {
+export function safeProjectHtmlDocument(source, dataScope = 'personal') {
   const csp = `<meta http-equiv="Content-Security-Policy" content="${SAFE_PROJECT_PREVIEW_CSP}">`
   // Keep the policy ahead of every untrusted byte. Inserting it after a
   // literal <head> is not sufficient: malformed HTML can place a fetching
   // element before that tag, causing the parser to issue a request (and ignore
   // the now-late head) before it ever encounters the policy.
-  return `${csp}${PROJECT_PREVIEW_RUNTIME}${String(source ?? '')}`
+  return `${csp}${projectPreviewRuntime(dataScope)}${String(source ?? '')}`
 }
 
 export function projectPreviewSandbox() {
@@ -106,7 +109,7 @@ function escapeInlineScript(source) {
  * interactive preview without exposing a project directory as a public URL.
  * Missing or remote dependencies stay in the document and are blocked by CSP.
  */
-export async function assembleProjectHtmlPreview(source, entryPath, loadText, loadDataUri = null) {
+export async function assembleProjectHtmlPreview(source, entryPath, loadText, loadDataUri = null, dataScope = 'personal') {
   let document = String(source ?? '')
   const stylesheet = /<link\b([^>]*\brel=["']?stylesheet["']?[^>]*)>/gi
   const script = /<script\b([^>]*\bsrc=["']([^"']+)["'][^>]*)><\/script\s*>/gi
@@ -173,5 +176,5 @@ export async function assembleProjectHtmlPreview(source, entryPath, loadText, lo
     }
   }
 
-  return safeProjectHtmlDocument(document)
+  return safeProjectHtmlDocument(document, dataScope)
 }

--- a/frontend/src/lib/sharedAppState.js
+++ b/frontend/src/lib/sharedAppState.js
@@ -1,0 +1,31 @@
+export function normalizeSharedAppSnapshot(current, next) {
+  const currentCursor = Number(current?.cursor || 0)
+  const nextCursor = Number(next?.cursor || 0)
+  if (nextCursor < currentCursor) return null
+  return {
+    cursor: nextCursor,
+    values: next?.values || {},
+    versions: next?.versions || {},
+  }
+}
+
+
+export function applySharedAppMutation(current, path, value, version, deleted = false) {
+  const values = { ...(current?.values || {}) }
+  const versions = { ...(current?.versions || {}) }
+  if (deleted) {
+    delete values[path]
+    delete versions[path]
+  } else {
+    values[path] = value
+    versions[path] = version
+  }
+  return {
+    // A mutation response identifies this write, but does not contain state
+    // for collaborator writes that may precede it. Retaining the last fully
+    // observed cursor makes the next change poll recover the entire interval.
+    cursor: Number(current?.cursor || 0),
+    values,
+    versions,
+  }
+}


### PR DESCRIPTION
## Summary
- add browser-private personal previews for project Creations
- add private shared app instances with one-use invitations, revocable roles, immutable releases, and confined live JSON state
- keep shared source private while supporting deliberate release moves and recoverable deletion/retention
- present outputs consistently as Creations across project, drawer, pane, and standalone surfaces

## Replacement
- supersedes obsolete stacked PR #967, whose parent has already merged
- starts from the accepted `main` on a fresh branch instead of rewriting or retargeting the old public PR
- the separately reviewed file-mention replacement is its exact child

## Safety and privacy
- personal preview data stays in the owner’s browser
- guests receive only an opaque, sandboxed runtime document; project source remains private
- invite redemption is one-use and every shared write re-checks current membership and release ownership
- normalized paths, serialized writes, immutable releases, and recovery-aware retention preserve owner data across concurrency and restart edges
- the landed Goal migration remains immutable; the five sharing migrations append as 0025–0029 and a regression proves installations that ran the earlier local review names still converge

## Testing
- The clean-environment full backend suite passed 4,540 tests with 18 skips on the semantic-equivalent reviewed candidate. After the final accepted-main reparent, 49 focused sharing/project/migration tests and 18 exact chat/file-mention tests pass. The complete semantic-candidate frontend suites passed 2,991 tests; final lint has zero errors and the existing 46-warning baseline. Ruff, compile, migration-history, generated-runtime, privacy, attribution, canonical diff, exact range-diff, and ancestry checks pass. The production-build admission guard safely deferred under host memory pressure; CI will run the exact staged heads.