### PR TITLE
Expose app playback speed in drawer controls

### DIFF
--- a/frontend/src/components/AppCanvas/AppCanvas.jsx
+++ b/frontend/src/components/AppCanvas/AppCanvas.jsx
@@ -901,7 +901,7 @@ const AppCanvas = forwardRef(function AppCanvas({
         frameMediaSessionRef.current.set(srcVersion, mediaEvent.sessionId)
         const source = e.source
         onMediaSessionRef.current?.(appId, mediaEvent, (action) => {
-          if (!['play', 'pause', 'stop'].includes(action)) return false
+          if (!['play', 'pause', 'stop', 'cycle-speed'].includes(action)) return false
           try {
             source?.postMessage({
               type: 'moebius:media-control',

--- a/frontend/src/components/AppCanvas/appFrameProtocol.js
+++ b/frontend/src/components/AppCanvas/appFrameProtocol.js
@@ -26,12 +26,19 @@ export function attributedShellShortcutAction(message, advertisedShortcuts) {
 const MEDIA_EVENTS = new Set(['open', 'update', 'close'])
 const MEDIA_STATES = new Set(['loading', 'playing', 'paused'])
 
+function appPlaybackRate(value) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return null
+  if (value < 0.25 || value > 4) return null
+  return Math.round(value * 100) / 100
+}
+
 export function appMediaSessionEvent(message) {
   if (!message || message.type !== 'moebius:media-session') return null
   if (!MEDIA_EVENTS.has(message.event)) return null
   const sessionId = typeof message.sessionId === 'string' ? message.sessionId : ''
   if (!sessionId || sessionId.length > 160 || sessionId.trim() !== sessionId) return null
   if (message.event === 'close') return { event: 'close', sessionId }
+  const playbackRate = appPlaybackRate(message.playbackRate)
   return {
     event: message.event,
     sessionId,
@@ -41,6 +48,7 @@ export function appMediaSessionEvent(message) {
     playbackState: MEDIA_STATES.has(message.playbackState)
       ? message.playbackState
       : 'loading',
+    ...(playbackRate === null ? {} : { playbackRate }),
   }
 }
 

--- a/frontend/src/components/Drawer/Drawer.css
+++ b/frontend/src/components/Drawer/Drawer.css
@@ -378,9 +378,9 @@
 }
 
 .drawer__now-playing-control {
-  flex: 0 0 34px;
-  width: 34px;
-  height: 34px;
+  flex: 0 0 44px;
+  width: 44px;
+  height: 44px;
   display: grid;
   place-items: center;
   padding: 8px;
@@ -390,6 +390,19 @@
 .drawer__now-playing-control svg {
   width: 17px;
   height: 17px;
+}
+
+.drawer__now-playing-speed {
+  width: auto;
+  min-width: 44px;
+  padding-inline: 7px;
+  border: 1px solid var(--border-light);
+  background: var(--bg);
+  font-size: 11.5px;
+  line-height: 1;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.01em;
 }
 
 .drawer__now-playing-main:focus-visible,

--- a/frontend/src/components/Drawer/Drawer.jsx
+++ b/frontend/src/components/Drawer/Drawer.jsx
@@ -1431,6 +1431,17 @@ function NowPlaying({ session, app, onOpen, onControl }) {
           <small>{appName} · {stateLabel}</small>
         </span>
       </button>
+      {Number.isFinite(session.playbackRate) && (
+        <button
+          type="button"
+          className="drawer__now-playing-control drawer__now-playing-speed"
+          aria-label={`Playback speed ${session.playbackRate} times. Change to next speed`}
+          title={`${session.playbackRate}× · next speed`}
+          onClick={() => onControl?.('cycle-speed')}
+        >
+          {session.playbackRate}×
+        </button>
+      )}
       <button
         type="button"
         className="drawer__now-playing-control"

--- a/frontend/src/components/Shell/__tests__/appFrameProtocol.test.js
+++ b/frontend/src/components/Shell/__tests__/appFrameProtocol.test.js
@@ -99,9 +99,17 @@ test('media-session messages are bounded to the drawer contract', () => {
   assert.deepEqual(appMediaSessionEvent({
     type: 'moebius:media-session', event: 'open', sessionId: 'digest-1',
     title: ' Daily digest ', subtitle: ' Untrusted app label ', playbackState: 'playing',
+    playbackRate: 1.5,
   }), {
     event: 'open', sessionId: 'digest-1', title: 'Daily digest',
-    playbackState: 'playing',
+    playbackState: 'playing', playbackRate: 1.5,
+  })
+  assert.deepEqual(appMediaSessionEvent({
+    type: 'moebius:media-session', event: 'update', sessionId: 'digest-1',
+    playbackState: 'paused', playbackRate: 99,
+  }), {
+    event: 'update', sessionId: 'digest-1', title: 'Playing audio',
+    playbackState: 'paused',
   })
   assert.deepEqual(appMediaSessionEvent({
     type: 'moebius:media-session', event: 'close', sessionId: 'digest-1',

--- a/frontend/src/components/Shell/__tests__/drawerAlignment.test.js
+++ b/frontend/src/components/Shell/__tests__/drawerAlignment.test.js
@@ -47,6 +47,15 @@ test('phone drawer increases row type without changing the section-title scale',
   assert.equal(px(drawerLabel, 'font-size'), 14)
 })
 
+test('now-playing actions keep full touch targets', () => {
+  const control = ruleBody(drawerCss, '.drawer__now-playing-control', 1)
+  const speed = ruleBody(drawerCss, '.drawer__now-playing-speed')
+
+  assert.equal(px(control, 'width'), 44)
+  assert.equal(px(control, 'height'), 44)
+  assert.equal(px(speed, 'min-width'), 44)
+})
+
 test('the docked notifications panel covers the drawer content column', () => {
   const panel = ruleBody(shellCss, '.shell--drawer-docked .notifications')
   const desktopDrawerBody = ruleBody(drawerCss, '.drawer__body', 1)

--- a/frontend/src/components/Shell/__tests__/mediaSessionOwner.test.js
+++ b/frontend/src/components/Shell/__tests__/mediaSessionOwner.test.js
@@ -3,12 +3,13 @@ import test from 'node:test'
 
 import { createMediaSessionOwner } from '../mediaSessionOwner.js'
 
-function event(kind, sessionId, playbackState = 'playing') {
+function event(kind, sessionId, playbackState = 'playing', playbackRate) {
   return {
     event: kind,
     sessionId,
     title: `Title ${sessionId}`,
     playbackState,
+    ...(playbackRate === undefined ? {} : { playbackRate }),
   }
 }
 
@@ -48,4 +49,18 @@ test('stop remains app-confirmed and a failed delivery keeps controls available'
 
   assert.equal(owner.receive(1, event('close', 'one'), () => true), true)
   assert.equal(changes.at(-1), null)
+})
+
+test('speed metadata persists across state updates and enables one cycle control', () => {
+  const changes = []
+  const controls = []
+  const owner = createMediaSessionOwner(value => changes.push(value))
+
+  const sendControl = (action) => { controls.push(action); return true }
+  owner.receive(1, event('open', 'one', 'loading', 1.5), sendControl)
+  owner.receive(1, event('update', 'one', 'playing'), sendControl)
+
+  assert.equal(changes.at(-1).playbackRate, 1.5)
+  assert.equal(owner.control('cycle-speed'), true)
+  assert.deepEqual(controls, ['cycle-speed'])
 })

--- a/frontend/src/components/Shell/mediaSessionOwner.js
+++ b/frontend/src/components/Shell/mediaSessionOwner.js
@@ -1,4 +1,4 @@
-const MEDIA_CONTROLS = new Set(['play', 'pause', 'stop'])
+const MEDIA_CONTROLS = new Set(['play', 'pause', 'stop', 'cycle-speed'])
 
 function sameSession(owner, appId, sessionId) {
   return owner
@@ -27,18 +27,21 @@ export function createMediaSessionOwner(onChange) {
       if (event.event === 'open' && owner && !matches) {
         owner.sendControl?.('stop')
       }
-      owner = { appId, sessionId: event.sessionId, sendControl }
+      const playbackRate = event.playbackRate ?? (matches ? owner.playbackRate : undefined)
+      owner = { appId, sessionId: event.sessionId, sendControl, playbackRate }
       onChange({
         appId,
         sessionId: event.sessionId,
         title: event.title,
         playbackState: event.playbackState,
+        ...(playbackRate === undefined ? {} : { playbackRate }),
       })
       return true
     },
 
     control(action) {
       if (!owner || !MEDIA_CONTROLS.has(action)) return false
+      if (action === 'cycle-speed' && owner.playbackRate === undefined) return false
       // A stop request is not completion. Keep the lease visible until the app
       // closes it, so a dead/stale frame cannot leave audible media unowned.
       return owner.sendControl?.(action) === true


### PR DESCRIPTION
## Summary
- let apps advertise a bounded playback rate with their shell media session
- show the current speed beside Now Playing and forward one explicit next-speed action to the owning app
- preserve the advertised speed across ordinary playback-state updates without giving the shell ownership of the media graph
- give every Now Playing action a 44 px touch target

## Testing
- full frontend library and hook suites passed
- focused media protocol, lease owner, and drawer alignment group: 14 passed
- frontend lint passed with no errors
- exact production build, offline/PWA asset checks, runtime guards, canonical diff, attribution, and privacy checks passed
- the Impeccable mechanical UI scan reported no findings

## Security and maintenance review
Playback rate remains untrusted app metadata: only finite numbers from 0.25× through 4× cross the frame boundary, values are rounded to two decimals, and the shell forwards `cycle-speed` only for a live lease that advertised speed support. Existing session attribution and app-confirmed state ownership remain unchanged.