### PR TITLE
Make fresh chats use one canonical composer

### DIFF
--- a/frontend/src/components/ChatView/ChatView.css
+++ b/frontend/src/components/ChatView/ChatView.css
@@ -2664,17 +2664,6 @@
   color: var(--text); /* CONTRACT: high-contrast text on opaque fill */
 }
 
-/* A New Chat already has the same final composer geometry, even during its
-   very short allocation handoff. The options button stays deliberately inert
-   until the row exists, but it must not pop into the layout afterwards. */
-.chat__plus--pending:disabled {
-  cursor: default;
-}
-.chat__plus--pending:disabled:hover {
-  background: color-mix(in srgb, var(--surface) 70%, transparent);
-  color: var(--muted);
-}
-
 /* Keyboard-only focus ring on the brain button. No :focus rule (pointer
    focus must not show a ring — the one-halo invariant). :focus-visible
    fires only for keyboard navigation. When the popover is active the

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -337,6 +337,9 @@ const NO_BUILT_APPS = []
 
 export default function ChatView({
   chatId,
+  newChatSession = null,
+  onNewChatSubmit,
+  onNewChatRetry,
   onStreamEnd,
   onFirstMessage,
   onSystemEvent,
@@ -385,6 +388,7 @@ export default function ChatView({
   onOpenArtifact = null,
 }) {
   const queryClient = useQueryClient()
+  const provisionalNewChat = !!newChatSession && !newChatSession.materialized
   const hiddenRef = useRef(hidden)
   hiddenRef.current = hidden
   // A drawer search may target a ChatView that is already mounted. Subscribe
@@ -459,9 +463,13 @@ export default function ChatView({
     initialActivationAnchorKey,
     !searchReveal && savedReadingAnchorHasNestedPart(chatId),
   )
-  const [loading, setLoading] = useState(initialCacheEntryState === 'missing')
+  const [loading, setLoading] = useState(
+    provisionalNewChat ? false : initialCacheEntryState === 'missing',
+  )
   const [initialEntryPhase, setInitialEntryPhase] = useState(
-    initialCacheEntryState === 'paintable'
+    provisionalNewChat
+      ? 'ready'
+      : initialCacheEntryState === 'paintable'
       ? 'cached'
       : initialCacheEntryState === 'validating'
         ? 'cache-validating'
@@ -471,7 +479,7 @@ export default function ChatView({
   // be stale. Do not publish a chat-to-chat handoff until this activation's
   // runtime/detail verdict has arrived: otherwise an apparently idle cache can
   // be promoted before the server reports that its turn is still running.
-  const [activationSettled, setActivationSettled] = useState(false)
+  const [activationSettled, setActivationSettled] = useState(provisionalNewChat)
   const acceptCachedReadingCoordinate = useCallback(() => {
     // The scroll owner has proved the exact nested part against committed DOM.
     setInitialEntryPhase(current => (
@@ -1117,13 +1125,14 @@ export default function ChatView({
   // freshness so the surface cannot paint stale history when it returns.
   useLayoutEffect(() => {
     if (!hidden) return
+    if (provisionalNewChat) return
     if (keepTranscriptPainted) return
     // Arm the freshness + restoration gate while this surface is still
     // physically hidden. A retained ChatView must not reappear with the
     // transcript from its previous visible lifetime for even one frame.
     setInitialEntryPhase('history')
     setLoading(true)
-  }, [hidden, keepTranscriptPainted])
+  }, [hidden, keepTranscriptPainted, provisionalNewChat])
 
   function rememberSendIntent(cid, intent) {
     if (!cid || !intent) return
@@ -1605,6 +1614,11 @@ export default function ChatView({
     request: apiFetch,
   })
 
+  useLayoutEffect(() => {
+    if (!newChatSession?.materialized || !newChatSession.chatInfo) return
+    setChatInfo(newChatSession.chatInfo)
+  }, [newChatSession?.chatInfo, newChatSession?.materialized, setChatInfo])
+
   const {
     streamItems,
     latestItemsRef,
@@ -2030,9 +2044,9 @@ export default function ChatView({
     }
   }, [chatId, connectToStream, embedded, fetchMessages, isStreamingRef])
   useEffect(() => {
-    if (hidden) return
+    if (hidden || provisionalNewChat) return
     reconcileExternalActivity()
-  }, [effectiveRunSignal.seq, hidden, reconcileExternalActivity])
+  }, [effectiveRunSignal.seq, hidden, provisionalNewChat, reconcileExternalActivity])
 
   const ensureRuntimeStreamConnected = useCallback((runtime) => {
     const action = runtimeStreamAttachAction({
@@ -2299,7 +2313,7 @@ export default function ChatView({
     // A hidden retained pane is not an active runtime. Returning to visibility
     // changes this dependency and re-runs the version + stream handshake
     // without losing the pane's DOM identity.
-    if (hidden) return
+    if (hidden || provisionalNewChat) return
     setActivationSettled(false)
     let cancelled = false
     const initialLoadController = new AbortController()
@@ -2576,6 +2590,17 @@ export default function ChatView({
         offset: refreshed.offset,
       })
 
+      // A freshly created chat has no transcript work to prepare. Settle this
+      // tiny activation immediately so the canonical composer finishes its
+      // allocation state without competing with unrelated continuous updates.
+      // Populated returns keep the interruptible paths below because they can
+      // own real reflow.
+      if (refreshed.messages.length === 0) {
+        applyMessagesToView([], refreshed.offset)
+        settleRuntime(runtime, [])
+        return
+      }
+
       // A return with a complete local window is a warm restoration even when
       // the version changed while away. Apply the authoritative replacement and
       // readiness in the SAME React batch (the transition callback runs
@@ -2686,6 +2711,7 @@ export default function ChatView({
     chatId,
     hidden,
     loadNonce,
+    provisionalNewChat,
     searchReveal?.anchorKey,
     searchReveal?.id,
     reconcileFailedSendOutbox,
@@ -3711,6 +3737,13 @@ export default function ChatView({
       return
     }
     doSend(input.trim())
+  }
+
+  async function handleProvisionalNewChatSubmit(e) {
+    e.preventDefault()
+    if (!provisionalNewChat || newChatSession?.submitted || !input.trim()) return
+    await settingsSaveTailRef.current
+    onNewChatSubmit?.(input)
   }
 
   function handleSubmitSteer(e) {
@@ -4744,6 +4777,21 @@ export default function ChatView({
   // whether the chat is empty — surfacing that branch separately keeps
   // us from lying with "What's on your mind?" over a network failure.
   const showEmpty = !loadError && messages.length === 0 && !turnActive && !loading
+  const newChatStatusMessage = !provisionalNewChat
+    ? null
+    : newChatSession.submitted
+      ? (newChatSession.failure === 'offline'
+          ? 'Queued — your message will send when Möbius reconnects.'
+          : (newChatSession.failure
+              ? 'Queued — waiting to start this chat.'
+              : 'Queued — starting this chat…'))
+      : (newChatSession.failure === 'offline'
+          ? 'You’re offline — your draft is safe.'
+          : (newChatSession.failure === 'queue'
+              ? 'Couldn’t queue this message — your draft is safe.'
+              : (newChatSession.failure
+                  ? 'Couldn’t start a new chat — your draft is safe.'
+                  : null)))
 
   // Collect the question keys currently live in streamItems so MsgContent
   // can suppress any persisted question block that is already rendered by
@@ -5349,6 +5397,25 @@ export default function ChatView({
             <div className="chat__empty">
               <img className="chat__empty-glyph" src="/moebius.png" alt="" width="76" height="76" />
               <p className="chat__empty-title">What's on your mind?</p>
+              {newChatStatusMessage && (
+                <>
+                  <p className="chat__empty-sub" role="status">
+                    {newChatStatusMessage}
+                  </p>
+                  {newChatSession.failure
+                    && newChatSession.failure !== 'queue'
+                    && onNewChatRetry && (
+                    <button
+                      type="button"
+                      className="chat__empty-action"
+                      onPointerDown={event => event.preventDefault()}
+                      onClick={onNewChatRetry}
+                    >
+                      Retry
+                    </button>
+                  )}
+                </>
+              )}
             </div>
           )}
         </div>
@@ -5680,8 +5747,10 @@ export default function ChatView({
           input={input}
           onInputChange={handleComposerInputChange}
           onInputIntent={composerEdited}
-          onSubmit={handleSubmit}
-          onSubmitSteer={handleSubmitSteer}
+          onSubmit={provisionalNewChat ? handleProvisionalNewChatSubmit : handleSubmit}
+          onSubmitSteer={provisionalNewChat
+            ? handleProvisionalNewChatSubmit
+            : handleSubmitSteer}
           inputRef={inputRef}
           sending={composerBusy}
           listening={listening}
@@ -5696,7 +5765,7 @@ export default function ChatView({
           canRequestSteer={canRequestSteer}
           canSubmitSteer={canSubmitSteer}
           sendFailure={sendFailure}
-          submissionBlocked={providerSwitching}
+          submissionBlocked={providerSwitching || !!newChatSession?.submitted}
           questionBlocked={hasPendingQuestion}
           pendingFiles={pendingFiles}
           onAddFiles={handleComposerAddFiles}
@@ -5719,6 +5788,7 @@ export default function ChatView({
                 triggerAriaLabel={embedded ? 'Attach files' : ariaLabel}
                 chatInfo={showPicker ? chatInfo : null}
                 chatId={chatId}
+                chatReady={!provisionalNewChat}
                 onAttachClick={() => attachTriggerRef.current?.()}
                 /* Derive live — `chatInfo.has_assistant_turns` is set
                    once on mount via the API and never refreshed when

--- a/frontend/src/components/ChatView/ComposerPopover.jsx
+++ b/frontend/src/components/ChatView/ComposerPopover.jsx
@@ -19,11 +19,9 @@
  * anchor — the form is only relative so other absolutely-positioned
  * children (none today) could anchor to it.
  *
- * A draft-first New Chat uses this same component with `pending` only until
- * its server row exists, then reuses the model picker with unrelated chat
- * actions omitted. Keeping both states here prevents the provisional composer
- * from maintaining a second lookalike button that can drift from the real
- * control.
+ * A draft-first New Chat mounts this canonical control immediately. Actions
+ * that need the row defer their reads through `chatReady`; local draft actions
+ * such as Attach files remain available throughout allocation.
  *
  * Soft-keyboard contract: opening or using this popover preserves whether the
  * owning textarea was focused. The brain trigger suppresses native button focus
@@ -72,6 +70,7 @@ import './ChatWork.css'
 export default function ComposerPopover({
   chatInfo,
   chatId,
+  chatReady = true,
   onAttachClick,
   onChangeChatInfo,
   // Live-derived in the parent: `chatInfo.has_assistant_turns` is
@@ -100,7 +99,6 @@ export default function ComposerPopover({
   appArtifacts = [],
   onOpenAppArtifact,
   embedded = false,
-  pending = false,
   triggerIcon = null,
   providerUsage = null,
   triggerAriaLabel = 'Chat options',
@@ -124,7 +122,7 @@ export default function ComposerPopover({
     composerInputRef,
   )
   const usageQuery = chatQueries.usage.useQuery(chatId, {
-    enabled: Boolean(open && !embedded && chatId && onOpenUsage),
+    enabled: Boolean(open && !embedded && chatReady && chatId && onOpenUsage),
   })
   const usageSummary = formatUsageMenuText(usageQuery.data?.totals)
   const artifactsQuery = useQuery({
@@ -134,14 +132,14 @@ export default function ComposerPopover({
       chatId,
       { signal, request: apiFetch },
     ),
-    enabled: Boolean(open && !embedded && artifactsAppId && chatId),
+    enabled: Boolean(open && !embedded && chatReady && artifactsAppId && chatId),
     staleTime: 0,
   })
   const changesOverview = useChatChangesOverview(chatId, initialChangeEntries, {
     // This compact query previously stayed live through the persistent review
     // card. Keep it live here after removing that card so the existing Brain
     // button can carry one geometry-free attention dot for Changes.
-    enabled: Boolean(!embedded && chatId),
+    enabled: Boolean(!embedded && chatReady && chatId),
   })
   const chatArtifacts = artifactsQuery.data || []
   const artifactItems = chatArtifactPickerItems(appArtifacts, chatArtifacts)
@@ -324,9 +322,7 @@ export default function ComposerPopover({
       <button
         ref={triggerRef}
         type="button"
-        className={`chat__plus chat__brain-usage${pending ? ' chat__plus--pending' : ''}`
-          + `${open && !pending ? ' chat__plus--active' : ''}`}
-        disabled={pending}
+        className={`chat__plus chat__brain-usage${open ? ' chat__plus--active' : ''}`}
         // PointerDown preventDefault stops the focus from moving off
         // the textarea — keeps the soft keyboard open when the user
         // taps the brain mid-typing. Without this, focus shifts to the
@@ -334,21 +330,19 @@ export default function ComposerPopover({
         // before the popover even renders.
         onPointerDown={(e) => e.preventDefault()}
         onClick={togglePopover}
-        aria-label={pending
-          ? 'Chat options unavailable until this chat is ready'
-          : [
-              triggerAriaLabel,
-              changesNeedAttention ? 'Changes need attention.' : '',
-            ].filter(Boolean).join(' ')}
-        aria-haspopup={pending ? undefined : 'dialog'}
-        aria-expanded={pending ? undefined : open}
+        aria-label={[
+          triggerAriaLabel,
+          changesNeedAttention ? 'Changes need attention.' : '',
+        ].filter(Boolean).join(' ')}
+        aria-haspopup="dialog"
+        aria-expanded={open}
       >
         {triggerIcon || <BrainUsageIcon />}
         {changesNeedAttention && (
           <span className="composer-plus__attention-dot" aria-hidden="true" />
         )}
       </button>
-      {open && !pending && (
+      {open && (
         <div
           className="composer-popover"
           role="dialog"

--- a/frontend/src/components/ChatView/__tests__/contextMenuOrder.test.js
+++ b/frontend/src/components/ChatView/__tests__/contextMenuOrder.test.js
@@ -43,7 +43,7 @@ test('chat context actions follow model selection and continuation policy', () =
 test('Changes owns contribution attention without adding a composer card', () => {
   assert.match(
     composerSource,
-    /useChatChangesOverview\(chatId, initialChangeEntries,[\s\S]*?enabled: Boolean\(!embedded && chatId\)/,
+    /useChatChangesOverview\(chatId, initialChangeEntries,[\s\S]*?enabled: Boolean\(!embedded && chatReady && chatId\)/,
   )
   assert.match(composerSource, /changesOverview\.needsAction \|\| changesOverview\.workState === 'attention'/)
   assert.match(composerSource, /composer-plus__attention-dot/)

--- a/frontend/src/components/ChatView/hooks/__tests__/useChatRuntimePolicy.test.js
+++ b/frontend/src/components/ChatView/hooks/__tests__/useChatRuntimePolicy.test.js
@@ -32,6 +32,33 @@ test('runtime policy derives resumability from the cached chat contract', () => 
   assert.equal(result.current.autoResumeEnabled, true)
 })
 
+test('a provisional chat adopts its created runtime policy without remounting', () => {
+  resetProviderSwitchMemoryForTests()
+  const props = {
+    chatId: 'policy-provisional',
+    cached: null,
+    hidden: false,
+    onProviderSwitchSettled() {},
+    request: unusedRequest,
+  }
+  const { result, rerender } = renderHook(useChatRuntimePolicy, props)
+  assert.equal(result.current.chatInfo, null)
+
+  rerender({
+    ...props,
+    cached: {
+      chatInfo: {
+        provider: 'codex',
+        auto_resume_on_limit: false,
+        effective: { model: 'gpt-current' },
+      },
+    },
+  })
+
+  assert.equal(result.current.chatInfo.provider, 'codex')
+  assert.deepEqual(result.current.chatInfo.effective, { model: 'gpt-current' })
+})
+
 test('a completed provider switch settles through one owner and clears its store', () => {
   resetProviderSwitchMemoryForTests()
   const chatId = 'policy-switch'

--- a/frontend/src/components/ChatView/hooks/useChatRuntimePolicy.js
+++ b/frontend/src/components/ChatView/hooks/useChatRuntimePolicy.js
@@ -46,6 +46,11 @@ export default function useChatRuntimePolicy({
 
   const cachedProvider = cached?.chatInfo?.provider || null
   const cachedSessionId = cached?.chatInfo?.session_id || null
+  const cachedChatInfo = cached?.chatInfo || null
+  useLayoutEffect(() => {
+    if (!cachedChatInfo) return
+    setChatInfo(previous => previous || cachedChatInfo)
+  }, [cachedChatInfo])
   useLayoutEffect(() => {
     if (!cachedSessionId) return
     setChatInfo(previous => {

--- a/frontend/src/components/Shell/NewChatLanding.jsx
+++ b/frontend/src/components/Shell/NewChatLanding.jsx
@@ -1,169 +1,27 @@
-import { useEffect, useLayoutEffect, useRef, useState } from 'react'
-
-import ChatInputBar from '../ChatView/ChatInputBar.jsx'
-import BrainUsageButton from '../ChatView/BrainUsageButton.jsx'
-import ComposerPopover from '../ChatView/ComposerPopover.jsx'
-import { selectedChatModel } from '../ChatView/modelSelectionPolicy.js'
-import {
-  composerDraftRevision,
-  persistComposerDraft,
-  readComposerDraft,
-  readComposerDraftAsync,
-} from '../ChatView/composerDraft.js'
-import {
-  focusComposerElement,
-  placeCaretAtTextEnd,
-} from '../ChatView/composerFocusPolicy.js'
-
-function composerFiles(files) {
-  return (files || []).map((file, index) => ({
-    ...file,
-    id: file.id || `new-chat-restored-${index}-${file.name || 'file'}`,
-  }))
-}
-
 /**
- * New Chat's immediate, draft-only compose surface.
+ * Passive home for a genuinely empty Standard slot.
  *
- * The client-minted chat id is already the final draft owner, so every edit is
- * durable before POST /chats settles. The Brain stays disabled only until the
- * row exists, then the canonical model picker becomes available on this same
- * surface while Shell hands focus to the real ChatView underneath.
+ * Interactive New Chat actions never render here: Shell mounts the canonical
+ * ChatView immediately on the client-minted final id. Keeping this component
+ * passive prevents a second composer from owning draft, files, focus, model
+ * settings, or first-send state.
  */
