### PR TITLE
Make provider usage reads resilient

### DIFF
--- a/backend/app/provider_usage.py
+++ b/backend/app/provider_usage.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import asyncio
+import copy
 import concurrent.futures as _cf
 import functools
 import logging
 import os
 import shutil
+import time
 from contextlib import suppress
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -22,6 +25,30 @@ log = logging.getLogger(__name__)
 
 _CLAUDE_USAGE_URL = "https://api.anthropic.com/api/oauth/usage"
 _PROVIDER_TIMEOUT_SECONDS = 12.0
+_PROVIDER_USAGE_FRESH_SECONDS = 2.0
+_PROVIDER_USAGE_STALE_SECONDS = 10 * 60.0
+# Claude's usage-only endpoint can briefly return no windows while ordinary
+# chat authentication and model discovery remain healthy. Retry only this
+# observed cold-read failure; Codex already owns a bounded protocol timeout and
+# Möbius can truthfully have no measurable balance yet.
+_CLAUDE_COLD_RETRY_DELAYS = (0.25, 0.75)
+
+# One browser query is shared across panes, but several browser sessions can
+# still open the same provider at once. Keep the external probe single-flight
+# per installation/provider and retain one recent successful observation for
+# short outages. Production has one configured data_dir and three providers,
+# so these maps are intrinsically bounded by the provider registry.
+
+@dataclass
+class _CachedProviderUsage:
+  observed_at: float
+  checked_at: float
+  snapshot: dict[str, Any]
+  stale: bool = False
+
+
+_provider_usage_cache: dict[tuple[str, str], _CachedProviderUsage] = {}
+_provider_usage_locks: dict[tuple[str, str], asyncio.Lock] = {}
 
 _CLAUDE_WINDOW_LABELS = {
   "five_hour": "5-hour",
@@ -322,12 +349,18 @@ async def _fetch_claude_usage(data_dir: str) -> dict[str, Any]:
     "Content-Type": "application/json",
   }
   async with httpx.AsyncClient(timeout=5.0) as client:
-    response = await client.get(_CLAUDE_USAGE_URL, headers=headers)
-    response.raise_for_status()
-    return normalize_claude_usage(
-      response.json(),
-      subscription_type=subscription_type,
-    )
+    for delay in (0.0, *_CLAUDE_COLD_RETRY_DELAYS):
+      if delay:
+        await asyncio.sleep(delay)
+      response = await client.get(_CLAUDE_USAGE_URL, headers=headers)
+      response.raise_for_status()
+      snapshot = normalize_claude_usage(
+        response.json(),
+        subscription_type=subscription_type,
+      )
+      if snapshot["state"] != "unavailable":
+        return snapshot
+  return snapshot
 
 
 def _codex_plan_type(account_response: Any) -> Any:
@@ -418,6 +451,45 @@ def _unavailable(plan_label: str | None = None) -> dict[str, Any]:
   }
 
 
+def _cache_key(provider_id: str, data_dir: str) -> tuple[str, str]:
+  return (str(Path(data_dir).resolve()), provider_id)
+
+
+def _cached_usage(
+  key: tuple[str, str],
+  *,
+  max_age: float,
+) -> dict[str, Any] | None:
+  cached = _provider_usage_cache.get(key)
+  if cached is None:
+    return None
+  if time.monotonic() - cached.checked_at > max_age:
+    return None
+  snapshot = copy.deepcopy(cached.snapshot)
+  snapshot["stale"] = cached.stale
+  return snapshot
+
+
+def _snapshot_boundaries_are_current(
+  snapshot: dict[str, Any],
+  *,
+  now: datetime | None = None,
+) -> bool:
+  """Never carry an observation across an allowance reset or expiry."""
+  current = now or datetime.now(UTC)
+  for window in snapshot.get("windows", []):
+    if not isinstance(window, dict):
+      continue
+    for field in ("resets_at", "expires_at"):
+      normalized = _reset_iso(window.get(field))
+      if (
+        normalized is not None
+        and datetime.fromisoformat(normalized) <= current
+      ):
+        return False
+  return True
+
+
 async def _provider_snapshot(provider_id: str, data_dir: str) -> dict[str, Any]:
   provider = providers.PROVIDERS[provider_id]
   if provider.check_auth(data_dir) is not None:
