### PR TITLE
Show shell updates in Notifications

### DIFF
--- a/frontend/src/components/NotificationBell/NotificationCenter.jsx
+++ b/frontend/src/components/NotificationBell/NotificationCenter.jsx
@@ -3,6 +3,7 @@
 import {
   forwardRef,
   useCallback,
+  useEffect,
   useImperativeHandle,
   useRef,
   useState,
@@ -14,17 +15,36 @@ import NotificationBell from './NotificationBell.jsx'
 import useNotificationCenter from './useNotificationCenter.js'
 
 const NotificationCenter = forwardRef(function NotificationCenter(
-  { commands, onOpenTarget, onRunCommand },
+  {
+    commands,
+    onOpenTarget,
+    onRunCommand,
+    updateAvailable = false,
+    onUpdateNow,
+  },
   eventActionsRef,
 ) {
   const queryClient = useQueryClient()
   const searchButtonRef = useRef(null)
   const [searchOpen, setSearchOpen] = useState(false)
+  const [updateNoticeSeen, setUpdateNoticeSeen] = useState(false)
   const {
     state: { open, unreadCount },
     actions: { toggle, close, clearAll, reconcile, onCreated },
     meta: { rootRef, bellRef },
   } = useNotificationCenter(queryClient)
+  const updateNoticeActive = updateAvailable && typeof onUpdateNow === 'function'
+  const visibleUnreadCount = unreadCount + (
+    updateNoticeActive && !updateNoticeSeen ? 1 : 0
+  )
+
+  useEffect(() => {
+    if (!updateNoticeActive) {
+      setUpdateNoticeSeen(false)
+    } else if (open) {
+      setUpdateNoticeSeen(true)
+    }
+  }, [open, updateNoticeActive])
 
   const openTarget = useCallback((target) => {
     close()
@@ -52,8 +72,21 @@ const NotificationCenter = forwardRef(function NotificationCenter(
 
   const toggleNotifications = useCallback(() => {
     setSearchOpen(false)
+    if (updateNoticeActive) setUpdateNoticeSeen(true)
     toggle()
-  }, [toggle])
+  }, [toggle, updateNoticeActive])
+
+  const applyUpdate = useCallback(() => {
+    setUpdateNoticeSeen(true)
+    close()
+    onUpdateNow?.()
+  }, [close, onUpdateNow])
+
+  const deferUpdate = useCallback(() => {
+    setUpdateNoticeSeen(true)
+    close()
+    bellRef.current?.focus()
+  }, [bellRef, close])
 
   return (
     <div ref={rootRef} className="notification-center">
@@ -64,7 +97,7 @@ const NotificationCenter = forwardRef(function NotificationCenter(
       />
       <NotificationBell
         buttonRef={bellRef}
-        unreadCount={unreadCount}
+        unreadCount={visibleUnreadCount}
         active={open}
         onClick={toggleNotifications}
       />
@@ -73,6 +106,9 @@ const NotificationCenter = forwardRef(function NotificationCenter(
           active
           onOpenTarget={openTarget}
           onClearAll={clearAll}
+          updateAvailable={updateNoticeActive}
+          onUpdateNow={applyUpdate}
+          onUpdateLater={deferUpdate}
         />
       )}
       {searchOpen && (

--- a/frontend/src/components/NotificationsView/NotificationsView.css
+++ b/frontend/src/components/NotificationsView/NotificationsView.css
@@ -108,6 +108,57 @@
   border-top: 1px solid var(--border-light);
 }
 
+.notifications__row--update {
+  padding-block: 14px;
+  background: color-mix(in srgb, var(--accent) 5%, transparent);
+}
+
+.notifications__update-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.notifications__update-action {
+  min-height: 44px;
+  padding: 0 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+  color: var(--text);
+  font: inherit;
+  font-size: 13px;
+  font-weight: 650;
+  cursor: pointer;
+}
+
+.notifications__update-action--primary {
+  border-color: var(--accent);
+  background: var(--accent);
+  color: var(--accent-fg, #fff);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .notifications__update-action:hover {
+    border-color: color-mix(in srgb, var(--text) 35%, var(--border));
+  }
+
+  .notifications__update-action--primary:hover {
+    border-color: color-mix(in srgb, var(--accent) 82%, var(--text));
+    background: color-mix(in srgb, var(--accent) 88%, var(--text));
+  }
+}
+
+.notifications__update-action:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.notifications__update-action--primary:focus-visible {
+  outline-color: var(--text);
+}
+
 .notifications__row {
   display: flex;
   align-items: flex-start;

--- a/frontend/src/components/NotificationsView/NotificationsView.jsx
+++ b/frontend/src/components/NotificationsView/NotificationsView.jsx
@@ -20,7 +20,14 @@ const ICONS = {
 // A deliberately small shell preview, not a new navigation world. TRUST:
 // app-authored title/body stay plain text, app-authored icon URLs are ignored,
 // and targets pass through the fail-closed shared parser before navigation.
-export default function NotificationsView({ active = false, onOpenTarget, onClearAll }) {
+export default function NotificationsView({
+  active = false,
+  onOpenTarget,
+  onClearAll,
+  updateAvailable = false,
+  onUpdateNow,
+  onUpdateLater,
+}) {
   const { data, isLoading, isError } = notificationQueries.list.useQuery({ enabled: active })
   const rows = data ?? []
   const [now, setNow] = useState(() => Date.now())
@@ -85,13 +92,46 @@ export default function NotificationsView({ active = false, onOpenTarget, onClea
             Couldn’t clear notifications. Try again when you’re online.
           </p>
         )}
-        {!isLoading && !isError && rows.length === 0 && (
+        {!isLoading && !isError && rows.length === 0 && !updateAvailable && (
           <div className="notifications__empty">
             <Bell width={28} height={28} aria-hidden="true" />
             <p>Updates from your apps and agents will appear here.</p>
           </div>
         )}
         <ul className="notifications__list">
+          {updateAvailable && (
+            <li className="notifications__row-item">
+              <div className="notifications__row notifications__row--update">
+                <span className="notifications__row-icon" aria-hidden="true">
+                  <SettingsSlider width={17} height={17} />
+                </span>
+                <span className="notifications__row-main">
+                  <span className="notifications__row-title">
+                    A Möbius update is ready.
+                  </span>
+                  <span className="notifications__row-body">
+                    Refresh to use the latest changes.
+                  </span>
+                  <span className="notifications__update-actions">
+                    <button
+                      type="button"
+                      className="notifications__update-action notifications__update-action--primary"
+                      onClick={onUpdateNow}
+                    >
+                      Update now
+                    </button>
+                    <button
+                      type="button"
+                      className="notifications__update-action"
+                      onClick={onUpdateLater}
+                    >
+                      Later
+                    </button>
+                  </span>
+                </span>
+              </div>
+            </li>
+          )}
           {rows.map((n) => {
             const nav = parseNotificationTarget(n.target)
             const Icon = ICONS[iconKindForSource(n.source_type)] ?? ICONS.default

--- a/frontend/src/components/NotificationsView/__tests__/notificationsActions.test.js
+++ b/frontend/src/components/NotificationsView/__tests__/notificationsActions.test.js
@@ -5,6 +5,10 @@ import test from 'node:test'
 
 const component = readFileSync(new URL('../NotificationsView.jsx', import.meta.url), 'utf8')
 const css = readFileSync(new URL('../NotificationsView.css', import.meta.url), 'utf8')
+const center = readFileSync(
+  new URL('../../NotificationBell/NotificationCenter.jsx', import.meta.url),
+  'utf8',
+)
 
 test('notification header clears immediately and closes through the bell boundary', () => {
   assert.match(component, /onClick=\{handleClearAll\}/)
@@ -18,4 +22,15 @@ test('notification header clears immediately and closes through the bell boundar
   )
   const clearRule = css.match(/\.notifications__clear\s*\{([^}]*)\}/)?.[1] ?? ''
   assert.match(clearRule, /color:\s*var\(--text\)/)
+})
+
+test('a ready shell update is an actionable bell notification, not a banner', () => {
+  assert.match(component, /A Möbius update is ready\./)
+  assert.match(component, /onClick=\{onUpdateNow\}[\s\S]*Update now/)
+  assert.match(component, /onClick=\{onUpdateLater\}[\s\S]*Later/)
+  assert.match(component, /rows\.length === 0 && !updateAvailable/)
+  assert.match(center, /visibleUnreadCount = unreadCount \+ \(/)
+  assert.match(center, /updateAvailable=\{updateNoticeActive\}/)
+  assert.match(center, /bellRef\.current\?\.focus\(\)/)
+  assert.match(css, /\.notifications__update-action\s*\{[\s\S]*?min-height:\s*44px/)
 })

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -674,10 +674,6 @@ export default function Shell({ onInitialVisualReady }) {
       return next
     })
   }, [])
-  // A ready update is coalesced separately from transient toasts. If another
-  // action owns the toast slot when the build lands, the update notice waits
-  // for that action to settle rather than replacing it.
-  const shellUpdateNoticeShownRef = useRef(false)
   const [composerRequest, setComposerRequest] = useState(null)
   const composerRequestRef = useRef(null)
   const composerRequestTokenRef = useRef(0)
@@ -2125,15 +2121,6 @@ export default function Shell({ onInitialVisualReady }) {
     activeViewRef,
     drawerOpenRef,
   })
-
-  useEffect(() => {
-    if (!shellUpdateAvailable || toast || shellUpdateNoticeShownRef.current) return
-    shellUpdateNoticeShownRef.current = true
-    showToast('A Möbius update is ready.', {
-      duration: 0,
-      action: { label: 'Update now', onAction: applyShellUpdate },
-    })
-  }, [applyShellUpdate, shellUpdateAvailable, showToast, toast])
 
   // Stable callbacks for ChatView — identity must not change across
   // renders or ChatView's onStreamEnd-handler memoization breaks. The
@@ -4434,6 +4421,8 @@ export default function Shell({ onInitialVisualReady }) {
             commands={shellCommands}
             onOpenTarget={handleNotificationOpen}
             onRunCommand={runShellShortcut}
+            updateAvailable={shellUpdateAvailable}
+            onUpdateNow={applyShellUpdate}
           />
         </div>
       </header>

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -1190,7 +1190,9 @@ test('a manual platform reconcile refreshes the persistent Settings surface', ()
 
 test('shell generations advertise one explicit update without intercepting navigation', () => {
   assert.match(shell, /markShellUpdateAvailable\(\)/)
-  assert.match(shell, /label: 'Update now', onAction: applyShellUpdate/)
+  assert.match(shell, /updateAvailable=\{shellUpdateAvailable\}/)
+  assert.match(shell, /onUpdateNow=\{applyShellUpdate\}/)
+  assert.doesNotMatch(shell, /showToast\('A Möbius update is ready\.'/)
   assert.doesNotMatch(shell, /requestShellReload|beforeNavigateRef/)
 })
 

--- a/tests/shell-update-idle.spec.mjs
+++ b/tests/shell-update-idle.spec.mjs
@@ -103,16 +103,26 @@ test.describe('shell update — owner-controlled navigation', () => {
     await resetLoadCount(page)
 
     releaseEvents()
+    await expect(page.getByRole('button', { name: /Notifications, \d+ unread/ })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Update now' })).toHaveCount(0)
+    await page.getByRole('button', { name: /Notifications/ }).click()
     await expect(page.getByRole('button', { name: 'Update now' })).toBeVisible()
     await expect(page.getByText('A Möbius update is ready.')).toHaveCount(1)
     expect(await loadCount(page)).toBe(0)
 
+    await page.getByRole('button', { name: 'Close notifications' }).click()
     await page.getByRole('button', { name: 'Toggle navigation' }).click()
     await page.locator(`[data-drawer-key="chat:${target.id}"]`).click()
     await expect(page.locator(
       `[data-chat-id="${target.id}"][data-chat-surface="painted"]`,
     )).toBeVisible({ timeout: 8000 })
     expect(await loadCount(page)).toBe(0)
+    await page.getByRole('button', { name: 'Notifications' }).click()
+    await expect(page.getByRole('button', { name: 'Update now' })).toBeVisible()
+    await page.getByRole('button', { name: 'Later' }).click()
+    await expect(page.getByRole('heading', { name: 'Notifications' })).toHaveCount(0)
+    expect(await loadCount(page)).toBe(0)
+    await page.getByRole('button', { name: 'Notifications' }).click()
     await expect(page.getByRole('button', { name: 'Update now' })).toBeVisible()
   })
 
@@ -139,6 +149,7 @@ test.describe('shell update — owner-controlled navigation', () => {
     })
 
     releaseEvent()
+    await page.getByRole('button', { name: /Notifications, \d+ unread/ }).click()
     const update = page.getByRole('button', { name: 'Update now' })
     await expect(update).toBeVisible()
     await update.click()


### PR DESCRIPTION
## Summary
- show a ready Möbius shell update as an actionable Notifications item instead of a navigation-intercepting toast
- keep the update unread until Notifications is opened, then retain Update now and Later without forcing a refresh
- keep owner-controlled navigation and restore focus to the notification bell after Later
- raise both update actions to 44 px touch targets during final review

## Relationship
This standalone mainline successor replaces draft #1026, whose base was the now-merged replacement root branch. It preserves the reviewed seven-file child layer while avoiding obsolete stack topology. It also supersedes the older closed #1015 version of the same layer.

## Testing
- full frontend library suite: 2,905 passed
- full frontend hook suite: 95 passed
- exact focused notification/workspace group: 93 passed
- frontend lint passed
- runtime, speech runtime, worker, pitch, and structural artifact checks passed through the full suite preflight
- exact-lock dependency tree, canonical diff, privacy paths, attribution, and ancestry checks passed
- exact production build, offline/PWA asset checks, runtime guards, and worker checks passed

## Review follow-up
The notification actions were the only 36 px controls in this reviewed layer. They now use the shell's 44 px touch-target minimum, and the owning regression test pins that accessibility contract.