-export default function NewChatLanding({
-  chatId = null,
-  failure = null,
-  focusToken = 0,
-  onComposerReady,
-  onRetry,
-  onSubmit,
-  submitted = false,
-  chatInfo = null,
-}) {
-  const inputRef = useRef(null)
-  const listeningRef = useRef(false)
-  const readyRef = useRef(null)
-  const initialRef = useRef(null)
-  if (!initialRef.current) {
-    initialRef.current = chatId == null
-      ? { input: '', attachments: [] }
-      : readComposerDraft(chatId)
-  }
-  const initialAttachments = composerFiles(initialRef.current.attachments)
-  const attachmentsRef = useRef(initialAttachments)
-  const inputValueRef = useRef(initialRef.current.input)
-  const [input, setInput] = useState(initialRef.current.input)
-  const [attachments, setAttachments] = useState(initialAttachments)
-  const [liveChatInfo, setLiveChatInfo] = useState(chatInfo)
-  const [submitPending, setSubmitPending] = useState(false)
-  const settingsSaveTailRef = useRef(Promise.resolve())
-
-  useEffect(() => {
-    if (chatInfo) setLiveChatInfo(chatInfo)
-  }, [chatInfo])
-
-  function mergeChatInfo({ agent_settings_json, provider, effective }) {
-    setLiveChatInfo(previous => previous ? ({
-      ...previous,
-      agent_settings_json,
-      provider: provider || previous.provider,
-      effective: effective || previous.effective,
-    }) : previous)
-  }
-
-  function updateInput(next) {
-    const value = String(next)
-    inputValueRef.current = value
-    if (chatId != null) {
-      persistComposerDraft(chatId, value, attachmentsRef.current)
-    }
-    setInput(value)
-  }
-
-  // The synchronous session/live mirror wins first paint. IndexedDB repairs a
-  // reload whose session write was older, but never overwrites a newer keypress.
-  useEffect(() => {
-    if (chatId == null) return undefined
-    let cancelled = false
-    const revision = composerDraftRevision(chatId)
-    readComposerDraftAsync(chatId).then(saved => {
-      if (cancelled || composerDraftRevision(chatId) !== revision) return
-      const nextAttachments = composerFiles(saved.attachments)
-      attachmentsRef.current = nextAttachments
-      setAttachments(nextAttachments)
-      if (saved.input !== inputValueRef.current) {
-        inputValueRef.current = saved.input
-        setInput(saved.input)
-      }
-    }).catch(() => {})
-    return () => { cancelled = true }
-  }, [chatId])
-
-  // Shell mounts this during the New Chat tap. A layout effect transfers the
-  // tap's live activation from the tiny fallback lease before the browser can
-  // paint or dispatch another key event.
-  useLayoutEffect(() => {
-    if (chatId == null || !focusToken) return
-    const readyKey = `${chatId}:${focusToken}`
-    if (readyRef.current === readyKey) return
-    readyRef.current = readyKey
-    focusComposerElement(inputRef.current)
-    placeCaretAtTextEnd(inputRef.current)
-    const focused = globalThis.document?.activeElement === inputRef.current
-    onComposerReady?.({ chatId: String(chatId), focusToken, focused })
-  }, [chatId, focusToken, onComposerReady])
-
-  function removeAttachment(fileId) {
-    const next = attachmentsRef.current.filter(file => String(file.id) !== String(fileId))
-    attachmentsRef.current = next
-    setAttachments(next)
-    if (chatId != null) persistComposerDraft(chatId, inputValueRef.current, next)
-  }
-
-  async function submitDraft(event) {
-    event?.preventDefault?.()
-    if (submitted || submitPending || !input.trim()) return
-    const draft = input
-    setSubmitPending(true)
-    try {
-      await settingsSaveTailRef.current
-      onSubmit?.(draft)
-    } finally {
-      setSubmitPending(false)
-    }
-  }
-
-  const statusMessage = submitted
-    ? (failure === 'offline'
-        ? 'Queued — your message will send when Möbius reconnects.'
-        : (failure
-            ? 'Queued — waiting to start this chat.'
-            : 'Queued — starting this chat…'))
-    : (failure === 'offline'
-        ? 'You’re offline — your draft is safe.'
-        : (failure === 'queue'
-            ? 'Couldn’t queue this message — your draft is safe.'
-            : (failure ? 'Couldn’t start a new chat — your draft is safe.' : null)))
-
-  const liveComposer = chatId != null
+export default function NewChatLanding({ failure = null, onRetry }) {
   return (
     <div className="chat chat--empty">
       <div className="chat__empty-wrap">
         <div className="chat__empty">
           <img className="chat__empty-glyph" src="/moebius.png" alt="" width="76" height="76" />
           <p className="chat__empty-title">What&apos;s on your mind?</p>
-          {statusMessage && (
+          {failure && (
             <>
               <p className="chat__empty-sub" role="status">
-                {statusMessage}
+                {failure === 'offline'
+                  ? 'You’re offline — a new chat needs the network.'
+                  : 'Couldn’t start a new chat — please try again.'}
               </p>
-              {failure && failure !== 'queue' && onRetry && (
-                <button
-                  type="button"
-                  className="chat__empty-action"
-                  onPointerDown={event => event.preventDefault()}
-                  onClick={onRetry}
-                >
+              {onRetry && (
+                <button type="button" className="chat__empty-action" onClick={onRetry}>
                   Retry
                 </button>
               )}
@@ -171,55 +29,6 @@ export default function NewChatLanding({
           )}
         </div>
       </div>
-      {liveComposer && !submitted && (
-        <div className="chat__foot">
-          <ChatInputBar
-            chatId={chatId}
-            input={input}
-            onInputChange={updateInput}
-            onInputIntent={() => {}}
-            onSubmit={submitDraft}
-            onSubmitSteer={submitDraft}
-            inputRef={inputRef}
-            sending={false}
-            listening={false}
-            listeningRef={listeningRef}
-            onManualVoiceEdit={() => {}}
-            onToggleVoice={() => {}}
-            onStop={() => {}}
-            onSteer={() => {}}
-            canSteer={false}
-            offline={failure === 'offline'}
-            submissionBlocked={submitted || submitPending}
-            pendingFiles={attachments}
-            onRemoveFile={removeAttachment}
-            leftButtons={liveChatInfo ? (
-              <BrainUsageButton
-                chatId={chatId}
-                provider={liveChatInfo.provider}
-                providerSessionId={liveChatInfo.session_id}
-                model={selectedChatModel(liveChatInfo)}
-              >
-                {({ icon, ariaLabel, providerUsage }) => (
-                  <ComposerPopover
-                    triggerIcon={icon}
-                    triggerAriaLabel={ariaLabel}
-                    providerUsage={providerUsage}
-                    chatInfo={liveChatInfo}
-                    chatId={chatId}
-                    hasAssistantTurns={false}
-                    onChangeChatInfo={mergeChatInfo}
-                    settingsSaveTailRef={settingsSaveTailRef}
-                    composerInputRef={inputRef}
-                    embedded
-                  />
-                )}
-              </BrainUsageButton>
-            ) : <ComposerPopover pending />}
-            attachmentsDisabled
-          />
-        </div>
-      )}
     </div>
   )
 }

--- a/frontend/src/components/Shell/PaneChatView.jsx
+++ b/frontend/src/components/Shell/PaneChatView.jsx
@@ -2,6 +2,7 @@ import { memo, useCallback, useEffect, useMemo, useRef } from 'react'
 import ChatView from '../ChatView/ChatView.jsx'
 import ErrorBoundary from '../ErrorBoundary/ErrorBoundary.jsx'
 import { builtAppsSignature, derivedBuiltApps } from './builtAppState.js'
+import { newChatServerReadsReady } from './newChatPolicy.js'
 import { samePaneChatProps } from './paneChatProps.js'
 import { scheduleAfterBrowserPaint } from './scheduleAfterBrowserPaint.js'
 
@@ -25,6 +26,9 @@ function PaneChatView({
   chatId,
   paneId,
   apps,
+  newChatSession = null,
+  onNewChatSubmit,
+  onNewChatRetry,
   artifactsAppId = null,
   runtimeActive = true,
   previewPresented = false,
@@ -52,12 +56,16 @@ function PaneChatView({
   onDisplayReady,
   onChatBoundaryError,
 }) {
+  // This is the pane boundary for every row-owned projection. Queries added
+  // here must use `{ enabled: chatReady }`: a provisional client id is already
+  // the visible owner, but it is not a readable server entity yet.
+  const chatReady = newChatServerReadsReady(newChatSession)
   // builtApps is derived PER chatId, memoized on the same signature Shell uses
   // for the primary chat — an unrelated app's refetch is a no-op for this pane.
   const builtApps = useMemo(
-    () => derivedBuiltApps(apps, chatId),
+    () => chatReady ? derivedBuiltApps(apps, chatId) : [],
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [builtAppsSignature(apps, chatId)],
+    [builtAppsSignature(apps, chatId), chatReady],
   )
 
   const handleStreamEnd = useCallback(({ continues } = {}) => {
@@ -145,6 +153,9 @@ function PaneChatView({
       <ChatView
         key={chatId}
         chatId={chatId}
+        newChatSession={newChatSession}
+        onNewChatSubmit={onNewChatSubmit}
+        onNewChatRetry={onNewChatRetry}
         hidden={!runtimeActive}
         previewPresented={previewPresented}
         keepTranscriptPainted={keepTranscriptPainted}

--- a/frontend/src/components/Shell/Shell.css
+++ b/frontend/src/components/Shell/Shell.css
@@ -455,35 +455,6 @@
   letter-spacing: 0.01em;
 }
 
-/* While New chat is allocating, the ordinary landing covers the outgoing
-   ChatView and its z:2 handoff cover. */
-.shell__new-chat-presentation {
-  z-index: 3;
-}
-
-/* The resolved ChatView is already painted underneath. Fade the complete,
-   opaque welcome surface rather than unmounting one logo and asking the next
-   image node to replace it on the same frame; matching pixels stay visually
-   stable while the real composer arrives softly. */
-.shell__new-chat-presentation--releasing {
-  pointer-events: none;
-  will-change: opacity;
-  animation: shell-new-chat-release 180ms ease-out both;
-}
-
-@keyframes shell-new-chat-release {
-  from { opacity: 1; }
-  to { opacity: 0; }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  /* Keep animationend as the state-machine completion signal without exposing
-     a visible transition to owners who prefer reduced motion. */
-  .shell__new-chat-presentation--releasing {
-    animation-duration: 1ms;
-  }
-}
-
 /* ── Tab strip: pinned chats/apps to swap between ─────────────────── */
 .shell__tabstrip {
   flex-shrink: 0;

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -88,7 +88,6 @@ import {
   currentReusableEmptyChat,
   failedNewChatPresentation,
   mergeChatListWithCreatedGuards,
-  newChatPresentationCoversSurface,
   newChatPresentationIsCurrent,
   readNewChatIntent,
   reconcileCreatedChatGuard,
@@ -741,8 +740,8 @@ export default function Shell({ onInitialVisualReady }) {
   const requestComposer = useCallback((chatId, {
     draft,
     focus = false,
+    submit = false,
     restoreExistingDraft = false,
-    releaseNewChatPresentationToken = null,
   } = {}) => {
     if (chatId == null) return
     if (draft == null && !focus && !restoreExistingDraft) return
@@ -752,8 +751,8 @@ export default function Shell({ onInitialVisualReady }) {
       token: composerRequestTokenRef.current,
       draft: draft == null ? null : String(draft),
       focus: focus === true,
+      submit: submit === true,
       restoreExistingDraft: restoreExistingDraft === true,
-      releaseNewChatPresentationToken,
     }
     composerRequestRef.current = request
     setComposerRequest(request)
@@ -821,35 +820,7 @@ export default function Shell({ onInitialVisualReady }) {
     setComposerRequest(current => (
       current?.token === token ? null : current
     ))
-    const presentation = newChatPresentationRef.current
-    if (
-      request.releaseNewChatPresentationToken != null
-      && presentation?.token === request.releaseNewChatPresentationToken
-      && !presentation.releasing
-    ) {
-      const releasing = { ...presentation, releasing: true }
-      newChatPresentationRef.current = releasing
-      setNewChatPresentation(current => (
-        current?.token === presentation.token ? releasing : current
-      ))
-    }
   }, [])
-
-  const handleNewChatLandingComposerReady = useCallback(({
-    chatId,
-    focusToken,
-    focused,
-  }) => {
-    const presentation = newChatPresentationRef.current
-    if (
-      !focused
-      || String(presentation?.chatId ?? '') !== String(chatId)
-      || presentation?.focusToken !== focusToken
-    ) return
-    releaseTouchComposerFocusLease({
-      owner: presentation.leaseOwner,
-    })
-  }, [releaseTouchComposerFocusLease])
 
   // One shell-wide indicator owns the persistent offline explanation. Chat
   // still disables sends while unavailable, but does not repeat this status
@@ -1262,24 +1233,15 @@ export default function Shell({ onInitialVisualReady }) {
     const presentation = newChatPresentationRef.current
     if (
       presentation?.materialized
-      && !presentation.handoffRequested
-      && !presentation.releasing
       && String(presentation?.chatId ?? '') === id
     ) {
-      const handingOff = { ...presentation, handoffRequested: true }
-      newChatPresentationRef.current = handingOff
+      // The same ChatView has owned this id since the New Chat tap. Its
+      // authoritative activation is now ready, so only the allocation marker
+      // retires; no composer, focus, or draft handoff exists.
+      newChatPresentationRef.current = null
       setNewChatPresentation(current => (
-        current?.token === presentation.token ? handingOff : current
+        current?.token === presentation.token ? null : current
       ))
-      // The live landing stays mounted until the real composer has focused and
-      // synchronously re-read draft:<id>. Its acknowledgement starts the cover
-      // release; display readiness alone is not enough because one final key can
-      // land on the outgoing textarea in this frame.
-      requestComposer(id, {
-        focus: true,
-        restoreExistingDraft: true,
-        releaseNewChatPresentationToken: presentation.token,
-      })
     }
     const appCover = appToChatCoverRef.current
     if (
@@ -1293,7 +1255,6 @@ export default function Shell({ onInitialVisualReady }) {
   }, [
     focusedPaneViewIdRef,
     markInitialVisualReady,
-    requestComposer,
     workspaceStateRef,
   ])
 
@@ -1309,23 +1270,15 @@ export default function Shell({ onInitialVisualReady }) {
     return () => cancelAnimationFrame(frame)
   }, [activeChatId, activeView, chatsQuery.isFetched, markInitialVisualReady])
 
-  const finishNewChatPresentationRelease = useCallback((presentation) => {
-    if (!presentation?.releasing || newChatPresentationRef.current !== presentation) return
-    newChatPresentationRef.current = null
-    setNewChatPresentation(current => (
-      current === presentation ? null : current
-    ))
-  }, [])
-
-  // A route change, Back gesture, drawer reopen, or mode switch supersedes a
-  // pending New-chat tap. Retire its cover and keyboard lease together so its
-  // eventual network result cannot repaint or navigate over the newer intent.
+  // A route, pane, or mode change supersedes a pending New-chat tap. Drawer
+  // visibility is deliberately irrelevant: the canonical ChatView already
+  // owns the final id, so opening or closing navigation cannot invalidate it.
+  // Retire the allocation marker and keyboard lease together so an eventual
+  // network result cannot navigate over a newer destination.
   useLayoutEffect(() => {
     const presentation = newChatPresentationRef.current
     if (!presentation || newChatPresentationIsCurrent(presentation, {
-      navigationEpoch: navigationEpochRef.current,
       viewMode: workspace.viewMode,
-      drawerEntryOpen: drawerPushedRef.current && navigationOpen,
       activeView,
       activeChatId,
       focusedPaneId: workspace.focusedPaneId,
@@ -1337,22 +1290,12 @@ export default function Shell({ onInitialVisualReady }) {
     setNewChatPresentation(current => (
       current === presentation ? null : current
     ))
-    const request = composerRequestRef.current
-    if (request?.releaseNewChatPresentationToken === presentation.token) {
-      composerRequestRef.current = null
-      setComposerRequest(current => (
-        current?.token === request.token ? null : current
-      ))
-    }
     releaseTouchComposerFocusLease({
       owner: presentation.leaseOwner,
     })
   }, [
     activeChatId,
     activeView,
-    drawerPushedRef,
-    navigationEpochRef,
-    navigationOpen,
     newChatPresentation,
     workspace,
     releaseTouchComposerFocusLease,
@@ -3368,9 +3311,7 @@ export default function Shell({ onInitialVisualReady }) {
     const ws = workspaceStateRef.current.ws
     return newChatPresentationRef.current?.token === presentation?.token
       && newChatPresentationIsCurrent(presentation, {
-        navigationEpoch: navigationEpochRef.current,
         viewMode: ws.viewMode,
-        drawerEntryOpen: drawerPushedRef.current && navigationOpen,
         activeView: activeViewRef.current,
         activeChatId: activeChatIdRef.current,
         focusedPaneId: ws.focusedPaneId,
@@ -3438,16 +3379,30 @@ export default function Shell({ onInitialVisualReady }) {
           const failed = {
             ...current,
             chatId: decision.chatId,
-            focusToken: current.focusToken + 1,
             submitted: false,
             failure: 'queue',
             failedAtRecoveryGeneration: recoveryGenerationRef.current,
             materialized: false,
             chatInfo: null,
-            handoffRequested: false,
+            paneActiveKey: current.viewMode === 'panes'
+              ? `chat:${decision.chatId}`
+              : null,
           }
           newChatPresentationRef.current = failed
-          flushSync(() => setNewChatPresentation(failed))
+          const ws = workspaceStateRef.current.ws
+          flushSync(() => {
+            setNewChatPresentation(failed)
+            applyModeDestination({
+              view: 'chat',
+              chatId: decision.chatId,
+              appId: null,
+              paneId: ws.focusedPaneId,
+            })
+          })
+          requestComposer(decision.chatId, {
+            focus: true,
+            restoreExistingDraft: true,
+          })
           return
         }
       }
@@ -3456,15 +3411,29 @@ export default function Shell({ onInitialVisualReady }) {
       const replacement = {
         ...current,
         chatId: decision.chatId,
-        focusToken: current.focusToken + 1,
         failure: null,
         failedAtRecoveryGeneration: null,
         materialized: false,
         chatInfo: null,
-        handoffRequested: false,
+        paneActiveKey: current.viewMode === 'panes'
+          ? `chat:${decision.chatId}`
+          : null,
       }
       newChatPresentationRef.current = replacement
-      flushSync(() => setNewChatPresentation(replacement))
+      const ws = workspaceStateRef.current.ws
+      flushSync(() => {
+        setNewChatPresentation(replacement)
+        applyModeDestination({
+          view: 'chat',
+          chatId: decision.chatId,
+          appId: null,
+          paneId: ws.focusedPaneId,
+        })
+      })
+      requestComposer(decision.chatId, {
+        focus: true,
+        restoreExistingDraft: true,
+      })
       void settleDraftFirstNewChat(replacement)
       return
     }
@@ -3490,48 +3459,23 @@ export default function Shell({ onInitialVisualReady }) {
     }
     if (!draftFirstPresentationIsCurrent(presentation)) return
 
-    // Allocation and the independent draft read race on a cold/restricted
-    // reload. Do not expose the destination ChatView until the final id's
-    // durable owner has hydrated into the live mirror; otherwise a fast focus
-    // handoff plus immediate keypress can overwrite the older saved text.
-    await readComposerDraftAsync(intentId)
-    if (!draftFirstPresentationIsCurrent(presentation)) return
-    if (String(newChatIntentRef.current?.chatId ?? '') !== intentId) return
-
     const current = newChatPresentationRef.current
-    const changesRoute = activeViewRef.current !== 'chat'
-      || String(activeChatIdRef.current) !== intentId
-    if (changesRoute) navTo('chat', { chatId: intentId })
     const resolved = {
       ...current,
       materialized: true,
       chatInfo: createdChatDetailCache(result.chat)?.chatInfo ?? null,
-      handoffRequested: !changesRoute,
       failure: null,
       failedAtRecoveryGeneration: null,
-      navigationEpoch: navigationEpochRef.current,
-      // navTo consumes the modal drawer entry synchronously. Carry that
-      // ownership change into the presentation or the validity guard will
-      // retire the cover before ChatView can accept focus and reread the draft.
-      drawerEntryOpen: false,
     }
     newChatPresentationRef.current = resolved
     setNewChatPresentation(current => (
       current?.token === presentation.token ? resolved : current
     ))
-    if (!changesRoute) {
-      closeDrawer()
-      const ws = workspaceStateRef.current.ws
-      applyModeDestination({
-        view: 'chat',
-        chatId: intentId,
-        appId: null,
-        paneId: ws.focusedPaneId,
-      })
+    const autoSendDraft = readComposerHandoff(intentId).autoSendDraft
+    if (current.submitted && autoSendDraft) {
       requestComposer(intentId, {
-        focus: true,
-        restoreExistingDraft: true,
-        releaseNewChatPresentationToken: presentation.token,
+        draft: autoSendDraft,
+        submit: true,
       })
     }
   }
@@ -3540,7 +3484,7 @@ export default function Shell({ onInitialVisualReady }) {
 
   const retryDraftFirstNewChat = useCallback(() => {
     const presentation = newChatPresentationRef.current
-    if (!presentation || presentation.materialized || presentation.releasing) return
+    if (!presentation || presentation.materialized) return
     const retrying = {
       ...presentation,
       failure: null,
@@ -3554,7 +3498,7 @@ export default function Shell({ onInitialVisualReady }) {
 
   const queueDraftFirstNewChat = useCallback((input) => {
     const presentation = newChatPresentationRef.current
-    if (!presentation || presentation.releasing) return
+    if (!presentation) return
     const text = typeof input === 'string' ? input : ''
     if (!text.trim()) return
 
@@ -3578,23 +3522,16 @@ export default function Shell({ onInitialVisualReady }) {
     const queued = {
       ...presentation,
       submitted: true,
-      // A materialized landing now owns the one destination handoff. Mark it
-      // before publishing state so a concurrent display-ready focus request
-      // cannot replace the submit request in Shell's single request slot.
-      handoffRequested: presentation.materialized
-        || presentation.handoffRequested,
     }
     newChatPresentationRef.current = queued
     setNewChatPresentation(queued)
     if (presentation.materialized) {
-      // Allocation may finish before the owner presses Send while the landing
-      // still covers the newly mounted ChatView. That visible composer remains
-      // the action owner: explicitly hand its verified draft to the real
-      // composer instead of treating materialization as a reason to ignore it.
+      // Allocation may finish before the owner presses Send. The already-
+      // mounted ChatView remains the action owner; route the verified draft
+      // back into that same composer rather than waiting for another render.
       requestComposer(presentation.chatId, {
         draft: text,
         submit: true,
-        releaseNewChatPresentationToken: presentation.token,
       })
       return
     }
@@ -3621,14 +3558,11 @@ export default function Shell({ onInitialVisualReady }) {
       setNewChatLandingFailure(null)
     }
     const currentPresentation = newChatPresentationRef.current
-    if (currentPresentation && !currentPresentation.releasing) {
-      if (currentPresentation.materialized && currentPresentation.handoffRequested) return
-      const refocused = {
-        ...currentPresentation,
-        focusToken: (currentPresentation.focusToken || 0) + 1,
-      }
-      newChatPresentationRef.current = refocused
-      setNewChatPresentation(refocused)
+    if (currentPresentation) {
+      requestComposer(currentPresentation.chatId, {
+        focus: true,
+        restoreExistingDraft: true,
+      })
       return
     }
 
@@ -3699,26 +3633,29 @@ export default function Shell({ onInitialVisualReady }) {
       chatId,
       materialized: false,
       chatInfo: null,
-      handoffRequested: false,
-      focusToken: token,
       failure: null,
       failedAtRecoveryGeneration: null,
       submitted: readComposerHandoff(chatId).autoSendDraft != null,
       leaseOwner,
-      navigationEpoch: navigationEpochRef.current,
       viewMode: ws.viewMode,
       paneId: forceNew ? ws.focusedPaneId : null,
-      paneActiveKey: forceNew
-        ? paneModel.activeKeyForOwner(ws, ws.focusedPaneId)
-        : null,
-      drawerEntryOpen: drawerPushedRef.current && navigationOpen,
+      paneActiveKey: forceNew ? `chat:${chatId}` : null,
     }
-    // Commit the visible, draft-backed textarea before the tap task ends. The
-    // mobile activation lease is only a one-commit bridge and can clear now.
+    // The client-minted id is the workspace destination immediately. This
+    // mounts ChatView's one canonical composer before the tap task ends; row
+    // allocation only unlocks its server runtime and never swaps its owner.
     flushSync(() => {
       newChatPresentationRef.current = presentation
       setNewChatPresentation(presentation)
+      applyModeDestination({
+        view: 'chat',
+        chatId,
+        appId: null,
+        paneId: ws.focusedPaneId,
+      })
     })
+    closeDrawer(modalDrawerOpen ? { preserveModalUntilTraversal: true } : undefined)
+    requestComposer(chatId, { focus: true, restoreExistingDraft: true })
     void settleDraftFirstNewChat(presentation)
   }
 
@@ -4272,14 +4209,6 @@ export default function Shell({ onInitialVisualReady }) {
   }, [chats, activeChatId, activeView, chatsQuery.isSuccess,
       chatsQuery.isFetchedAfterMount, requestEmptySingleNewChat, workspaceStateRef])
 
-  const newChatCoversSurface = (paneId, chatId = null) => (
-    newChatPresentationCoversSurface(newChatPresentation, {
-      viewMode: workspace.viewMode,
-      paneId,
-      chatId,
-    })
-  )
-
   return (
     <HistoryDismissProvider
       openHistoryDismiss={openHistoryDismiss}
@@ -4327,7 +4256,7 @@ export default function Shell({ onInitialVisualReady }) {
           // Focus transfer itself is not an edit. In quota/privacy modes the
           // synchronous mirror can be empty while IndexedDB owns a valid
           // draft; writing this untouched empty lease would tombstone that
-          // durable value before NewChatLanding hydrates it. Every real edit
+          // durable value before the canonical ChatView hydrates it. Every real edit
           // fires input synchronously, including deleting back to empty.
           if (draftId != null && composerFocusLeaseDirtyRef.current) {
             const saved = readComposerDraft(draftId)
@@ -4606,10 +4535,7 @@ export default function Shell({ onInitialVisualReady }) {
             && String(appToChatCover?.appId ?? '') === String(id)
           const fullBleed = !paned && (tabKey === fullBleedKey || heldForChat)
           const surfaceVisible = !!(paned || fullBleed)
-          const surfacePaneId = paned?.paneId
-            ?? (fullBleed ? workspace.focusedPaneId : null)
-          const coveredByNewChat = newChatCoversSurface(surfacePaneId)
-          const appSurfaceInert = !surfaceVisible || heldForChat || coveredByNewChat
+          const appSurfaceInert = !surfaceVisible || heldForChat
           const appRuntimeVisible = visibleAppIds.has(String(id)) && !heldForChat
           // Keep the held frame alive until the chat has painted: apps may
           // legitimately clear their own UI after `frame-visibility:false`, but
@@ -4669,7 +4595,7 @@ export default function Shell({ onInitialVisualReady }) {
               // suspend its iframe interaction while the drawer is open OR during any
               // mode scene (cross-origin app interaction is inert throughout).
               interactive={appRuntimeVisible
-                && !coveredByNewChat && !navigationSurfaceOpen && !modeBeatActive}
+                && !navigationSurfaceOpen && !modeBeatActive}
               version={versionForApp(id)}
               appName={app?.name}
               appSlug={app?.slug}
@@ -4718,11 +4644,12 @@ export default function Shell({ onInitialVisualReady }) {
               ? effectiveViewMode === 'single'
               : (builderPainted && !paned))
           const surfaceVisible = !!(paned || fullBleed)
-          const coveredByNewChat = newChatCoversSurface(layoutPaneId, chatId)
+          const newChatSession = String(newChatPresentation?.chatId ?? '') === String(chatId)
+            ? newChatPresentation
+            : null
           const chatSurfaceInteractive = surfaceVisible
             && role === 'active'
             && !settingsOverlay
-            && !coveredByNewChat
             && !navigationSurfaceOpen
           const tabPanel = role !== 'held' && paned
           // A retained owner may belong to the hidden workspace world. Its
@@ -4797,6 +4724,9 @@ export default function Shell({ onInitialVisualReady }) {
                 chatId={chatId}
                 paneId={paneId}
                 apps={apps}
+                newChatSession={newChatSession}
+                onNewChatSubmit={queueDraftFirstNewChat}
+                onNewChatRetry={retryDraftFirstNewChat}
                 artifactsAppId={artifactsAppId}
                 // Runtime activity and painting are independent during a handoff:
                 // staging owns the work while held remains the visual cover.
@@ -4855,10 +4785,7 @@ export default function Shell({ onInitialVisualReady }) {
             : null
           const appsTabPanel = appsPaned
           const appsSurfaceVisible = !!(appsPaned || appsFullBleed)
-          const appsSurfacePaneId = appsPaned?.paneId
-            ?? (appsFullBleed ? workspace.focusedPaneId : null)
           const appsSurfaceInert = !appsSurfaceVisible
-            || newChatCoversSurface(appsSurfacePaneId)
           return (
             <div
               key="apps"
@@ -5049,10 +4976,7 @@ export default function Shell({ onInitialVisualReady }) {
             : null
           const settingsTabPanel = settingsPaned
           const settingsSurfaceVisible = !!(settingsPaned || settingsFullBleed)
-          const settingsSurfacePaneId = settingsPaned?.paneId
-            ?? (settingsFullBleed ? workspace.focusedPaneId : null)
           const settingsSurfaceInert = !settingsSurfaceVisible
-            || newChatCoversSurface(settingsSurfacePaneId)
           return (
           <div
             key="settings"
@@ -5092,73 +5016,19 @@ export default function Shell({ onInitialVisualReady }) {
           </div>
           )
         })()}
-        {/* One New Chat landing owns both the resting null slot and the immediate
-            user-initiated cover while its chat row is allocated. */}
-        {(() => {
-          const presentingNewChat = newChatPresentation != null
-          const releasingNewChat = !!newChatPresentation?.releasing
-          const builderPresentation = presentingNewChat
-            && newChatPresentation.viewMode === 'panes'
-          const builderPaneRect = builderPresentation && workspaceChromeActive
-            ? projection.rects[newChatPresentation.paneId]
-            : null
-          const presentationPos = builderPaneRect
-            ? {
-                top: builderPaneRect.y + paneModel.STRIP_H,
-                left: builderPaneRect.x,
-                width: builderPaneRect.w,
-                height: Math.max(0, builderPaneRect.h - paneModel.STRIP_H),
-              }
-            : null
-          const newChatSurface = fullBleedKey === EMPTY_SINGLE_SURFACE_KEY
-            || presentingNewChat
-          if (!newChatSurface) return null
-          return (
-            <div
-              key="home-new-chat"
-              className={`shell__view shell__chat-view ${presentationPos
-                ? 'shell__view--paned'
-                : 'shell__view--active'}`
-                + `${presentingNewChat ? ' shell__new-chat-presentation' : ''}`
-                + `${releasingNewChat ? ' shell__new-chat-presentation--releasing' : ''}`}
-              style={presentationPos || undefined}
-              data-mode-pane-vt={presentationPos ? newChatPresentation.paneId : undefined}
-              data-new-chat-presentation={presentingNewChat
-                ? newChatPresentation.chatId || 'allocating'
-                : undefined}
-              inert={(presentingNewChat && newChatPresentation.releasing) || undefined}
-              aria-hidden={(presentingNewChat && newChatPresentation.releasing)
-                ? 'true'
-                : undefined}
-              onAnimationEnd={releasingNewChat
-                ? event => {
-                  if (event.target === event.currentTarget
-                    && event.animationName === 'shell-new-chat-release') {
-                    finishNewChatPresentationRelease(newChatPresentation)
-                  }
-                }
-                : undefined}
-            >
-              <NewChatLanding
-                key={presentingNewChat ? newChatPresentation.chatId : 'resting'}
-                chatId={presentingNewChat ? newChatPresentation.chatId : null}
-                focusToken={presentingNewChat ? newChatPresentation.focusToken : 0}
-                failure={presentingNewChat
-                  ? newChatPresentation.failure
-                  : newChatLandingFailure}
-                onComposerReady={handleNewChatLandingComposerReady}
-                submitted={!!newChatPresentation?.submitted}
-                chatInfo={newChatPresentation?.chatInfo ?? null}
-                onSubmit={presentingNewChat
-                  ? queueDraftFirstNewChat
-                  : undefined}
-                onRetry={presentingNewChat
-                  ? retryDraftFirstNewChat
-                  : requestEmptySingleNewChat}
-              />
-            </div>
-          )
-        })()}
+        {/* The landing is only the passive null-slot home. An owner-initiated
+            New Chat already renders above as its canonical ChatView. */}
+        {fullBleedKey === EMPTY_SINGLE_SURFACE_KEY && (
+          <div
+            key="home-new-chat"
+            className="shell__view shell__chat-view shell__view--active"
+          >
+            <NewChatLanding
+              failure={newChatLandingFailure}
+              onRetry={requestEmptySingleNewChat}
+            />
+          </div>
+        )}
         {/* Chrome layer — sibling AFTER the content wrappers, over the whole
             content box, carrying its own inert. Only at ≥2 visible leaves and
             never while Settings overlays. Draws per-pane strips and dividers;

--- a/frontend/src/components/Shell/__tests__/chatHandoff.test.js
+++ b/frontend/src/components/Shell/__tests__/chatHandoff.test.js
@@ -130,8 +130,8 @@ test('activation presents a confirmed running transcript while stream catch-up r
   )
   assert.match(
     chatView,
-    /const \[activationSettled, setActivationSettled\] = useState\(false\)[\s\S]*if \(hidden\) return[\s\S]*setActivationSettled\(false\)[\s\S]*const settleRuntime[\s\S]*setActivationSettled\(true\)[\s\S]*const displayReady = activationSettled/,
-    'a cached idle verdict must not publish before this activation learns that the chat is running',
+    /const \[activationSettled, setActivationSettled\] = useState\(provisionalNewChat\)[\s\S]*if \(hidden \|\| provisionalNewChat\) return[\s\S]*setActivationSettled\(false\)[\s\S]*const settleRuntime[\s\S]*setActivationSettled\(true\)[\s\S]*const displayReady = activationSettled/,
+    'a provisional empty chat is ready immediately while persisted chats still wait for runtime truth',
   )
   assert.match(
     initialLoad,
@@ -159,6 +159,30 @@ test('a staging chat cannot leave the outgoing transcript held on a wedged reque
     'switching panes must not trigger a redundant connectivity probe')
 })
 
+test('a fresh empty chat settles before interruptible transcript work', () => {
+  const emptySettlement = chatView.indexOf('if (refreshed.messages.length === 0)')
+  const warmTransition = chatView.indexOf(
+    'if (activationCache && cacheCoversSavedAnchor && !anchorRetired)',
+    emptySettlement,
+  )
+
+  assert.ok(emptySettlement >= 0,
+    'fresh empty chats need an explicit synchronous readiness path')
+  assert.ok(warmTransition > emptySettlement,
+    'empty readiness must settle before any transition that outgoing activity can starve')
+  const branch = chatView.slice(emptySettlement, warmTransition)
+  const emptyBody = branch.match(
+    /if \(refreshed\.messages\.length === 0\) \{([\s\S]*?)\n      \}/,
+  )?.[1] || ''
+  assert.match(
+    emptyBody,
+    /applyMessagesToView\(\[\], refreshed\.offset\)[\s\S]*settleRuntime\(runtime, \[\]\)[\s\S]*return/,
+    'the full empty ChatView must become ready without waiting for transcript scheduling',
+  )
+  assert.doesNotMatch(emptyBody, /startTransition/,
+    'an empty chat has no reflow worth deprioritizing')
+})
+
 test('each pane holds one outgoing chat over one staging chat', () => {
   assert.match(chatSurfaceModel, /chatId: previousId,[\s\S]*role: 'held'/,
     'the transition keeps only the last painted chat in its pane')
@@ -181,7 +205,7 @@ test('each pane holds one outgoing chat over one staging chat', () => {
   )
   assert.match(
     chatView,
-    /if \(!hidden\) return[\s\S]*if \(keepTranscriptPainted\) return[\s\S]*setInitialEntryPhase\('history'\)[\s\S]*setLoading\(true\)/,
+    /if \(!hidden\) return[\s\S]*if \(provisionalNewChat\) return[\s\S]*if \(keepTranscriptPainted\) return[\s\S]*setInitialEntryPhase\('history'\)[\s\S]*setLoading\(true\)/,
     'a held cover must relinquish runtime ownership without arming the transcript blanking gate',
   )
 })
@@ -281,15 +305,14 @@ test('direct chat actions hand focus to the destination composer', () => {
   assert.match(startUserNewChatPresentation,
     /const visibleBlank = !forceNew[\s\S]*resolveNewChatIntentId\([\s\S]*paneId: forceNew \? ws\.focusedPaneId : null[\s\S]*flushSync\([\s\S]*settleDraftFirstNewChat\(presentation\)/,
     'Builder stays additive while mounting the UUID-backed presentation synchronously')
+  assert.match(startUserNewChatPresentation,
+    /flushSync\(\(\) => \{[\s\S]*setNewChatPresentation\(presentation\)[\s\S]*applyModeDestination\(\{[\s\S]*chatId,[\s\S]*paneId: ws\.focusedPaneId[\s\S]*closeDrawer\(modalDrawerOpen \? \{ preserveModalUntilTraversal: true \} : undefined\)/,
+    'the client id must enter the workspace before the tap dismisses navigation, independent of allocation')
   assert.match(shell,
-    /const resolved = \{[\s\S]*navigationEpoch: navigationEpochRef\.current,[\s\S]*drawerEntryOpen: false/,
-    'route materialization transfers drawer-entry ownership before the focus handoff')
-  assert.match(shell,
-    /const newChatCoversSurface =[\s\S]*newChatPresentationCoversSurface\(newChatPresentation[\s\S]*const coveredByNewChat = newChatCoversSurface\(layoutPaneId, chatId\)[\s\S]*!coveredByNewChat[\s\S]*composerRequest=\{chatSurfaceInteractive/,
-    'the immediate composer owns covered surfaces until its matching ChatView can accept handoff')
-  assert.match(shell,
-    /const builderPresentation = presentingNewChat[\s\S]*newChatPresentation\.viewMode === 'panes'[\s\S]*projection\.rects\[newChatPresentation\.paneId\][\s\S]*shell__view--paned/,
-    'a tiled Builder presentation covers only the pane that owns the tap')
+    /const newChatSession = String\(newChatPresentation\?\.chatId[\s\S]*<PaneChatView[\s\S]*newChatSession=\{newChatSession\}[\s\S]*onNewChatSubmit=\{queueDraftFirstNewChat\}/,
+    'the active pane passes allocation state into its canonical ChatView instead of covering it')
+  assert.doesNotMatch(shell, /shell__new-chat-presentation|handleNewChatLandingComposerReady/,
+    'the interactive New Chat path must not retain a second visual/composer owner')
   assert.match(shell,
     /className="shell__composer-focus-lease"[\s\S]*onInput=\{\(event\) => \{[\s\S]*composerFocusLeaseDirtyRef\.current = true[\s\S]*persistComposerDraft\([\s\S]*onBlur=\{\(event\) => \{[\s\S]*draftId != null && composerFocusLeaseDirtyRef\.current[\s\S]*persistComposerDraft\(/,
     'the temporary touch lease persists real edits without erasing an untouched durable fallback')

--- a/frontend/src/components/Shell/__tests__/newChatPolicy.test.js
+++ b/frontend/src/components/Shell/__tests__/newChatPolicy.test.js
@@ -11,8 +11,8 @@ import {
   clearNewChatIntent,
   mergeChatListWithCreatedGuards,
   mintNewChatIntentId,
-  newChatPresentationCoversSurface,
   newChatPresentationIsCurrent,
+  newChatServerReadsReady,
   readNewChatIntent,
   reconcileCreatedChatGuard,
   reconcileNewChatIntentCreate,
@@ -25,14 +25,11 @@ import {
 import { chatQueries } from '../../../hooks/queries.js'
 
 const shellSource = readFileSync(new URL('../Shell.jsx', import.meta.url), 'utf8')
-const newChatLandingSource = readFileSync(
-  new URL('../NewChatLanding.jsx', import.meta.url),
-  'utf8',
-)
 const chatViewSource = readFileSync(
   new URL('../../ChatView/ChatView.jsx', import.meta.url),
   'utf8',
 )
+const paneChatViewSource = readFileSync(new URL('../PaneChatView.jsx', import.meta.url), 'utf8')
 const queriesSource = readFileSync(new URL('../../../hooks/queries.js', import.meta.url), 'utf8')
 const clientSource = readFileSync(new URL('../../../api/client.js', import.meta.url), 'utf8')
 
@@ -60,6 +57,18 @@ test('New Chat intent id: valid UUID, unique, injectable, fail-safe', () => {
   // A throwing or malformed source falls back to a valid manual v4 mint.
   assert.match(mintNewChatIntentId({ randomUUID: () => { throw new Error('nope') } }), UUID_RE)
   assert.match(mintNewChatIntentId({ randomUUID: () => 'not-a-uuid' }), UUID_RE)
+})
+
+test('server-backed pane projections wait for the provisional row', () => {
+  assert.equal(newChatServerReadsReady(null), true)
+  assert.equal(newChatServerReadsReady({ materialized: false }), false)
+  assert.equal(newChatServerReadsReady({}), false)
+  assert.equal(newChatServerReadsReady({ materialized: true }), true)
+  assert.match(
+    paneChatViewSource,
+    /const chatReady = newChatServerReadsReady\(newChatSession\)[\s\S]*\(\) => chatReady \? derivedBuiltApps\(apps, chatId\) : \[\]/,
+    'another entity projection must not read through a provisional chat id',
+  )
 })
 
 test('resolveNewChatIntentId resumes every open intent, else mints fresh', () => {
@@ -146,18 +155,21 @@ test('a superseded create waiter cannot rotate the reopened New Chat draft', () 
     'rotation must reclaim presentation ownership after durable hydration')
 })
 
-test('an accepted allocation hydrates durable draft ownership before handoff', () => {
+test('an accepted allocation activates the already-mounted canonical composer', () => {
   const settle = shellSource.match(
     /async function settleDraftFirstNewChat\(presentation\) \{([\s\S]*?)\n  \}\n\n  settleDraftFirstNewChatRef\.current/,
   )?.[1] || ''
   const accepted = settle.slice(settle.indexOf("if (decision.action !== 'accept')"))
-  const hydrate = accepted.indexOf('await readComposerDraftAsync(intentId)')
-  const currentAgain = accepted.indexOf(
-    'if (!draftFirstPresentationIsCurrent(presentation)) return', hydrate,
-  )
-  const route = accepted.indexOf("if (changesRoute) navTo('chat', { chatId: intentId })")
-  assert.ok(hydrate >= 0 && currentAgain > hydrate && route > currentAgain,
-    'destination navigation must wait for durable hydration and reclaimed ownership')
+  const activate = accepted.indexOf('materialized: true')
+  assert.ok(activate >= 0,
+    'allocation activates the ChatView already mounted on the final id')
+  assert.doesNotMatch(accepted, /navTo\(|applyModeDestination\(/,
+    'normal allocation must not navigate or replace its canonical destination')
+  assert.doesNotMatch(accepted, /await readComposerDraftAsync\(intentId\)/,
+    'normal allocation must not re-read a draft merely to transfer it between composers')
+  assert.match(chatViewSource,
+    /const provisionalNewChat = !!newChatSession[\s\S]*if \(hidden \|\| provisionalNewChat\) return/,
+    'the canonical view pauses only its server activation while the row is provisional')
 })
 
 test('a provisional Send becomes one durable handoff and retries on proven recovery', () => {
@@ -170,12 +182,13 @@ test('a provisional Send becomes one durable handoff and retries on proven recov
   assert.ok(stage >= 0 && verify > stage && submitted > verify,
     'the UI must claim a queued send only after its autosend marker reads back')
 
-  assert.match(newChatLandingSource, /onSubmit=\{submitDraft\}/)
-  assert.match(newChatLandingSource,
-    /submissionBlocked=\{submitted \|\| submitPending\}/)
-  assert.match(newChatLandingSource, /\{liveComposer && !submitted && \(/,
-    'the queued snapshot must not remain editable before its handoff')
-  assert.match(newChatLandingSource, /will send when Möbius reconnects/)
+  assert.match(chatViewSource,
+    /handleProvisionalNewChatSubmit[\s\S]*await settingsSaveTailRef\.current[\s\S]*onNewChatSubmit\?\.\(input\)/,
+    'the canonical composer owns provisional Send and waits for any settings save')
+  assert.match(chatViewSource,
+    /submissionBlocked=\{providerSwitching \|\| !!newChatSession\?\.submitted\}/,
+    'a verified queued snapshot cannot be submitted twice')
+  assert.match(chatViewSource, /will send when Möbius reconnects/)
 
   assert.match(shellSource, /const recoveryGeneration = useRecoveryGeneration\(\)/)
   assert.match(
@@ -195,23 +208,21 @@ test('a provisional Send becomes one durable handoff and retries on proven recov
   )
 })
 
-test('Send remains owned by the landing after allocation materializes', () => {
-  const queue = shellSource.match(
-    /const queueDraftFirstNewChat = useCallback\(\(input\) => \{([\s\S]*?)\n  \}, \[requestComposer, retryDraftFirstNewChat\]\)/,
+test('a queued first Send continues in the same ChatView after allocation', () => {
+  const settle = shellSource.match(
+    /async function settleDraftFirstNewChat\(presentation\) \{([\s\S]*?)\n  \}\n\n  settleDraftFirstNewChatRef\.current/,
   )?.[1] || ''
-
-  assert.doesNotMatch(queue, /!presentation \|\| presentation\.materialized/,
-    'a materialized row must not turn the still-visible Send button into a no-op')
   assert.match(
-    queue,
-    /if \(presentation\.materialized\) \{[\s\S]*?requestComposer\(presentation\.chatId, \{[\s\S]*?draft: text,[\s\S]*?submit: true,[\s\S]*?releaseNewChatPresentationToken: presentation\.token/,
-    'the landing must submit through the mounted destination and release itself',
+    settle,
+    /const autoSendDraft = readComposerHandoff\(intentId\)\.autoSendDraft[\s\S]*current\.submitted && autoSendDraft[\s\S]*requestComposer\(intentId, \{[\s\S]*draft: autoSendDraft,[\s\S]*submit: true/,
+    'allocation resumes the verified queued send through the already-mounted view',
   )
-  assert.match(
-    queue,
-    /submitted: true,[\s\S]*?handoffRequested: presentation\.materialized[\s\S]*?\|\| presentation\.handoffRequested/,
-    'the submit handoff must claim the request slot before display-ready focus can replace it',
-  )
+  assert.match(chatViewSource,
+    /onSubmit=\{provisionalNewChat \? handleProvisionalNewChatSubmit : handleSubmit\}/,
+    'the one composer switches from provisional queueing to ordinary Send without remounting')
+  assert.doesNotMatch(shellSource,
+    /releaseNewChatPresentationToken|handoffRequested/,
+    'normal first Send must not coordinate a second composer handoff')
   assert.match(
     chatViewSource,
     /if \(request\.storedHandoff\) \{[\s\S]*?consumeComposerHandoff[\s\S]*?doSend\(text\)[\s\S]*?onComposerRequestHandled\?\.\(request\.token\)/,
@@ -260,43 +271,31 @@ test('New Chat intent ids are canonicalized before storage and allocation', () =
   assert.equal(clearNewChatIntent(upper, storage), true)
 })
 
-test('New Chat presentation ownership follows allocation context then destination', () => {
+test('New Chat presentation ownership is the canonical destination from birth', () => {
   const presentation = {
-    chatId: null,
+    chatId: 'client-owned',
     materialized: false,
-    navigationEpoch: 4,
     viewMode: 'single',
-    drawerEntryOpen: true,
   }
   const current = {
-    navigationEpoch: 4,
     viewMode: 'single',
-    drawerEntryOpen: true,
     activeView: 'chat',
-    activeChatId: 'old',
+    activeChatId: 'client-owned',
   }
 
   for (const [change, expected] of [
     [{}, true],
-    [{ navigationEpoch: 5 }, false],
-    [{ drawerEntryOpen: false }, false],
     [{ viewMode: 'panes' }, false],
+    [{ activeView: 'canvas' }, false],
+    [{ activeChatId: 'other' }, false],
   ]) {
     assert.equal(newChatPresentationIsCurrent(presentation, {
       ...current, ...change,
     }), expected)
   }
   assert.equal(newChatPresentationIsCurrent({
-    ...presentation, drawerEntryOpen: false,
-  }, current), false)
-  // A provisional client UUID is still allocation-owned until the server row
-  // has been accepted; merely having an id must not adopt route semantics.
-  assert.equal(newChatPresentationIsCurrent({
-    ...presentation, chatId: 'client-owned',
-  }, current), true)
-  assert.equal(newChatPresentationIsCurrent({
-    ...presentation, chatId: 'client-owned',
-  }, { ...current, navigationEpoch: 5 }), false)
+    ...presentation, materialized: true,
+  }, current), true, 'allocation does not change presentation ownership')
 
   const builderPresentation = {
     ...presentation,
@@ -322,22 +321,15 @@ test('New Chat presentation ownership follows allocation context then destinatio
   const resolvedPresentation = {
     chatId: 'new',
     materialized: true,
-    navigationEpoch: 4,
     viewMode: 'single',
-    drawerEntryOpen: false,
   }
   const resolvedCurrent = {
-    navigationEpoch: 9,
     viewMode: 'single',
-    drawerEntryOpen: false,
     activeView: 'chat',
     activeChatId: 'new',
   }
 
   assert.equal(newChatPresentationIsCurrent(resolvedPresentation, resolvedCurrent), true)
-  assert.equal(newChatPresentationIsCurrent(resolvedPresentation, {
-    ...resolvedCurrent, drawerEntryOpen: true,
-  }), false, 'reopening navigation supersedes a materialized cover')
   assert.equal(newChatPresentationIsCurrent(resolvedPresentation, {
     ...resolvedCurrent, activeView: 'canvas', activeChatId: null,
   }), false)
@@ -345,55 +337,6 @@ test('New Chat presentation ownership follows allocation context then destinatio
     ...resolvedCurrent, activeChatId: 'other',
   }), false)
 
-  // Route still catching up to the resolved chat: activeChatId has not
-  // committed yet, but no navigation happened since it resolved (epoch
-  // unchanged). The cover stays current so the outgoing chat never flashes
-  // between the New chat surface and its destination.
-  assert.equal(newChatPresentationIsCurrent(resolvedPresentation, {
-    ...resolvedCurrent, navigationEpoch: 4, activeChatId: 'old',
-  }), true)
-  // A genuine supersede in that same window (navigation bumped the epoch and
-  // landed elsewhere) must still retire the cover.
-  assert.equal(newChatPresentationIsCurrent(resolvedPresentation, {
-    ...resolvedCurrent, navigationEpoch: 5, activeChatId: 'old',
-  }), false)
-})
-
-test('New Chat cover gates only its owned surface and destination handoff', () => {
-  const standard = {
-    chatId: 'new',
-    materialized: false,
-    viewMode: 'single',
-    paneId: null,
-  }
-  assert.equal(newChatPresentationCoversSurface(null, {
-    viewMode: 'single', paneId: 'single', chatId: 'old',
-  }), false)
-  assert.equal(newChatPresentationCoversSurface(standard, {
-    viewMode: 'single', paneId: 'single', chatId: 'old',
-  }), true)
-  assert.equal(newChatPresentationCoversSurface({ ...standard, materialized: true }, {
-    viewMode: 'single', paneId: 'single', chatId: 'new',
-  }), false, 'the matching destination becomes interactive for handoff')
-  assert.equal(newChatPresentationCoversSurface({ ...standard, materialized: true }, {
-    viewMode: 'single', paneId: 'single', chatId: 'old',
-  }), true)
-
-  const builder = {
-    chatId: 'new',
-    materialized: false,
-    viewMode: 'panes',
-    paneId: 'left',
-  }
-  assert.equal(newChatPresentationCoversSurface(builder, {
-    viewMode: 'panes', paneId: 'left', chatId: 'old',
-  }), true)
-  assert.equal(newChatPresentationCoversSurface(builder, {
-    viewMode: 'panes', paneId: 'right', chatId: 'sibling',
-  }), false, 'Builder sibling panes remain usable')
-  assert.equal(newChatPresentationCoversSurface(builder, {
-    viewMode: 'single', paneId: 'single', chatId: 'old',
-  }), true, 'a stale world stays blocked until layout-effect retirement')
 })
 
 test('empty-single policy fires only on the transition edge', () => {

--- a/frontend/src/components/Shell/__tests__/workspaceUi.test.js
+++ b/frontend/src/components/Shell/__tests__/workspaceUi.test.js
@@ -19,6 +19,7 @@ const workspaceSession = readFileSync(
 )
 const shellBrand = readFileSync(new URL('../ShellBrand.jsx', import.meta.url), 'utf8')
 const newChatLanding = readFileSync(new URL('../NewChatLanding.jsx', import.meta.url), 'utf8')
+const chatView = readFileSync(new URL('../../ChatView/ChatView.jsx', import.meta.url), 'utf8')
 const chatInputBar = readFileSync(new URL('../../ChatView/ChatInputBar.jsx', import.meta.url), 'utf8')
 const composerPopover = readFileSync(new URL('../../ChatView/ComposerPopover.jsx', import.meta.url), 'utf8')
 const workspaceViewSrc = readFileSync(new URL('../workspaceView.js', import.meta.url), 'utf8')
@@ -1365,41 +1366,34 @@ test('deletion-evidence contract: probeDeletion classifies 404 vs exists vs unkn
   assert.match(shell, /probeDeletion\(`\/chats\//)
 })
 
-test('round4-3: the New Chat landing renders for a null slot and reuses ChatView empty visuals', () => {
-  // The presentation key + its wiring.
+test('round4-3: the null-slot landing is passive and interactive New Chat uses ChatView', () => {
   assert.match(workspaceViewSrc, /export const EMPTY_SINGLE_SURFACE_KEY = 'home:new-chat'/)
-  assert.match(shell, /const newChatSurface = fullBleedKey === EMPTY_SINGLE_SURFACE_KEY/)
-  assert.match(shell, /<NewChatLanding/)
-  assert.match(shell, /chatId=\{presentingNewChat \? newChatPresentation\.chatId : null\}/)
-  assert.match(shell, /chatInfo=\{newChatPresentation\?\.chatInfo \?\? null\}/)
+  assert.match(shell,
+    /fullBleedKey === EMPTY_SINGLE_SURFACE_KEY && \([\s\S]*<NewChatLanding[\s\S]*failure=\{newChatLandingFailure\}/)
+  assert.match(shell,
+    /setNewChatPresentation\(presentation\)[\s\S]*applyModeDestination\(\{[\s\S]*chatId,[\s\S]*paneId: ws\.focusedPaneId/,
+    'the final client id must mount in the workspace immediately')
+  assert.match(shell,
+    /<PaneChatView[\s\S]*newChatSession=\{newChatSession\}[\s\S]*onNewChatSubmit=\{queueDraftFirstNewChat\}/)
   assert.match(shell,
     /materialized: true,[\s\S]*chatInfo: createdChatDetailCache\(result\.chat\)\?\.chatInfo \?\? null/,
     'the accepted create response must unlock the model picker without another read')
   assert.match(shell, /retryDraftFirstNewChat/)
-  assert.match(newChatLanding, /submissionBlocked[\s\S]*attachmentsDisabled/)
-  assert.match(newChatLanding,
-    /focusComposerElement\(inputRef\.current\)[\s\S]*placeCaretAtTextEnd\(inputRef\.current\)/,
-    'the provisional draft resumes at its text end without changing generic focus policy')
-  assert.match(newChatLanding,
-    /leftButtons=\{liveChatInfo \? \([\s\S]*<BrainUsageButton[\s\S]*<ComposerPopover[\s\S]*chatInfo=\{liveChatInfo\}[\s\S]*embedded[\s\S]*\) : <ComposerPopover pending \/>\}/,
-    'the provisional composer must unlock the canonical model picker once its chat row exists')
-  assert.match(newChatLanding,
-    /async function submitDraft[\s\S]*await settingsSaveTailRef\.current[\s\S]*onSubmit\?\.\(draft\)/,
-    'a first send must follow any model choice the owner just made')
+  assert.match(chatView,
+    /const provisionalNewChat = !!newChatSession[\s\S]*onSubmit=\{provisionalNewChat \? handleProvisionalNewChatSubmit : handleSubmit\}/,
+    'the canonical composer owns both pre-allocation and ordinary Send')
+  assert.match(chatView,
+    /pendingFiles=\{pendingFiles\}[\s\S]*onAddFiles=\{handleComposerAddFiles\}[\s\S]*onAttachClick=\{\(\) => attachTriggerRef\.current\?\.\(\)\}/,
+    'the canonical draft/file owner is available before allocation')
   assert.match(composerPopover, /\{onAttachClick && \(/,
-    'a model-only New Chat Brain must not expose a dead attachment action')
+    'the canonical New Chat Brain exposes Attach files')
   assert.match(composerPopover, /\{!embedded && onOpenChanges && \(/,
-    'a model-only New Chat Brain must not expose a dead Changes action')
-  assert.match(composerPopover, /\{!embedded && \(onOpenUsage \|\| onOpenSummary \|\| onOpenInspector\) && \(/,
-    'a model-only New Chat Brain must not expose dead continuity actions')
-  assert.doesNotMatch(newChatLanding, /attachTriggerRef/,
-    'the pre-allocation surface must not expose server-bound attachment behavior')
-  assert.match(chatInputBar,
-    /const files = attachmentsDisabled \? \[\] : pastedFiles\(e\.clipboardData\)/,
-    'disabled attachments must suppress only pasted files, not text handling')
-  assert.match(chatInputBar, /\{!attachmentsDisabled && \(\s*<input/,
-    'disabled attachments must not mount a hidden file picker')
-  // Seamless swap: the landing reuses ChatView's exact empty treatment.
+    'the canonical New Chat Brain exposes Changes')
+  assert.match(composerPopover,
+    /\{!embedded && \(onOpenUsage \|\| onOpenSummary \|\| onOpenInspector\) && \(/,
+    'the full canonical option set cannot be stranded behind a temporary composer')
+  assert.doesNotMatch(newChatLanding, /ChatInputBar|ComposerPopover|inputRef/,
+    'the passive landing must never become a second interactive owner')
   assert.match(newChatLanding, /className="chat chat--empty"/)
   assert.match(newChatLanding, /className="chat__empty-wrap"/)
   assert.match(newChatLanding, /className="chat__empty-glyph"/)

--- a/frontend/src/components/Shell/newChatPolicy.js
+++ b/frontend/src/components/Shell/newChatPolicy.js
@@ -18,8 +18,13 @@ export function stageVerifiedNewChatHandoff(chatId, input, {
 /** A failed allocation retries only after the shared owner proves recovery. */
 export function shouldRetryNewChatAllocation(presentation, recoveryGeneration) {
   if (!presentation?.failure || presentation.failure === 'queue') return false
-  if (presentation.materialized || presentation.releasing) return false
+  if (presentation.materialized) return false
   return recoveryGeneration > (presentation.failedAtRecoveryGeneration ?? 0)
+}
+
+/** Row-owned reads stay dormant until the client-minted chat exists server-side. */
+export function newChatServerReadsReady(newChatSession) {
+  return !newChatSession || newChatSession.materialized === true
 }
 
 /** Preserve live presentation state when an asynchronous allocation fails. */
@@ -31,82 +36,27 @@ export function failedNewChatPresentation(current, verdict, recoveryGeneration) 
   }
 }
 
-/**
- * Whether an immediate New Chat surface still owns what the user is seeing.
- *
- * Allocation is allowed to finish only while the route generation, layout
- * world, and drawer-history ownership captured by the tap are unchanged. A
- * provisional client UUID is still allocation-owned. Once the server row is
- * accepted, the concrete chat route is the simpler authority: it owns the
- * cover until that ChatView reports a painted frame.
- */
+/** Whether an allocating New Chat still owns the canonical destination. */
 export function newChatPresentationIsCurrent(presentation, {
-  navigationEpoch,
   viewMode,
-  drawerEntryOpen,
   activeView,
   activeChatId,
   focusedPaneId,
   paneActiveKey,
 } = {}) {
   if (!presentation || presentation.viewMode !== viewMode) return false
-  if (presentation.materialized && presentation.chatId != null) {
-    if (activeView !== 'chat') return false
-    // The temporary cover owns the exact drawer state captured by the
-    // destination handoff. Reopening navigation is an explicit superseding
-    // action, even while the destination ChatView is still becoming ready.
-    if (presentation.drawerEntryOpen !== !!drawerEntryOpen) return false
-    // The concrete chat route owns the cover once it exists — but navTo bumps
-    // the epoch and commits `activeChatId` a render later, so the route is still
-    // catching up to the resolved chat for one commit. Treat that in-flight
-    // window as current: `activeChatId` already matches, OR no navigation has
-    // happened since the cover resolved (epoch unchanged). A real supersede
-    // (Back, another chat, an app) bumps the epoch past the resolved value and
-    // retires the cover. Without this the cover retires over the OUTGOING chat
-    // mid-transition, flashing it between the New chat surface and its
-    // destination.
-    return normalizedId(activeChatId) === normalizedId(presentation.chatId)
-      || presentation.navigationEpoch === navigationEpoch
-  }
-  const allocationContextCurrent = presentation.navigationEpoch === navigationEpoch
-    && presentation.drawerEntryOpen === !!drawerEntryOpen
-  if (!allocationContextCurrent || presentation.viewMode !== 'panes') {
-    return allocationContextCurrent
-  }
-  // Builder's immediate draft surface temporarily covers exactly the pane and
-  // tab that owned the New Chat tap. Focusing another pane or selecting another
-  // tab is a newer intent even if it does not change the browser route.
+  // The client id is the final route from the first commit, before and after
+  // allocation. Drawer state and history epochs are therefore irrelevant: the
+  // presentation lives exactly as long as its canonical ChatView remains the
+  // active destination.
+  if (activeView !== 'chat') return false
+  if (normalizedId(activeChatId) !== normalizedId(presentation.chatId)) return false
+  if (presentation.viewMode !== 'panes') return true
+  // Builder additionally owns one exact focused pane/tab. Focusing another
+  // pane or selecting another tab is a newer intent even when the global route
+  // still names a chat.
   return normalizedId(presentation.paneId) === normalizedId(focusedPaneId)
     && normalizedId(presentation.paneActiveKey) === normalizedId(paneActiveKey)
-}
-
-/**
- * Whether the immediate New Chat cover owns a rendered workspace surface.
- *
- * Standard covers the whole content world. Builder covers only the pane that
- * received the New Chat action, leaving sibling panes available to supersede
- * it. Once allocation succeeds, the matching destination ChatView is the sole
- * covered surface allowed to become interactive so it can accept the durable
- * draft/focus handoff. A mode-mismatched cover blocks the current world for its
- * final pre-retirement commit; otherwise the newly exposed surface could steal
- * focus through the stale cover.
- */
-export function newChatPresentationCoversSurface(presentation, {
-  viewMode,
-  paneId = null,
-  chatId = null,
-} = {}) {
-  if (!presentation) return false
-  if (presentation.viewMode !== viewMode) return true
-
-  const coversWholeWorld = presentation.viewMode !== 'panes'
-    || presentation.paneId == null
-  if (!coversWholeWorld
-      && normalizedId(presentation.paneId) !== normalizedId(paneId)) {
-    return false
-  }
-  return !presentation.materialized
-    || normalizedId(presentation.chatId) !== normalizedId(chatId)
 }
 
 /**

--- a/frontend/src/lib/__tests__/chatEmbedOpaqueSandbox.test.js
+++ b/frontend/src/lib/__tests__/chatEmbedOpaqueSandbox.test.js
@@ -99,7 +99,7 @@ test('embedded chat never starts the owner app inventory query', () => {
   )?.[0] || ''
   assert.match(
     changesOverviewCall,
-    /enabled: Boolean\(!embedded && chatId\)/,
+    /enabled: Boolean\(!embedded && chatReady && chatId\)/,
   )
   assert.match(changesSource, /appQueries\.list\.useQuery\(\{ enabled \}\)/)
   assert.match(


### PR DESCRIPTION
## Summary
- mount the final-ID ChatView immediately for an owner-initiated New Chat instead of layering a second temporary composer over it
- keep draft text, files, focus, model settings, and first Send under one composer across allocation, while deferring server-bound reads until the chat row is ready
- preserve offline/retry and workspace-supersession behavior, with guards that prevent another chat or embedded surface from contributing state
- keep every row-owned pane read disabled until the client-minted chat has materialized, so follow-on artifact queries do not turn a provisional ID into a false 404

## Why
#745 gave New Chat its final client ID and durable draft ownership before allocation, while #559 established the keyboard handoff contract. The current shell still renders a second interactive NewChatLanding during allocation and then coordinates a draft/focus/Send transfer into ChatView.

This removes that remaining transfer boundary. NewChatLanding is passive and used only for a genuinely empty Standard slot; an explicit New Chat mounts its canonical ChatView from the first frame.

## Testing
- `npm ci --ignore-scripts`
- `npm test` (3,003 passed)
- `npm run lint` (0 errors; 39 warnings)
- `npm run build`
- focused New Chat, pane isolation, embed privacy, and runtime-policy tests (167 passed)
- Impeccable mechanical detector (one pre-existing, untouched easing warning)
- `git diff --check`