@@ -467,5 +539,62 @@ async def read_provider_usage(
   provider_id: str,
   data_dir: str,
 ) -> dict[str, Any]:
-  """Read one provider's plan usage only when its disclosure is opened."""
-  return await _provider_snapshot(provider_id, data_dir)
+  """Return one coalesced provider usage observation with bounded fallback.
+
+  A connected provider's usage service is advisory and can fail independently
+  from chat authentication. A recent successful observation is safer and more
+  useful than erasing the gauge after one failed probe, but it must never live
+  past either the stale bound or a provider reset.
+  """
+  key = _cache_key(provider_id, data_dir)
+  cached = _cached_usage(key, max_age=_PROVIDER_USAGE_FRESH_SECONDS)
+  if cached is not None:
+    return cached
+
+  lock = _provider_usage_locks.setdefault(key, asyncio.Lock())
+  async with lock:
+    # Another request may have refreshed while this one waited.
+    cached = _cached_usage(key, max_age=_PROVIDER_USAGE_FRESH_SECONDS)
+    if cached is not None:
+      return cached
+
+    snapshot = await _provider_snapshot(provider_id, data_dir)
+    if snapshot.get("state") == "ready":
+      ready = copy.deepcopy(snapshot)
+      ready["stale"] = False
+      checked_at = time.monotonic()
+      _provider_usage_cache[key] = _CachedProviderUsage(
+        observed_at=checked_at,
+        checked_at=checked_at,
+        snapshot=ready,
+      )
+      return copy.deepcopy(ready)
+
+    if snapshot.get("state") == "disconnected":
+      _provider_usage_cache.pop(key, None)
+      return snapshot
+
+    prior = _provider_usage_cache.get(key)
+    now = time.monotonic()
+    if (
+      prior is not None
+      and prior.snapshot.get("state") == "ready"
+      and now - prior.observed_at <= _PROVIDER_USAGE_STALE_SECONDS
+      and _snapshot_boundaries_are_current(prior.snapshot)
+    ):
+      # Suppress a second browser waiting on the same failed live probe while
+      # preserving the original observation age for the stale ceiling.
+      prior.checked_at = now
+      prior.stale = True
+      fallback = copy.deepcopy(prior.snapshot)
+      fallback["stale"] = True
+      return fallback
+
+    unavailable = copy.deepcopy(snapshot)
+    unavailable["stale"] = False
+    _provider_usage_cache[key] = _CachedProviderUsage(
+      observed_at=now,
+      checked_at=now,
+      snapshot=unavailable,
+    )
+    return unavailable

--- a/backend/tests/test_provider_usage.py
+++ b/backend/tests/test_provider_usage.py
@@ -11,6 +11,34 @@ from types import ModuleType, SimpleNamespace
 import pytest
 
 
+def _ready_usage_snapshot(**window_updates):
+  window = {
+    "id": "seven_day",
+    "kind": "weekly",
+    "label": "Weekly",
+    "used_percent": 24,
+    "resets_at": "2099-09-05T03:00:00+00:00",
+  }
+  window.update(window_updates)
+  return {
+    "state": "ready",
+    "plan_label": "Max plan",
+    "windows": [window],
+    "credit_balance": None,
+  }
+
+
+@pytest.fixture(autouse=True)
+def _reset_provider_usage_state():
+  from app import provider_usage
+
+  provider_usage._provider_usage_cache.clear()
+  provider_usage._provider_usage_locks.clear()
+  yield
+  provider_usage._provider_usage_cache.clear()
+  provider_usage._provider_usage_locks.clear()
+
+
 def test_normalize_claude_usage_keeps_current_and_model_windows():
   from app.provider_usage import normalize_claude_usage
 
@@ -176,7 +204,263 @@ def test_provider_usage_reads_only_requested_plan(monkeypatch):
   body = asyncio.run(provider_usage.read_provider_usage("codex", "/data"))
 
   assert body["state"] == "ready"
+  assert body["stale"] is False
   assert seen == ["codex"]
