### PR TITLE
Preserve active runtime overlays during host replacement

### DIFF
--- a/backend/app/deployment_control.py
+++ b/backend/app/deployment_control.py
@@ -63,9 +63,11 @@ _KNOWN_STATES = {
 }
 _ACTIVE_STATES = {"queued", "preparing", "replacing", "verifying"}
 _HANDOFF_VERSION = "external-cutover-v1"
+_RUNTIME_OVERLAY_VERSION = "active-runtime-v1"
 _managed_recovery_tasks: set[asyncio.Task[None]] = set()
 _UPGRADE_MESSAGE = (
-  "The Host replacement helper predates safe chat continuation. Re-run "
+  "The Host replacement helper predates safe active-runtime carry-forward. "
+  "Re-run "
   "scripts/install-rebuild-helper.sh from the current trusted checkout."
 )
 
@@ -307,12 +309,16 @@ def _read_host_status() -> dict[str, Any]:
         "expected_sha": expected,
         "message": "Container replacement queued.",
         "handoff": value.get("handoff"),
+        "runtime_overlay": value.get("runtime_overlay"),
       }
   return value
 
 
 def _current_handoff(raw: dict[str, Any]) -> bool:
-  return raw.get("handoff") == _HANDOFF_VERSION
+  return (
+    raw.get("handoff") == _HANDOFF_VERSION
+    and raw.get("runtime_overlay") == _RUNTIME_OVERLAY_VERSION
+  )
 
 
 def _write_request(expected_sha: str) -> None:
@@ -466,12 +472,19 @@ async def request_rebuild() -> RebuildStatus:
       "Möbius cannot identify the official version to deploy.",
       status_code=409,
     )
-  blockers = platform_update.container_replacement_blockers()
+  blockers = platform_update.container_replacement_blockers(
+    expected_sha,
+    preserve_active_runtime=deployment == "self_hosted",
+  )
   if blockers:
+    visible = ", ".join(blockers[:5])
+    if len(blockers) > 5:
+      visible += f", and {len(blockers) - 5} more"
     raise DeploymentControlError(
       "local_runtime_changes",
-      "The official image does not contain local runtime changes. "
-      "Commit them upstream or remove them before replacing this container.",
+      "The official image cannot preserve these local image inputs: "
+      f"{visible}. Commit them upstream, rebuild locally, or remove them "
+      "before replacing this container.",
       status_code=409,
     )
   if deployment == "railway":

--- a/backend/tests/test_deployment_control.py
+++ b/backend/tests/test_deployment_control.py
@@ -18,7 +18,8 @@ def _install_control(tmp_path, monkeypatch):
   inbox = control / "inbox"
   inbox.mkdir(parents=True)
   (control / "status.json").write_text(
-    '{"state":"idle","handoff":"external-cutover-v1"}',
+    '{"state":"idle","handoff":"external-cutover-v1",'
+    '"runtime_overlay":"active-runtime-v1"}',
     encoding="utf-8",
   )
   monkeypatch.setattr(dc, "_control_dir", lambda: control)
