### PR TITLE
Mention project files from chat

### DIFF
--- a/frontend/src/components/ChatView/ChatInputBar.jsx
+++ b/frontend/src/components/ChatView/ChatInputBar.jsx
@@ -107,6 +107,16 @@ import {
   slashCommandUnavailableReason,
   visibleSlashCommands,
 } from './slashCommands.js'
+import FileMentionMenu from './FileMentionMenu.jsx'
+import {
+  applyFileMention,
+  matchMentionFiles,
+  mentionAgentPath,
+  mentionQueryFor,
+} from './fileMentions.js'
+import { useQuery } from '@tanstack/react-query'
+import { api, jsonOrThrow } from '../../api/client.js'
+import { projectQueries } from '../../hooks/queries.js'
 import { filePasteNeedsDefaultPrevented, pastedFiles } from './pasteUpload.js'
 import { hasSendablePayload } from './composerSubmission.js'
 import {
@@ -518,6 +528,7 @@ export default function ChatInputBar({
   attachmentsDisabled = false,
   messageHistory = [],
   provider,
+  projectRef = null,
 }) {
   const fileInputRef = useRef(null)
   const historyIndexRef = useRef(null)
@@ -560,6 +571,45 @@ export default function ChatInputBar({
   useEffect(() => {
     if (slashCandidates.length === 0) setSlashDismissed(false)
   }, [slashCandidates.length])
+
+  // @-mention of project files, for chats that belong to a project. Mirrors
+  // slash-menu mechanics: the token is derived from the text every render,
+  // only highlight and dismissal are state, and the textarea keeps focus.
+  const [mentionIndex, setMentionIndex] = useState(0)
+  const [mentionDismissed, setMentionDismissed] = useState(false)
+  const mention = projectRef ? mentionQueryFor(input) : null
+  // The whole project's file list is fetched once per mention session (and
+  // kept briefly fresh) so filtering is instant while the owner types.
+  const mentionFilesQuery = useQuery({
+    queryKey: projectQueries.keys.fileIndex(projectRef?.id),
+    queryFn: async ({ signal }) => jsonOrThrow(
+      await api.projects.files(projectRef.id, '', { signal, recursive: true }),
+      'Project files failed:',
+    ),
+    enabled: !!projectRef && mention !== null,
+    staleTime: 15_000,
+  })
+  const mentionMatches = (mention !== null && slashInputFocused && !mentionDismissed)
+    ? matchMentionFiles(mention.query, mentionFilesQuery.data?.entries)
+    : []
+  const mentionActiveIndex = Math.min(mentionIndex, Math.max(mentionMatches.length - 1, 0))
+  const mentionListId = `file-mention-${chatId}`
+  const mentionOptionId = `${mentionListId}-active`
+  useEffect(() => { setMentionIndex(0) }, [mention?.query])
+  useEffect(() => {
+    if (mention === null) setMentionDismissed(false)
+    // Recompute only when mention mode opens/closes, not per keystroke.
+  }, [mention === null]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  function acceptFileMention(file) {
+    if (!file || !mention) return
+    const next = applyFileMention(input, mention, mentionAgentPath(projectRef?.root_path, file.path))
+    resetMessageHistory()
+    if (listeningRef?.current) onManualVoiceEdit?.(next)
+    onInputChange(next)
+    focusComposerElement(inputRef?.current)
+    requestAnimationFrame(() => placeCaretAtTextEnd(inputRef?.current))
+  }
 
   // Expose the hidden-file-input trigger to the parent. The parent
   // owns the visible "attach" affordance (now part of ComposerPopover);
@@ -723,9 +773,25 @@ export default function ChatInputBar({
 
   function handleKeyDown(e) {
     pasteAsPlainTextRef.current = isPlainTextPasteShortcut(e)
-    // The menu claims Enter and the arrows while it is open — the same keys
-    // that otherwise send and walk sent-message history — so it resolves
-    // BEFORE both. Keys it doesn't claim fall through untouched.
+    // The menus claim Enter and the arrows while open — the same keys that
+    // otherwise send and walk sent-message history — so they resolve BEFORE
+    // both. Keys they don't claim fall through untouched. Mention and slash
+    // modes are mutually exclusive (a leading "/" cannot also end in an
+    // "@token"), so ordering between them never decides a key.
+    const mentionAction = resolveSlashMenuKey(e, {
+      open: mentionMatches.length > 0,
+      count: mentionMatches.length,
+    })
+    if (mentionAction) {
+      e.preventDefault()
+      const total = mentionMatches.length
+      if (mentionAction === 'dismiss') setMentionDismissed(true)
+      else if (mentionAction === 'next') setMentionIndex((i) => (i + 1) % total)
+      else if (mentionAction === 'previous') setMentionIndex((i) => (i - 1 + total) % total)
+      else if (mentionAction === 'accept') acceptFileMention(mentionMatches[mentionActiveIndex])
+      return
+    }
+
     const slashAction = resolveSlashMenuKey(e, {
       open: slashMatches.length > 0,
       count: slashMatches.length,
@@ -875,6 +941,13 @@ export default function ChatInputBar({
         listId={slashListId}
         optionId={slashOptionId}
       />
+      <FileMentionMenu
+        files={mentionMatches}
+        activeIndex={mentionActiveIndex}
+        onSelect={acceptFileMention}
+        listId={mentionListId}
+        optionId={mentionOptionId}
+      />
       <div className="chat__input-row">
         {leftButtons}
         <div className={`chat__pill${hasFiles ? ' chat__pill--with-attach' : ''}`}>
@@ -907,11 +980,11 @@ export default function ChatInputBar({
               // Combobox semantics apply only while the menu is open. Left on
               // permanently they would announce this plain prose textarea as a
               // picker in every ordinary message the user writes.
-              {...(slashMatches.length > 0 ? {
+              {...(slashMatches.length > 0 || mentionMatches.length > 0 ? {
                 role: 'combobox',
                 'aria-expanded': true,
-                'aria-controls': slashListId,
-                'aria-activedescendant': slashOptionId,
+                'aria-controls': slashMatches.length > 0 ? slashListId : mentionListId,
+                'aria-activedescendant': slashMatches.length > 0 ? slashOptionId : mentionOptionId,
                 'aria-autocomplete': 'list',
               } : {})}
             />

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -5471,6 +5471,7 @@ export default function ChatView({
           attachTriggerRef={attachTriggerRef}
           messageHistory={messageHistory}
           provider={chatInfo?.provider}
+          projectRef={chatInfo?.project || null}
           leftButtons={
             <BrainUsageButton
               usageEnabled={!embedded}

--- a/frontend/src/components/ChatView/FileMentionMenu.jsx
+++ b/frontend/src/components/ChatView/FileMentionMenu.jsx
@@ -1,0 +1,48 @@
+/* FileMentionMenu — the project-file picker that floats above the composer while typing "@". */
+
+import { useEffect, useRef } from 'react'
+import './SlashMenu.css'
+
+/**
+ * Presentational, exactly like SlashMenu and for the same reasons: the caller
+ * owns matching, highlight, and acceptance; the textarea keeps focus the whole
+ * time (rows prevent default on pointerdown) and points at the active row via
+ * aria-activedescendant. Reuses the slash-menu styling so the two composer
+ * pickers read as one system.
+ */
+export default function FileMentionMenu({ files, activeIndex, onSelect, listId, optionId }) {
+  const activeRef = useRef(null)
+
+  useEffect(() => {
+    activeRef.current?.scrollIntoView({ block: 'nearest' })
+  }, [activeIndex])
+
+  if (!files.length) return null
+
+  return (
+    <div className="slash-menu-anchor">
+      <ul className="slash-menu" id={listId} role="listbox" aria-label="Project files">
+        {files.map((file, index) => {
+          const active = index === activeIndex
+          return (
+            <li
+              key={file.path}
+              ref={active ? activeRef : null}
+              id={active ? optionId : undefined}
+              className={`slash-menu__item${active ? ' slash-menu__item--active' : ''}`}
+              role="option"
+              aria-selected={active}
+              onPointerDown={(event) => event.preventDefault()}
+              onClick={() => onSelect(file)}
+            >
+              <div className="slash-menu__line">
+                <span className="slash-menu__name">{file.name}</span>
+                <span className="slash-menu__args">{file.path}</span>
+              </div>
+            </li>
+          )
+        })}
+      </ul>
+    </div>
+  )
+}

--- a/frontend/src/components/ChatView/__tests__/chatDetailCache.test.js
+++ b/frontend/src/components/ChatView/__tests__/chatDetailCache.test.js
@@ -110,6 +110,7 @@ test('prefetched chat detail matches the synchronous ChatView cache contract', (
     effective_agent_settings: { effort: 'high' },
     has_assistant_turns: true,
     auto_resume_on_limit: true,
+    project: { id: 'p1', name: 'Site', root_path: 'projects/p1' },
   }
 
   const cached = chatDetailCacheValue(source)
@@ -131,6 +132,7 @@ test('prefetched chat detail matches the synchronous ChatView cache contract', (
     effective: { effort: 'high' },
     has_assistant_turns: true,
     auto_resume_on_limit: true,
+    project: { id: 'p1', name: 'Site', root_path: 'projects/p1' },
   })
 })
 

--- a/frontend/src/components/ChatView/__tests__/fileMentions.test.js
+++ b/frontend/src/components/ChatView/__tests__/fileMentions.test.js
@@ -1,0 +1,74 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import FileMentionMenu from '../FileMentionMenu.jsx'
+import {
+  applyFileMention,
+  matchMentionFiles,
+  mentionAgentPath,
+  mentionQueryFor,
+} from '../fileMentions.js'
+
+const files = [
+  { name: 'index.html', path: 'index.html', type: 'file' },
+  { name: 'main.tex', path: 'src/main.tex', type: 'file' },
+  { name: 'style.css', path: 'assets/style.css', type: 'file' },
+  { name: 'src', path: 'src', type: 'directory' },
+]
+
+test('mentionQueryFor opens on a leading or space-preceded @ and tracks the token', () => {
+  assert.deepEqual(mentionQueryFor('@'), { start: 0, query: '' })
+  assert.deepEqual(mentionQueryFor('fix @main'), { start: 4, query: 'main' })
+  assert.deepEqual(mentionQueryFor('see @src/ma'), { start: 4, query: 'src/ma' })
+})
+
+test('mentionQueryFor stays closed for emails, finished tokens, and plain text', () => {
+  assert.equal(mentionQueryFor('user@example.com'), null)
+  assert.equal(mentionQueryFor('fix @main.tex please'), null)
+  assert.equal(mentionQueryFor('no mention here'), null)
+  assert.equal(mentionQueryFor(''), null)
+})
+
+test('matchMentionFiles ranks basename hits above path-only hits and skips directories', () => {
+  const matches = matchMentionFiles('main', files)
+  assert.equal(matches[0].path, 'src/main.tex')
+  assert.ok(matches.every((file) => file.type !== 'directory'))
+})
+
+test('matchMentionFiles offers the head of the listing for an empty query', () => {
+  const matches = matchMentionFiles('', files, 2)
+  assert.equal(matches.length, 2)
+  assert.ok(matches.every((file) => file.type !== 'directory'))
+})
+
+test('mentionAgentPath joins the logical project root under /data', () => {
+  assert.equal(mentionAgentPath('projects/p1', 'src/main.tex'), '/data/projects/p1/src/main.tex')
+  // Rolling-upgrade compatibility rows store an absolute root.
+  assert.equal(mentionAgentPath('/data/projects/p2', 'a.html'), '/data/projects/p2/a.html')
+})
+
+test('applyFileMention replaces the token with the path and a trailing space', () => {
+  const mention = mentionQueryFor('fix @main')
+  assert.equal(
+    applyFileMention('fix @main', mention, '/data/projects/p1/src/main.tex'),
+    'fix /data/projects/p1/src/main.tex ',
+  )
+  assert.equal(
+    applyFileMention('open @draft', mentionQueryFor('open @draft'), '/data/projects/p1/My Draft.md'),
+    'open "/data/projects/p1/My Draft.md" ',
+  )
+})
+
+test('the file picker exposes one active listbox option without stealing textarea focus', () => {
+  const html = renderToStaticMarkup(createElement(FileMentionMenu, {
+    files: files.filter((file) => file.type === 'file'),
+    activeIndex: 1,
+    onSelect: () => {},
+    listId: 'project-files',
+    optionId: 'project-file-active',
+  }))
+  assert.match(html, /role="listbox"[^>]*aria-label="Project files"/)
+  assert.match(html, /id="project-file-active"[^>]*role="option"[^>]*aria-selected="true"/)
+  assert.equal((html.match(/aria-selected="true"/g) || []).length, 1)
+})

--- a/frontend/src/components/ChatView/fileMentions.js
+++ b/frontend/src/components/ChatView/fileMentions.js
@@ -1,0 +1,75 @@
+/* @-mention of project files: token detection, fuzzy ranking, insertion. */
+
+/**
+ * The composer's "@" file mention for project chats.
+ *
+ * A mention is presentation-only sugar: accepting one inserts the file's
+ * ordinary path (under the data directory the agent already works in) as plain
+ * composer text. Nothing downstream parses a special reference format — the
+ * agent receives exactly what the owner could have typed by hand, so the
+ * backend, transcript, and every provider stay mention-agnostic.
+ *
+ * Token rules mirror slash mode's narrowness: mention mode opens on an "@" at
+ * the start of the text or after whitespace, tracks the whitespace-free token
+ * typed after it, and closes the moment the token ends (a space means the
+ * owner has moved on). An "@" inside a word ("user@example.com") never opens
+ * the menu.
+ */
+
+import { fuzzyScore } from './slashCommands.js'
+
+/** The active mention token at the end of `input`, or null. */
+export function mentionQueryFor(input) {
+  const text = input ?? ''
+  const match = /(^|\s)@([^\s@]*)$/.exec(text)
+  if (!match) return null
+  return { start: text.length - match[2].length - 1, query: match[2] }
+}
+
+/**
+ * Project files ranked for a mention query, best first.
+ *
+ * The basename is what owners usually think in, so it outweighs a match that
+ * only lands somewhere in the directory chain. An empty query simply offers
+ * the first files of the listing — the menu opening on a bare "@" is what
+ * makes the feature discoverable.
+ */
+export function matchMentionFiles(query, files, limit = 8) {
+  const candidates = (files ?? []).filter((file) => file?.type !== 'directory')
+  if (!query) return candidates.slice(0, limit)
+  return candidates
+    .map((file) => {
+      const name = fuzzyScore(query, file.name)
+      const path = fuzzyScore(query, file.path)
+      if (name === null && path === null) return null
+      return { file, score: Math.max((name ?? -1) * 2, path ?? -1) }
+    })
+    .filter(Boolean)
+    .sort((a, b) => b.score - a.score || a.file.path.localeCompare(b.file.path))
+    .slice(0, limit)
+    .map((entry) => entry.file)
+}
+
+/**
+ * The ordinary filesystem path the agent receives for a mentioned file.
+ *
+ * `rootPath` is the project's stored locator: logical ("projects/<id>") for
+ * every current row, absolute only on rolling-upgrade compatibility rows —
+ * the same two shapes the backend's `_project_root` resolves.
+ */
+export function mentionAgentPath(rootPath, filePath) {
+  const root = String(rootPath ?? '').replace(/\/+$/, '')
+  const file = String(filePath ?? '').replace(/^\/+/, '')
+  if (!root) return file
+  return root.startsWith('/') ? `${root}/${file}` : `/data/${root}/${file}`
+}
+
+/** Composer text after accepting a mention: token replaced by the path. */
+export function applyFileMention(input, mention, agentPath) {
+  const text = input ?? ''
+  const path = String(agentPath ?? '')
+  // Preserve path identity when an ordinary filename contains whitespace or
+  // another separator that would make plain prose ambiguous to the agent.
+  const inserted = /\s/.test(path) ? JSON.stringify(path) : path
+  return `${text.slice(0, mention.start)}${inserted} `
+}

--- a/frontend/src/lib/chatDetailCache.js
+++ b/frontend/src/lib/chatDetailCache.js
@@ -198,6 +198,9 @@ export function chatDetailCacheValue(data = {}) {
       effective: data.effective_agent_settings || {},
       has_assistant_turns: !!data.has_assistant_turns,
       auto_resume_on_limit: !!data.auto_resume_on_limit,
+      // The composer uses this bounded project locator to turn an @-selected
+      // file into the ordinary /data path the agent can read.
+      project: data.project || null,
     },
   }
 }


### PR DESCRIPTION
## Summary
- add an accessible `@` picker for files in the current Project workspace
- fuzzy-rank basenames and paths while reusing the composer’s existing menu interaction model
- insert an ordinary `/data/...` path, quoting whitespace safely, so every provider receives plain text rather than a new reference protocol
- carry the bounded Project locator through prefetched chat detail

## Replacement
- supersedes obsolete stacked PR #968
- is the exact seven-file child of the fresh Shared Creations replacement root
- keeps the old public PR unchanged rather than using an unsafe branch rewrite or base retarget

## Safety and accessibility
- results come from the existing authorized, confined Project listing
- directories are excluded and a mention never reads file contents
- email-like `@` text and completed tokens do not open the picker
- the textarea keeps focus and exposes the active result through combobox/listbox semantics

## Testing
- The clean-environment full backend suite passed 4,540 tests with 18 skips on the semantic-equivalent reviewed candidate. After the final accepted-main reparent, 49 focused sharing/project/migration tests and 18 exact chat/file-mention tests pass. The complete semantic-candidate frontend suites passed 2,991 tests; final lint has zero errors and the existing 46-warning baseline. Ruff, compile, migration-history, generated-runtime, privacy, attribution, canonical diff, exact range-diff, and ancestry checks pass. The production-build admission guard safely deferred under host memory pressure; CI will run the exact staged heads.