+
+
+@pytest.mark.asyncio
+async def test_provider_usage_coalesces_concurrent_live_reads(
+  monkeypatch, tmp_path,
+):
+  from app import provider_usage
+
+  started = asyncio.Event()
+  release = asyncio.Event()
+  calls = 0
+
+  async def fake_snapshot(_provider_id, _data_dir):
+    nonlocal calls
+    calls += 1
+    started.set()
+    await release.wait()
+    return _ready_usage_snapshot()
+
+  monkeypatch.setattr(provider_usage, "_provider_snapshot", fake_snapshot)
+  first = asyncio.create_task(
+    provider_usage.read_provider_usage("claude", str(tmp_path))
+  )
+  await started.wait()
+  second = asyncio.create_task(
+    provider_usage.read_provider_usage("claude", str(tmp_path))
+  )
+  await asyncio.sleep(0)
+  release.set()
+  first_result, second_result = await asyncio.gather(first, second)
+
+  assert calls == 1
+  assert first_result == second_result
+  assert first_result["stale"] is False
+
+
+@pytest.mark.asyncio
+async def test_provider_usage_coalesces_concurrent_failed_cold_reads(
+  monkeypatch, tmp_path,
+):
+  from app import provider_usage
+
+  started = asyncio.Event()
+  release = asyncio.Event()
+  calls = 0
+
+  async def fake_snapshot(_provider_id, _data_dir):
+    nonlocal calls
+    calls += 1
+    started.set()
+    await release.wait()
+    return provider_usage._unavailable("Max plan")
+
+  monkeypatch.setattr(provider_usage, "_provider_snapshot", fake_snapshot)
+  first = asyncio.create_task(
+    provider_usage.read_provider_usage("claude", str(tmp_path))
+  )
+  await started.wait()
+  second = asyncio.create_task(
+    provider_usage.read_provider_usage("claude", str(tmp_path))
+  )
+  await asyncio.sleep(0)
+  release.set()
+  first_result, second_result = await asyncio.gather(first, second)
+
+  assert calls == 1
+  assert first_result == second_result
+  assert first_result["state"] == "unavailable"
+
+
+@pytest.mark.asyncio
+async def test_claude_usage_retries_a_successful_cold_read(
+  monkeypatch, tmp_path,
+):
+  from app import provider_usage, providers
+
+  monkeypatch.setattr(provider_usage, "_CLAUDE_COLD_RETRY_DELAYS", (0,))
+  monkeypatch.setattr(
+    providers, "claude_subscription_type", lambda _data_dir: "max",
+  )
+
+  async def fake_access_token(_data_dir):
+    return "token"
+
+  monkeypatch.setattr(providers, "claude_access_token", fake_access_token)
+  payloads = [{}, {
+    "seven_day": {
+      "utilization": 24,
+      "resets_at": "2099-09-05T03:00:00+00:00",
+    },
+  }]
+
+  class FakeResponse:
+    def raise_for_status(self):
+      pass
+
+    def json(self):
+      return payloads.pop(0)
+
+  class FakeClient:
+    def __init__(self, **_kwargs):
+      pass
+
+    async def __aenter__(self):
+      return self
+
+    async def __aexit__(self, *_args):
+      pass
+
+    async def get(self, *_args, **_kwargs):
+      return FakeResponse()
+
+  monkeypatch.setattr(provider_usage.httpx, "AsyncClient", FakeClient)
+  result = await provider_usage._fetch_claude_usage(str(tmp_path))
+
+  assert result["state"] == "ready"
+  assert result["windows"][0]["used_percent"] == 24
+  assert payloads == []
+
+
+@pytest.mark.asyncio
+async def test_claude_usage_does_not_retry_transport_failures(
+  monkeypatch, tmp_path,
+):
+  from app import provider_usage, providers
+
+  monkeypatch.setattr(provider_usage, "_CLAUDE_COLD_RETRY_DELAYS", (0, 0))
+  monkeypatch.setattr(
+    providers, "claude_subscription_type", lambda _data_dir: "max",
+  )
+
+  async def fake_access_token(_data_dir):
+    return "token"
+
+  monkeypatch.setattr(providers, "claude_access_token", fake_access_token)
+  calls = 0
+
+  class FailingClient:
+    def __init__(self, **_kwargs):
+      pass
+
+    async def __aenter__(self):
+      return self
+
+    async def __aexit__(self, *_args):
+      pass
+
+    async def get(self, *_args, **_kwargs):
+      nonlocal calls
+      calls += 1
+      raise RuntimeError("offline")
+
+  monkeypatch.setattr(provider_usage.httpx, "AsyncClient", FailingClient)
+
+  with pytest.raises(RuntimeError, match="offline"):
+    await provider_usage._fetch_claude_usage(str(tmp_path))
+  assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_provider_usage_keeps_recent_success_through_transient_failure(
+  monkeypatch, tmp_path,
+):
+  from app import provider_usage
+
+  clock = [100.0]
+  monkeypatch.setattr(provider_usage.time, "monotonic", lambda: clock[0])
+  live = [_ready_usage_snapshot()]
+
+  async def fake_snapshot(_provider_id, _data_dir):
+    return live.pop(0) if live else provider_usage._unavailable("Max plan")
+
+  monkeypatch.setattr(provider_usage, "_provider_snapshot", fake_snapshot)
+  first = await provider_usage.read_provider_usage("claude", str(tmp_path))
+  clock[0] += provider_usage._PROVIDER_USAGE_FRESH_SECONDS + 1
+  fallback = await provider_usage.read_provider_usage("claude", str(tmp_path))
+
+  assert first["stale"] is False
+  assert fallback["state"] == "ready"
+  assert fallback["stale"] is True
+  assert fallback["windows"][0]["used_percent"] == 24
+
+
+@pytest.mark.asyncio
+async def test_provider_usage_stops_reusing_a_success_after_the_stale_limit(
+  monkeypatch, tmp_path,
+):
+  from app import provider_usage
+
+  clock = [100.0]
+  monkeypatch.setattr(provider_usage.time, "monotonic", lambda: clock[0])
+  live = [_ready_usage_snapshot()]
+
+  async def fake_snapshot(_provider_id, _data_dir):
+    return live.pop(0) if live else provider_usage._unavailable("Max plan")
+
+  monkeypatch.setattr(provider_usage, "_provider_snapshot", fake_snapshot)
+  await provider_usage.read_provider_usage("claude", str(tmp_path))
+  clock[0] += provider_usage._PROVIDER_USAGE_STALE_SECONDS + 1
+  result = await provider_usage.read_provider_usage("claude", str(tmp_path))
+
+  assert result["state"] == "unavailable"
+  assert result["stale"] is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("boundary", ["resets_at", "expires_at"])
+async def test_provider_usage_never_reuses_a_snapshot_past_its_boundary(
+  monkeypatch, tmp_path, boundary,
+):
+  from app import provider_usage
+
+  clock = [100.0]
+  monkeypatch.setattr(provider_usage.time, "monotonic", lambda: clock[0])
+  live = [_ready_usage_snapshot(
+    used_percent=99,
+    **{boundary: "2020-01-01T00:00:00+00:00"},
+  )]
+
+  async def fake_snapshot(_provider_id, _data_dir):
+    return live.pop(0) if live else provider_usage._unavailable("Max plan")
+
+  monkeypatch.setattr(provider_usage, "_provider_snapshot", fake_snapshot)
+  await provider_usage.read_provider_usage("claude", str(tmp_path))
+  clock[0] += provider_usage._PROVIDER_USAGE_FRESH_SECONDS + 1
+  result = await provider_usage.read_provider_usage("claude", str(tmp_path))
+
+  assert result["state"] == "unavailable"
+
+
+@pytest.mark.asyncio
+async def test_provider_usage_disconnect_discards_a_prior_observation(
+  monkeypatch, tmp_path,
+):
+  from app import provider_usage
+
+  clock = [100.0]
+  monkeypatch.setattr(provider_usage.time, "monotonic", lambda: clock[0])
+  live = [_ready_usage_snapshot(), {
+    "state": "disconnected",
+    "plan_label": None,
+    "windows": [],
+    "credit_balance": None,
+  }]
+
+  async def fake_snapshot(_provider_id, _data_dir):
+    return live.pop(0)
+
+  monkeypatch.setattr(provider_usage, "_provider_snapshot", fake_snapshot)
+  await provider_usage.read_provider_usage("claude", str(tmp_path))
+  clock[0] += provider_usage._PROVIDER_USAGE_FRESH_SECONDS + 1
+  result = await provider_usage.read_provider_usage("claude", str(tmp_path))
+
+  assert result["state"] == "disconnected"
+  assert provider_usage._provider_usage_cache == {}
 
 
 def test_settings_provider_usage_endpoint(client, auth, monkeypatch):

