### PR TITLE
Make Connect dispatch deadline test scheduler-safe

### DIFF
--- a/backend/tests/test_connect.py
+++ b/backend/tests/test_connect.py
@@ -972,13 +972,17 @@ async def test_unacknowledged_dispatch_expires_and_sends_cancel(
   connect_routes._channels[pairing["id"]] = channel
   request_id = "f" * 16
   monkeypatch.setattr(connect_routes, "_START_ACK_TIMEOUT", 0.01)
+  dispatch_requested_at = time.time()
   request = asyncio.create_task(connect_routes.exec_on_host(
     pairing["id"],
     connect_routes.ExecBody(cmd="must expire", request_id=request_id),
     _owner=object(),
   ))
   dispatched = await asyncio.wait_for(channel.queue.get(), timeout=1)
-  assert dispatched["not_after"] > time.time()
+  # The deliberately tiny deadline may pass while a busy test worker resumes
+  # this coroutine. Verify that dispatch minted a forward deadline instead of
+  # requiring it to still be in the future when the observer is scheduled.
+  assert dispatched["not_after"] > dispatch_requested_at
 
   with pytest.raises(connect_routes.HTTPException) as raised:
     await request


### PR DESCRIPTION
## Summary
- make the Connect dispatch-expiry test compare its tiny deadline with the moment dispatch was requested, rather than with a later scheduler observation
- retain the real behavioral proof that an unacknowledged command expires, returns 504, emits cancellation, and clears durable command state

## Context
The merge-group run for #1020 completed 4,574 backend tests and failed only this assertion: its deliberately 10 ms deadline elapsed while the busy worker was descheduled for about 65 ms. The production deadline and expiration behavior were correct; the observation-time assertion was not scheduler-safe. This small prerequisite fixes the owning test without weakening the runtime invariant or folding unrelated code into #1020.

## Testing
- complete Connect backend suite: 62 passed
- canonical diff, clean-worktree, attribution, ancestry, and privacy-path checks passed