@@ -114,7 +115,11 @@ async def test_legacy_railway_image_offers_managed_bootstrap(tmp_path, monkeypat
   monkeypatch.setattr(dc.platform_activation, "deployment_kind", lambda: "railway")
   monkeypatch.setattr(dc, "get_settings", lambda: type("S", (), {"data_dir": str(tmp_path)})())
   monkeypatch.setattr(dc, "_expected_upstream_sha", lambda: "a" * 40)
-  monkeypatch.setattr(dc.platform_update, "container_replacement_blockers", lambda: [])
+  monkeypatch.setattr(
+    dc.platform_update,
+    "container_replacement_blockers",
+    lambda *_args, **_kwargs: [],
+  )
   calls = []
 
   def managed_request(method, suffix, payload=None):
@@ -240,7 +245,11 @@ async def test_legacy_railway_bootstrap_waits_for_idle_chats(tmp_path, monkeypat
   monkeypatch.setattr(dc.platform_activation, "deployment_kind", lambda: "railway")
   monkeypatch.setattr(dc, "get_settings", lambda: type("S", (), {"data_dir": str(tmp_path)})())
   monkeypatch.setattr(dc, "_expected_upstream_sha", lambda: "a" * 40)
-  monkeypatch.setattr(dc.platform_update, "container_replacement_blockers", lambda: [])
+  monkeypatch.setattr(
+    dc.platform_update,
+    "container_replacement_blockers",
+    lambda *_args, **_kwargs: [],
+  )
   calls = []
 
   def managed_request(method, suffix, payload=None):
@@ -320,7 +329,17 @@ async def test_request_rebuild_selects_managed_railway_handoff(tmp_path, monkeyp
   monkeypatch.setattr(dc.platform_activation, "deployment_kind", lambda: "railway")
   monkeypatch.setattr(dc, "get_settings", lambda: settings)
   monkeypatch.setattr(dc, "_expected_upstream_sha", lambda: "a" * 40)
-  monkeypatch.setattr(dc.platform_update, "container_replacement_blockers", lambda: [])
+  blocker_calls = []
+
+  def blockers(expected, *, preserve_active_runtime):
+    blocker_calls.append((expected, preserve_active_runtime))
+    return []
+
+  monkeypatch.setattr(
+    dc.platform_update,
+    "container_replacement_blockers",
+    blockers,
+  )
   calls = []
 
   def managed_request(method, suffix, payload=None):
@@ -350,6 +369,7 @@ async def test_request_rebuild_selects_managed_railway_handoff(tmp_path, monkeyp
 
   assert status["deployment"] == "railway"
   assert status["state"] == "queued"
+  assert blocker_calls == [("a" * 40, False)]
   assert calls == [
     ("POST", "prepare", {"expected_sha": "a" * 40}),
     ("POST", "start", {
@@ -375,7 +395,11 @@ async def test_managed_start_failure_restarts_only_after_definitive_rejection(
   monkeypatch.setattr(dc.platform_activation, "deployment_kind", lambda: "railway")
   monkeypatch.setattr(dc, "get_settings", lambda: settings)
   monkeypatch.setattr(dc, "_expected_upstream_sha", lambda: "a" * 40)
-  monkeypatch.setattr(dc.platform_update, "container_replacement_blockers", lambda: [])
+  monkeypatch.setattr(
+    dc.platform_update,
+    "container_replacement_blockers",
+    lambda *_args, **_kwargs: [],
+  )
 
   def managed_request(method, suffix, payload=None):
     if suffix == "prepare":
@@ -419,7 +443,11 @@ async def test_pre_start_receipt_timeout_recovers_the_drained_worker(
   monkeypatch.setattr(dc.platform_activation, "deployment_kind", lambda: "railway")
   monkeypatch.setattr(dc, "get_settings", lambda: settings)
   monkeypatch.setattr(dc, "_expected_upstream_sha", lambda: "a" * 40)
-  monkeypatch.setattr(dc.platform_update, "container_replacement_blockers", lambda: [])
+  monkeypatch.setattr(
+    dc.platform_update,
+    "container_replacement_blockers",
+    lambda *_args, **_kwargs: [],
+  )
 
   requests = []
 
@@ -473,7 +501,11 @@ async def test_definitive_rejection_owns_recovery_until_restart_settles(
   monkeypatch.setattr(dc.platform_activation, "deployment_kind", lambda: "railway")
   monkeypatch.setattr(dc, "get_settings", lambda: settings)
   monkeypatch.setattr(dc, "_expected_upstream_sha", lambda: "a" * 40)
-  monkeypatch.setattr(dc.platform_update, "container_replacement_blockers", lambda: [])
+  monkeypatch.setattr(
+    dc.platform_update,
+    "container_replacement_blockers",
+    lambda *_args, **_kwargs: [],
+  )
 
   def managed_request(method, suffix, _payload=None):
     if suffix == "prepare":
@@ -522,13 +554,26 @@ async def test_request_writes_only_the_derived_sha(tmp_path, monkeypatch):
   _control, inbox = _install_control(tmp_path, monkeypatch)
   monkeypatch.setattr(dc.platform_activation, "deployment_kind", lambda: "self_hosted")
   monkeypatch.setattr(dc, "_expected_upstream_sha", lambda: "c" * 40)
-  monkeypatch.setattr(dc.platform_update, "container_replacement_blockers", lambda: [])
+  seen = {}
+
+  def blockers(expected, *, preserve_active_runtime):
+    seen["expected"] = expected
+    seen["preserve_active_runtime"] = preserve_active_runtime
+    return []
+
+  monkeypatch.setattr(
+    dc.platform_update, "container_replacement_blockers", blockers,
+  )
 
   status = await dc.request_rebuild()
 
   assert status["state"] == "queued"
   assert json.loads((inbox / "request.json").read_text()) == {
     "version": 1, "expected_sha": "c" * 40,
+  }
+  assert seen == {
+    "expected": "c" * 40,
+    "preserve_active_runtime": True,
   }
 
 
@@ -537,7 +582,8 @@ async def test_queued_request_masks_the_previous_terminal_status(tmp_path, monke
   control, inbox = _install_control(tmp_path, monkeypatch)
   (control / "status.json").write_text(
     '{"state":"succeeded","operation_id":"old",'
-    '"handoff":"external-cutover-v1"}', encoding="utf-8",
+    '"handoff":"external-cutover-v1",'
+    '"runtime_overlay":"active-runtime-v1"}', encoding="utf-8",
   )
   (inbox / "request.json").write_text(json.dumps({
     "version": 1, "expected_sha": "e" * 40,
@@ -556,7 +602,9 @@ async def test_request_refuses_local_runtime_changes(tmp_path, monkeypatch):
   monkeypatch.setattr(dc.platform_activation, "deployment_kind", lambda: "self_hosted")
   monkeypatch.setattr(dc, "_expected_upstream_sha", lambda: "d" * 40)
   monkeypatch.setattr(
-    dc.platform_update, "container_replacement_blockers", lambda: ["Dockerfile"],
+    dc.platform_update,
+    "container_replacement_blockers",
+    lambda _expected, *, preserve_active_runtime: ["Dockerfile"],
   )
 
   with pytest.raises(dc.DeploymentControlError) as exc:

--- a/backend/tests/test_mobius_rebuild_host.py
+++ b/backend/tests/test_mobius_rebuild_host.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib.util
 import os
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -39,6 +40,14 @@ def test_installer_enables_boot_time_reconciliation():
   assert "Before=mobius-rebuild.path" in source
   assert "WantedBy=multi-user.target" in source
   assert "systemctl enable mobius-rebuild-reconcile.service" in source
+  assert 'bootstrap-runtime "$CID"' in source
+  assert "MOBIUS_RUNTIME_OVERLAY" in source
+  assert "target: /app/runtime" in source
+  assert "FROZEN_SOURCE=/etc/mobius-rebuild/compose.yml" in source
+  assert '"com.docker.compose.project.environment_file"' in source
+  assert 'ARGS+=(--env-file "$file")' in source
+  assert "CURRENT_IMAGE=$(docker inspect" in source
+  assert 'MOBIUS_IMAGE="$CURRENT_IMAGE" docker compose' in source
 
 
 def _frozen(tmp_path: Path, monkeypatch) -> tuple[dict, Path]:
@@ -91,6 +100,44 @@ def test_frozen_config_rejects_symlinked_input(tmp_path, monkeypatch):
     host.validate_config(value, trusted_uid=os.getuid())
 
 
+def test_served_generation_accepts_pending_source_but_requires_exact_overlay(
+  monkeypatch,
+):
+  def version(payload):
+    return subprocess.CompletedProcess(
+      [], 0, stdout=payload, stderr="",
+    )
+
+  monkeypatch.setattr(
+    host.subprocess, "run",
+    lambda *_args, **_kwargs: version(
+      '{"sha":"' + "a" * 40 + '","protected_runtime_state":"stale",'
+      '"protected_runtime":{"deployed_sha256":"' + "b" * 64 + '"}}',
+    ),
+  )
+  host.verify_served_generation("cid", "a" * 40, "b" * 64)
+
+  monkeypatch.setattr(
+    host.subprocess, "run",
+    lambda *_args, **_kwargs: version(
+      '{"sha":"' + "a" * 40 + '","protected_runtime":'
+      '{"deployed_sha256":"' + "c" * 64 + '"}}',
+    ),
+  )
+  with pytest.raises(RuntimeError, match="prepared generation"):
+    host.verify_served_generation("cid", "a" * 40, "b" * 64)
+
+
+def test_replacement_verifies_provenance_before_retiring_chat_handoff():
+  source = SCRIPT.read_text(encoding="utf-8")
+  run = source[source.index("def run()") : source.index("def reconcile()")]
+  healthy = run.index("if not wait_healthy(config_value)")
+  provenance = run.index("verify_served_generation(", healthy)
+  finalize = run.index('"finalize-cutover"', provenance)
+
+  assert healthy < provenance < finalize
+
+
 def _worker_paths(tmp_path: Path, monkeypatch):
   state = tmp_path / "state"
   inbox = tmp_path / "control" / "inbox"
@@ -100,9 +147,504 @@ def _worker_paths(tmp_path: Path, monkeypatch):
   monkeypatch.setattr(host, "LOCK", state / "replace.lock")
   monkeypatch.setattr(host, "STATUS", state / "status.json")
   monkeypatch.setattr(host, "IMAGES", state / "images.json")
-  config = {"project": "mobius", "control_dir": inbox.parent}
+  monkeypatch.setattr(host, "RUNTIME_GENERATIONS", state / "runtime-generations")
+  monkeypatch.setattr(host, "RUNTIME_STATE", state / "runtime.json")
+  monkeypatch.setattr(host, "RUNTIME_RESOLUTIONS", state / "runtime-resolutions")
+  monkeypatch.setattr(host, "RUNTIME_RESOLUTION", state / "runtime-resolution.json")
+  runtime = host.RUNTIME_GENERATIONS / f"runtime-{'a' * 16}-{'b' * 8}"
+  runtime.mkdir(parents=True)
+  (runtime / "identity_broker.py").write_text("active\n", encoding="utf-8")
+  digest, _files = host._runtime_snapshot(runtime)
+  host._write_runtime_state(
+    host.RuntimeGeneration(runtime.name, runtime, digest), None,
+  )
+  data = tmp_path / "data"
+  data.mkdir()
+  config = {
+    "project": "mobius", "control_dir": inbox.parent, "data_dir": data,
+  }
   monkeypatch.setattr(host, "config", lambda: config)
   return config, inbox
+
+
+def _prepared_runtime() -> host.PreparedRuntime:
+  prior_active, prior_rollback = host._read_runtime_state()
+  previous = prior_active
+  candidate_path = host.RUNTIME_GENERATIONS / f"runtime-{'c' * 16}-{'d' * 8}"
+  candidate_path.mkdir(exist_ok=True)
+  (candidate_path / "identity_broker.py").write_text(
+    "merged\n", encoding="utf-8",
+  )
+  digest, _files = host._runtime_snapshot(candidate_path)
+  candidate = host.RuntimeGeneration(candidate_path.name, candidate_path, digest)
+  return host.PreparedRuntime(
+    previous, candidate, ("identity_broker.py",), prior_active, prior_rollback,
+  )
+
+
+def _write_runtime_tree(root: Path, value: str) -> None:
+  root.mkdir(parents=True)
+  (root / "identity_broker.py").write_text(value, encoding="utf-8")
+
+
+def test_runtime_merge_carries_active_edits_onto_incoming_official_tree(
+  tmp_path, monkeypatch,
+):
+  monkeypatch.setattr(host.os, "chown", lambda *_args: None)
+  base = tmp_path / "base"
+  active = tmp_path / "active"
+  incoming = tmp_path / "incoming"
+  result = tmp_path / "result"
+  _write_runtime_tree(base, "alpha=old\nshared=keep\nomega=old\n")
+  _write_runtime_tree(active, "alpha=local\nshared=keep\nomega=old\n")
+  _write_runtime_tree(incoming, "alpha=old\nshared=keep\nomega=official\n")
+
+  digest, carried = host._merge_runtime_trees(base, active, incoming, result)
+
+  assert (result / "identity_broker.py").read_text(encoding="utf-8") == (
+    "alpha=local\nshared=keep\nomega=official\n"
+  )
+  assert carried == ("identity_broker.py",)
+  assert digest == host._runtime_snapshot(result)[0]
+
+
+def test_runtime_merge_blocks_a_real_active_vs_official_conflict(tmp_path):
+  base = tmp_path / "base"
+  active = tmp_path / "active"
+  incoming = tmp_path / "incoming"
+  _write_runtime_tree(base, "route=old\n")
+  _write_runtime_tree(active, "route=local\n")
+  _write_runtime_tree(incoming, "route=official\n")
+
+  with pytest.raises(host.RuntimeOverlayConflict) as exc:
+    host._merge_runtime_trees(base, active, incoming, tmp_path / "result")
+
+  assert exc.value.paths == ("identity_broker.py",)
+
+
+def test_runtime_merge_applies_an_exact_target_bound_reviewed_resolution(
+  tmp_path, monkeypatch,
+):
+  monkeypatch.setattr(host.os, "chown", lambda *_args: None)
+  base = tmp_path / "base"
+  active = tmp_path / "active"
+  incoming = tmp_path / "incoming"
+  reviewed = tmp_path / "reviewed"
+  result = tmp_path / "result"
+  _write_runtime_tree(base, "route=old\nkeep=base\n")
+  _write_runtime_tree(active, "route=local\nkeep=base\n")
+  _write_runtime_tree(incoming, "route=official\nkeep=official\n")
+  _write_runtime_tree(reviewed, "route=combined\nkeep=official\n")
+  digest = host._runtime_snapshot(reviewed)[0]
+  resolution = host.RuntimeResolution(
+    "a" * 40, "b" * 64, "c" * 40, ("identity_broker.py",),
+    (), digest, reviewed,
+  )
+
+  merged_digest, carried = host._merge_runtime_trees(
+    base, active, incoming, result, resolution,
+  )
+
+  assert (result / "identity_broker.py").read_text(encoding="utf-8") == (
+    "route=combined\nkeep=official\n"
+  )
+  assert carried == ("identity_broker.py",)
+  assert merged_digest == host._runtime_snapshot(result)[0]
+
+
+def test_runtime_merge_applies_a_reviewed_followup_after_a_clean_merge(
+  tmp_path, monkeypatch,
+):
+  monkeypatch.setattr(host.os, "chown", lambda *_args: None)
+  base = tmp_path / "base"
+  active = tmp_path / "active"
+  incoming = tmp_path / "incoming"
+  reviewed = tmp_path / "reviewed"
+  result = tmp_path / "result"
+  _write_runtime_tree(base, "route=official\n")
+  _write_runtime_tree(active, "route=local-v1\n")
+  _write_runtime_tree(incoming, "route=official\n")
+  _write_runtime_tree(reviewed, "route=local-v2\n")
+  resolution = host.RuntimeResolution(
+    "a" * 40, "b" * 64, "c" * 40, ("identity_broker.py",),
+    (), host._runtime_snapshot(reviewed)[0], reviewed,
+  )
+
+  merged_digest, carried = host._merge_runtime_trees(
+    base, active, incoming, result, resolution,
+  )
+
+  assert (result / "identity_broker.py").read_text(encoding="utf-8") == (
+    "route=local-v2\n"
+  )
+  assert carried == ("identity_broker.py",)
+  assert merged_digest == host._runtime_snapshot(result)[0]
+
+
+def test_runtime_merge_rejects_a_resolution_for_different_conflict_paths(
+  tmp_path,
+):
+  base = tmp_path / "base"
+  active = tmp_path / "active"
+  incoming = tmp_path / "incoming"
+  reviewed = tmp_path / "reviewed"
+  _write_runtime_tree(base, "route=old\n")
+  _write_runtime_tree(active, "route=local\n")
+  _write_runtime_tree(incoming, "route=official\n")
+  reviewed.mkdir()
+  (reviewed / "other.py").write_text("reviewed\n", encoding="utf-8")
+  resolution = host.RuntimeResolution(
+    "a" * 40, "b" * 64, "c" * 40, ("other.py",),
+    (), host._runtime_snapshot(reviewed)[0], reviewed,
+  )
+
+  with pytest.raises(host.RuntimeOverlayConflict) as exc:
+    host._merge_runtime_trees(
+      base, active, incoming, tmp_path / "result", resolution,
+    )
+
+  assert exc.value.paths == ("identity_broker.py",)
+
+
+def test_runtime_merge_applies_a_reviewed_conflict_deletion(
+  tmp_path, monkeypatch,
+):
+  monkeypatch.setattr(host.os, "chown", lambda *_args: None)
+  base = tmp_path / "base"
+  active = tmp_path / "active"
+  incoming = tmp_path / "incoming"
+  reviewed = tmp_path / "reviewed"
+  result = tmp_path / "result"
+  _write_runtime_tree(base, "base\n")
+  _write_runtime_tree(active, "local edit\n")
+  incoming.mkdir()
+  reviewed.mkdir()
+  deleted = ("identity_broker.py",)
+  digest = host._runtime_resolution_digest(reviewed, deleted)[0]
+  resolution = host.RuntimeResolution(
+    "a" * 40, "b" * 64, "c" * 40, deleted, deleted, digest, reviewed,
+  )
+
+  merged_digest, carried = host._merge_runtime_trees(
+    base, active, incoming, result, resolution,
+  )
+
+  assert not (result / "identity_broker.py").exists()
+  assert carried == deleted
+  assert merged_digest == host._runtime_snapshot(result)[0]
+
+
+def test_prepare_runtime_uses_commit_merge_base_for_a_local_image(
+  tmp_path, monkeypatch,
+):
+  _config, _inbox = _worker_paths(tmp_path, monkeypatch)
+  monkeypatch.setattr(host.os, "chown", lambda *_args: None)
+  repo = tmp_path / "platform"
+  repo.mkdir()
+
+  def git(*args):
+    return subprocess.run(
+      ["git", "-C", str(repo), *args], text=True, capture_output=True, check=True,
+    )
+
+  git("init", "-q")
+  git("config", "user.name", "Test")
+  git("config", "user.email", "test@example.com")
+  runtime = repo / "backend" / "runtime"
+  _write_runtime_tree(
+    runtime, "alpha=old\nkeep=one\nkeep=two\nkeep=three\nomega=old\n",
+  )
+  git("add", "-A")
+  git("commit", "-q", "-m", "base")
+  base = git("rev-parse", "HEAD").stdout.strip()
+
+  git("checkout", "-q", "-b", "local")
+  (runtime / "identity_broker.py").write_text(
+    "alpha=local\nkeep=one\nkeep=two\nkeep=three\nomega=old\n",
+    encoding="utf-8",
+  )
+  git("commit", "-qam", "local runtime")
+  current = git("rev-parse", "HEAD").stdout.strip()
+  local_tree = tmp_path / "local-tree"
+  shutil.copytree(runtime, local_tree)
+
+  git("checkout", "-q", "-b", "official", base)
+  (runtime / "identity_broker.py").write_text(
+    "alpha=old\nkeep=one\nkeep=two\nkeep=three\nomega=official\n",
+    encoding="utf-8",
+  )
+  git("commit", "-qam", "official runtime")
+  incoming = git("rev-parse", "HEAD").stdout.strip()
+  incoming_tree = tmp_path / "incoming-tree"
+  shutil.copytree(runtime, incoming_tree)
+
+  def copy_active(_cid, destination):
+    shutil.copytree(local_tree, destination, dirs_exist_ok=True)
+    return host._normalize_runtime_tree(destination)
+
+  def copy_image(image, destination):
+    source = local_tree if image == "current-image" else incoming_tree
+    shutil.copytree(source, destination, dirs_exist_ok=True)
+    digest = host._normalize_runtime_tree(destination)
+    return digest, {"sha": current if image == "current-image" else incoming}
+
+  monkeypatch.setattr(host, "_copy_container_runtime", copy_active)
+  monkeypatch.setattr(host, "_copy_image_runtime", copy_image)
+
+  prepared = host.prepare_runtime_overlay(
+    "container", "current-image", "incoming-image", repo, incoming,
+  )
+
+  assert prepared.carried_paths == ("identity_broker.py",)
+  assert (prepared.candidate.path / "identity_broker.py").read_text(
+    encoding="utf-8",
+  ) == "alpha=local\nkeep=one\nkeep=two\nkeep=three\nomega=official\n"
+
+
+def test_stage_runtime_resolution_binds_reviewed_file_to_active_tree_and_target(
+  tmp_path, monkeypatch,
+):
+  config, _inbox = _worker_paths(tmp_path, monkeypatch)
+  monkeypatch.setattr(host.os, "chown", lambda *_args: None)
+  repo = config["data_dir"] / "platform"
+  repo.mkdir()
+
+  def git(*args):
+    return subprocess.run(
+      ["git", "-C", str(repo), *args], text=True, capture_output=True, check=True,
+    )
+
+  git("init", "-q")
+  git("config", "user.name", "Test")
+  git("config", "user.email", "test@example.com")
+  runtime = repo / "backend" / "runtime"
+  runtime.mkdir(parents=True)
+  (runtime / "restart_ledger.py").write_text("base\n", encoding="utf-8")
+  git("add", "-A")
+  git("commit", "-q", "-m", "base")
+  base = git("rev-parse", "HEAD").stdout.strip()
+
+  git("checkout", "-q", "-b", "local")
+  (runtime / "identity_broker.py").write_text("local\n", encoding="utf-8")
+  git("add", "-A")
+  git("commit", "-q", "-m", "local")
+  current = git("rev-parse", "HEAD").stdout.strip()
+  active_tree = tmp_path / "active-tree"
+  shutil.copytree(runtime, active_tree)
+
+  git("checkout", "-q", "-b", "official", base)
+  (runtime / "identity_broker.py").write_text("official\n", encoding="utf-8")
+  git("add", "-A")
+  git("commit", "-q", "-m", "official")
+  expected = git("rev-parse", "HEAD").stdout.strip()
+  git("checkout", "-q", "-b", "reviewed")
+  (runtime / "identity_broker.py").write_text("combined\n", encoding="utf-8")
+  git("commit", "-qam", "reviewed resolution")
+  source_commit = git("rev-parse", "HEAD").stdout.strip()
+
+  def copy_active(_cid, destination):
+    shutil.copytree(active_tree, destination, dirs_exist_ok=True)
+    return host._normalize_runtime_tree(destination)
+
+  def copy_image(_image, destination):
+    shutil.copytree(active_tree, destination, dirs_exist_ok=True)
+    return host._normalize_runtime_tree(destination), {"sha": current}
+
+  monkeypatch.setattr(host, "app_container", lambda _config: ("a" * 12, "image"))
+  monkeypatch.setattr(host, "_copy_container_runtime", copy_active)
+  monkeypatch.setattr(host, "_copy_image_runtime", copy_image)
+  statuses = []
+  monkeypatch.setattr(
+    host, "write_status", lambda _config, **fields: statuses.append(fields) or fields,
+  )
+
+  resolution = host.stage_runtime_resolution(
+    config, "a" * 12, expected, source_commit,
+  )
+
+  assert resolution.paths == ("identity_broker.py",)
+  assert (resolution.directory / "identity_broker.py").read_text(
+    encoding="utf-8",
+  ) == "combined\n"
+  assert resolution.active_digest == host._runtime_snapshot(active_tree)[0]
+  assert statuses[-1]["code"] == "runtime_overlay_resolved"
+
+
+def test_staged_runtime_resolution_can_delete_a_conflicted_file(
+  tmp_path, monkeypatch,
+):
+  config, _inbox = _worker_paths(tmp_path, monkeypatch)
+  monkeypatch.setattr(host.os, "chown", lambda *_args: None)
+  repo = config["data_dir"] / "platform"
+  repo.mkdir()
+
+  def git(*args):
+    return subprocess.run(
+      ["git", "-C", str(repo), *args], text=True, capture_output=True, check=True,
+    )
+
+  git("init", "-q")
+  git("config", "user.name", "Test")
+  git("config", "user.email", "test@example.com")
+  runtime = repo / "backend" / "runtime"
+  _write_runtime_tree(runtime, "base\n")
+  (runtime / "keep.py").write_text("keep\n", encoding="utf-8")
+  git("add", "-A")
+  git("commit", "-q", "-m", "base")
+  base = git("rev-parse", "HEAD").stdout.strip()
+
+  git("checkout", "-q", "-b", "local")
+  (runtime / "identity_broker.py").write_text("local edit\n", encoding="utf-8")
+  git("commit", "-qam", "local runtime")
+  current = git("rev-parse", "HEAD").stdout.strip()
+  active_tree = tmp_path / "active-tree-delete"
+  shutil.copytree(runtime, active_tree)
+
+  git("checkout", "-q", "-b", "official", base)
+  (runtime / "identity_broker.py").unlink()
+  git("commit", "-qam", "official deletion")
+  expected = git("rev-parse", "HEAD").stdout.strip()
+  official_tree = tmp_path / "official-tree-delete"
+  shutil.copytree(runtime, official_tree)
+
+  def copy_active(_cid, destination):
+    shutil.copytree(active_tree, destination, dirs_exist_ok=True)
+    return host._normalize_runtime_tree(destination)
+
+  def copy_image(image, destination):
+    source = active_tree if image == "current-image" else official_tree
+    shutil.copytree(source, destination, dirs_exist_ok=True)
+    digest = host._normalize_runtime_tree(destination)
+    return digest, {"sha": current if image == "current-image" else expected}
+
+  monkeypatch.setattr(host, "app_container", lambda _config: ("a" * 12, "current-image"))
+  monkeypatch.setattr(host, "_copy_container_runtime", copy_active)
+  monkeypatch.setattr(host, "_copy_image_runtime", copy_image)
+  monkeypatch.setattr(host, "write_status", lambda _config, **fields: fields)
+
+  resolution = host.stage_runtime_resolution(
+    config, "a" * 12, expected, expected,
+  )
+  prepared = host.prepare_runtime_overlay(
+    "a" * 12, "current-image", "incoming-image", repo, expected,
+  )
+
+  assert resolution.paths == ("identity_broker.py",)
+  assert resolution.deleted_paths == ("identity_broker.py",)
+  assert not (resolution.directory / "identity_broker.py").exists()
+  assert not (prepared.candidate.path / "identity_broker.py").exists()
+  assert (prepared.candidate.path / "keep.py").read_text(encoding="utf-8") == "keep\n"
+
+
+def test_stage_runtime_resolution_accepts_a_reviewed_clean_followup(
+  tmp_path, monkeypatch,
+):
+  config, _inbox = _worker_paths(tmp_path, monkeypatch)
+  monkeypatch.setattr(host.os, "chown", lambda *_args: None)
+  repo = config["data_dir"] / "platform"
+  repo.mkdir()
+
+  def git(*args):
+    return subprocess.run(
+      ["git", "-C", str(repo), *args], text=True, capture_output=True, check=True,
+    )
+
+  git("init", "-q")
+  git("config", "user.name", "Test")
+  git("config", "user.email", "test@example.com")
+  runtime = repo / "backend" / "runtime"
+  _write_runtime_tree(runtime, "official\n")
+  git("add", "-A")
+  git("commit", "-q", "-m", "official")
+  expected = git("rev-parse", "HEAD").stdout.strip()
+  official_tree = tmp_path / "official-tree"
+  shutil.copytree(runtime, official_tree)
+
+  (runtime / "identity_broker.py").write_text("reviewed-v2\n", encoding="utf-8")
+  git("commit", "-qam", "reviewed followup")
+  source_commit = git("rev-parse", "HEAD").stdout.strip()
+  active_tree = tmp_path / "active-tree"
+  _write_runtime_tree(active_tree, "active-v1\n")
+
+  def copy_active(_cid, destination):
+    shutil.copytree(active_tree, destination, dirs_exist_ok=True)
+    return host._normalize_runtime_tree(destination)
+
+  def copy_image(_image, destination):
+    shutil.copytree(official_tree, destination, dirs_exist_ok=True)
+    return host._normalize_runtime_tree(destination), {"sha": expected}
+
+  monkeypatch.setattr(host, "app_container", lambda _config: ("a" * 12, "image"))
+  monkeypatch.setattr(host, "_copy_container_runtime", copy_active)
+  monkeypatch.setattr(host, "_copy_image_runtime", copy_image)
+  monkeypatch.setattr(host, "write_status", lambda _config, **fields: fields)
+
+  resolution = host.stage_runtime_resolution(
+    config, "a" * 12, expected, source_commit,
+  )
+
+  assert resolution.paths == ("identity_broker.py",)
+  assert (resolution.directory / "identity_broker.py").read_text(
+    encoding="utf-8",
+  ) == "reviewed-v2\n"
+
+
+def test_controller_status_advertises_active_runtime_support(
+  tmp_path, monkeypatch,
+):
+  config, _inbox = _worker_paths(tmp_path, monkeypatch)
+
+  status = host.write_status(config, state="idle")
+
+  assert status["handoff"] == "external-cutover-v1"
+  assert status["runtime_overlay"] == "active-runtime-v1"
+
+
+def test_runtime_resolution_receipt_is_exact_target_and_content_bound(
+  tmp_path, monkeypatch,
+):
+  _config, _inbox = _worker_paths(tmp_path, monkeypatch)
+  monkeypatch.setattr(host.os, "chown", lambda *_args: None)
+  directory = host.RUNTIME_RESOLUTIONS / f"resolution-{'a' * 32}"
+  _write_runtime_tree(directory, "combined\n")
+  digest = host._normalize_runtime_tree(directory)
+  host._atomic_json(host.RUNTIME_RESOLUTION, {
+    "version": 1,
+    "expected_sha": "b" * 40,
+    "active_digest": "c" * 64,
+    "source_commit": "d" * 40,
+    "paths": ["identity_broker.py"],
+    "digest": digest,
+    "directory": directory.name,
+  })
+
+  resolution = host._read_runtime_resolution("b" * 40, "c" * 64)
+
+  assert resolution is not None
+  assert resolution.paths == ("identity_broker.py",)
+  assert host._read_runtime_resolution("e" * 40, "c" * 64) is None
+  resolved_file = directory / "identity_broker.py"
+  resolved_file.chmod(0o644)
+  resolved_file.write_text("changed\n", encoding="utf-8")
+  with pytest.raises(host.RuntimeOverlayError, match="invalid"):
+    host._read_runtime_resolution("b" * 40, "c" * 64)
+
+
+def test_compose_mounts_the_selected_runtime_generation(tmp_path, monkeypatch):
+  config, _inbox = _worker_paths(tmp_path, monkeypatch)
+  selected = host.active_runtime_generation()
+  calls = []
+
+  def execute(args, **kwargs):
+    calls.append((args, kwargs))
+    return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+  monkeypatch.setattr(host.subprocess, "run", execute)
+
+  host.compose(config, "ps", runtime=selected)
+
+  _args, kwargs = calls[0]
+  assert kwargs["env"]["MOBIUS_RUNTIME_OVERLAY"] == str(selected.path)
 
 
 def test_no_change_does_not_drain_active_chats(tmp_path, monkeypatch):
@@ -120,6 +662,7 @@ def test_no_change_does_not_drain_active_chats(tmp_path, monkeypatch):
     "amd64" if "Architecture" in template else "same"
   ))
   monkeypatch.setattr(host, "retain_images", lambda *_args: None)
+  monkeypatch.setattr(host, "verify_served_generation", lambda *_args: None)
   monkeypatch.setattr(
     host, "request_drain",
     lambda *_args: (_ for _ in ()).throw(AssertionError("no-change must not drain")),
@@ -131,6 +674,49 @@ def test_no_change_does_not_drain_active_chats(tmp_path, monkeypatch):
 
   assert host.run() == 0
   assert statuses[-1]["state"] == "no_change"
+
+
+def test_same_image_applies_a_staged_runtime_followup(tmp_path, monkeypatch):
+  _config, inbox = _worker_paths(tmp_path, monkeypatch)
+  expected = "c" * 40
+  (inbox / "request.json").write_text(
+    f'{{"version":1,"expected_sha":"{expected}"}}', encoding="utf-8",
+  )
+  monkeypatch.setattr(host, "app_container", lambda _config: ("cid", "same"))
+  monkeypatch.setattr(host, "require_pull_space", lambda _image: None)
+  monkeypatch.setattr(host.subprocess, "run", lambda *_args, **_kwargs: None)
+  monkeypatch.setattr(host, "inspect_image", lambda _image, template: (
+    expected if "revision" in template else
+    host.IMAGE_SOURCE if "source" in template else
+    "amd64" if "Architecture" in template else "same"
+  ))
+  monkeypatch.setattr(host, "verify_served_generation", lambda *_args: None)
+  monkeypatch.setattr(host, "_read_runtime_resolution", lambda *_args: object())
+  monkeypatch.setattr(host, "_consume_runtime_resolution", lambda *_args: None)
+  prepared = _prepared_runtime()
+  prepared_calls = []
+  monkeypatch.setattr(
+    host, "prepare_runtime_overlay",
+    lambda *_args: prepared_calls.append(True) or prepared,
+  )
+  monkeypatch.setattr(host, "request_drain", lambda *_args: None)
+  compose_calls = []
+  monkeypatch.setattr(
+    host, "compose",
+    lambda *_args, **kwargs: compose_calls.append(kwargs.get("runtime")),
+  )
+  monkeypatch.setattr(host, "wait_healthy", lambda *_args: True)
+  monkeypatch.setattr(host, "restart_ledger", lambda *_args, **_kwargs: True)
+  monkeypatch.setattr(host, "retain_images", lambda *_args: None)
+  statuses = []
+  monkeypatch.setattr(
+    host, "write_status", lambda _config, **fields: statuses.append(fields) or fields,
+  )
+
+  assert host.run() == 0
+  assert prepared_calls == [True]
+  assert compose_calls == [prepared.candidate]
+  assert statuses[-1]["state"] == "succeeded"
 
 
 def test_request_is_claimed_on_the_control_filesystem(tmp_path, monkeypatch):
@@ -159,6 +745,7 @@ def test_request_is_claimed_on_the_control_filesystem(tmp_path, monkeypatch):
     "amd64" if "Architecture" in template else "same"
   ))
   monkeypatch.setattr(host, "retain_images", lambda *_args: None)
+  monkeypatch.setattr(host, "verify_served_generation", lambda *_args: None)
   monkeypatch.setattr(host, "write_status", lambda _config, **fields: fields)
 
   assert host.run() == 0
@@ -197,6 +784,7 @@ def test_worker_locks_before_exposing_claim_to_reconcile(tmp_path, monkeypatch):
     "amd64" if "Architecture" in template else "same"
   ))
   monkeypatch.setattr(host, "retain_images", lambda *_args: None)
+  monkeypatch.setattr(host, "verify_served_generation", lambda *_args: None)
   monkeypatch.setattr(host, "write_status", lambda _config, **fields: fields)
 
   assert host.run() == 0
@@ -229,6 +817,7 @@ def test_worker_waits_for_boot_reconcile_before_claiming(tmp_path, monkeypatch):
     "amd64" if "Architecture" in template else "same"
   ))
   monkeypatch.setattr(host, "retain_images", lambda *_args: None)
+  monkeypatch.setattr(host, "verify_served_generation", lambda *_args: None)
   monkeypatch.setattr(host, "write_status", lambda _config, **fields: fields)
 
   assert host.run() == 0
@@ -255,6 +844,43 @@ def test_failed_request_claim_is_terminal_and_retryable(tmp_path, monkeypatch):
   assert not request.exists()
 
 
+def test_runtime_overlay_conflict_stops_before_chat_drain(tmp_path, monkeypatch):
+  _config, inbox = _worker_paths(tmp_path, monkeypatch)
+  expected = "8" * 40
+  (inbox / "request.json").write_text(
+    f'{{"version":1,"expected_sha":"{expected}"}}', encoding="utf-8",
+  )
+  monkeypatch.setattr(host, "app_container", lambda _config: ("cid", "old"))
+  monkeypatch.setattr(host, "require_pull_space", lambda _image: None)
+  monkeypatch.setattr(host.subprocess, "run", lambda *_args, **_kwargs: None)
+  monkeypatch.setattr(host, "inspect_image", lambda _image, template: (
+    expected if "revision" in template else
+    host.IMAGE_SOURCE if "source" in template else
+    "amd64" if "Architecture" in template else "new"
+  ))
+  monkeypatch.setattr(
+    host,
+    "prepare_runtime_overlay",
+    lambda *_args: (_ for _ in ()).throw(
+      host.RuntimeOverlayConflict(["identity_broker.py"]),
+    ),
+  )
+  monkeypatch.setattr(
+    host, "request_drain",
+    lambda *_args: (_ for _ in ()).throw(
+      AssertionError("a runtime conflict must stop before chat drain"),
+    ),
+  )
+  statuses = []
+  monkeypatch.setattr(
+    host, "write_status", lambda _config, **fields: statuses.append(fields) or fields,
+  )
+
+  assert host.run() == 1
+  assert statuses[-1]["code"] == "runtime_overlay_conflict"
+  assert "identity_broker.py" in statuses[-1]["message"]
+
+
 def test_replacement_drains_then_rolls_back_after_cutover_error(tmp_path, monkeypatch):
   config, inbox = _worker_paths(tmp_path, monkeypatch)
   expected = "d" * 40
@@ -269,6 +895,8 @@ def test_replacement_drains_then_rolls_back_after_cutover_error(tmp_path, monkey
     host.IMAGE_SOURCE if "source" in template else
     "amd64" if "Architecture" in template else "new"
   ))
+  prepared = _prepared_runtime()
+  monkeypatch.setattr(host, "prepare_runtime_overlay", lambda *_args: prepared)
   order = []
   ready = inbox / "ready"
   monkeypatch.setattr(
@@ -314,10 +942,13 @@ def test_success_reports_when_chat_handoff_receipt_cannot_be_retired(
     host.IMAGE_SOURCE if "source" in template else
     "amd64" if "Architecture" in template else "new"
   ))
+  prepared = _prepared_runtime()
+  monkeypatch.setattr(host, "prepare_runtime_overlay", lambda *_args: prepared)
   monkeypatch.setattr(host, "request_drain", lambda *_args: None)
   monkeypatch.setattr(host, "compose", lambda *_args, **_kwargs: None)
   monkeypatch.setattr(host, "wait_healthy", lambda *_args, **_kwargs: True)
   monkeypatch.setattr(host, "retain_images", lambda *_args: None)
+  monkeypatch.setattr(host, "verify_served_generation", lambda *_args: None)
   monkeypatch.setattr(
     host, "restart_ledger",
     lambda _config, _cid, command, _operation, **_kwargs:
@@ -396,6 +1027,22 @@ def test_reconcile_cleans_claim_abandoned_before_first_status(tmp_path, monkeypa
   assert host.reconcile() == 0
   assert written == [{}]
   assert not abandoned.exists()
+
+
+def test_reconcile_refreshes_an_idle_controller_capability_receipt(
+  tmp_path, monkeypatch,
+):
+  _config, _inbox = _worker_paths(tmp_path, monkeypatch)
+  host.STATUS.write_text(
+    '{"state":"idle","handoff":"external-cutover-v1"}', encoding="utf-8",
+  )
+  written = []
+  monkeypatch.setattr(
+    host, "write_status", lambda _config, **fields: written.append(fields) or fields,
+  )
+
+  assert host.reconcile() == 0
+  assert written == [{}]
 
 
 def test_drain_requires_root_open_prepare_accept_order(tmp_path, monkeypatch):

--- a/backend/tests/test_rebuild_topology.py
+++ b/backend/tests/test_rebuild_topology.py
@@ -44,11 +44,50 @@ def test_shared_edge_preserves_overlay_and_external_network(tmp_path):
   }) == ["edge-mobius", "mobius_default"]
 
 
+def test_topology_accepts_a_compose_directory_inside_the_checkout(tmp_path):
+  deploy = tmp_path / "deploy"
+  deploy.mkdir()
+  compose = deploy / "docker-compose.runtime.yml"
+  compose.write_text("services: {}\n", encoding="utf-8")
+
+  assert topology.compose_files(tmp_path, deploy, str(compose)) == [compose]
+
+
 def test_topology_refuses_a_different_checkout(tmp_path):
+  trusted = tmp_path / "trusted"
+  trusted.mkdir()
   other = tmp_path / "other"
   other.mkdir()
   compose = other / "docker-compose.yml"
   compose.write_text("services: {}\n", encoding="utf-8")
 
   with pytest.raises(ValueError, match="different checkout"):
-    topology.compose_files(tmp_path, other, str(compose))
+    topology.compose_files(trusted, other, str(compose))
+
+
+def test_environment_files_accept_absolute_regular_files(tmp_path):
+  first = tmp_path / "first.env"
+  second = tmp_path / "second.env"
+  first.write_text("FIRST=1\n", encoding="utf-8")
+  second.write_text("SECOND=2\n", encoding="utf-8")
+
+  assert topology.environment_files(f"{first},{second}") == [first, second]
+  assert topology.environment_files("") == []
+
+
+def test_environment_files_reject_relative_paths(tmp_path, monkeypatch):
+  monkeypatch.chdir(tmp_path)
+  Path("relative.env").write_text("VALUE=1\n", encoding="utf-8")
+
+  with pytest.raises(ValueError, match="absolute paths"):
+    topology.environment_files("relative.env")
+
+
+def test_environment_files_reject_symlinks(tmp_path):
+  target = tmp_path / "target.env"
+  target.write_text("VALUE=1\n", encoding="utf-8")
+  linked = tmp_path / "linked.env"
+  linked.symlink_to(target)
+
+  with pytest.raises(ValueError, match="symlinks"):
+    topology.environment_files(str(linked))

--- a/scripts/install-rebuild-helper.sh
+++ b/scripts/install-rebuild-helper.sh
@@ -37,18 +37,45 @@ mapfile -t CANDIDATES < <(docker ps -q \
 [[ ${#CANDIDATES[@]} -eq 1 ]] \
   || { echo "Expected exactly one running app for Compose project '$PROJECT'." >&2; exit 1; }
 CID=${CANDIDATES[0]}
+CURRENT_IMAGE=$(docker inspect "$CID" --format '{{.Config.Image}}')
+[[ -n $CURRENT_IMAGE && $CURRENT_IMAGE != *$'\n'* ]] \
+  || { echo "Could not resolve the running app image." >&2; exit 1; }
 readarray -t LABELS < <(docker inspect "$CID" --format \
-  '{{index .Config.Labels "com.docker.compose.project"}}{{println}}{{index .Config.Labels "com.docker.compose.project.working_dir"}}{{println}}{{index .Config.Labels "com.docker.compose.project.config_files"}}')
+  '{{index .Config.Labels "com.docker.compose.project"}}{{println}}{{index .Config.Labels "com.docker.compose.project.working_dir"}}{{println}}{{index .Config.Labels "com.docker.compose.project.config_files"}}{{println}}{{index .Config.Labels "com.docker.compose.project.environment_file"}}')
 [[ ${LABELS[0]:-} == "$PROJECT" ]] || { echo "Compose project label mismatch." >&2; exit 1; }
 WORKING_DIR=${LABELS[1]:-}
-FILES_OUTPUT=$(python3 "$ROOT/scripts/rebuild-topology.py" compose-files \
-  "$ROOT" "$WORKING_DIR" "${LABELS[2]:-}")
-mapfile -t FILES <<<"$FILES_OUTPUT"
-for file in "${FILES[@]}"; do
-  relative=${file#"$ROOT/"}
-  git -C "$ROOT" ls-files --error-unmatch "$relative" >/dev/null \
-    || { echo "Compose input is not tracked: $relative" >&2; exit 1; }
-done
+FROZEN_SOURCE=
+FILES=()
+ENV_FILES=()
+if [[ $WORKING_DIR == /etc/mobius-rebuild \
+      && ${LABELS[2]:-} == "/etc/mobius-rebuild/compose.yml,/etc/mobius-rebuild/image.override.yml" ]]; then
+  # A container already recreated by this helper records the frozen root-owned
+  # files in its Compose labels rather than the original checkout. Preserve the
+  # proven resolved topology while upgrading only the reviewed controller and
+  # its narrow image/runtime override.
+  for frozen in /etc/mobius-rebuild/config.json \
+                /etc/mobius-rebuild/compose.yml \
+                /etc/mobius-rebuild/image.override.yml; do
+    [[ -f $frozen && ! -L $frozen && $(stat -c '%u' "$frozen") == 0 \
+       && $((8#$(stat -c '%a' "$frozen") & 8#022)) == 0 ]] \
+      || { echo "Existing replacement topology is not root-controlled." >&2; exit 1; }
+  done
+  FROZEN_SOURCE=/etc/mobius-rebuild/compose.yml
+else
+  FILES_OUTPUT=$(python3 "$ROOT/scripts/rebuild-topology.py" compose-files \
+    "$ROOT" "$WORKING_DIR" "${LABELS[2]:-}")
+  mapfile -t FILES <<<"$FILES_OUTPUT"
+  ENV_FILES_OUTPUT=$(python3 "$ROOT/scripts/rebuild-topology.py" \
+    environment-files "${LABELS[3]:-}")
+  if [[ -n $ENV_FILES_OUTPUT ]]; then
+    mapfile -t ENV_FILES <<<"$ENV_FILES_OUTPUT"
+  fi
+  for file in "${FILES[@]}"; do
+    relative=${file#"$ROOT/"}
+    git -C "$ROOT" ls-files --error-unmatch "$relative" >/dev/null \
+      || { echo "Compose input is not tracked: $relative" >&2; exit 1; }
+  done
+fi
 git -C "$ROOT" diff --quiet HEAD -- \
   scripts/install-rebuild-helper.sh scripts/mobius-rebuild-host.py \
   scripts/rebuild-topology.py backend/scripts/prepare-container-replacement.py \
@@ -62,7 +89,9 @@ git -C "$ROOT" diff --quiet HEAD -- \
   "${FILES[@]#"$ROOT/"}") ]] \
   || { echo "The selected helper and Compose inputs must be clean." >&2; exit 1; }
 
-ARGS=(-p "$PROJECT")
+ARGS=()
+for file in "${ENV_FILES[@]}"; do ARGS+=(--env-file "$file"); done
+ARGS+=(-p "$PROJECT")
 for file in "${FILES[@]}"; do ARGS+=(-f "$file"); done
 DATA_SOURCE=$(docker inspect "$CID" --format \
   '{{range .Mounts}}{{if eq .Destination "/data"}}{{.Source}}{{end}}{{end}}')
@@ -79,7 +108,13 @@ RUNNING_NETWORKS=$(docker inspect "$CID" --format \
   | sed '/^$/d' | sort)
 RESOLVED=$(mktemp)
 trap 'rm -f "$RESOLVED"' EXIT
-docker compose "${ARGS[@]}" config --format json >"$RESOLVED"
+if [[ -n $FROZEN_SOURCE ]]; then
+  MOBIUS_IMAGE="$CURRENT_IMAGE" docker compose \
+    -p "$PROJECT" -f "$FROZEN_SOURCE" config --format json >"$RESOLVED"
+else
+  MOBIUS_IMAGE="$CURRENT_IMAGE" docker compose \
+    "${ARGS[@]}" config --format json >"$RESOLVED"
+fi
 EXPECTED_NETWORKS=$(python3 "$ROOT/scripts/rebuild-topology.py" \
   expected-networks "$RESOLVED")
 [[ $RUNNING_NETWORKS == "$EXPECTED_NETWORKS" ]] \
@@ -90,14 +125,25 @@ umask 077
 install -d -m 0700 /etc/mobius-rebuild /var/lib/mobius-rebuild
 install -D -m 0755 "$ROOT/scripts/mobius-rebuild-host.py" \
   /usr/local/libexec/mobius-rebuild-host
+/usr/local/libexec/mobius-rebuild-host bootstrap-runtime "$CID"
 SNAPSHOT=$(mktemp /etc/mobius-rebuild/compose.XXXXXX)
-docker compose "${ARGS[@]}" config >"$SNAPSHOT"
+if [[ -n $FROZEN_SOURCE ]]; then
+  cp "$FROZEN_SOURCE" "$SNAPSHOT"
+else
+  MOBIUS_IMAGE="$CURRENT_IMAGE" docker compose \
+    "${ARGS[@]}" config >"$SNAPSHOT"
+fi
 chmod 0600 "$SNAPSHOT"
 mv -f "$SNAPSHOT" /etc/mobius-rebuild/compose.yml
 cat >/etc/mobius-rebuild/image.override.yml <<'EOF'
 services:
   app:
     image: ${MOBIUS_IMAGE:?MOBIUS_IMAGE is required}
+    volumes:
+      - type: bind
+        source: ${MOBIUS_RUNTIME_OVERLAY:?MOBIUS_RUNTIME_OVERLAY is required}
+        target: /app/runtime
+        read_only: true
 EOF
 chmod 0600 /etc/mobius-rebuild/image.override.yml
 python3 - "$PROJECT" "$DATA_SOURCE" <<'PY'
@@ -159,5 +205,5 @@ systemctl enable mobius-rebuild-reconcile.service
 systemctl enable --now mobius-rebuild.path
 
 echo "Container replacement installed for Compose project '$PROJECT'."
-echo "Topology: ${FILES[*]}"
+echo "Topology: ${FILES[*]:-$FROZEN_SOURCE}"
 echo "Rerun this installer after an intentional Compose topology change."

--- a/scripts/mobius-rebuild-host.py
+++ b/scripts/mobius-rebuild-host.py
@@ -4,17 +4,20 @@
 from __future__ import annotations
 
 import fcntl
+import hashlib
 import json
 import os
 import re
 import shutil
 import subprocess
 import sys
+import tarfile
 import tempfile
 import time
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import NamedTuple
 
 STATE_DIR = Path("/var/lib/mobius-rebuild")
 CONFIG = Path("/etc/mobius-rebuild/config.json")
@@ -23,13 +26,70 @@ OVERRIDE = Path("/etc/mobius-rebuild/image.override.yml")
 STATUS = STATE_DIR / "status.json"
 LOCK = STATE_DIR / "replace.lock"
 IMAGES = STATE_DIR / "images.json"
+RUNTIME_GENERATIONS = STATE_DIR / "runtime-generations"
+RUNTIME_STATE = STATE_DIR / "runtime.json"
+RUNTIME_RESOLUTIONS = STATE_DIR / "runtime-resolutions"
+RUNTIME_RESOLUTION = STATE_DIR / "runtime-resolution.json"
 SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 OPERATION_RE = re.compile(r"^[0-9a-f]{32}$")
+CONTAINER_RE = re.compile(r"^[0-9a-f]{12,64}$")
+GENERATION_RE = re.compile(r"^runtime-[0-9a-f]{16}-[0-9a-f]{8}$")
+RESOLUTION_RE = re.compile(r"^resolution-[0-9a-f]{32}$")
 IMAGE = "ghcr.io/mobius-os/mobius"
 IMAGE_SOURCE = "https://github.com/mobius-os/mobius"
 ROLLBACK_TAG = f"{IMAGE}:mobius-rebuild-last-good"
 ACTIVE_STATES = {"queued", "preparing", "replacing", "verifying"}
 HANDOFF_VERSION = "external-cutover-v1"
+RUNTIME_OVERLAY_VERSION = "active-runtime-v1"
+MAX_RUNTIME_ARCHIVE_BYTES = 32 * 1024 * 1024
+
+
+class RuntimeGeneration(NamedTuple):
+    """One immutable root-owned protected-runtime generation."""
+
+    name: str
+    path: Path
+    digest: str
+
+
+class PreparedRuntime(NamedTuple):
+    """The exact rollback and candidate generations for one replacement."""
+
+    previous: RuntimeGeneration
+    candidate: RuntimeGeneration
+    carried_paths: tuple[str, ...]
+    prior_active: RuntimeGeneration
+    prior_rollback: RuntimeGeneration | None
+
+
+class RuntimeResolution(NamedTuple):
+    """One root-approved conflict resolution bound to an active tree + target."""
+
+    expected_sha: str
+    active_digest: str
+    source_commit: str
+    paths: tuple[str, ...]
+    deleted_paths: tuple[str, ...]
+    digest: str
+    directory: Path
+
+
+class RuntimeOverlayError(RuntimeError):
+    code = "runtime_overlay_failed"
+
+
+class RuntimeOverlayConflict(RuntimeOverlayError):
+    code = "runtime_overlay_conflict"
+
+    def __init__(self, paths: list[str]) -> None:
+        self.paths = tuple(paths)
+        visible = ", ".join(paths[:5])
+        if len(paths) > 5:
+            visible += f" and {len(paths) - 5} more"
+        super().__init__(
+            "The active local runtime conflicts with the official update: "
+            + visible
+        )
 
 
 def now() -> str:
@@ -92,11 +152,573 @@ def config() -> dict:
     return validate_config(read_json(CONFIG))
 
 
+def _runtime_snapshot(root: Path) -> tuple[str, dict[str, str]]:
+    """Hash one regular-file runtime tree with the app's provenance contract."""
+    if not root.is_dir() or root.is_symlink():
+        raise RuntimeOverlayError("the protected runtime tree is unavailable")
+    files: dict[str, str] = {}
+    for path in sorted(root.rglob("*")):
+        relative = path.relative_to(root)
+        if "__pycache__" in relative.parts or relative.suffix in {".pyc", ".pyo"}:
+            continue
+        name = relative.as_posix()
+        if path.is_symlink() or (not path.is_dir() and not path.is_file()):
+            raise RuntimeOverlayError(
+                f"the protected runtime contains an unsafe path: {name}"
+            )
+        if path.is_file():
+            files[name] = hashlib.sha256(path.read_bytes()).hexdigest()
+    tree = hashlib.sha256()
+    for name, digest in sorted(files.items()):
+        tree.update(name.encode("utf-8"))
+        tree.update(b"\0")
+        tree.update(digest.encode("ascii"))
+        tree.update(b"\n")
+    return tree.hexdigest(), files
+
+
+def _runtime_resolution_digest(
+    root: Path, deleted_paths: tuple[str, ...],
+) -> tuple[str, dict[str, str]]:
+    """Bind replacement bytes and reviewed deletions into one receipt digest."""
+    tree_digest, files = _runtime_snapshot(root)
+    digest = hashlib.sha256()
+    digest.update(tree_digest.encode("ascii"))
+    digest.update(b"\n")
+    for name in deleted_paths:
+        digest.update(b"delete\0")
+        digest.update(name.encode("utf-8"))
+        digest.update(b"\n")
+    return digest.hexdigest(), files
+
+
+def _normalize_runtime_tree(root: Path) -> str:
+    """Remove inert bytecode and freeze a copied tree as root-owned read-only."""
+    if not root.is_dir() or root.is_symlink():
+        raise RuntimeOverlayError("the protected runtime tree is unavailable")
+    for path in sorted(root.rglob("*"), reverse=True):
+        relative = path.relative_to(root)
+        if path.is_symlink():
+            raise RuntimeOverlayError(
+                f"the protected runtime contains an unsafe path: {relative.as_posix()}"
+            )
+        if path.is_dir() and path.name == "__pycache__":
+            shutil.rmtree(path)
+            continue
+        if path.is_file() and path.suffix in {".pyc", ".pyo"}:
+            path.unlink()
+            continue
+        if not path.is_dir() and not path.is_file():
+            raise RuntimeOverlayError(
+                f"the protected runtime contains an unsafe path: {relative.as_posix()}"
+            )
+    digest, _files = _runtime_snapshot(root)
+    for path in sorted(root.rglob("*")):
+        if path.is_dir():
+            os.chmod(path, 0o755)
+        else:
+            executable = bool(path.stat().st_mode & 0o111)
+            os.chmod(path, 0o555 if executable else 0o444)
+        os.chown(path, 0, 0)
+    os.chmod(root, 0o755)
+    os.chown(root, 0, 0)
+    return digest
+
+
+def _copy_container_runtime(cid: str, destination: Path) -> str:
+    destination.mkdir(mode=0o700, parents=True)
+    subprocess.run(
+        ["docker", "cp", f"{cid}:/app/runtime/.", str(destination)],
+        text=True, capture_output=True, check=True,
+    )
+    return _normalize_runtime_tree(destination)
+
+
+def _copy_image_runtime(image: str, destination: Path) -> tuple[str, dict]:
+    """Copy the raw image tree, bypassing any Compose runtime mount."""
+    created = subprocess.run(
+        ["docker", "create", image], text=True, capture_output=True, check=True,
+    ).stdout.strip()
+    if not CONTAINER_RE.fullmatch(created):
+        raise RuntimeOverlayError("Docker returned an invalid image container id")
+    build_info: dict = {}
+    try:
+        digest = _copy_container_runtime(created, destination)
+        info_path = destination.parent / f".{destination.name}-build-info.json"
+        copied = subprocess.run(
+            ["docker", "cp", f"{created}:/app/build-info.json", str(info_path)],
+            text=True, capture_output=True,
+        )
+        if copied.returncode == 0:
+            try:
+                value = read_json(info_path)
+                build_info = value
+            finally:
+                info_path.unlink(missing_ok=True)
+        return digest, build_info
+    finally:
+        subprocess.run(
+            ["docker", "rm", "-f", created], text=True, capture_output=True,
+        )
+
+
+def _extract_git_runtime(repo: Path, revision: str, destination: Path) -> str:
+    """Extract one content-addressed runtime tree without trusting a branch."""
+    if repo.is_symlink() or not (repo / ".git").is_dir() or not SHA_RE.fullmatch(
+        revision
+    ):
+        raise RuntimeOverlayError("the platform runtime provenance is unavailable")
+    with tempfile.TemporaryFile() as payload:
+        result = subprocess.run(
+            ["git", "-c", f"safe.directory={repo}",
+             "-c", "core.hooksPath=/dev/null", "-C", str(repo), "archive",
+             "--format=tar", revision, "backend/runtime"],
+            stdout=payload, stderr=subprocess.PIPE,
+        )
+        if result.returncode != 0:
+            raise RuntimeOverlayError(
+                "the platform checkout does not contain the required runtime provenance"
+            )
+        if payload.tell() > MAX_RUNTIME_ARCHIVE_BYTES:
+            raise RuntimeOverlayError("the protected runtime archive is unexpectedly large")
+        payload.seek(0)
+        destination.mkdir(mode=0o700, parents=True)
+        prefix = "backend/runtime/"
+        with tarfile.open(fileobj=payload, mode="r:") as archive:
+            for member in archive.getmembers():
+                if member.name in {"backend", "backend/runtime"}:
+                    continue
+                if not member.name.startswith(prefix):
+                    raise RuntimeOverlayError("the runtime base archive is invalid")
+                relative = member.name[len(prefix):]
+                if (
+                    not relative
+                    or relative.startswith("/")
+                    or ".." in Path(relative).parts
+                ):
+                    raise RuntimeOverlayError("the runtime base archive is invalid")
+                target = destination / relative
+                if member.isdir():
+                    target.mkdir(mode=0o700, parents=True, exist_ok=True)
+                    continue
+                if not member.isfile():
+                    raise RuntimeOverlayError("the runtime base archive is invalid")
+                target.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+                source = archive.extractfile(member)
+                if source is None:
+                    raise RuntimeOverlayError("the runtime base archive is invalid")
+                target.write_bytes(source.read())
+                os.chmod(target, member.mode & 0o777)
+    return _normalize_runtime_tree(destination)
+
+
+def _git(repo: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess:
+    env = os.environ.copy()
+    for name in (
+        "GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_OBJECT_DIRECTORY",
+        "GIT_COMMON_DIR", "GIT_NAMESPACE",
+    ):
+        env.pop(name, None)
+    return subprocess.run(
+        ["git", "-c", f"safe.directory={repo}",
+         "-c", "core.hooksPath=/dev/null", "-C", str(repo), *args],
+        text=True, capture_output=True, check=check, env=env,
+    )
+
+
+def _replace_checkout(repo: Path, source: Path) -> None:
+    for child in repo.iterdir():
+        if child.name == ".git":
+            continue
+        if child.is_dir() and not child.is_symlink():
+            shutil.rmtree(child)
+        else:
+            child.unlink()
+    for child in source.iterdir():
+        target = repo / child.name
+        if child.is_dir():
+            shutil.copytree(child, target)
+        else:
+            shutil.copy2(child, target)
+    for path in repo.rglob("*"):
+        if ".git" not in path.parts:
+            os.chmod(path, path.stat().st_mode | 0o200)
+
+
+def _apply_runtime_resolution(repo: Path, resolution: RuntimeResolution) -> None:
+    """Materialize one verified replacement/deletion outcome into the merge."""
+    deleted = set(resolution.deleted_paths)
+    for name in resolution.paths:
+        target = repo / name
+        if target.is_dir() and not target.is_symlink():
+            shutil.rmtree(target)
+        elif target.exists() or target.is_symlink():
+            target.unlink()
+        if name not in deleted:
+            source = resolution.directory / name
+            target.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+            shutil.copy2(source, target)
+
+
+def _merge_runtime_trees(
+    base: Path, local: Path, incoming: Path, result: Path,
+    resolution: RuntimeResolution | None = None,
+) -> tuple[str, tuple[str, ...]]:
+    """Three-way merge an already-active runtime onto an official runtime."""
+    repo = result.parent / "merge-repo"
+    repo.mkdir(mode=0o700)
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.name", "Möbius Runtime Controller")
+    _git(repo, "config", "user.email", "runtime-controller@localhost")
+    _replace_checkout(repo, base)
+    _git(repo, "add", "-A", "-f")
+    _git(repo, "commit", "-q", "--allow-empty", "-m", "runtime base")
+    base_sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
+
+    _git(repo, "checkout", "-q", "-b", "active")
+    _replace_checkout(repo, local)
+    _git(repo, "add", "-A", "-f")
+    _git(repo, "commit", "-q", "--allow-empty", "-m", "active local runtime")
+    active_sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
+    carried = tuple(
+        line for line in _git(
+            repo, "diff", "--name-only", base_sha, active_sha,
+        ).stdout.splitlines() if line
+    )
+
+    _git(repo, "checkout", "-q", "-b", "incoming", base_sha)
+    _replace_checkout(repo, incoming)
+    _git(repo, "add", "-A", "-f")
+    _git(repo, "commit", "-q", "--allow-empty", "-m", "incoming official runtime")
+    merged = _git(
+        repo, "merge", "--no-commit", "--no-ff", "active", check=False,
+    )
+    resolution_applied = False
+    if merged.returncode:
+        conflicts = sorted(
+            line for line in _git(
+                repo, "diff", "--name-only", "--diff-filter=U", check=False,
+            ).stdout.splitlines() if line
+        )
+        if conflicts:
+            if resolution is None or tuple(conflicts) != resolution.paths:
+                raise RuntimeOverlayConflict(conflicts)
+            _apply_runtime_resolution(repo, resolution)
+            _git(repo, "add", "-A", "-f")
+            resolution_applied = True
+            unresolved = [
+                line for line in _git(
+                    repo, "diff", "--name-only", "--diff-filter=U", check=False,
+                ).stdout.splitlines() if line
+            ]
+            if unresolved:
+                raise RuntimeOverlayConflict(unresolved)
+            carried = tuple(sorted({*carried, *resolution.paths}))
+        else:
+            raise RuntimeOverlayError(
+                (merged.stderr or merged.stdout or "runtime merge failed").strip()[:300]
+            )
+    if resolution is not None and not resolution_applied:
+        _apply_runtime_resolution(repo, resolution)
+        _git(repo, "add", "-A", "-f")
+        carried = tuple(sorted({*carried, *resolution.paths}))
+    result.mkdir(mode=0o700)
+    for child in repo.iterdir():
+        if child.name == ".git":
+            continue
+        target = result / child.name
+        if child.is_dir():
+            shutil.copytree(child, target)
+        else:
+            shutil.copy2(child, target)
+    return _normalize_runtime_tree(result), carried
+
+
+def _runtime_generation(value: dict) -> RuntimeGeneration:
+    if not isinstance(value, dict) or set(value) != {"name", "digest"}:
+        raise RuntimeOverlayError("the active runtime receipt is invalid")
+    name = str(value["name"])
+    digest = str(value["digest"])
+    if not GENERATION_RE.fullmatch(name) or not re.fullmatch(r"[0-9a-f]{64}", digest):
+        raise RuntimeOverlayError("the active runtime receipt is invalid")
+    path = RUNTIME_GENERATIONS / name
+    actual, _files = _runtime_snapshot(path)
+    if actual != digest:
+        raise RuntimeOverlayError("the active runtime generation was modified")
+    return RuntimeGeneration(name=name, path=path, digest=digest)
+
+
+def _runtime_record(generation: RuntimeGeneration | None) -> dict | None:
+    if generation is None:
+        return None
+    return {"name": generation.name, "digest": generation.digest}
+
+
+def _read_runtime_state() -> tuple[RuntimeGeneration, RuntimeGeneration | None]:
+    try:
+        value = read_json(RUNTIME_STATE)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        raise RuntimeOverlayError("the active runtime receipt is unavailable") from exc
+    if value.get("version") != 1 or set(value) != {"version", "active", "rollback"}:
+        raise RuntimeOverlayError("the active runtime receipt is invalid")
+    active = _runtime_generation(value["active"])
+    rollback_value = value["rollback"]
+    rollback = _runtime_generation(rollback_value) if rollback_value else None
+    return active, rollback
+
+
+def active_runtime_generation() -> RuntimeGeneration:
+    return _read_runtime_state()[0]
+
+
+def _safe_runtime_path(value: object) -> str:
+    path = Path(str(value))
+    if (
+        path.is_absolute()
+        or not path.parts
+        or ".." in path.parts
+        or any(part in {"", ".git"} for part in path.parts)
+    ):
+        raise RuntimeOverlayError("the staged runtime resolution is invalid")
+    return path.as_posix()
+
+
+def _read_runtime_resolution(
+    expected_sha: str, active_digest: str,
+) -> RuntimeResolution | None:
+    try:
+        value = read_json(RUNTIME_RESOLUTION)
+    except FileNotFoundError:
+        return None
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        raise RuntimeOverlayError("the staged runtime resolution is invalid") from exc
+    required_v1 = {
+        "version", "expected_sha", "active_digest", "source_commit",
+        "paths", "digest", "directory",
+    }
+    required_v2 = {*required_v1, "deleted_paths"}
+    version = value.get("version")
+    if (
+        version not in {1, 2}
+        or set(value) != (required_v1 if version == 1 else required_v2)
+    ):
+        raise RuntimeOverlayError("the staged runtime resolution is invalid")
+    target = str(value["expected_sha"])
+    active = str(value["active_digest"])
+    source_commit = str(value["source_commit"])
+    resolution_digest = str(value["digest"])
+    directory_name = str(value["directory"])
+    raw_paths = value["paths"]
+    raw_deleted_paths = value.get("deleted_paths", [])
+    if (
+        not SHA_RE.fullmatch(target)
+        or not re.fullmatch(r"[0-9a-f]{64}", active)
+        or not SHA_RE.fullmatch(source_commit)
+        or not re.fullmatch(r"[0-9a-f]{64}", resolution_digest)
+        or not RESOLUTION_RE.fullmatch(directory_name)
+        or not isinstance(raw_paths, list)
+        or not raw_paths
+        or not isinstance(raw_deleted_paths, list)
+    ):
+        raise RuntimeOverlayError("the staged runtime resolution is invalid")
+    paths = tuple(sorted({_safe_runtime_path(item) for item in raw_paths}))
+    deleted_paths = tuple(sorted({
+        _safe_runtime_path(item) for item in raw_deleted_paths
+    }))
+    path_set = set(paths)
+    if (
+        len(paths) != len(raw_paths)
+        or len(deleted_paths) != len(raw_deleted_paths)
+        or not set(deleted_paths).issubset(path_set)
+        or any(
+            parent.as_posix() in path_set
+            for name in paths for parent in Path(name).parents
+            if parent.as_posix() != "."
+        )
+    ):
+        raise RuntimeOverlayError("the staged runtime resolution is invalid")
+    directory = RUNTIME_RESOLUTIONS / directory_name
+    trusted_uid = os.geteuid()
+    for path in (RUNTIME_RESOLUTION, directory, *directory.rglob("*")):
+        if path.is_symlink():
+            raise RuntimeOverlayError("the staged runtime resolution is unsafe")
+        stat = path.stat()
+        if stat.st_uid != trusted_uid or stat.st_mode & 0o022:
+            raise RuntimeOverlayError("the staged runtime resolution is unsafe")
+    if version == 1:
+        actual_digest, files = _runtime_snapshot(directory)
+    else:
+        actual_digest, files = _runtime_resolution_digest(
+            directory, deleted_paths,
+        )
+    if (
+        actual_digest != resolution_digest
+        or set(files) != set(paths) - set(deleted_paths)
+    ):
+        raise RuntimeOverlayError("the staged runtime resolution is invalid")
+    if target != expected_sha or active != active_digest:
+        return None
+    return RuntimeResolution(
+        target, active, source_commit, paths, deleted_paths,
+        resolution_digest, directory,
+    )
+
+
+def _consume_runtime_resolution(expected_sha: str, active_digest: str) -> None:
+    resolution = _read_runtime_resolution(expected_sha, active_digest)
+    if resolution is None:
+        return
+    RUNTIME_RESOLUTION.unlink(missing_ok=True)
+    shutil.rmtree(resolution.directory, ignore_errors=True)
+
+
+def _write_runtime_state(
+    active: RuntimeGeneration, rollback: RuntimeGeneration | None,
+) -> None:
+    _atomic_json(RUNTIME_STATE, {
+        "version": 1,
+        "active": _runtime_record(active),
+        "rollback": _runtime_record(rollback),
+    })
+
+
+def _store_runtime_generation(source: Path) -> RuntimeGeneration:
+    digest, _files = _runtime_snapshot(source)
+    RUNTIME_GENERATIONS.mkdir(mode=0o700, parents=True, exist_ok=True)
+    os.chmod(RUNTIME_GENERATIONS, 0o700)
+    name = f"runtime-{digest[:16]}-{uuid.uuid4().hex[:8]}"
+    path = RUNTIME_GENERATIONS / name
+    shutil.copytree(source, path)
+    stored_digest = _normalize_runtime_tree(path)
+    if stored_digest != digest:
+        shutil.rmtree(path, ignore_errors=True)
+        raise RuntimeOverlayError("the runtime generation changed while being stored")
+    return RuntimeGeneration(name=name, path=path, digest=digest)
+
+
+def _remove_runtime_generation(generation: RuntimeGeneration | None) -> None:
+    if generation is None:
+        return
+    if generation.path.parent != RUNTIME_GENERATIONS or not GENERATION_RE.fullmatch(
+        generation.name
+    ):
+        raise RuntimeOverlayError("refusing to remove an invalid runtime generation")
+    shutil.rmtree(generation.path, ignore_errors=True)
+
+
+def bootstrap_runtime(cid: str) -> RuntimeGeneration:
+    """Adopt the exact runtime already executing when the helper is installed."""
+    if not CONTAINER_RE.fullmatch(cid):
+        raise RuntimeOverlayError("invalid running container id")
+    STATE_DIR.mkdir(mode=0o700, parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(dir=STATE_DIR, prefix="runtime-bootstrap-") as raw:
+        tree = Path(raw) / "active"
+        _copy_container_runtime(cid, tree)
+        current = _store_runtime_generation(tree)
+    previous: RuntimeGeneration | None = None
+    old_rollback: RuntimeGeneration | None = None
+    try:
+        previous, old_rollback = _read_runtime_state()
+    except RuntimeOverlayError:
+        pass
+    if previous and previous.digest == current.digest:
+        _remove_runtime_generation(current)
+        return previous
+    _write_runtime_state(current, previous)
+    if old_rollback and (not previous or old_rollback.name != previous.name):
+        _remove_runtime_generation(old_rollback)
+    return current
+
+
+def prepare_runtime_overlay(
+    cid: str, current_image: str, incoming_image: str,
+    repo: Path, expected_sha: str,
+) -> PreparedRuntime:
+    """Prepare a clean merge without reading editable /data platform source."""
+    STATE_DIR.mkdir(mode=0o700, parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(dir=STATE_DIR, prefix="runtime-prepare-") as raw:
+        workspace = Path(raw)
+        local = workspace / "active"
+        current_raw = workspace / "current-image"
+        current_source = workspace / "current-source"
+        incoming = workspace / "incoming-image"
+        incoming_source = workspace / "incoming-source"
+        base = workspace / "base"
+        merged = workspace / "merged"
+
+        prior_active, prior_rollback = _read_runtime_state()
+        active_digest = _copy_container_runtime(cid, local)
+        previous = _store_runtime_generation(local)
+        try:
+            current_digest, build_info = _copy_image_runtime(
+                current_image, current_raw,
+            )
+            incoming_digest, _incoming_info = _copy_image_runtime(
+                incoming_image, incoming,
+            )
+            current_sha = str(build_info.get("sha") or "").strip().lower()
+            if not SHA_RE.fullmatch(current_sha) or not SHA_RE.fullmatch(expected_sha):
+                raise RuntimeOverlayError(
+                    "the active image does not expose an exact runtime revision"
+                )
+            if _extract_git_runtime(repo, current_sha, current_source) != current_digest:
+                raise RuntimeOverlayError(
+                    "the active image runtime does not match its recorded revision"
+                )
+            if _extract_git_runtime(
+                repo, expected_sha, incoming_source,
+            ) != incoming_digest:
+                raise RuntimeOverlayError(
+                    "the official image runtime does not match its requested revision"
+                )
+            merge_base = _git(
+                repo, "merge-base", current_sha, expected_sha, check=False,
+            ).stdout.strip()
+            if not SHA_RE.fullmatch(merge_base):
+                raise RuntimeOverlayError(
+                    "the active and official runtimes have no verifiable merge base"
+                )
+            _extract_git_runtime(repo, merge_base, base)
+
+            resolution = _read_runtime_resolution(expected_sha, active_digest)
+            _merged_digest, carried = _merge_runtime_trees(
+                base, local, incoming, merged, resolution,
+            )
+            candidate = _store_runtime_generation(merged)
+        except Exception:
+            _remove_runtime_generation(previous)
+            raise
+    return PreparedRuntime(
+        previous=previous,
+        candidate=candidate,
+        carried_paths=carried,
+        prior_active=prior_active,
+        prior_rollback=prior_rollback,
+    )
+
+
+def activate_runtime_overlay(prepared: PreparedRuntime) -> None:
+    active, rollback = _read_runtime_state()
+    if (
+        active.name != prepared.prior_active.name
+        or (rollback.name if rollback else None)
+        != (prepared.prior_rollback.name if prepared.prior_rollback else None)
+    ):
+        raise RuntimeOverlayError("the active runtime receipt changed during replacement")
+    _write_runtime_state(prepared.candidate, prepared.previous)
+    for retired in (prepared.prior_active, prepared.prior_rollback):
+        if retired and retired.name not in {
+            prepared.previous.name, prepared.candidate.name,
+        }:
+            _remove_runtime_generation(retired)
+
+
 def write_status(config_value: dict, **fields) -> dict:
     current = {
         "supported": True, "operation_id": None, "state": "idle",
         "expected_sha": None, "code": None, "message": None,
         "handoff": HANDOFF_VERSION,
+        "runtime_overlay": RUNTIME_OVERLAY_VERSION,
     }
     try:
         current.update(read_json(STATUS))
@@ -104,6 +726,7 @@ def write_status(config_value: dict, **fields) -> dict:
         pass
     current.update(fields)
     current["handoff"] = HANDOFF_VERSION
+    current["runtime_overlay"] = RUNTIME_OVERLAY_VERSION
     current["updated_at"] = now()
     _atomic_json(STATUS, current)
     _atomic_json(config_value["control_dir"] / "status.json", current, 0o644)
@@ -111,9 +734,12 @@ def write_status(config_value: dict, **fields) -> dict:
 
 
 def compose(config_value: dict, *args: str, image: str | None = None,
+            runtime: RuntimeGeneration | None = None,
             check: bool = True) -> subprocess.CompletedProcess:
     env = os.environ.copy()
     env["MOBIUS_IMAGE"] = image or IMAGE
+    selected = runtime or active_runtime_generation()
+    env["MOBIUS_RUNTIME_OVERLAY"] = str(selected.path)
     return subprocess.run(
         ["docker", "compose", "-p", config_value["project"],
          "-f", str(COMPOSE), "-f", str(OVERRIDE), *args],
@@ -141,6 +767,143 @@ def app_container(config_value: dict) -> tuple[str, str]:
     return cid, inspected.stdout.strip()
 
 
+def stage_runtime_resolution(
+    config_value: dict, cid: str, expected_sha: str, source_commit: str,
+) -> RuntimeResolution:
+    """Stage reviewed conflict files without modifying the running runtime."""
+    if not CONTAINER_RE.fullmatch(cid):
+        raise RuntimeOverlayError("invalid running container id")
+    if not SHA_RE.fullmatch(expected_sha) or not SHA_RE.fullmatch(source_commit):
+        raise RuntimeOverlayError("invalid runtime resolution revision")
+    current_cid, current_image = app_container(config_value)
+    if cid != current_cid:
+        raise RuntimeOverlayError("the runtime resolution targets another container")
+    repo = Path(config_value["data_dir"]) / "platform"
+    if _git(
+        repo, "cat-file", "-e", f"{source_commit}^{{commit}}", check=False,
+    ).returncode:
+        raise RuntimeOverlayError("the reviewed runtime resolution is unavailable")
+    if _git(
+        repo, "merge-base", "--is-ancestor", expected_sha, source_commit,
+        check=False,
+    ).returncode:
+        raise RuntimeOverlayError(
+            "the reviewed runtime resolution does not contain the official target"
+        )
+
+    STATE_DIR.mkdir(mode=0o700, parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(
+        dir=STATE_DIR, prefix="runtime-resolution-prepare-",
+    ) as raw:
+        workspace = Path(raw)
+        local = workspace / "active"
+        current_raw = workspace / "current-image"
+        current_source = workspace / "current-source"
+        incoming = workspace / "incoming"
+        base = workspace / "base"
+        attempted = workspace / "attempted"
+        reviewed = workspace / "reviewed"
+        selected = workspace / "selected"
+
+        active_digest = _copy_container_runtime(cid, local)
+        current_digest, build_info = _copy_image_runtime(current_image, current_raw)
+        current_sha = str(build_info.get("sha") or "").strip().lower()
+        if not SHA_RE.fullmatch(current_sha):
+            raise RuntimeOverlayError(
+                "the active image does not expose an exact runtime revision"
+            )
+        if _extract_git_runtime(repo, current_sha, current_source) != current_digest:
+            raise RuntimeOverlayError(
+                "the active image runtime does not match its recorded revision"
+            )
+        _extract_git_runtime(repo, expected_sha, incoming)
+        merge_base = _git(
+            repo, "merge-base", current_sha, expected_sha, check=False,
+        ).stdout.strip()
+        if not SHA_RE.fullmatch(merge_base):
+            raise RuntimeOverlayError(
+                "the active and official runtimes have no verifiable merge base"
+            )
+        _extract_git_runtime(repo, merge_base, base)
+        _extract_git_runtime(repo, source_commit, reviewed)
+        try:
+            _merge_runtime_trees(base, local, incoming, attempted)
+        except RuntimeOverlayConflict as exc:
+            selected_paths = exc.paths
+        else:
+            _attempted_digest, attempted_files = _runtime_snapshot(attempted)
+            _reviewed_digest, reviewed_files = _runtime_snapshot(reviewed)
+            selected_paths = tuple(sorted(
+                name for name in {*attempted_files, *reviewed_files}
+                if attempted_files.get(name) != reviewed_files.get(name)
+            ))
+            if not selected_paths:
+                raise RuntimeOverlayError(
+                    "the reviewed runtime matches the active official merge"
+                )
+
+        selected.mkdir(mode=0o700)
+        deleted_paths: list[str] = []
+        for name in selected_paths:
+            source = reviewed / name
+            if source.is_symlink() or (source.exists() and not source.is_file()):
+                raise RuntimeOverlayError(
+                    f"the reviewed resolution has an invalid path: {name}"
+                )
+            if not source.exists():
+                deleted_paths.append(name)
+                continue
+            target = selected / name
+            target.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+            shutil.copy2(source, target)
+        _normalize_runtime_tree(selected)
+        deleted = tuple(sorted(deleted_paths))
+        resolution_digest, _selected_files = _runtime_resolution_digest(
+            selected, deleted,
+        )
+
+        RUNTIME_RESOLUTIONS.mkdir(mode=0o700, parents=True, exist_ok=True)
+        os.chmod(RUNTIME_RESOLUTIONS, 0o700)
+        directory_name = f"resolution-{uuid.uuid4().hex}"
+        directory = RUNTIME_RESOLUTIONS / directory_name
+        shutil.copytree(selected, directory)
+        _normalize_runtime_tree(directory)
+
+    old_directory: Path | None = None
+    try:
+        old_value = read_json(RUNTIME_RESOLUTION)
+        old_name = str(old_value.get("directory") or "")
+        if RESOLUTION_RE.fullmatch(old_name):
+            old_directory = RUNTIME_RESOLUTIONS / old_name
+    except (OSError, ValueError, json.JSONDecodeError):
+        pass
+    paths = tuple(sorted(selected_paths))
+    _atomic_json(RUNTIME_RESOLUTION, {
+        "version": 2,
+        "expected_sha": expected_sha,
+        "active_digest": active_digest,
+        "source_commit": source_commit,
+        "paths": list(paths),
+        "deleted_paths": list(deleted),
+        "digest": resolution_digest,
+        "directory": directory_name,
+    })
+    if old_directory and old_directory != directory:
+        shutil.rmtree(old_directory, ignore_errors=True)
+    resolution = _read_runtime_resolution(expected_sha, active_digest)
+    if resolution is None:
+        raise RuntimeOverlayError("the staged runtime resolution could not be verified")
+    write_status(
+        config_value,
+        operation_id=None,
+        state="idle",
+        expected_sha=expected_sha,
+        code="runtime_overlay_resolved",
+        message="A reviewed runtime conflict resolution is staged. Replace again when ready.",
+    )
+    return resolution
+
+
 def wait_healthy(config_value: dict, timeout: int = 180) -> bool:
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
@@ -156,6 +919,36 @@ def wait_healthy(config_value: dict, timeout: int = 180) -> bool:
                 return True
         time.sleep(3)
     return False
+
+
+def verify_served_generation(
+    cid: str, expected_sha: str, runtime_digest: str,
+) -> None:
+    """Prove the image and mounted protected runtime are the requested bytes.
+
+    Desired source under /data may legitimately be newer than the active
+    root-owned overlay, so source parity is not a cutover invariant. The Host
+    instead verifies the deployed digest against its immutable generation.
+    """
+    result = subprocess.run(
+        ["docker", "exec", cid, "curl", "-fsS",
+         "http://127.0.0.1:8000/api/version"],
+        text=True, capture_output=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError("the container did not expose build provenance")
+    try:
+        version = json.loads(result.stdout)
+    except (TypeError, json.JSONDecodeError) as exc:
+        raise RuntimeError("the container returned invalid build provenance") from exc
+    if not isinstance(version, dict) or version.get("sha") != expected_sha:
+        raise RuntimeError("the container is not serving the requested image revision")
+    protected = version.get("protected_runtime")
+    deployed = protected.get("deployed_sha256") if isinstance(protected, dict) else None
+    if deployed != runtime_digest:
+        raise RuntimeError(
+            "the container's protected runtime does not match the prepared generation"
+        )
 
 
 def _docker_root() -> Path:
@@ -177,7 +970,8 @@ def require_pull_space(current_image: str) -> None:
 
 
 def restart_ledger(config_value: dict, cid: str, command: str,
-                   operation: str, *, image: str | None = None) -> bool:
+                   operation: str, *, image: str | None = None,
+                   runtime: RuntimeGeneration | None = None) -> bool:
     """Run one root ledger command, even when the app is crash-looping."""
     invocation = ["python3", "-P", "/app/runtime/restart_ledger.py",
                   command, operation]
@@ -192,9 +986,12 @@ def restart_ledger(config_value: dict, cid: str, command: str,
     # A failed replacement may not stay alive long enough for docker exec.
     # The prior verified image carries the same frozen helper; mount only the
     # persistent data root and run no entrypoint or application code.
+    selected = runtime or active_runtime_generation()
     result = subprocess.run(
         ["docker", "run", "--rm", "--mount",
          f"type=bind,src={config_value['data_dir']},dst=/data",
+         "--mount",
+         f"type=bind,src={selected.path},dst=/app/runtime,readonly",
          "--entrypoint", "python3", image, *invocation[1:]],
         text=True, capture_output=True,
     )
@@ -270,7 +1067,10 @@ def retain_images(target_ref: str, rollback_image_id: str | None = None) -> None
 
 
 def rollback(config_value: dict, operation: str, expected: str,
-             code: str, detail: str) -> int:
+             code: str, detail: str, *,
+             runtime: RuntimeGeneration | None = None,
+             failed_runtime: RuntimeGeneration | None = None,
+             retired_runtimes: tuple[RuntimeGeneration | None, ...] = ()) -> int:
     write_status(config_value, operation_id=operation, state="verifying",
                  expected_sha=expected, code=code,
                  message="Replacement failed; restoring the previous container.")
@@ -280,14 +1080,15 @@ def rollback(config_value: dict, operation: str, expected: str,
         cid = ""
     handoff_rearmed = restart_ledger(
         config_value, cid, "rearm-cutover", operation, image=ROLLBACK_TAG,
+        runtime=runtime,
     )
     compose(config_value, "up", "-d", "--no-build", "--no-deps",
-            "--force-recreate", "app", image=ROLLBACK_TAG)
+            "--force-recreate", "app", image=ROLLBACK_TAG, runtime=runtime)
     if wait_healthy(config_value, 120):
         cid, _current = app_container(config_value)
         handoff_finalized = restart_ledger(
             config_value, cid, "finalize-cutover", operation,
-            image=ROLLBACK_TAG,
+            image=ROLLBACK_TAG, runtime=runtime,
         )
         if handoff_finalized:
             status_code = code
@@ -309,6 +1110,12 @@ def rollback(config_value: dict, operation: str, expected: str,
         write_status(config_value, operation_id=operation, state="rolled_back",
                      expected_sha=expected, code=status_code,
                      message=message[:300])
+        if runtime is not None:
+            _write_runtime_state(runtime, None)
+        _remove_runtime_generation(failed_runtime)
+        for retired in retired_runtimes:
+            if retired and (runtime is None or retired.name != runtime.name):
+                _remove_runtime_generation(retired)
         return 1
     write_status(config_value, operation_id=operation, state="needs_recovery",
                  expected_sha=expected, code="rollback_failed",
@@ -333,6 +1140,8 @@ def run() -> int:
     image_ref = None
     pulled_recorded = False
     replacement_started = False
+    prepared_runtime: PreparedRuntime | None = None
+    runtime_activated = False
     try:
         with LOCK.open("a+") as lock:
             acquire_lock(lock)
@@ -371,11 +1180,35 @@ def run() -> int:
                 raise RuntimeError("the downloaded image is not the requested official amd64 release")
             digest = inspect_image(image_ref, "{{.Id}}")
             if previous == digest:
-                retain_images(image_ref, _image_state()["rollback_image_id"])
-                write_status(config_value, operation_id=operation, state="no_change",
-                             expected_sha=expected, code=None,
-                             message="This container already uses that official image.")
-                return 0
+                try:
+                    active_runtime = active_runtime_generation()
+                    verify_served_generation(
+                        cid, expected, active_runtime.digest,
+                    )
+                except RuntimeError as exc:
+                    write_status(
+                        config_value, operation_id=operation, state="failed",
+                        expected_sha=expected, code="provenance_failed",
+                        message=str(exc)[:300],
+                    )
+                    return 1
+                if _read_runtime_resolution(expected, active_runtime.digest) is None:
+                    retain_images(image_ref, _image_state()["rollback_image_id"])
+                    write_status(
+                        config_value, operation_id=operation, state="no_change",
+                        expected_sha=expected, code=None,
+                        message="This container already uses that official image.",
+                    )
+                    return 0
+            write_status(
+                config_value, operation_id=operation, state="preparing",
+                expected_sha=expected, code=None,
+                message="Merging the active local runtime with the official image.",
+            )
+            prepared_runtime = prepare_runtime_overlay(
+                cid, previous, image_ref,
+                Path(config_value["data_dir"]) / "platform", expected,
+            )
             subprocess.run(["docker", "tag", previous, ROLLBACK_TAG], check=True,
                            text=True, capture_output=True)
             request_drain(config_value, operation, cid)
@@ -384,25 +1217,44 @@ def run() -> int:
                          message="Replacing the container.")
             replacement_started = True
             compose(config_value, "up", "-d", "--no-build", "--no-deps",
-                    "--force-recreate", "app", image=image_ref)
+                    "--force-recreate", "app", image=image_ref,
+                    runtime=prepared_runtime.candidate)
             write_status(config_value, operation_id=operation, state="verifying",
                          expected_sha=expected, message="Checking the new container.")
             if not wait_healthy(config_value):
                 result = rollback(
                     config_value, operation, expected,
                     "health_check_failed", "the new container was unhealthy",
+                    runtime=prepared_runtime.previous,
+                    failed_runtime=prepared_runtime.candidate,
+                    retired_runtimes=(
+                        prepared_runtime.prior_active,
+                        prepared_runtime.prior_rollback,
+                    ),
                 )
                 discard_pulled_image(image_ref)
                 return result
             cid, _current = app_container(config_value)
+            verify_served_generation(
+                cid, expected, prepared_runtime.candidate.digest,
+            )
+            activate_runtime_overlay(prepared_runtime)
+            _consume_runtime_resolution(expected, prepared_runtime.previous.digest)
+            runtime_activated = True
             handoff_finalized = restart_ledger(
                 config_value, cid, "finalize-cutover", operation,
-                image=image_ref,
+                image=image_ref, runtime=prepared_runtime.candidate,
             )
             retain_images(image_ref, previous)
             if handoff_finalized:
                 status_code = None
-                message = "Container replaced successfully."
+                if prepared_runtime.carried_paths:
+                    message = (
+                        "Container replaced successfully; the active local "
+                        "runtime overlay was carried forward."
+                    )
+                else:
+                    message = "Container replaced successfully."
             else:
                 status_code = "handoff_finalize_failed"
                 message = (
@@ -424,7 +1276,22 @@ def run() -> int:
         if replacement_started and previous and expected:
             try:
                 result = rollback(config_value, operation, expected,
-                                  "replacement_failed", detail)
+                                  "replacement_failed", detail,
+                                  runtime=(
+                                      prepared_runtime.previous
+                                      if prepared_runtime else None
+                                  ),
+                                  failed_runtime=(
+                                      prepared_runtime.candidate
+                                      if prepared_runtime else None
+                                  ),
+                                  retired_runtimes=(
+                                      (
+                                          prepared_runtime.prior_active,
+                                          prepared_runtime.prior_rollback,
+                                      )
+                                      if prepared_runtime else ()
+                                  ))
                 if image_ref and pulled_recorded:
                     discard_pulled_image(image_ref)
                 return result
@@ -436,8 +1303,12 @@ def run() -> int:
                 return 1
         if image_ref and pulled_recorded:
             discard_pulled_image(image_ref)
+        if prepared_runtime and not runtime_activated:
+            _remove_runtime_generation(prepared_runtime.candidate)
+            _remove_runtime_generation(prepared_runtime.previous)
+        code = exc.code if isinstance(exc, RuntimeOverlayError) else "replacement_failed"
         write_status(config_value, operation_id=operation, state="failed",
-                     expected_sha=expected, code="replacement_failed", message=detail)
+                     expected_sha=expected, code=code, message=detail)
         return 1
     finally:
         claimed.unlink(missing_ok=True)
@@ -469,6 +1340,11 @@ def reconcile() -> int:
         elif current.get("state") in ACTIVE_STATES:
             write_status(config_value, state="failed", code="worker_interrupted",
                          message="The host replacement worker stopped unexpectedly.")
+        else:
+            # Installation and boot reconciliation also refresh the controller
+            # capability receipt.  Otherwise an upgraded helper can remain
+            # invisible behind an idle status written by the previous binary.
+            write_status(config_value)
     return 0
 
 
@@ -477,5 +1353,36 @@ if __name__ == "__main__":
         raise SystemExit(run())
     if len(sys.argv) == 2 and sys.argv[1] == "reconcile" and os.geteuid() == 0:
         raise SystemExit(reconcile())
+    if (
+        len(sys.argv) == 3
+        and sys.argv[1] == "bootstrap-runtime"
+        and os.geteuid() == 0
+    ):
+        STATE_DIR.mkdir(mode=0o700, parents=True, exist_ok=True)
+        with LOCK.open("a+") as lock:
+            acquire_lock(lock)
+            generation = bootstrap_runtime(sys.argv[2])
+        print(generation.digest)
+        raise SystemExit(0)
+    if (
+        len(sys.argv) == 5
+        and sys.argv[1] == "stage-runtime-resolution"
+        and os.geteuid() == 0
+    ):
+        config_value = config()
+        STATE_DIR.mkdir(mode=0o700, parents=True, exist_ok=True)
+        with LOCK.open("a+") as lock:
+            acquire_lock(lock)
+            resolution = stage_runtime_resolution(
+                config_value, sys.argv[2], sys.argv[3], sys.argv[4],
+            )
+        print(json.dumps({
+            "expected_sha": resolution.expected_sha,
+            "active_digest": resolution.active_digest,
+            "source_commit": resolution.source_commit,
+            "paths": list(resolution.paths),
+            "digest": resolution.digest,
+        }, separators=(",", ":")))
+        raise SystemExit(0)
     print("invalid invocation", file=sys.stderr)
     raise SystemExit(2)

--- a/scripts/rebuild-topology.py
+++ b/scripts/rebuild-topology.py
@@ -11,7 +11,7 @@ from pathlib import Path
 def compose_files(root: Path, working_dir: Path, label: str) -> list[Path]:
     root = root.resolve(strict=True)
     working_dir = working_dir.resolve(strict=True)
-    if working_dir != root:
+    if not working_dir.is_relative_to(root):
         raise ValueError("the running app belongs to a different checkout")
     files: list[Path] = []
     for raw in label.split(","):
@@ -29,6 +29,30 @@ def compose_files(root: Path, working_dir: Path, label: str) -> list[Path]:
     return files
 
 
+def environment_files(label: str) -> list[Path]:
+    """Resolve the exact Compose environment files recorded on the container.
+
+    These files may intentionally live beside the main checkout rather than a
+    nested deployment worktree.  They are used only as Compose interpolation
+    inputs, so require absolute, existing, non-symlinked regular files instead
+    of pretending they are tracked topology source.
+    """
+    files: list[Path] = []
+    for raw in label.split(","):
+        if not raw:
+            continue
+        candidate = Path(raw)
+        if not candidate.is_absolute():
+            raise ValueError("Compose environment files must use absolute paths")
+        if candidate.is_symlink():
+            raise ValueError("Compose environment files may not use symlinks")
+        resolved = candidate.resolve(strict=True)
+        if not resolved.is_file():
+            raise ValueError("Compose environment input is not a regular file")
+        files.append(resolved)
+    return files
+
+
 def expected_networks(value: dict) -> list[str]:
     service_networks = value["services"]["app"].get("networks", {})
     definitions = value.get("networks", {})
@@ -42,6 +66,10 @@ def main() -> int:
     try:
         if len(sys.argv) == 5 and sys.argv[1] == "compose-files":
             for path in compose_files(Path(sys.argv[2]), Path(sys.argv[3]), sys.argv[4]):
+                print(path)
+            return 0
+        if len(sys.argv) == 3 and sys.argv[1] == "environment-files":
+            for path in environment_files(sys.argv[2]):
                 print(path)
             return 0
         if len(sys.argv) == 3 and sys.argv[1] == "expected-networks":


### PR DESCRIPTION
## Summary
- preserve the active root-owned protected runtime across official container replacements
- three-way merge local runtime changes onto the exact incoming image revision and stop before chat drain on a real conflict
- accept only reviewed conflict resolutions bound to the exact active runtime digest and target commit
- freeze the proven Compose topology, environment-file receipt, running image, and runtime mount when the host helper is refreshed
- verify both the served image revision and mounted runtime digest before retiring the chat handoff
- roll back the image and protected runtime together after a failed cutover
- require the current runtime-overlay handoff before queuing self-hosted replacement, while Railway keeps its own fail-closed blocker policy

## Replacement
- supersedes obsolete stacked PR #971 and uses the fresh provenance replacement as its exact parent
- preserves the complete final #971 layer, including content-bound deletion tombstones
- composes the landed Railway bootstrap flow with the target-aware runtime blocker contract instead of overwriting either behavior

## Safety
- runtime generations are immutable, root-owned, content-addressed, and reject symlinks and special files
- Git operations disable hooks and ignore inherited repository control variables
- archive extraction is path-confined and size-bounded
- a runtime conflict remains visible and leaves the running container untouched

## Prior work
This is the fresh Host layer above the protected-runtime provenance replacement. It preserves the twice-reviewed #971 implementation and follows #813 and #903, which established safe self-hosted and managed container replacement.

## Testing
- 176 focused provenance, platform-update, version, deployment-control, Host replacement, and topology tests passed on the exact stack head
- the complete Host layer is patch-equivalent to final #971 except for two test-only adaptations required by the landed Railway bootstrap flow
- shell syntax, Python compilation, focused Ruff, canonical diff, attribution, ancestry, privacy history, privacy-gate, and documentation-link checks passed