--- a/frontend/src/components/SettingsView/ProviderUsage.jsx
+++ b/frontend/src/components/SettingsView/ProviderUsage.jsx
@@ -58,6 +58,9 @@ export default function ProviderUsage({
           {snapshot?.credit_balance && (
             <span className="provider-usage__credit">{snapshot.credit_balance}</span>
           )}
+          {snapshot?.stale && (
+            <span className="provider-usage__credit">Last available reading</span>
+          )}
         </span>
       ) : (
         <span className="provider-usage__unavailable">Usage unavailable</span>

--- a/frontend/src/components/SettingsView/providerUsage.js
+++ b/frontend/src/components/SettingsView/providerUsage.js
@@ -65,6 +65,7 @@ export function providerAllowance(provider, snapshot) {
     label,
     usedPercent: Number.isFinite(used) ? clampUsagePercent(used) : null,
     expiresAt: typeof window?.expires_at === 'string' ? window.expires_at : null,
+    ...(snapshot.stale === true ? { stale: true } : {}),
   }
 }
 
@@ -76,7 +77,10 @@ export function providerAllowanceSummary(provider, allowance, now = new Date()) 
     ].filter(Boolean).join(' · ')
   }
   if (typeof allowance?.usedPercent === 'number') {
-    return `${Math.round(allowance.usedPercent)}% ${allowance.label.toLowerCase()}`
+    return [
+      `${Math.round(allowance.usedPercent)}% ${allowance.label.toLowerCase()}`,
+      allowance.stale ? 'last available' : '',
+    ].filter(Boolean).join(' · ')
   }
   return allowance?.label || 'Usage'
 }

--- a/frontend/src/lib/__tests__/providerUsageBehavior.test.js
+++ b/frontend/src/lib/__tests__/providerUsageBehavior.test.js
@@ -53,3 +53,19 @@ test('Möbius allowance copy matches the consumed brain gauge at integer precisi
     expiresAt: '2026-09-07T19:40:34.682998+00:00',
   }, now), '3% used · 13d left')
 })
+
+test('plan allowance copy identifies a recent fallback reading', () => {
+  const allowance = providerAllowance('claude', {
+    state: 'ready',
+    stale: true,
+    windows: [
+      { kind: 'weekly', label: 'Weekly', used_percent: 24 },
+    ],
+  })
+
+  assert.equal(allowance.stale, true)
+  assert.equal(
+    providerAllowanceSummary('claude', allowance),
+    '24% weekly usage · last available',
+  )
+})


### PR DESCRIPTION
## Summary
- coalesce simultaneous usage reads so multiple panes share one provider probe
- retry Claude only when a successful response contains no usage windows, without retrying transport or API failures
- keep the latest successful reading through a brief outage, clearly mark it as last available, and discard it after ten minutes or any allowance reset or expiry
- clear retained usage when the provider disconnects

## Testing
- backend provider-usage suite: 20 passed
- frontend library suite: 2,908 passed
- frontend hook suite: 95 passed
- dependency-tree and lock-version checks passed
- frontend lint passed with 0 errors and 39 pre-existing warnings
- production build plus runtime, offline/PWA, push-worker, and packaged-worker checks passed
- canonical diff, merge-tree, attribution, and privacy review passed

## Security and maintenance review
The cache is process-local, keyed by provider and installation data directory, and bounded by the registered provider set in production. Callers receive copies rather than shared mutable snapshots. A failed live read may reuse only a prior successful observation that is younger than ten minutes and has not crossed a reset or expiry boundary; disconnected state evicts the observation instead of reusing it.