### PR TITLE
Make merged-parent PR updates restart-safe

### DIFF
--- a/backend/app/github_contributions.py
+++ b/backend/app/github_contributions.py
@@ -695,11 +695,6 @@ def _claim_record(
   record_path, diff_path = _record_paths(app_id, record_id)
   _recheck_submit_app(db, app_id, expected_nonce)
   record = _read_record(record_path)
-  if record.get("status") != "prepared":
-    raise HTTPException(
-      status_code=409,
-      detail="This contribution is no longer waiting for approval.",
-    )
   plan = record.get("plan")
   if not isinstance(plan, dict):
     raise HTTPException(
@@ -715,6 +710,17 @@ def _claim_record(
         else "This approval action no longer matches the prepared PR update."
       ),
     )
+  resumable_successor = (
+    record.get("status") == "submitting"
+    and expected_action == "pr_update"
+    and isinstance(plan.get("successor"), dict)
+    and record.get("submitter") == submitter
+  )
+  if record.get("status") != "prepared" and not resumable_successor:
+    raise HTTPException(
+      status_code=409,
+      detail="This contribution is no longer waiting for approval.",
+    )
   if isinstance(plan.get("stack"), dict):
     raise HTTPException(
       status_code=409,
@@ -723,6 +729,9 @@ def _claim_record(
         "chain together."
       ),
     )
+  _require_all_clear_review(record)
+  if resumable_successor:
+    return record, record_path, diff_path
   now = _now_iso()
   claimed = {
     **record,
@@ -1246,6 +1255,30 @@ def _mark_submit_failure(
   return next_record
 
 
+def _note_submit_unconfirmed(
+  *, record_path: Path, message: str, record_patch: dict,
+  code: str, detail: str,
+) -> dict:
+  """Keep one already-authorized public action resumable after ambiguity."""
+  record = _read_record(record_path)
+  if record.get("status") != "submitting":
+    return record
+  next_record = {
+    **record,
+    **record_patch,
+    "status": "submitting",
+    "last_submit_error": message,
+    "last_submit_error_code": code or "update_unconfirmed",
+    "updated_at": _now_iso(),
+  }
+  if detail:
+    next_record["last_submit_error_detail"] = detail
+  else:
+    next_record.pop("last_submit_error_detail", None)
+  _write_record(record_path, next_record)
+  return next_record
+
+
 def _mark_submit_success(
   *,
   record_path: Path,
@@ -1575,6 +1608,7 @@ def _confirm_existing_pr_update(
   expected_head_sha: str,
   branch: str,
   base_branch: str,
+  expected_base_sha: str | None = None,
 ) -> tuple[str, str] | None:
   """Confirm one known PR after its reviewed branch was pushed.
 
@@ -1583,7 +1617,14 @@ def _confirm_existing_pr_update(
   the new head. Read the known PR directly and retry only this exact,
   side-effect-free confirmation. The push itself is never repeated here.
   """
-  if number < 1 or not _GIT_SHA.match(str(expected_head_sha or "")):
+  if (
+    number < 1
+    or not _GIT_SHA.match(str(expected_head_sha or ""))
+    or (
+      expected_base_sha is not None
+      and not _GIT_SHA.match(str(expected_base_sha or ""))
+    )
+  ):
     return None
   args = ("api", f"repos/{upstream_repo}/pulls/{number}")
   for attempt in range(_PR_VISIBILITY_RETRIES):
@@ -1610,6 +1651,10 @@ def _confirm_existing_pr_update(
         and head.get("ref") == branch
         and head.get("sha") == expected_head_sha
         and base.get("ref") == base_branch
+        and (
+          expected_base_sha is None
+          or base.get("sha") == expected_base_sha
+        )
         and isinstance(live.get("draft"), bool)
         and isinstance(url, str)
         and url == f"https://github.com/{upstream_repo}/pull/{number}"
@@ -2683,31 +2728,43 @@ def _push_stack_tip_with_lease(
   remote = f"https://github.com/{upstream_repo}.git"
   last_error = ""
   last_actual = expected_base
+  saw_ambiguous_attempt = False
   for attempt in range(_PUSH_RETRIES):
-    proc = _git_ops._git(
-      repo,
-      "push",
-      f"--force-with-lease=refs/heads/{target_branch}:{expected_base}",
-      remote,
-      f"{landed_sha}:refs/heads/{target_branch}",
-      check=False,
-    )
-    if proc.returncode == 0:
-      return
-    last_error = (proc.stderr or proc.stdout or "").strip()
+    try:
+      proc = _git_ops._git(
+        repo,
+        "push",
+        f"--force-with-lease=refs/heads/{target_branch}:{expected_base}",
+        remote,
+        f"{landed_sha}:refs/heads/{target_branch}",
+        check=False,
+      )
+    except (subprocess.TimeoutExpired, OSError) as exc:
+      proc = None
+      last_error = str(exc)
+      saw_ambiguous_attempt = True
+    else:
+      if proc.returncode == 0:
+        return
+      last_error = (proc.stderr or proc.stdout or "").strip()
     # A transport can fail after GitHub has accepted the ref update. Re-read the
     # target before reporting failure or retrying: the exact landed tip is proof
     # that this compare-and-swap succeeded, while every other value remains a
     # safe failure. This mirrors submission's lost-response reconciliation and
     # prevents the ledger from reopening a stack that is already live.
-    last_actual = _git_ops._upstream_branch_sha(repo, upstream_repo, target_branch)
+    try:
+      last_actual = _git_ops._upstream_branch_sha(
+        repo, upstream_repo, target_branch,
+      )
+    except (subprocess.TimeoutExpired, OSError):
+      last_actual = None
     if last_actual == landed_sha:
       return
-    if not _is_transient_push_error(last_error):
+    if proc is not None and not _is_transient_push_error(last_error):
       break
     if attempt + 1 < _PUSH_RETRIES:
       time.sleep(_PUSH_RETRY_BASE_SECONDS * (2 ** attempt))
-  if last_actual is None:
+  if last_actual is None or saw_ambiguous_attempt:
     raise ContributionSubmitError(
       "GitHub did not confirm whether the atomic landing completed. The "
       "recovery journal is still intact; check again shortly.",
@@ -2725,6 +2782,596 @@ def _push_stack_tip_with_lease(
     )
   raise ContributionSubmitError(
     (last_error[:600] if last_error else "GitHub rejected the atomic landing.")
+  )
+
+
+def _merged_parent_successor_plan(record: dict) -> dict:
+  """Validate the durable merged-parent successor claim carried by one card.
+
+  A squash/queue-merged parent leaves its reviewed child pointed at a base
+  branch that no longer carries that commit. The agent re-reviews the child
+  rebased onto the surviving target base; this claim records BOTH public
+  mutations that reviewed successor authorizes — the exact branch rewrite and
+  the base retarget — so neither can be inferred from an agent-writable ledger.
+  """
+  plan = record.get("plan") if isinstance(record.get("plan"), dict) else {}
+  if plan.get("action") != "pr_update":
+    raise ContributionSubmitError(
+      "This reviewed update is not a merged-parent successor. Nothing was pushed."
+    )
+  if isinstance(plan.get("stack"), dict):
+    raise ContributionSubmitError(
+      "A merged-parent successor must be detached from its settled stack "
+      "before review. Nothing was pushed."
+    )
+  successor = (
+    plan.get("successor") if isinstance(plan.get("successor"), dict) else {}
+  )
+  branch = _git_ops._validate_branch(plan.get("branch") or record.get("branch"))
+  old_head_sha = str(successor.get("old_head_sha") or "").strip()
+  old_base_sha = str(successor.get("old_base_sha") or "").strip()
+  merged_base_sha = str(successor.get("merged_base_sha") or "").strip()
+  successor_head_sha = str(plan.get("head_sha") or "").strip()
+  target_base_sha = str(plan.get("base_sha") or "").strip()
+  if not all(
+    _GIT_SHA.fullmatch(value)
+    for value in (old_head_sha, old_base_sha, successor_head_sha, target_base_sha)
+  ):
+    raise ContributionSubmitError(
+      "This merged-parent successor is missing its exact reviewed commits. "
+      "Nothing was pushed."
+    )
+  if merged_base_sha and not _GIT_SHA.fullmatch(merged_base_sha):
+    raise ContributionSubmitError(
+      "This merged-parent successor has an invalid merged-parent commit. "
+      "Nothing was pushed."
+    )
+  old_base_branch = _git_ops._validate_branch(successor.get("old_base_branch"))
+  target_base_branch = _git_ops._validate_branch(
+    successor.get("base_branch") or plan.get("base_branch")
+  )
+  if old_base_branch == target_base_branch:
+    raise ContributionSubmitError(
+      "A merged-parent successor must retarget its base to a new branch. "
+      "Nothing was pushed."
+    )
+  if old_head_sha == successor_head_sha:
+    raise ContributionSubmitError(
+      "A merged-parent successor must rewrite its branch to a new commit. "
+      "Nothing was pushed."
+    )
+  return {
+    "branch": branch,
+    "old_head_sha": old_head_sha,
+    "old_base_branch": old_base_branch,
+    "old_base_sha": old_base_sha,
+    "merged_base_sha": merged_base_sha or None,
+    "successor_head_sha": successor_head_sha,
+    "target_base_branch": target_base_branch,
+    "target_base_sha": target_base_sha,
+  }
+
+
+def _classify_merged_parent_successor(
+  journal: dict, *, live_head_sha: str, live_base_branch: str,
+) -> str:
+  """Decide the one safe next step purely from the live public PR facts.
+
+  Never authorize from the ledger: the branch rewrite and base retarget are
+  keyed only on what GitHub currently exposes, so a crashed run resumes exactly
+  where it stopped and any drifted pull request fails closed with no mutation.
+
+  * old head + old base -> ``push`` (rewrite the branch, then retarget)
+  * new head + old base -> ``retarget`` (branch already rewritten; retarget only)
+  * new head + new base -> ``settle`` (both mutations landed; ledger only)
+  * anything else -> fail closed without touching anything public
+  """
+  live_head = str(live_head_sha or "").strip()
+  live_base = str(live_base_branch or "").strip()
+  old_head = journal["old_head_sha"]
+  new_head = journal["successor_head_sha"]
+  old_base = journal["old_base_branch"]
+  new_base = journal["target_base_branch"]
+  if live_head == old_head and live_base == old_base:
+    return "push"
+  if live_head == new_head and live_base == old_base:
+    return "retarget"
+  if live_head == new_head and live_base == new_base:
+    return "settle"
+  raise ContributionSubmitError(
+    "This pull request changed after the merged-parent successor was reviewed. "
+    "Nothing was pushed. Ask the agent to refresh and review it against the "
+    "current pull request.",
+    code="review_refresh_needed",
+    detail=(
+      "The live pull request head or base no longer matches the reviewed "
+      "successor."
+    ),
+  )
+
+
+def _assert_merged_parent_tree_equivalence(
+  repo: Path, *, old_base_sha: str, target_base_sha: str,
+  merged_base_sha: str | None = None,
+) -> None:
+  """Prove the merged parent reached the reviewed target base unchanged.
+
+  Immediately after the parent lands, the target tip itself has the parent's
+  exact tree. Later contributions may advance that target before the reviewed
+  child is ready. In that case the durable claim identifies the exact merged
+  parent commit: its tree must equal the old public parent branch, and it must
+  be an ancestor of the exact target tip the successor was reviewed on. The
+  successor's canonical diff is still owned by that target tip. A read that
+  cannot complete fails closed rather than guessing.
+  """
+  merged_sha = str(merged_base_sha or target_base_sha)
+  trees = []
+  for sha in (old_base_sha, merged_sha):
+    proc = _git_ops._git(
+      repo, "rev-parse", "--verify", "--quiet", f"{sha}^{{tree}}", check=False,
+    )
+    tree = (proc.stdout or "").strip()
+    if proc.returncode != 0 or not _GIT_SHA.fullmatch(tree):
+      raise ContributionSubmitError(
+        "Could not verify that the merged parent reached the target base. "
+        "Nothing was pushed.",
+        status_code=503,
+        code="update_unconfirmed",
+        detail="The merged-parent or target-base tree could not be resolved.",
+      )
+    trees.append(tree)
+  if trees[0] != trees[1]:
+    raise ContributionSubmitError(
+      "The merged parent no longer matches the parent branch that was reviewed. "
+      "Nothing was pushed. Ask the agent to refresh the successor.",
+      code="review_refresh_needed",
+      detail="The merged commit's tree differs from the reviewed parent branch.",
+    )
+  if merged_base_sha:
+    ancestry = _git_ops._git(
+      repo,
+      "merge-base",
+      "--is-ancestor",
+      merged_sha,
+      target_base_sha,
+      check=False,
+    )
+    if ancestry.returncode == 1:
+      raise ContributionSubmitError(
+        "The reviewed target base does not contain the merged parent. Nothing "
+        "was pushed. Ask the agent to refresh the successor.",
+        code="review_refresh_needed",
+        detail="The merged parent is not an ancestor of the reviewed target base.",
+      )
+    if ancestry.returncode != 0:
+      raise ContributionSubmitError(
+        "Could not verify that the merged parent reached the target base. "
+        "Nothing was pushed.",
+        status_code=503,
+        code="update_unconfirmed",
+        detail="The merged-parent ancestry check could not complete.",
+      )
+
+
+def _retarget_pr_base(
+  repo: Path, upstream_repo: str, number: int, *, base_branch: str,
+) -> tuple[str, str]:
+  """Retarget one known PR base and classify the single public attempt.
+
+  The caller re-reads the pull request to confirm the new base, so a lost or
+  ambiguous edit response never issues a second mutation: the read is the
+  authority. This function deliberately attempts the mutation once.
+  """
+  base_branch = _git_ops._validate_branch(base_branch)
+  try:
+    proc = _git_ops._gh(
+      repo, "pr", "edit", str(number), "-R", upstream_repo,
+      "--base", base_branch, check=False,
+    )
+  except (subprocess.TimeoutExpired, OSError) as exc:
+    return "ambiguous", str(exc)
+  if proc.returncode == 0:
+    return "accepted", ""
+  error = (proc.stderr or proc.stdout or "").strip()
+  if _is_transient_push_error(error):
+    return "ambiguous", error
+  return "rejected", error
+
+
+def _successor_record_patch(
+  journal: dict, witness: dict, *, target_base_sha: str, stage: str,
+) -> dict:
+  """Assemble the settled ledger patch for one detached successor."""
+  return {
+    **witness,
+    "last_successor_base_sha": target_base_sha,
+    "last_submit_base_branch": journal["target_base_branch"],
+    "publication_stage": stage,
+  }
+
+
+def _advance_merged_parent_successor(
+  record: dict,
+  diff_path: Path,
+  *,
+  expected_number: int,
+  expected_head_repository: str,
+  live_head_sha: str,
+  live_base_branch: str,
+) -> tuple[str, int, dict]:
+  """Apply one reviewed merged-parent successor to an already-open PR.
+
+  This is the single owning primitive for a squash/queue-merged parent's child.
+  It rewrites the child branch to the reviewed successor with an exact
+  force-with-lease from the old public head, confirms that rewrite while the
+  merged-parent base still stands, then retargets the pull request base to the
+  surviving target branch and confirms the exact new head and base. Both
+  mutations are recorded on the durable claim and keyed only on the live pull
+  request, so every crash resumes state-by-state and any drift fails closed
+  with nothing pushed. Never authorize from the ledger alone.
+  """
+  if not shutil.which("git") or not shutil.which("gh"):
+    raise ContributionSubmitError(
+      "This platform needs git and gh installed before it can update PRs.",
+      status_code=409,
+    )
+  token = github_auth.get_token()
+  state = github_auth.read_state() or {}
+  login = str(state.get("login") or "")
+  if not token or not login:
+    raise ContributionSubmitError("Connect GitHub before approving this update.", 401)
+  if not has_full_pr_access(state.get("scopes")):
+    raise ContributionSubmitError(
+      "Reconnect GitHub with full PR access before approving this update.",
+      status_code=409,
+    )
+  author_name, author_email = _git_ops._connected_git_identity(state, login)
+
+  journal = _merged_parent_successor_plan(record)
+  plan = record.get("plan") or {}
+  upstream_repo = _git_ops._validate_repo_slug(plan.get("repo") or record.get("repo"))
+  branch = journal["branch"]
+  head_repository = _git_ops._validate_repo_slug(expected_head_repository)
+  if (
+    head_repository.casefold() != upstream_repo.casefold()
+    and head_repository.split("/", 1)[0].casefold() != login.casefold()
+  ):
+    raise ContributionSubmitError(
+      "This pull request branch is not owned by the connected GitHub account. "
+      "Nothing was pushed."
+    )
+  repo = _safe_repo_path(plan.get("repo_path"))
+  if not (repo / ".git").exists():
+    raise ContributionSubmitError("The staged repo is not a git checkout.")
+
+  old_head = journal["old_head_sha"]
+  new_head = journal["successor_head_sha"]
+  old_base_branch = journal["old_base_branch"]
+  target_base_branch = journal["target_base_branch"]
+
+  step = _classify_merged_parent_successor(
+    journal, live_head_sha=live_head_sha, live_base_branch=live_base_branch,
+  )
+
+  same_repo = head_repository.casefold() == upstream_repo.casefold()
+  witness = {
+    "last_successor_old_head": old_head,
+    "last_successor_base_branch": target_base_branch,
+    "last_submit_push_sha": new_head,
+    "last_submit_stage": "pushed",
+    "head_repository": head_repository,
+    "last_pushed_branch": branch if same_repo else f"{login}:{branch}",
+    "last_pushed_branch_url": (
+      f"https://github.com/{head_repository}/tree/{quote(branch, safe='/')}"
+    ),
+  }
+
+  def confirm_state(
+    expected_head_sha: str, base_branch: str, expected_base_sha: str | None,
+  ):
+    return _confirm_existing_pr_update(
+      repo,
+      upstream_repo,
+      expected_number,
+      expected_head_repository=head_repository,
+      expected_head_sha=expected_head_sha,
+      branch=branch,
+      base_branch=base_branch,
+      expected_base_sha=expected_base_sha,
+    )
+
+  def confirm(base_branch: str, expected_base_sha: str | None):
+    return confirm_state(new_head, base_branch, expected_base_sha)
+
+  def require_target_base(*, record_patch: dict | None = None) -> str:
+    try:
+      current = _git_ops._upstream_branch_sha(
+        repo, upstream_repo, target_base_branch,
+      )
+    except (subprocess.TimeoutExpired, OSError):
+      current = None
+    if current is None:
+      raise ContributionSubmitError(
+        "GitHub could not verify the merged-parent successor's target base. "
+        "Nothing further was changed.",
+        status_code=503,
+        code="update_unconfirmed",
+        detail="The current target base branch tip could not be verified.",
+        record_patch=record_patch,
+      )
+    if current != journal["target_base_sha"]:
+      raise ContributionSubmitError(
+        "The successor's target base branch moved after review. Nothing "
+        "further was changed. Ask the agent to refresh the successor.",
+        code="review_refresh_needed",
+        detail="The target base branch tip changed from the reviewed commit.",
+        record_patch=record_patch,
+      )
+    return current
+
+  # Every entry and recovery state must still prove the exact reviewed local
+  # branch, stored diff, base, attribution, and merge result. Public state alone
+  # never substitutes for the private all-clear snapshot.
+  checkout_back = None
+  try:
+    current_branch = _git_ops._git(
+      repo, "rev-parse", "--abbrev-ref", "HEAD",
+    ).stdout.strip()
+    checkout_back = (
+      _git_ops._git(repo, "rev-parse", "HEAD").stdout.strip()
+      if current_branch == "HEAD"
+      else current_branch
+    )
+    _git_ops._git(repo, "check-ref-format", "--branch", branch)
+    _git_ops._assert_clean_worktree(repo)
+    _git_ops._git(repo, "checkout", "-q", branch)
+    _git_ops._assert_clean_worktree(repo)
+    expected_base, expected_head, _diff = _git_ops._assert_fresh(
+      record, diff_path, repo, branch,
+    )
+    if (
+      expected_base != journal["target_base_sha"]
+      or expected_head != new_head
+    ):
+      raise ContributionSubmitError(
+        "The reviewed successor branch changed after review. Nothing was "
+        "changed.",
+        code="review_refresh_needed",
+      )
+    _git_ops._assert_coauthor_trailer(repo, branch)
+    _git_ops._assert_head_attribution(
+      repo, branch, author_name=author_name, author_email=author_email,
+    )
+    _git_ops._assert_clean_worktree(repo)
+    _git_ops._assert_merges_with_upstream(repo, upstream_repo, branch)
+    landed_sha = _git_ops._git(repo, "rev-parse", "HEAD").stdout.strip()
+    if landed_sha != new_head:
+      raise ContributionSubmitError(
+        "Could not verify the exact reviewed successor commit."
+      )
+  finally:
+    if checkout_back:
+      _git_ops._git(repo, "checkout", "-q", checkout_back, check=False)
+
+  # Settle-only recovery: both public mutations already landed. Never re-push or
+  # re-edit; only prove the exact new head and base, then settle the ledger.
+  if step == "settle":
+    target_base_sha = require_target_base(record_patch=witness)
+    try:
+      confirmed = confirm(target_base_branch, target_base_sha)
+    except ContributionSubmitError as exc:
+      raise ContributionSubmitError(
+        exc.message,
+        status_code=exc.status_code,
+        code=exc.code or "update_unconfirmed",
+        detail=exc.detail,
+        record_patch=_git_ops._record_patch_with(witness, exc.record_patch),
+      ) from exc
+    if not confirmed:
+      raise ContributionSubmitError(
+        "The merged-parent successor could not be confirmed on GitHub.",
+        status_code=503,
+        code="update_unconfirmed",
+        detail=(
+          "The live pull request did not expose the reviewed successor head "
+          "and base."
+        ),
+        record_patch=witness,
+      )
+    url, stage = confirmed
+    return url, expected_number, _successor_record_patch(
+      journal, witness, target_base_sha=target_base_sha, stage=stage,
+    )
+
+  # GitHub's pull-request ``base.sha`` is a comparison snapshot, not a lease on
+  # the current base ref. Resolve the named old base directly before either
+  # mutation; this also supports a parent branch that advanced after the child
+  # PR was opened but whose reviewed final tree is what reached main.
+  try:
+    current_old_base_sha = _git_ops._upstream_branch_sha(
+      repo, upstream_repo, old_base_branch,
+    )
+  except (subprocess.TimeoutExpired, OSError):
+    current_old_base_sha = None
+  if current_old_base_sha is None:
+    raise ContributionSubmitError(
+      "GitHub could not verify the merged-parent successor's current base. "
+      "Nothing further was changed.",
+      status_code=503,
+      code="update_unconfirmed",
+      detail="The current merged-parent branch tip could not be verified.",
+      record_patch=(witness if step == "retarget" else None),
+    )
+  if current_old_base_sha != journal["old_base_sha"]:
+    raise ContributionSubmitError(
+      "The successor's current base branch moved after review. Nothing was "
+      "pushed. Ask the agent to refresh the successor.",
+      code="review_refresh_needed",
+      detail="The pull request base no longer points at the reviewed parent commit.",
+      record_patch=(witness if step == "retarget" else None),
+    )
+
+  # Both push and retarget need a verified, tree-equivalent target base.
+  target_base_sha = require_target_base(
+    record_patch=(witness if step == "retarget" else None),
+  )
+  try:
+    _assert_merged_parent_tree_equivalence(
+      repo,
+      old_base_sha=journal["old_base_sha"],
+      merged_base_sha=journal["merged_base_sha"],
+      target_base_sha=target_base_sha,
+    )
+  except ContributionSubmitError as exc:
+    if step == "retarget" and exc.code == "update_unconfirmed":
+      raise ContributionSubmitError(
+        exc.message,
+        status_code=exc.status_code,
+        code=exc.code,
+        detail=exc.detail,
+        record_patch=_git_ops._record_patch_with(witness, exc.record_patch),
+      ) from exc
+    raise
+
+  if step == "push":
+    # Re-read both public bases and the exact old PR state immediately before
+    # mutation. The earlier route snapshot and local checks are not leases.
+    target_base_sha = require_target_base()
+    confirmed_old = confirm_state(
+      old_head, old_base_branch, journal["old_base_sha"],
+    )
+    if not confirmed_old:
+      raise ContributionSubmitError(
+        "The pull request changed while its reviewed successor was being "
+        "checked. Nothing was pushed.",
+        status_code=503,
+        code="update_unconfirmed",
+        detail="The exact old head and base could not be confirmed before push.",
+      )
+    # Public mutation #1: exact force-with-lease from the old public head to
+    # the reviewed successor. A moved lease fails closed inside this call.
+    try:
+      _push_stack_tip_with_lease(
+        repo,
+        upstream_repo=head_repository,
+        target_branch=branch,
+        expected_base=old_head,
+        landed_sha=new_head,
+      )
+    except ContributionSubmitError as exc:
+      if exc.code == "landing_unconfirmed":
+        raise ContributionSubmitError(
+          exc.message,
+          status_code=exc.status_code,
+          code=exc.code,
+          detail=exc.detail,
+          record_patch=witness,
+        ) from exc
+      raise
+    # Confirm the rewrite while the merged-parent base still stands, before
+    # any retarget. A base that already moved here is drift, not this action.
+    try:
+      confirmed_pre = confirm(old_base_branch, journal["old_base_sha"])
+    except ContributionSubmitError as exc:
+      raise ContributionSubmitError(
+        exc.message,
+        status_code=exc.status_code,
+        code=exc.code or "update_unconfirmed",
+        detail=exc.detail,
+        record_patch=_git_ops._record_patch_with(witness, exc.record_patch),
+      ) from exc
+    if not confirmed_pre:
+      raise ContributionSubmitError(
+        "The reviewed successor branch was pushed, but GitHub did not confirm "
+        "the rewrite before the base retarget.",
+        status_code=503,
+        code="update_unconfirmed",
+        detail=(
+          "The live pull request did not expose the successor head on the "
+          "merged-parent base."
+        ),
+        record_patch=witness,
+      )
+  # Re-read the target and both possible exact PR states immediately before the
+  # second mutation. If an earlier ambiguous edit actually landed, settle it;
+  # if the PR is still conclusively on the reviewed old base, one new attempt is
+  # safe. Any other state fails closed without another edit.
+  target_base_sha = require_target_base(record_patch=witness)
+  try:
+    confirmed = confirm(target_base_branch, target_base_sha)
+  except ContributionSubmitError as exc:
+    raise ContributionSubmitError(
+      exc.message,
+      status_code=exc.status_code,
+      code=exc.code or "update_unconfirmed",
+      detail=exc.detail,
+      record_patch=_git_ops._record_patch_with(witness, exc.record_patch),
+    ) from exc
+  if confirmed:
+    url, stage = confirmed
+    return url, expected_number, _successor_record_patch(
+      journal, witness, target_base_sha=target_base_sha, stage=stage,
+    )
+  try:
+    confirmed_old = confirm(old_base_branch, journal["old_base_sha"])
+  except ContributionSubmitError as exc:
+    raise ContributionSubmitError(
+      exc.message,
+      status_code=exc.status_code,
+      code=exc.code or "update_unconfirmed",
+      detail=exc.detail,
+      record_patch=_git_ops._record_patch_with(witness, exc.record_patch),
+    ) from exc
+  if not confirmed_old:
+    raise ContributionSubmitError(
+      "The reviewed successor branch is live, but its current base could not "
+      "be confirmed. Nothing further was changed.",
+      status_code=503,
+      code="update_unconfirmed",
+      detail="Neither the reviewed old nor target base state was authoritative.",
+      record_patch=witness,
+    )
+
+  # Public mutation #2: retarget the base to the surviving branch, then confirm
+  # the exact new head and base. Each request attempts the edit once, and only
+  # after the authoritative read above proves it still has not landed.
+  edit_result, edit_error = _retarget_pr_base(
+    repo, upstream_repo, expected_number, base_branch=target_base_branch,
+  )
+  try:
+    confirmed = confirm(target_base_branch, target_base_sha)
+  except ContributionSubmitError as exc:
+    raise ContributionSubmitError(
+      exc.message,
+      status_code=exc.status_code,
+      code=exc.code or "update_unconfirmed",
+      detail=exc.detail,
+      record_patch=_git_ops._record_patch_with(witness, exc.record_patch),
+    ) from exc
+  if not confirmed:
+    if edit_result in {"accepted", "ambiguous"}:
+      raise ContributionSubmitError(
+        "The reviewed successor branch is live, but GitHub did not confirm the "
+        "base retarget.",
+        status_code=503,
+        code="update_unconfirmed",
+        detail=(
+          "The pull request did not expose the retargeted base after the edit."
+          if edit_result == "accepted"
+          else "GitHub's response to the base retarget was ambiguous."
+        ),
+        record_patch=witness,
+      )
+    raise ContributionSubmitError(
+      "The reviewed successor branch is live, but its base could not be "
+      "retargeted. Nothing else was changed.",
+      code="review_refresh_needed",
+      detail=(edit_error[:300] if edit_error else "The base retarget was rejected."),
+      record_patch=witness,
+    )
+  url, stage = confirmed
+  return url, expected_number, _successor_record_patch(
+    journal, witness, target_base_sha=target_base_sha, stage=stage,
   )
 
 

--- a/backend/app/routes/github.py
+++ b/backend/app/routes/github.py
@@ -175,6 +175,7 @@ from app.github_contributions import (
   _mark_submit_failure,
   _mark_submit_success,
   _mark_existing_pr_update_success,
+  _note_submit_unconfirmed,
   _claim_personal_pr_ready,
   _inspect_personal_pr_ready_target,
   _mark_personal_pr_ready,
@@ -198,6 +199,7 @@ from app.github_contributions import (
   _submit_prepared_pr,
   _preflight_prepared_stack,
   _push_stack_tip_with_lease,
+  _advance_merged_parent_successor,
   _land_reviewed_stack,
 )
 from app.deps import (
@@ -1140,6 +1142,7 @@ def _chat_review_projection(record: dict, app_id: int) -> dict:
     "type": text(record.get("type")),
     "status": text(record.get("status")),
     "action": text(plan.get("action")),
+    "successor": isinstance(plan.get("successor"), dict),
     "title": text(plan.get("title") or record.get("title")),
     "summary": text(record.get("summary")),
     "repo": text(plan.get("repo") or record.get("repo")),
@@ -1273,6 +1276,13 @@ def _chat_action_key(record: dict, review: object) -> str:
   identity = json.dumps({
     "status": record.get("status"),
     "action": plan.get("action"),
+    "repo": plan.get("repo") or record.get("repo"),
+    "number": record.get("number"),
+    "url": record.get("url"),
+    "head_repository": record.get("head_repository") or plan.get("head_repository"),
+    "branch": plan.get("branch") or record.get("branch"),
+    "base": plan.get("base_sha"),
+    "successor": plan.get("successor"),
     "head": plan.get("head_sha"),
     "attention": attention.get("key"),
     "needs_attention": record.get("needs_attention") is True,
@@ -1504,7 +1514,12 @@ async def _chat_work_record_views(
       not requested_root or bool(contribution_work.project_root(requested_root))
     )
     review = None
-    if record.get("status") == "prepared" and not view["is_stack"]:
+    resumable_successor = (
+      record.get("status") == "submitting" and view["successor"]
+    )
+    if (
+      record.get("status") == "prepared" or resumable_successor
+    ) and not view["is_stack"]:
       plan = record.get("plan") if isinstance(record.get("plan"), dict) else {}
       _, diff_path = _record_paths(app_id, str(record.get("id") or ""))
       try:
@@ -2018,7 +2033,12 @@ async def contributions_for_chat(
   for record in records:
     view = _chat_review_projection(record, app_id)
     review = None
-    if record.get("status") == "prepared" and not view["is_stack"]:
+    resumable_successor = (
+      record.get("status") == "submitting" and view["successor"]
+    )
+    if (
+      record.get("status") == "prepared" or resumable_successor
+    ) and not view["is_stack"]:
       plan = record.get("plan") if isinstance(record.get("plan"), dict) else {}
       _, diff_path = _record_paths(app_id, str(record.get("id") or ""))
       try:
@@ -2591,12 +2611,14 @@ async def update_existing_contribution(
   db: Session = Depends(get_db),
   principal: Principal = Depends(get_principal),
 ):
-  """Apply one owner-approved reviewed fast-forward to an existing open PR.
+  """Apply one owner-approved reviewed update to an existing open PR.
 
   A prepared ``pr_update`` record temporarily brings the existing contribution
   back to the private review queue. The owner's Update PR click claims that
   exact head and diff, verifies the live PR identity before any push, then
-  reuses the ordinary guarded push path in existing-PR mode. Normal Send keeps
+  reuses the ordinary guarded push path in existing-PR mode. A detached
+  merged-parent successor carries an additional reviewed journal and uses the
+  exact lease-rewrite + base-retarget state machine instead. Normal Send keeps
   refusing existing branches, so an agent cannot turn an ordinary PR card into
   a silent rewrite.
   """
@@ -2622,13 +2644,14 @@ async def update_existing_contribution(
 
   try:
     repo, number, head_repository, branch = _prepared_existing_pr_target(claimed)
-    target_error = await asyncio.to_thread(
-      _autopilot_live_target_error,
+    live_target = await asyncio.to_thread(
+      _autopilot_live_target,
       repo,
       number,
       head_repository,
       branch,
     )
+    target_error = live_target.get("error")
     if target_error:
       raise ContributionSubmitError(
         "The open pull request changed since this update was prepared. Nothing was pushed.",
@@ -2649,13 +2672,78 @@ async def update_existing_contribution(
         await source_locks.enter_async_context(
           fs_locks.source_dir_lock(lock_path)
         )
-      pr_url, returned_number, record_patch = await asyncio.to_thread(
-        _submit_prepared_pr,
-        claimed,
-        diff_path,
-        expected_existing_pr_number=number,
-        expected_existing_head_repository=head_repository,
-      )
+      if isinstance(plan.get("successor"), dict):
+        pr_url, returned_number, record_patch = await asyncio.to_thread(
+          _advance_merged_parent_successor,
+          claimed,
+          diff_path,
+          expected_number=number,
+          expected_head_repository=head_repository,
+          live_head_sha=str(live_target.get("head_sha") or ""),
+          live_base_branch=str(live_target.get("base_branch") or ""),
+        )
+        # The state machine owns both public mutations, but the route must not
+        # settle its durable claim from a returned success alone. Re-read the
+        # exact PR and independently require the reviewed successor head AND
+        # its reviewed target base. This is deliberately a postcondition, not
+        # another mutation: a stale/ignored base edit leaves the claim
+        # resumable and can never be reported as a successful update.
+        successor = plan["successor"]
+        target_base_branch = str(
+          successor.get("base_branch") or plan.get("base_branch") or ""
+        )
+        settled_target = await asyncio.to_thread(
+          _autopilot_live_target,
+          repo,
+          number,
+          head_repository,
+          branch,
+        )
+        expected_head = str(plan.get("head_sha") or "")
+        if (
+          settled_target.get("error")
+          or str(settled_target.get("head_sha") or "") != expected_head
+          or str(settled_target.get("base_branch") or "")
+          != target_base_branch
+        ):
+          unconfirmed_patch = dict(record_patch or {})
+          # Never persist an old base as the successful submit base merely
+          # because an inner helper returned it. Preserve only the branch
+          # rewrite witness and the reviewed target needed for safe resume.
+          unconfirmed_patch.pop("last_submit_base_branch", None)
+          unconfirmed_patch.update({
+            "last_submit_push_sha": expected_head,
+            "last_successor_base_branch": target_base_branch,
+          })
+          raise ContributionSubmitError(
+            "The reviewed successor branch is live, but GitHub did not "
+            "confirm its base retarget.",
+            status_code=503,
+            code="update_unconfirmed",
+            detail=(
+              str(settled_target.get("error") or "")
+              or (
+                "The public pull request still exposes "
+                f"{settled_target.get('base_branch') or 'an unknown base'}; "
+                f"the reviewed target is {target_base_branch}."
+              )
+            ),
+            record_patch=unconfirmed_patch,
+          )
+      else:
+        _assert_reviewed_update_contains_live_head(
+          repo_path,
+          str(live_target.get("head_sha") or ""),
+          str(plan.get("head_sha") or ""),
+        )
+        pr_url, returned_number, record_patch = await asyncio.to_thread(
+          _submit_prepared_pr,
+          claimed,
+          diff_path,
+          direct_base_branch=str(live_target.get("base_branch") or ""),
+          expected_existing_pr_number=number,
+          expected_existing_head_repository=head_repository,
+        )
       if returned_number != number:
         raise ContributionSubmitError(
           "GitHub returned a different pull request for this reviewed update."
@@ -2676,13 +2764,28 @@ async def update_existing_contribution(
     async with fs_locks.app_storage_lock(app_id):
       _recheck_submit_app(db, app_id, expected_nonce)
       db.close()
-      record = _mark_submit_failure(
-        app_id=app_id,
-        record_path=record_path,
-        message=exc.message,
-        record_patch=exc.record_patch,
-        detail=exc.detail,
-      )
+      successor = isinstance((claimed.get("plan") or {}).get("successor"), dict)
+      if (
+        successor
+        and exc.code in {"update_unconfirmed", "landing_unconfirmed"}
+        and exc.record_patch
+      ):
+        record = _note_submit_unconfirmed(
+          record_path=record_path,
+          message=exc.message,
+          record_patch=exc.record_patch,
+          code=exc.code,
+          detail=exc.detail,
+        )
+      else:
+        record = _mark_submit_failure(
+          app_id=app_id,
+          record_path=record_path,
+          message=exc.message,
+          record_patch=exc.record_patch,
+          code=exc.code or "",
+          detail=exc.detail,
+        )
     raise HTTPException(
       status_code=exc.status_code,
       detail={
@@ -2694,14 +2797,29 @@ async def update_existing_contribution(
     )
   except Exception as exc:
     log.exception("Contribution update failed for %s/%s", app_id, record_id)
-    message = "Could not update this pull request. Nothing else was published."
+    successor = isinstance((claimed.get("plan") or {}).get("successor"), dict)
+    message = (
+      "GitHub did not confirm whether this reviewed successor update completed."
+      if successor else
+      "Could not update this pull request. Nothing else was published."
+    )
     async with fs_locks.app_storage_lock(app_id):
       _recheck_submit_app(db, app_id, expected_nonce)
       db.close()
-      record = _mark_submit_failure(
-        app_id=app_id,
-        record_path=record_path,
-        message=message,
+      record = (
+        _note_submit_unconfirmed(
+          record_path=record_path,
+          message=message,
+          record_patch={},
+          code="update_unconfirmed",
+          detail="The exact public pull request state must be checked again.",
+        )
+        if successor else
+        _mark_submit_failure(
+          app_id=app_id,
+          record_path=record_path,
+          message=message,
+        )
       )
     raise HTTPException(
       status_code=500,
@@ -4074,6 +4192,7 @@ def _autopilot_live_target(
     live_branch = head.get("ref")
     live_head_sha = str(head.get("sha") or "")
     live_base_repository = base_repo.get("full_name")
+    live_base_sha = str(base.get("sha") or "")
     try:
       live_base_branch = _validate_branch(base.get("ref"))
     except ContributionSubmitError:
@@ -4085,6 +4204,7 @@ def _autopilot_live_target(
       or not _GIT_SHA.fullmatch(live_head_sha)
       or live_base_repository != repo
       or not live_base_branch
+      or not _GIT_SHA.fullmatch(live_base_sha)
     ):
       return {
         "error": "The live pull request no longer matches the approved target.",
@@ -4096,6 +4216,7 @@ def _autopilot_live_target(
     "error": None,
     "head_sha": live_head_sha,
     "base_branch": live_base_branch,
+    "base_sha": live_base_sha,
   }
 
 

--- a/backend/tests/test_github_routes.py
+++ b/backend/tests/test_github_routes.py
@@ -1645,6 +1645,15 @@ def _write_contribution(app_id, record_id, record, diff_text=""):
     atomic_write(base / f"{record_id}.diff", diff_text)
 
 
+def _all_clear_review(head_sha: str) -> dict:
+  """The exact-head review precondition for tests exercising public work."""
+  return {
+    "state": "all_clear",
+    "reviewed_head_sha": head_sha,
+    "reviewed_at": "2026-08-30T00:00:00Z",
+  }
+
+
 def _write_personal_draft(app_id, record_id="personal-draft", number=58):
   head = "a" * 40
   base = "b" * 40
@@ -1982,6 +1991,7 @@ def _prepared_real_review(app_id, record_id):
     "status": "prepared",
     "title": "Reviewed fix",
     "branch": "fix/demo-review",
+    "quality_review": _all_clear_review(head),
     "plan": {
       "action": "pr",
       "repo": "mobius-os/app-demo",
@@ -3312,6 +3322,7 @@ def test_submit_contribution_keeps_accepted_ready_pr_on_label_transport_failure(
     "branch": "fix/demo-polish",
     "created_at": "2026-07-09T00:00:00Z",
     "updated_at": "2026-07-09T00:00:00Z",
+    "quality_review": _all_clear_review(head),
     "plan": {
       "action": "pr",
       "repo": "mobius-os/app-demo",
@@ -3481,6 +3492,7 @@ def test_submit_contribution_recovers_ambiguous_create_by_exact_pushed_head(
     "branch": "fix/demo-polish",
     "created_at": "2026-07-09T00:00:00Z",
     "updated_at": "2026-07-09T00:00:00Z",
+    "quality_review": _all_clear_review(head),
     "plan": {
       "action": "pr",
       "repo": "mobius-os/app-demo",
@@ -3661,6 +3673,47 @@ def test_existing_pr_update_confirmation_reads_the_known_pr_directly(
     ("api", "repos/mobius-os/app-demo/pulls/58"),
   ]
 
+
+def test_existing_pr_update_confirmation_pins_the_reviewed_base_commit(
+  tmp_path, monkeypatch,
+):
+  """A matching base name cannot hide a base ref that advanced after review."""
+  from app.github_contributions import _confirm_existing_pr_update
+
+  expected_head = "a" * 40
+  expected_base = "b" * 40
+  observed_bases = ["c" * 40, expected_base]
+
+  def fake_gh(_repo_path, *_args, **_kwargs):
+    return _cp(json.dumps({
+      "html_url": "https://github.com/mobius-os/app-demo/pull/58",
+      "state": "open",
+      "head": {
+        "ref": "feat/existing-review",
+        "sha": expected_head,
+        "repo": {"full_name": "octocat/app-demo"},
+      },
+      "base": {"ref": "main", "sha": observed_bases.pop(0)},
+      "draft": False,
+    }))
+
+  monkeypatch.setattr("app.github_contribution_git._gh", fake_gh)
+  monkeypatch.setattr("app.github_contributions.time.sleep", lambda _seconds: None)
+
+  assert _confirm_existing_pr_update(
+    tmp_path,
+    "mobius-os/app-demo",
+    58,
+    expected_head_repository="octocat/app-demo",
+    expected_head_sha=expected_head,
+    branch="feat/existing-review",
+    base_branch="main",
+    expected_base_sha=expected_base,
+  ) == (
+    "https://github.com/mobius-os/app-demo/pull/58", "ready",
+  )
+  assert observed_bases == []
+
 def test_submit_contribution_normalizes_fallback_author_before_push(
   client, owner_token, monkeypatch,
 ):
@@ -3680,6 +3733,7 @@ def test_submit_contribution_normalizes_fallback_author_before_push(
     "status": "prepared",
     "title": "Polish demo",
     "branch": "fix/demo-polish",
+    "quality_review": _all_clear_review(old_head),
     "plan": {
       "action": "pr",
       "repo": "mobius-os/app-demo",
@@ -3807,6 +3861,7 @@ def test_submit_contribution_replaces_stale_fork_remote_before_push(
     "status": "prepared",
     "title": "Polish demo",
     "branch": "fix/demo-polish",
+    "quality_review": _all_clear_review(head),
     "plan": {
       "action": "pr",
       "repo": "mobius-os/app-demo",
@@ -5044,6 +5099,70 @@ def test_stack_tip_push_keeps_journal_when_result_cannot_be_read(
   assert caught.value.code == "landing_unconfirmed"
 
 
+def test_stack_tip_push_keeps_journal_when_transport_and_probe_raise(
+  monkeypatch, tmp_path,
+):
+  """Raised transport errors remain an ambiguous public outcome."""
+  from app.routes.github import ContributionSubmitError, _push_stack_tip_with_lease
+
+  monkeypatch.setattr("app.github_contributions._PUSH_RETRIES", 1)
+  monkeypatch.setattr(
+    "app.github_contribution_git._git",
+    lambda *_args, **_kwargs: (_ for _ in ()).throw(
+      subprocess.TimeoutExpired("git push", 1),
+    ),
+  )
+  monkeypatch.setattr(
+    "app.github_contribution_git._upstream_branch_sha",
+    lambda *_args, **_kwargs: (_ for _ in ()).throw(
+      OSError("temporary GitHub transport failure"),
+    ),
+  )
+
+  with pytest.raises(ContributionSubmitError) as caught:
+    _push_stack_tip_with_lease(
+      tmp_path,
+      upstream_repo="mobius-os/app-demo",
+      target_branch="main",
+      expected_base="b" * 40,
+      landed_sha="c" * 40,
+    )
+
+  assert caught.value.status_code == 503
+  assert caught.value.code == "landing_unconfirmed"
+
+
+def test_stack_tip_push_timeout_stays_ambiguous_when_probe_is_still_old(
+  monkeypatch, tmp_path,
+):
+  """An early old-tip read cannot prove a timed-out push will not land later."""
+  from app.routes.github import ContributionSubmitError, _push_stack_tip_with_lease
+
+  monkeypatch.setattr("app.github_contributions._PUSH_RETRIES", 1)
+  monkeypatch.setattr(
+    "app.github_contribution_git._git",
+    lambda *_args, **_kwargs: (_ for _ in ()).throw(
+      subprocess.TimeoutExpired("git push", 1),
+    ),
+  )
+  monkeypatch.setattr(
+    "app.github_contribution_git._upstream_branch_sha",
+    lambda *_args, **_kwargs: "b" * 40,
+  )
+
+  with pytest.raises(ContributionSubmitError) as caught:
+    _push_stack_tip_with_lease(
+      tmp_path,
+      upstream_repo="mobius-os/app-demo",
+      target_branch="main",
+      expected_base="b" * 40,
+      landed_sha="c" * 40,
+    )
+
+  assert caught.value.status_code == 503
+  assert caught.value.code == "landing_unconfirmed"
+
+
 def test_submit_contribution_rejects_branch_diff_mismatch(
   client, owner_token, monkeypatch,
 ):
@@ -5063,6 +5182,7 @@ def test_submit_contribution_rejects_branch_diff_mismatch(
     "status": "prepared",
     "title": "Polish demo",
     "branch": "fix/demo-polish",
+    "quality_review": _all_clear_review(head),
     "plan": {
       "action": "pr",
       "repo": "mobius-os/app-demo",
@@ -5144,6 +5264,7 @@ def test_submit_contribution_rejects_unmergeable_branch_before_push(
     "status": "prepared",
     "title": "Polish demo",
     "branch": "fix/demo-polish",
+    "quality_review": _all_clear_review(head),
     "plan": {
       "action": "pr",
       "repo": "mobius-os/app-demo",
@@ -5230,6 +5351,7 @@ def test_submit_contribution_records_public_branch_after_pr_create_failure(
     "status": "prepared",
     "title": "Polish demo",
     "branch": "fix/demo-polish",
+    "quality_review": _all_clear_review(head),
     "plan": {
       "action": "pr",
       "repo": "mobius-os/app-demo",
@@ -5389,19 +5511,21 @@ def test_submit_contribution_rolls_back_unready_record(
   _write_token(login="octocat")
   app_id, _ = _app_token(client, owner_token, github_access=True)
   record_id = "rec-pr-unready"
+  head = "a" * 40
   record = {
     "id": record_id,
     "type": "pr",
     "repo": "mobius-os/app-demo",
     "status": "prepared",
     "title": "Polish demo",
+    "quality_review": _all_clear_review(head),
     "plan": {
       "action": "pr",
       "repo": "mobius-os/app-demo",
       "title": "Polish demo",
       "body_draft": "Body",
       "branch": "fix/demo-polish",
-      "head_sha": "abc123",
+      "head_sha": head,
     },
   }
   _write_contribution(app_id, record_id, record)
@@ -5460,6 +5584,22 @@ def _prepared_existing_pr_update(app_id: int, record_id: str) -> dict:
     },
   }
   _write_contribution(app_id, record_id, record, "reviewed diff")
+  return record
+
+
+def _prepared_merged_parent_successor(app_id: int, record_id: str) -> dict:
+  """A standalone reviewed successor that reuses the ordinary update action."""
+  record = _prepared_existing_pr_update(app_id, record_id)
+  record["plan"]["base_sha"] = _SUCCESSOR_TARGET_BASE_SHA
+  record["plan"]["head_sha"] = _SUCCESSOR_NEW_HEAD
+  record["plan"]["successor"] = {
+    "old_head_sha": _SUCCESSOR_OLD_HEAD,
+    "old_base_branch": _SUCCESSOR_OLD_BASE_BRANCH,
+    "old_base_sha": _SUCCESSOR_OLD_BASE_SHA,
+    "base_branch": _SUCCESSOR_TARGET_BASE_BRANCH,
+  }
+  record["quality_review"]["reviewed_head_sha"] = _SUCCESSOR_NEW_HEAD
+  _write_contribution(app_id, record_id, record, "reviewed successor diff")
   return record
 
 
@@ -5781,7 +5921,7 @@ def test_existing_pr_stack_update_preserves_parent_when_child_fails(
   }]
 
 
-def test_existing_pr_target_includes_the_live_base_branch(monkeypatch):
+def test_existing_pr_target_returns_the_authoritative_pr_base_snapshot(monkeypatch):
   _write_token(login="octocat")
   live = {
     "state": "open",
@@ -5792,6 +5932,7 @@ def test_existing_pr_target_includes_the_live_base_branch(monkeypatch):
     },
     "base": {
       "ref": "stack/review/01-parent",
+      "sha": "8" * 40,
       "repo": {"full_name": "mobius-os/app-demo"},
     },
   }
@@ -5810,6 +5951,7 @@ def test_existing_pr_target_includes_the_live_base_branch(monkeypatch):
     "error": None,
     "head_sha": "9" * 40,
     "base_branch": "stack/review/01-parent",
+    "base_sha": "8" * 40,
   }
 
 
@@ -5826,23 +5968,31 @@ def test_existing_pr_update_uses_owner_approved_exact_target(
 
   monkeypatch.setattr(
     github_routes,
-    "_autopilot_live_target_error",
+    "_autopilot_live_target",
     lambda repo, number, head_repo, branch: calls.append(
       ("target", repo, number, head_repo, branch)
-    ) or None,
+    ) or {"error": None, "head_sha": "9" * 40, "base_branch": "release"},
+  )
+  monkeypatch.setattr(
+    github_routes,
+    "_assert_reviewed_update_contains_live_head",
+    lambda repo_path, live_head, reviewed_head: calls.append(
+      ("ancestry", repo_path.name, live_head, reviewed_head)
+    ),
   )
 
   def submit(
     record,
     diff_path,
     *,
+    direct_base_branch=None,
     expected_existing_pr_number=None,
     expected_existing_head_repository=None,
-    **_kwargs,
   ):
     calls.append((
       "submit",
       record["status"],
+      direct_base_branch,
       expected_existing_pr_number,
       expected_existing_head_repository,
       diff_path.name,
@@ -5877,10 +6027,309 @@ def test_existing_pr_update_uses_owner_approved_exact_target(
       "octocat/app-demo", "feat/existing-review",
     ),
     (
-      "submit", "submitting", 58, "octocat/app-demo",
+      "ancestry", "worktree", "9" * 40, original["plan"]["head_sha"],
+    ),
+    (
+      "submit", "submitting", "release", 58, "octocat/app-demo",
       f"{record_id}.diff",
     ),
   ]
+
+
+def test_existing_pr_update_routes_detached_successor_through_state_machine(
+  client, owner_token, monkeypatch,
+):
+  """The existing update endpoint owns both ordinary and successor updates."""
+  _write_token(login="octocat")
+  app_id, app_token = _app_token(client, owner_token, github_access=True)
+  record_id = "existing-pr-successor"
+  original = _prepared_merged_parent_successor(app_id, record_id)
+  calls = []
+  live_targets = [
+    {
+      "error": None,
+      "head_sha": _SUCCESSOR_OLD_HEAD,
+      "base_branch": _SUCCESSOR_OLD_BASE_BRANCH,
+      "base_sha": _SUCCESSOR_OLD_BASE_SHA,
+    },
+    {
+      "error": None,
+      "head_sha": _SUCCESSOR_NEW_HEAD,
+      "base_branch": _SUCCESSOR_TARGET_BASE_BRANCH,
+      "base_sha": _SUCCESSOR_TARGET_BASE_SHA,
+    },
+  ]
+  monkeypatch.setattr(
+    github_routes,
+    "_autopilot_live_target",
+    lambda *_args: live_targets.pop(0),
+  )
+  monkeypatch.setattr(
+    github_routes,
+    "_assert_reviewed_update_contains_live_head",
+    lambda *_args: pytest.fail("a reviewed successor is intentionally non-fast-forward"),
+  )
+  monkeypatch.setattr(
+    github_routes,
+    "_submit_prepared_pr",
+    lambda *_args, **_kwargs: pytest.fail("successors use the owning state machine"),
+  )
+
+  def advance(record, diff_path, **kwargs):
+    calls.append((record["status"], diff_path.name, kwargs))
+    return (
+      "https://github.com/mobius-os/app-demo/pull/58",
+      58,
+      {
+        "last_submit_push_sha": record["plan"]["head_sha"],
+        "last_submit_base_branch": _SUCCESSOR_TARGET_BASE_BRANCH,
+        "publication_stage": "ready",
+      },
+    )
+
+  monkeypatch.setattr(github_routes, "_advance_merged_parent_successor", advance)
+  response = client.post(
+    f"/api/github/contributions/{app_id}/{record_id}/update-existing",
+    headers={"Authorization": f"Bearer {app_token}"},
+    json={},
+  )
+
+  assert response.status_code == 200, response.text
+  updated = response.json()["record"]
+  assert updated["status"] == "open"
+  assert updated["plan"]["action"] == "pr_update"
+  assert updated["plan"]["successor"] == original["plan"]["successor"]
+  assert calls == [(
+    "submitting",
+    f"{record_id}.diff",
+    {
+      "expected_number": 58,
+      "expected_head_repository": "octocat/app-demo",
+      "live_head_sha": _SUCCESSOR_OLD_HEAD,
+      "live_base_branch": _SUCCESSOR_OLD_BASE_BRANCH,
+    },
+  )]
+  assert live_targets == []
+
+
+def test_existing_pr_successor_never_settles_while_public_base_is_old(
+  client, owner_token, monkeypatch,
+):
+  """A pushed head with an ignored retarget remains resumable, never success."""
+  _write_token(login="octocat")
+  app_id, app_token = _app_token(client, owner_token, github_access=True)
+  record_id = "existing-pr-successor-old-public-base"
+  _prepared_merged_parent_successor(app_id, record_id)
+  live_targets = [
+    {
+      "error": None,
+      "head_sha": _SUCCESSOR_OLD_HEAD,
+      "base_branch": _SUCCESSOR_OLD_BASE_BRANCH,
+      "base_sha": _SUCCESSOR_OLD_BASE_SHA,
+    },
+    {
+      "error": None,
+      "head_sha": _SUCCESSOR_NEW_HEAD,
+      "base_branch": _SUCCESSOR_OLD_BASE_BRANCH,
+      "base_sha": _SUCCESSOR_OLD_BASE_SHA,
+    },
+  ]
+  monkeypatch.setattr(
+    github_routes,
+    "_autopilot_live_target",
+    lambda *_args: live_targets.pop(0),
+  )
+  monkeypatch.setattr(
+    github_routes,
+    "_advance_merged_parent_successor",
+    lambda *_args, **_kwargs: (
+      "https://github.com/mobius-os/app-demo/pull/58",
+      58,
+      {
+        "last_submit_push_sha": _SUCCESSOR_NEW_HEAD,
+        # Model the field incident: an inner helper claimed success while
+        # retaining the obsolete parent branch as submit metadata.
+        "last_submit_base_branch": _SUCCESSOR_OLD_BASE_BRANCH,
+        "publication_stage": "ready",
+      },
+    ),
+  )
+
+  response = client.post(
+    f"/api/github/contributions/{app_id}/{record_id}/update-existing",
+    headers={"Authorization": f"Bearer {app_token}"},
+    json={},
+  )
+
+  assert response.status_code == 503, response.text
+  detail = response.json()["detail"]
+  assert detail["code"] == "update_unconfirmed"
+  saved = detail["record"]
+  assert saved["status"] == "submitting"
+  assert saved["last_submit_push_sha"] == _SUCCESSOR_NEW_HEAD
+  assert saved["last_successor_base_branch"] == _SUCCESSOR_TARGET_BASE_BRANCH
+  assert saved.get("last_submit_base_branch") != _SUCCESSOR_OLD_BASE_BRANCH
+  assert live_targets == []
+
+
+def test_existing_pr_successor_resumes_its_exact_submitting_claim(
+  client, owner_token, monkeypatch,
+):
+  """A crash after claim can re-enter the same approved state machine."""
+  _write_token(login="octocat")
+  app_id, app_token = _app_token(client, owner_token, github_access=True)
+  record_id = "existing-pr-successor-resume"
+  record = _prepared_merged_parent_successor(app_id, record_id)
+  record["status"] = "submitting"
+  record["submitter"] = "contribute-update-button"
+  record["submit_started_at"] = "2026-08-30T22:00:00Z"
+  _write_contribution(app_id, record_id, record, "reviewed successor diff")
+  live_targets = [
+    {
+      "error": None,
+      "head_sha": _SUCCESSOR_NEW_HEAD,
+      "base_branch": _SUCCESSOR_OLD_BASE_BRANCH,
+      "base_sha": _SUCCESSOR_OLD_BASE_SHA,
+    },
+    {
+      "error": None,
+      "head_sha": _SUCCESSOR_NEW_HEAD,
+      "base_branch": _SUCCESSOR_TARGET_BASE_BRANCH,
+      "base_sha": _SUCCESSOR_TARGET_BASE_SHA,
+    },
+  ]
+  monkeypatch.setattr(
+    github_routes,
+    "_autopilot_live_target",
+    lambda *_args: live_targets.pop(0),
+  )
+  seen = []
+  monkeypatch.setattr(
+    github_routes,
+    "_advance_merged_parent_successor",
+    lambda claimed, _diff, **_kwargs: (
+      seen.append((claimed["status"], claimed["submit_started_at"]))
+      or (
+        "https://github.com/mobius-os/app-demo/pull/58",
+        58,
+        {
+          "last_submit_push_sha": _SUCCESSOR_NEW_HEAD,
+          "publication_stage": "ready",
+        },
+      )
+    ),
+  )
+
+  response = client.post(
+    f"/api/github/contributions/{app_id}/{record_id}/update-existing",
+    headers={"Authorization": f"Bearer {app_token}"},
+    json={},
+  )
+
+  assert response.status_code == 200, response.text
+  assert response.json()["record"]["status"] == "open"
+  assert seen == [("submitting", "2026-08-30T22:00:00Z")]
+  assert live_targets == []
+
+
+@pytest.mark.parametrize("error_code", ["update_unconfirmed", "landing_unconfirmed"])
+def test_existing_pr_successor_preserves_ambiguous_public_claim(
+  client, owner_token, monkeypatch, error_code,
+):
+  """A lost public response keeps the prior approval resumable, not re-prepared."""
+  _write_token(login="octocat")
+  app_id, app_token = _app_token(client, owner_token, github_access=True)
+  record_id = f"existing-pr-successor-{error_code}"
+  _prepared_merged_parent_successor(app_id, record_id)
+  monkeypatch.setattr(
+    github_routes,
+    "_autopilot_live_target",
+    lambda *_args: {
+      "error": None,
+      "head_sha": _SUCCESSOR_NEW_HEAD,
+      "base_branch": _SUCCESSOR_OLD_BASE_BRANCH,
+      "base_sha": _SUCCESSOR_OLD_BASE_SHA,
+    },
+  )
+
+  def unconfirmed(*_args, **_kwargs):
+    raise ContributionSubmitError(
+      "GitHub did not confirm the base retarget.",
+      status_code=503,
+      code=error_code,
+      detail="The exact PR read was inconclusive.",
+      record_patch={"last_submit_push_sha": _SUCCESSOR_NEW_HEAD},
+    )
+
+  monkeypatch.setattr(github_routes, "_advance_merged_parent_successor", unconfirmed)
+  response = client.post(
+    f"/api/github/contributions/{app_id}/{record_id}/update-existing",
+    headers={"Authorization": f"Bearer {app_token}"},
+    json={},
+  )
+
+  assert response.status_code == 503, response.text
+  saved = response.json()["detail"]["record"]
+  assert saved["status"] == "submitting"
+  assert saved["last_submit_push_sha"] == _SUCCESSOR_NEW_HEAD
+  assert saved["last_submit_error_code"] == error_code
+
+
+def test_existing_pr_successor_preserves_claim_after_unexpected_failure(
+  client, owner_token, monkeypatch,
+):
+  """Unknown failures cannot reopen a possibly completed public action."""
+  _write_token(login="octocat")
+  app_id, app_token = _app_token(client, owner_token, github_access=True)
+  record_id = "existing-pr-successor-unexpected"
+  _prepared_merged_parent_successor(app_id, record_id)
+  monkeypatch.setattr(
+    github_routes,
+    "_autopilot_live_target",
+    lambda *_args: (_ for _ in ()).throw(RuntimeError("unexpected read failure")),
+  )
+
+  response = client.post(
+    f"/api/github/contributions/{app_id}/{record_id}/update-existing",
+    headers={"Authorization": f"Bearer {app_token}"},
+    json={},
+  )
+
+  assert response.status_code == 500, response.text
+  saved = response.json()["detail"]["record"]
+  assert saved["status"] == "submitting"
+  assert saved["last_submit_error_code"] == "update_unconfirmed"
+  assert "check" in saved["last_submit_error_detail"].lower()
+
+
+def test_existing_pr_successor_rejects_residual_stack_before_public_work(
+  client, owner_token, monkeypatch,
+):
+  """Stack detachment is an explicit private preparation, never a runtime rewrite."""
+  _write_token(login="octocat")
+  app_id, app_token = _app_token(client, owner_token, github_access=True)
+  record_id = "existing-pr-successor-stacked"
+  record = _prepared_merged_parent_successor(app_id, record_id)
+  record["plan"]["stack"] = {"id": "demo", "position": 1, "total": 2}
+  _write_contribution(app_id, record_id, record, "reviewed successor diff")
+  monkeypatch.setattr(
+    github_routes,
+    "_advance_merged_parent_successor",
+    lambda *_args, **_kwargs: pytest.fail("a stacked successor must not mutate"),
+  )
+
+  response = client.post(
+    f"/api/github/contributions/{app_id}/{record_id}/update-existing",
+    headers={"Authorization": f"Bearer {app_token}"},
+    json={},
+  )
+
+  assert response.status_code == 409, response.text
+  stored = json.loads(
+    (Path(get_settings().data_dir) / "apps" / str(app_id)
+     / "contributions" / f"{record_id}.json").read_text()
+  )
+  assert stored["status"] == "prepared"
 
 
 def test_existing_pr_update_stays_successful_if_followup_metadata_fails(
@@ -5894,7 +6343,12 @@ def test_existing_pr_update_stays_successful_if_followup_metadata_fails(
   original = _prepared_existing_pr_update(app_id, record_id)
   monkeypatch.setattr(
     github_routes,
-    "_autopilot_live_target_error",
+    "_autopilot_live_target",
+    lambda *_args: {"error": None, "head_sha": "9" * 40},
+  )
+  monkeypatch.setattr(
+    github_routes,
+    "_assert_reviewed_update_contains_live_head",
     lambda *_args: None,
   )
   monkeypatch.setattr(
@@ -5940,8 +6394,8 @@ def test_existing_pr_update_rechecks_target_before_any_push(
   pushed = []
   monkeypatch.setattr(
     github_routes,
-    "_autopilot_live_target_error",
-    lambda *_args: "The live branch moved.",
+    "_autopilot_live_target",
+    lambda *_args: {"error": "The live branch moved.", "head_sha": None},
   )
   monkeypatch.setattr(
     github_routes,
@@ -6058,6 +6512,48 @@ def test_chat_projection_marks_exact_reviewed_pr_updates_sendable(
   assert projected["quality_review_ready"] is True
   assert projected["review"]["state"] == "ready"
   assert projected["coverage_at"] == "2026-08-27T12:34:56Z"
+
+
+def test_chat_projection_keeps_an_interrupted_successor_resumable(
+  client, owner_token, monkeypatch,
+):
+  """A durable successor claim stays reviewable after a process restart."""
+  app_id, app_token = _app_token(client, owner_token, github_access=True)
+  record_id = "existing-pr-successor-card"
+  record = _prepared_merged_parent_successor(app_id, record_id)
+  record.update({
+    "chat_id": "chat-successor-resume",
+    "status": "submitting",
+    "submitter": "contribute-update-button",
+    "submit_started_at": "2026-08-30T22:00:00Z",
+  })
+  _write_contribution(app_id, record_id, record, "reviewed successor diff")
+  inspected = []
+  monkeypatch.setattr(
+    github_routes,
+    "_inspect_prepared_review",
+    lambda current, _diff_path, _github_state: (
+      inspected.append(current["status"])
+      or {
+        "id": current["id"], "state": "ready", "code": "ready",
+        "message": "Still matches the exact source you reviewed.",
+      }
+    ),
+  )
+
+  response = client.get(
+    f"/api/github/contributions/{app_id}/for-chat/chat-successor-resume",
+    headers={"Authorization": f"Bearer {app_token}"},
+  )
+
+  assert response.status_code == 200, response.text
+  projected = response.json()["records"][0]
+  assert projected["status"] == "submitting"
+  assert projected["action"] == "pr_update"
+  assert projected["successor"] is True
+  assert projected["quality_review_ready"] is True
+  assert projected["review"]["state"] == "ready"
+  assert inspected == ["submitting"]
 
 
 def test_chat_projection_uses_private_review_time_after_the_public_submission(
@@ -6931,6 +7427,29 @@ def test_chat_action_key_ignores_poll_timestamps_but_changes_with_attention(
   assert third != first
 
 
+def test_chat_action_key_changes_with_successor_authorization(
+  client, owner_token,
+):
+  """Any changed successor mutation invalidates an older confirmation."""
+  app_id, _ = _app_token(client, owner_token, github_access=True)
+  record_id = "successor-action-key"
+  record = _prepared_merged_parent_successor(app_id, record_id)
+  record["chat_id"] = "chat-a"
+  _write_contribution(app_id, record_id, record, "reviewed successor diff")
+  headers = {"Authorization": f"Bearer {owner_token}"}
+
+  first = client.get(
+    f"/api/github/contributions/{app_id}/for-chat/chat-a", headers=headers,
+  ).json()["records"][0]["action_key"]
+  record["plan"]["successor"]["base_branch"] = "release"
+  _write_contribution(app_id, record_id, record, "reviewed successor diff")
+  second = client.get(
+    f"/api/github/contributions/{app_id}/for-chat/chat-a", headers=headers,
+  ).json()["records"][0]["action_key"]
+
+  assert second != first
+
+
 def test_diff_file_paths_reads_headers_not_source_that_looks_like_one(tmp_path):
   diff_path = tmp_path / "review.diff"
   diff_path.write_text(
@@ -7561,3 +8080,823 @@ def test_a_dirty_checkout_is_named_before_an_upstream_conflict(
     headers={"Authorization": f"Bearer {app_token}"},
   )
   assert response.json()["records"][0]["code"] == "working_changes"
+
+
+# --- merged-parent successor transition -------------------------------------
+#
+# A squash/queue-merged parent (#966) leaves its reviewed child (#967) pointed
+# at a base branch that no longer carries that commit. The guarded successor
+# action rewrites the child branch to the reviewed successor with an exact
+# force-with-lease from the old public head, then retargets the PR base to the
+# surviving branch. Both mutations are keyed only on the live PR so every crash
+# resumes state-by-state and any drift fails closed with nothing pushed.
+
+_SUCCESSOR_OLD_HEAD = "a" * 40
+_SUCCESSOR_NEW_HEAD = "b" * 40
+_SUCCESSOR_OLD_BASE_SHA = "c" * 40
+_SUCCESSOR_TARGET_BASE_SHA = "d" * 40
+_SUCCESSOR_MERGED_BASE_SHA = "e" * 40
+_SUCCESSOR_OLD_BASE_BRANCH = "stack/demo/01-parent"
+_SUCCESSOR_TARGET_BASE_BRANCH = "main"
+_SUCCESSOR_BRANCH = "stack/demo/02-child"
+
+
+def _successor_submission(tmp_path, monkeypatch, *, stack=None):
+  """One reviewed detached ``pr_update`` successor card whose parent already squash-merged."""
+  _write_token(login="octocat", user_id=42)
+  repo = tmp_path / "successor-pr"
+  (repo / ".git").mkdir(parents=True)
+  diff_text = "diff --git a/model.py b/model.py\n+reviewed successor\n"
+  diff_path = tmp_path / "successor.diff"
+  diff_path.write_text(diff_text)
+  plan = {
+    "action": "pr_update",
+    "repo": "mobius-os/app-demo",
+    "title": "Rebase the child onto the surviving base",
+    "body_draft": "Reviewed merged-parent successor.",
+    "branch": _SUCCESSOR_BRANCH,
+    "repo_path": str(repo),
+    "base_sha": _SUCCESSOR_TARGET_BASE_SHA,
+    "head_sha": _SUCCESSOR_NEW_HEAD,
+    "diff_sha256": hashlib.sha256(diff_text.encode()).hexdigest(),
+    "successor": {
+      "old_head_sha": _SUCCESSOR_OLD_HEAD,
+      "old_base_branch": _SUCCESSOR_OLD_BASE_BRANCH,
+      "old_base_sha": _SUCCESSOR_OLD_BASE_SHA,
+      "base_branch": _SUCCESSOR_TARGET_BASE_BRANCH,
+    },
+  }
+  if stack is not None:
+    plan["stack"] = stack
+  record = {
+    "id": "successor-pr",
+    "type": "pr",
+    "repo": "mobius-os/app-demo",
+    "status": "submitting",
+    "title": "Rebase the child onto the surviving base",
+    "branch": _SUCCESSOR_BRANCH,
+    "url": "https://github.com/mobius-os/app-demo/pull/967",
+    "number": 967,
+    "head_repository": "mobius-os/app-demo",
+    "plan": plan,
+  }
+  monkeypatch.setattr(
+    "app.github_contributions.shutil.which", lambda name: f"/bin/{name}",
+  )
+  monkeypatch.setattr(
+    "app.github_contributions._safe_repo_path", lambda _raw: repo,
+  )
+  monkeypatch.setattr(
+    "app.github_contribution_git._connected_git_identity",
+    lambda *_args, **_kwargs: (
+      "Octo Cat", "octocat@users.noreply.github.com",
+    ),
+  )
+  monkeypatch.setattr(
+    "app.github_contribution_git._assert_fresh",
+    lambda *_args, **_kwargs: (
+      _SUCCESSOR_TARGET_BASE_SHA,
+      _SUCCESSOR_NEW_HEAD,
+      record["plan"]["diff_sha256"],
+    ),
+  )
+  monkeypatch.setattr(
+    "app.github_contribution_git._assert_clean_worktree", lambda *_args: None,
+  )
+  monkeypatch.setattr(
+    "app.github_contribution_git._assert_coauthor_trailer", lambda *_args: None,
+  )
+  monkeypatch.setattr(
+    "app.github_contribution_git._assert_head_attribution",
+    lambda *_args, **_kwargs: None,
+  )
+  monkeypatch.setattr(
+    "app.github_contribution_git._assert_merges_with_upstream",
+    lambda *_args, **_kwargs: {
+      "last_submit_upstream_branch": _SUCCESSOR_TARGET_BASE_BRANCH,
+      "last_submit_upstream_sha": _SUCCESSOR_TARGET_BASE_SHA,
+    },
+  )
+  monkeypatch.setattr(
+    "app.github_contribution_git._upstream_branch_sha",
+    lambda _repo, _upstream, branch: (
+      _SUCCESSOR_OLD_BASE_SHA
+      if branch == _SUCCESSOR_OLD_BASE_BRANCH
+      else _SUCCESSOR_TARGET_BASE_SHA
+    ),
+  )
+  monkeypatch.setattr(
+    "app.github_contributions._assert_merged_parent_tree_equivalence",
+    lambda *_args, **_kwargs: None,
+  )
+
+  def fake_git(_repo, *args, check=True):
+    if args == ("rev-parse", "--abbrev-ref", "HEAD"):
+      return _cp(_SUCCESSOR_BRANCH + "\n")
+    if args == ("rev-parse", "HEAD"):
+      return _cp(_SUCCESSOR_NEW_HEAD + "\n")
+    return _cp("")
+
+  monkeypatch.setattr("app.github_contribution_git._git", fake_git)
+  return record, diff_path
+
+
+def _capture_successor_confirmations(
+  monkeypatch,
+  *,
+  url="https://github.com/mobius-os/app-demo/pull/967",
+  target_results=None,
+):
+  confirms = []
+  target_results = list(target_results or [None, (url, "ready")])
+
+  def fake_confirm(_repo, _upstream, number, **kwargs):
+    confirms.append({"number": number, **kwargs})
+    if kwargs.get("base_branch") == _SUCCESSOR_TARGET_BASE_BRANCH:
+      if len(target_results) > 1:
+        return target_results.pop(0)
+      return target_results[0]
+    return url, "ready"
+
+  monkeypatch.setattr(
+    "app.github_contributions._confirm_existing_pr_update", fake_confirm,
+  )
+  return confirms
+
+
+def test_merged_parent_successor_leases_promoted_child_after_squash_merge(
+  tmp_path, monkeypatch,
+):
+  """old head + old base -> force-with-lease rewrite, then base retarget."""
+  from app.github_contributions import _advance_merged_parent_successor
+
+  record, diff_path = _successor_submission(tmp_path, monkeypatch)
+  lease_calls = []
+  monkeypatch.setattr(
+    "app.github_contributions._push_stack_tip_with_lease",
+    lambda repo, **kwargs: lease_calls.append(kwargs),
+  )
+  retarget_calls = []
+
+  def fake_retarget(_repo, _upstream, number, *, base_branch):
+    retarget_calls.append((number, base_branch))
+    return "accepted", ""
+
+  monkeypatch.setattr(
+    "app.github_contributions._retarget_pr_base", fake_retarget,
+  )
+  confirms = _capture_successor_confirmations(monkeypatch)
+
+  url, number, patch = _advance_merged_parent_successor(
+    record,
+    diff_path,
+    expected_number=967,
+    expected_head_repository="mobius-os/app-demo",
+    live_head_sha=_SUCCESSOR_OLD_HEAD,
+    live_base_branch=_SUCCESSOR_OLD_BASE_BRANCH,
+  )
+
+  assert (url, number) == ("https://github.com/mobius-os/app-demo/pull/967", 967)
+  # Public mutation #1: exact force-with-lease from the old public head.
+  assert lease_calls == [{
+    "upstream_repo": "mobius-os/app-demo",
+    "target_branch": _SUCCESSOR_BRANCH,
+    "expected_base": _SUCCESSOR_OLD_HEAD,
+    "landed_sha": _SUCCESSOR_NEW_HEAD,
+  }]
+  # Public mutation #2: retarget to the surviving base.
+  assert retarget_calls == [(967, _SUCCESSOR_TARGET_BASE_BRANCH)]
+  # The old public state is re-read before the lease, the rewrite is confirmed
+  # on the old base, and the exact new head+base is confirmed after retarget.
+  assert confirms[0]["base_branch"] == _SUCCESSOR_OLD_BASE_BRANCH
+  assert confirms[0]["expected_base_sha"] == _SUCCESSOR_OLD_BASE_SHA
+  assert confirms[0]["expected_head_sha"] == _SUCCESSOR_OLD_HEAD
+  assert confirms[1]["base_branch"] == _SUCCESSOR_OLD_BASE_BRANCH
+  assert confirms[1]["expected_head_sha"] == _SUCCESSOR_NEW_HEAD
+  assert confirms[-1]["base_branch"] == _SUCCESSOR_TARGET_BASE_BRANCH
+  assert confirms[-1]["expected_base_sha"] == _SUCCESSOR_TARGET_BASE_SHA
+  assert patch["last_submit_push_sha"] == _SUCCESSOR_NEW_HEAD
+  assert patch["last_successor_old_head"] == _SUCCESSOR_OLD_HEAD
+  assert patch["last_successor_base_branch"] == _SUCCESSOR_TARGET_BASE_BRANCH
+  assert patch["last_successor_base_sha"] == _SUCCESSOR_TARGET_BASE_SHA
+  assert patch["publication_stage"] == "ready"
+
+
+def test_merged_parent_successor_proves_tree_equivalence_before_mutation(
+  tmp_path, monkeypatch,
+):
+  """A target base that does not carry the merged parent's tree fails closed."""
+  from app.github_contributions import _assert_merged_parent_tree_equivalence
+
+  repo = tmp_path / "tree"
+  (repo / ".git").mkdir(parents=True)
+
+  def fake_git(_repo, *args, check=True):
+    # rev-parse --verify --quiet <sha>^{tree}
+    if args[:3] == ("rev-parse", "--verify", "--quiet"):
+      spec = args[3]
+      if spec.startswith(_SUCCESSOR_OLD_BASE_SHA):
+        return _cp("1" * 40 + "\n")
+      return _cp("2" * 40 + "\n")
+    return _cp("")
+
+  monkeypatch.setattr("app.github_contribution_git._git", fake_git)
+  with pytest.raises(ContributionSubmitError) as caught:
+    _assert_merged_parent_tree_equivalence(
+      repo,
+      old_base_sha=_SUCCESSOR_OLD_BASE_SHA,
+      target_base_sha=_SUCCESSOR_TARGET_BASE_SHA,
+    )
+  assert caught.value.code == "review_refresh_needed"
+
+  # Matching trees prove the merged parent already reached the target base.
+  monkeypatch.setattr(
+    "app.github_contribution_git._git",
+    lambda _repo, *args, check=True: (
+      _cp("e" * 40 + "\n")
+      if args[:3] == ("rev-parse", "--verify", "--quiet")
+      else _cp("")
+    ),
+  )
+  _assert_merged_parent_tree_equivalence(
+    repo,
+    old_base_sha=_SUCCESSOR_OLD_BASE_SHA,
+    target_base_sha=_SUCCESSOR_TARGET_BASE_SHA,
+  )
+
+
+def test_merged_parent_successor_stops_when_tree_is_unreadable(
+  tmp_path, monkeypatch,
+):
+  """An unresolved merged-parent or target-base tree fails closed, no mutation."""
+  from app.github_contributions import _assert_merged_parent_tree_equivalence
+
+  repo = tmp_path / "tree"
+  (repo / ".git").mkdir(parents=True)
+  monkeypatch.setattr(
+    "app.github_contribution_git._git",
+    lambda _repo, *args, check=True: _cp("", "bad object", 128),
+  )
+  with pytest.raises(ContributionSubmitError) as caught:
+    _assert_merged_parent_tree_equivalence(
+      repo,
+      old_base_sha=_SUCCESSOR_OLD_BASE_SHA,
+      target_base_sha=_SUCCESSOR_TARGET_BASE_SHA,
+    )
+  assert caught.value.code == "update_unconfirmed"
+  assert caught.value.status_code == 503
+
+
+def test_merged_parent_successor_accepts_an_advanced_target_with_exact_merge_proof(
+  tmp_path, monkeypatch,
+):
+  """Later target commits are safe when the exact parent merge is in their history."""
+  from app.github_contributions import _assert_merged_parent_tree_equivalence
+
+  repo = tmp_path / "advanced-tree"
+  (repo / ".git").mkdir(parents=True)
+  calls = []
+
+  def fake_git(_repo, *args, check=True):
+    calls.append(args)
+    if args[:3] == ("rev-parse", "--verify", "--quiet"):
+      # The old public parent and its exact merge commit share one tree. The
+      # later target tip deliberately has a different tree and is not compared.
+      return _cp("1" * 40 + "\n")
+    if args[:2] == ("merge-base", "--is-ancestor"):
+      return _cp("")
+    return _cp("", "unexpected git call", 128)
+
+  monkeypatch.setattr("app.github_contribution_git._git", fake_git)
+  _assert_merged_parent_tree_equivalence(
+    repo,
+    old_base_sha=_SUCCESSOR_OLD_BASE_SHA,
+    merged_base_sha=_SUCCESSOR_MERGED_BASE_SHA,
+    target_base_sha=_SUCCESSOR_TARGET_BASE_SHA,
+  )
+  assert (
+    "merge-base", "--is-ancestor",
+    _SUCCESSOR_MERGED_BASE_SHA, _SUCCESSOR_TARGET_BASE_SHA,
+  ) in calls
+  assert not any(
+    args[:3] == ("rev-parse", "--verify", "--quiet")
+    and args[3].startswith(_SUCCESSOR_TARGET_BASE_SHA)
+    for args in calls
+  )
+
+
+@pytest.mark.parametrize("ancestry_returncode, expected_code", [
+  (1, "review_refresh_needed"),
+  (128, "update_unconfirmed"),
+])
+def test_merged_parent_successor_rejects_unproven_advanced_target_ancestry(
+  tmp_path, monkeypatch, ancestry_returncode, expected_code,
+):
+  """A missing or unreadable parent-to-target edge always fails closed."""
+  from app.github_contributions import _assert_merged_parent_tree_equivalence
+
+  repo = tmp_path / f"advanced-tree-{ancestry_returncode}"
+  (repo / ".git").mkdir(parents=True)
+
+  def fake_git(_repo, *args, check=True):
+    if args[:3] == ("rev-parse", "--verify", "--quiet"):
+      return _cp("1" * 40 + "\n")
+    if args[:2] == ("merge-base", "--is-ancestor"):
+      return _cp("", "bad ancestry", ancestry_returncode)
+    return _cp("")
+
+  monkeypatch.setattr("app.github_contribution_git._git", fake_git)
+  with pytest.raises(ContributionSubmitError) as caught:
+    _assert_merged_parent_tree_equivalence(
+      repo,
+      old_base_sha=_SUCCESSOR_OLD_BASE_SHA,
+      merged_base_sha=_SUCCESSOR_MERGED_BASE_SHA,
+      target_base_sha=_SUCCESSOR_TARGET_BASE_SHA,
+    )
+  assert caught.value.code == expected_code
+
+
+def test_merged_parent_successor_resumes_retarget_without_pushing(
+  tmp_path, monkeypatch,
+):
+  """new head + old base -> skip the push, retarget only."""
+  from app.github_contributions import _advance_merged_parent_successor
+
+  record, diff_path = _successor_submission(tmp_path, monkeypatch)
+  monkeypatch.setattr(
+    "app.github_contributions._push_stack_tip_with_lease",
+    lambda *_args, **_kwargs: pytest.fail(
+      "a resumed successor at the new head must never push again"
+    ),
+  )
+  retarget_calls = []
+  monkeypatch.setattr(
+    "app.github_contributions._retarget_pr_base",
+    lambda _repo, _upstream, number, *, base_branch: (
+      retarget_calls.append((number, base_branch)) or ("accepted", "")
+    ),
+  )
+  confirms = _capture_successor_confirmations(monkeypatch)
+
+  url, number, patch = _advance_merged_parent_successor(
+    record,
+    diff_path,
+    expected_number=967,
+    expected_head_repository="mobius-os/app-demo",
+    live_head_sha=_SUCCESSOR_NEW_HEAD,
+    live_base_branch=_SUCCESSOR_OLD_BASE_BRANCH,
+  )
+
+  assert (url, number) == ("https://github.com/mobius-os/app-demo/pull/967", 967)
+  assert retarget_calls == [(967, _SUCCESSOR_TARGET_BASE_BRANCH)]
+  # A resume first checks whether the retarget already landed, proves the exact
+  # old base before one edit, then confirms the target base after it.
+  assert [c["base_branch"] for c in confirms] == [
+    _SUCCESSOR_TARGET_BASE_BRANCH,
+    _SUCCESSOR_OLD_BASE_BRANCH,
+    _SUCCESSOR_TARGET_BASE_BRANCH,
+  ]
+  assert patch["last_submit_push_sha"] == _SUCCESSOR_NEW_HEAD
+
+
+def test_merged_parent_successor_recovers_a_lost_retarget_response(
+  tmp_path, monkeypatch,
+):
+  """A lost/ambiguous edit response reconciles from the PR read, not a re-edit."""
+  from app.github_contributions import _advance_merged_parent_successor
+
+  record, diff_path = _successor_submission(tmp_path, monkeypatch)
+  monkeypatch.setattr(
+    "app.github_contributions._push_stack_tip_with_lease",
+    lambda *_args, **_kwargs: None,
+  )
+  edit_attempts = []
+
+  def lost_response(_repo, _upstream, number, *, base_branch):
+    edit_attempts.append((number, base_branch))
+    return "ambiguous", "Timed out waiting for GitHub."
+
+  monkeypatch.setattr(
+    "app.github_contributions._retarget_pr_base", lost_response,
+  )
+  # The PR read is the authority: it shows the retarget already landed.
+  confirms = _capture_successor_confirmations(monkeypatch)
+
+  url, number, _patch = _advance_merged_parent_successor(
+    record,
+    diff_path,
+    expected_number=967,
+    expected_head_repository="mobius-os/app-demo",
+    live_head_sha=_SUCCESSOR_NEW_HEAD,
+    live_base_branch=_SUCCESSOR_OLD_BASE_BRANCH,
+  )
+
+  assert number == 967
+  assert edit_attempts == [(967, _SUCCESSOR_TARGET_BASE_BRANCH)]
+  assert confirms[-1]["base_branch"] == _SUCCESSOR_TARGET_BASE_BRANCH
+
+
+def test_merged_parent_successor_fails_when_retarget_is_unconfirmed(
+  tmp_path, monkeypatch,
+):
+  """An accepted edit that GitHub never exposes fails closed with the witness."""
+  from app.github_contributions import _advance_merged_parent_successor
+
+  record, diff_path = _successor_submission(tmp_path, monkeypatch)
+  monkeypatch.setattr(
+    "app.github_contributions._push_stack_tip_with_lease",
+    lambda *_args, **_kwargs: None,
+  )
+  monkeypatch.setattr(
+    "app.github_contributions._retarget_pr_base",
+    lambda *_args, **_kwargs: ("accepted", ""),
+  )
+  monkeypatch.setattr(
+    "app.github_contributions._confirm_existing_pr_update",
+    lambda *_args, **_kwargs: None,
+  )
+
+  with pytest.raises(ContributionSubmitError) as caught:
+    _advance_merged_parent_successor(
+      record,
+      diff_path,
+      expected_number=967,
+      expected_head_repository="mobius-os/app-demo",
+      live_head_sha=_SUCCESSOR_NEW_HEAD,
+      live_base_branch=_SUCCESSOR_OLD_BASE_BRANCH,
+    )
+  assert caught.value.code == "update_unconfirmed"
+  assert caught.value.status_code == 503
+  assert caught.value.record_patch["last_submit_push_sha"] == _SUCCESSOR_NEW_HEAD
+
+
+def test_merged_parent_successor_settles_when_already_live(
+  tmp_path, monkeypatch,
+):
+  """new head + new base -> settle the ledger only; never push or edit."""
+  from app.github_contributions import _advance_merged_parent_successor
+
+  record, diff_path = _successor_submission(tmp_path, monkeypatch)
+  monkeypatch.setattr(
+    "app.github_contribution_git._upstream_branch_sha",
+    lambda _repo, _upstream, branch: (
+      "f" * 40
+      if branch == _SUCCESSOR_OLD_BASE_BRANCH
+      else _SUCCESSOR_TARGET_BASE_SHA
+    ),
+  )
+  monkeypatch.setattr(
+    "app.github_contributions._push_stack_tip_with_lease",
+    lambda *_args, **_kwargs: pytest.fail("settle must never push"),
+  )
+  monkeypatch.setattr(
+    "app.github_contributions._retarget_pr_base",
+    lambda *_args, **_kwargs: pytest.fail("settle must never retarget"),
+  )
+  confirms = _capture_successor_confirmations(
+    monkeypatch,
+    target_results=[("https://github.com/mobius-os/app-demo/pull/967", "ready")],
+  )
+
+  url, number, patch = _advance_merged_parent_successor(
+    record,
+    diff_path,
+    expected_number=967,
+    expected_head_repository="mobius-os/app-demo",
+    live_head_sha=_SUCCESSOR_NEW_HEAD,
+    live_base_branch=_SUCCESSOR_TARGET_BASE_BRANCH,
+  )
+
+  assert (url, number) == ("https://github.com/mobius-os/app-demo/pull/967", 967)
+  assert [c["base_branch"] for c in confirms] == [_SUCCESSOR_TARGET_BASE_BRANCH]
+  assert patch["last_successor_base_sha"] == _SUCCESSOR_TARGET_BASE_SHA
+
+
+def test_merged_parent_successor_settle_rejects_moved_target_base(
+  tmp_path, monkeypatch,
+):
+  """Settle-only recovery remains pinned to the reviewed target-base SHA."""
+  from app.github_contributions import _advance_merged_parent_successor
+
+  record, diff_path = _successor_submission(tmp_path, monkeypatch)
+  monkeypatch.setattr(
+    "app.github_contribution_git._upstream_branch_sha",
+    lambda *_args, **_kwargs: "f" * 40,
+  )
+  monkeypatch.setattr(
+    "app.github_contributions._confirm_existing_pr_update",
+    lambda *_args, **_kwargs: pytest.fail("a moved base must not settle"),
+  )
+  with pytest.raises(ContributionSubmitError) as caught:
+    _advance_merged_parent_successor(
+      record,
+      diff_path,
+      expected_number=967,
+      expected_head_repository="mobius-os/app-demo",
+      live_head_sha=_SUCCESSOR_NEW_HEAD,
+      live_base_branch=_SUCCESSOR_TARGET_BASE_BRANCH,
+      )
+  assert caught.value.code == "review_refresh_needed"
+
+
+@pytest.mark.parametrize(
+  ("live_base_branch", "target_results"),
+  [
+    (
+      _SUCCESSOR_OLD_BASE_BRANCH,
+      [None, ("https://github.com/mobius-os/app-demo/pull/967", "ready")],
+    ),
+    (
+      _SUCCESSOR_TARGET_BASE_BRANCH,
+      [("https://github.com/mobius-os/app-demo/pull/967", "ready")],
+    ),
+  ],
+)
+def test_merged_parent_successor_recovery_revalidates_reviewed_head(
+  tmp_path, monkeypatch, live_base_branch, target_results,
+):
+  """Retarget and settle recovery never substitute public state for review."""
+  from app.github_contributions import _advance_merged_parent_successor
+
+  record, diff_path = _successor_submission(tmp_path, monkeypatch)
+  validations = []
+
+  def assert_fresh(*_args, **_kwargs):
+    validations.append("fresh")
+    return (
+      _SUCCESSOR_TARGET_BASE_SHA,
+      _SUCCESSOR_NEW_HEAD,
+      record["plan"]["diff_sha256"],
+    )
+
+  monkeypatch.setattr("app.github_contribution_git._assert_fresh", assert_fresh)
+  monkeypatch.setattr(
+    "app.github_contributions._retarget_pr_base",
+    lambda *_args, **_kwargs: ("accepted", ""),
+  )
+  _capture_successor_confirmations(
+    monkeypatch, target_results=target_results,
+  )
+
+  _advance_merged_parent_successor(
+    record,
+    diff_path,
+    expected_number=967,
+    expected_head_repository="mobius-os/app-demo",
+    live_head_sha=_SUCCESSOR_NEW_HEAD,
+    live_base_branch=live_base_branch,
+  )
+
+  assert validations == ["fresh"]
+
+
+def test_merged_parent_successor_preserves_witness_when_target_read_raises(
+  tmp_path, monkeypatch,
+):
+  """A recovery-time target lookup exception cannot reopen the public action."""
+  from app.github_contributions import _advance_merged_parent_successor
+
+  record, diff_path = _successor_submission(tmp_path, monkeypatch)
+  monkeypatch.setattr(
+    "app.github_contribution_git._upstream_branch_sha",
+    lambda *_args, **_kwargs: (_ for _ in ()).throw(
+      subprocess.TimeoutExpired("gh api", 1),
+    ),
+  )
+  monkeypatch.setattr(
+    "app.github_contributions._push_stack_tip_with_lease",
+    lambda *_args, **_kwargs: pytest.fail("recovery must never push again"),
+  )
+
+  with pytest.raises(ContributionSubmitError) as caught:
+    _advance_merged_parent_successor(
+      record,
+      diff_path,
+      expected_number=967,
+      expected_head_repository="mobius-os/app-demo",
+      live_head_sha=_SUCCESSOR_NEW_HEAD,
+      live_base_branch=_SUCCESSOR_OLD_BASE_BRANCH,
+    )
+
+  assert caught.value.code == "update_unconfirmed"
+  assert caught.value.status_code == 503
+  assert caught.value.record_patch["last_submit_push_sha"] == _SUCCESSOR_NEW_HEAD
+
+
+def test_merged_parent_successor_rejects_moved_old_base_before_mutation(
+  tmp_path, monkeypatch,
+):
+  """The authoritative PR base SHA must still match the reviewed parent."""
+  from app.github_contributions import _advance_merged_parent_successor
+
+  record, diff_path = _successor_submission(tmp_path, monkeypatch)
+  monkeypatch.setattr(
+    "app.github_contribution_git._upstream_branch_sha",
+    lambda _repo, _upstream, branch: (
+      "f" * 40
+      if branch == _SUCCESSOR_OLD_BASE_BRANCH
+      else _SUCCESSOR_TARGET_BASE_SHA
+    ),
+  )
+  monkeypatch.setattr(
+    "app.github_contributions._push_stack_tip_with_lease",
+    lambda *_args, **_kwargs: pytest.fail("a moved old base must not push"),
+  )
+  monkeypatch.setattr(
+    "app.github_contributions._retarget_pr_base",
+    lambda *_args, **_kwargs: pytest.fail("a moved old base must not retarget"),
+  )
+  with pytest.raises(ContributionSubmitError) as caught:
+    _advance_merged_parent_successor(
+      record,
+      diff_path,
+      expected_number=967,
+      expected_head_repository="mobius-os/app-demo",
+      live_head_sha=_SUCCESSOR_OLD_HEAD,
+      live_base_branch=_SUCCESSOR_OLD_BASE_BRANCH,
+    )
+  assert caught.value.code == "review_refresh_needed"
+
+
+def test_merged_parent_successor_fails_closed_on_unexpected_state(
+  tmp_path, monkeypatch,
+):
+  """Any head/base that is not one of the three known states mutates nothing."""
+  from app.github_contributions import _advance_merged_parent_successor
+
+  record, diff_path = _successor_submission(tmp_path, monkeypatch)
+  monkeypatch.setattr(
+    "app.github_contributions._push_stack_tip_with_lease",
+    lambda *_args, **_kwargs: pytest.fail("a drifted PR must never push"),
+  )
+  monkeypatch.setattr(
+    "app.github_contributions._retarget_pr_base",
+    lambda *_args, **_kwargs: pytest.fail("a drifted PR must never retarget"),
+  )
+  monkeypatch.setattr(
+    "app.github_contributions._confirm_existing_pr_update",
+    lambda *_args, **_kwargs: pytest.fail("a drifted PR must never be confirmed"),
+  )
+
+  with pytest.raises(ContributionSubmitError) as caught:
+    _advance_merged_parent_successor(
+      record,
+      diff_path,
+      expected_number=967,
+      expected_head_repository="mobius-os/app-demo",
+      live_head_sha="9" * 40,
+      live_base_branch=_SUCCESSOR_OLD_BASE_BRANCH,
+      )
+  assert caught.value.code == "review_refresh_needed"
+
+
+def test_merged_parent_successor_never_authorizes_from_ledger_alone(monkeypatch):
+  """The classifier keys only on live facts, so a stale ledger cannot promote."""
+  from app.github_contributions import (
+    _classify_merged_parent_successor,
+    _merged_parent_successor_plan,
+  )
+
+  journal = _merged_parent_successor_plan({
+    "branch": _SUCCESSOR_BRANCH,
+    "plan": {
+      "action": "pr_update",
+      "branch": _SUCCESSOR_BRANCH,
+      "head_sha": _SUCCESSOR_NEW_HEAD,
+      "base_sha": _SUCCESSOR_TARGET_BASE_SHA,
+      "successor": {
+        "old_head_sha": _SUCCESSOR_OLD_HEAD,
+        "old_base_branch": _SUCCESSOR_OLD_BASE_BRANCH,
+        "old_base_sha": _SUCCESSOR_OLD_BASE_SHA,
+        "base_branch": _SUCCESSOR_TARGET_BASE_BRANCH,
+      },
+    },
+  })
+  assert _classify_merged_parent_successor(
+    journal,
+    live_head_sha=_SUCCESSOR_OLD_HEAD,
+    live_base_branch=_SUCCESSOR_OLD_BASE_BRANCH,
+  ) == "push"
+  assert _classify_merged_parent_successor(
+    journal,
+    live_head_sha=_SUCCESSOR_NEW_HEAD,
+    live_base_branch=_SUCCESSOR_OLD_BASE_BRANCH,
+  ) == "retarget"
+  assert _classify_merged_parent_successor(
+    journal,
+    live_head_sha=_SUCCESSOR_NEW_HEAD,
+    live_base_branch=_SUCCESSOR_TARGET_BASE_BRANCH,
+  ) == "settle"
+  # Base retargeted but head never rewritten is not a reachable resume point.
+  with pytest.raises(ContributionSubmitError) as caught:
+    _classify_merged_parent_successor(
+      journal,
+      live_head_sha=_SUCCESSOR_OLD_HEAD,
+      live_base_branch=_SUCCESSOR_TARGET_BASE_BRANCH,
+    )
+  assert caught.value.code == "review_refresh_needed"
+
+
+def test_merged_parent_successor_plan_requires_distinct_branch_and_head():
+  """The durable claim must record a real rewrite AND a real retarget."""
+  from app.github_contributions import _merged_parent_successor_plan
+
+  def plan(**overrides):
+    base = {
+      "action": "pr_update",
+      "branch": _SUCCESSOR_BRANCH,
+      "head_sha": _SUCCESSOR_NEW_HEAD,
+      "base_sha": _SUCCESSOR_TARGET_BASE_SHA,
+      "successor": {
+        "old_head_sha": _SUCCESSOR_OLD_HEAD,
+        "old_base_branch": _SUCCESSOR_OLD_BASE_BRANCH,
+        "old_base_sha": _SUCCESSOR_OLD_BASE_SHA,
+        "base_branch": _SUCCESSOR_TARGET_BASE_BRANCH,
+      },
+    }
+    base.update(overrides)
+    return {"plan": base}
+
+  # Same old/new head is not a rewrite.
+  with pytest.raises(ContributionSubmitError):
+    _merged_parent_successor_plan(plan(head_sha=_SUCCESSOR_OLD_HEAD))
+  # A non-successor action never reaches this owning claim.
+  with pytest.raises(ContributionSubmitError):
+    _merged_parent_successor_plan({"plan": {"action": "pr_update"}})
+  # Same old/target base is not a retarget.
+  same_base = {
+    "action": "pr_update",
+    "branch": _SUCCESSOR_BRANCH,
+    "head_sha": _SUCCESSOR_NEW_HEAD,
+    "base_sha": _SUCCESSOR_TARGET_BASE_SHA,
+    "successor": {
+      "old_head_sha": _SUCCESSOR_OLD_HEAD,
+      "old_base_branch": _SUCCESSOR_TARGET_BASE_BRANCH,
+      "old_base_sha": _SUCCESSOR_OLD_BASE_SHA,
+      "base_branch": _SUCCESSOR_TARGET_BASE_BRANCH,
+    },
+  }
+  with pytest.raises(ContributionSubmitError):
+    _merged_parent_successor_plan({"plan": same_base})
+  # Runtime publication never silently detaches or rewrites stack metadata.
+  stacked = plan()["plan"]
+  stacked["stack"] = {"id": "demo", "position": 1, "total": 2}
+  with pytest.raises(ContributionSubmitError):
+    _merged_parent_successor_plan({"plan": stacked})
+
+  advanced = plan()["plan"]
+  advanced["successor"]["merged_base_sha"] = _SUCCESSOR_MERGED_BASE_SHA
+  assert _merged_parent_successor_plan({"plan": advanced})[
+    "merged_base_sha"
+  ] == _SUCCESSOR_MERGED_BASE_SHA
+  advanced["successor"]["merged_base_sha"] = "not-a-commit"
+  with pytest.raises(ContributionSubmitError):
+    _merged_parent_successor_plan({"plan": advanced})
+
+
+def test_retarget_pr_base_attempts_one_mutation_only(tmp_path, monkeypatch):
+  """An ambiguous base edit response is never followed by a second mutation."""
+  from app.github_contributions import _retarget_pr_base
+
+  attempts = []
+
+  def ambiguous_gh(_repo, *args, check=True):
+    attempts.append(args)
+    return _cp("", "fatal: unable to access: Connection timed out", 1)
+
+  monkeypatch.setattr("app.github_contribution_git._gh", ambiguous_gh)
+  result, error = _retarget_pr_base(
+    tmp_path, "mobius-os/app-demo", 967, base_branch="main",
+  )
+  assert result == "ambiguous"
+  assert "timed out" in error.lower()
+  assert len(attempts) == 1
+  assert attempts[0][:5] == ("pr", "edit", "967", "-R", "mobius-os/app-demo")
+
+
+def test_retarget_pr_base_distinguishes_deterministic_rejection(
+  tmp_path, monkeypatch,
+):
+  """A validation rejection may re-prepare; a transport failure may not."""
+  from app.github_contributions import _retarget_pr_base
+
+  monkeypatch.setattr(
+    "app.github_contribution_git._gh",
+    lambda *_args, **_kwargs: _cp("", "GraphQL: Base branch is invalid", 1),
+  )
+  result, error = _retarget_pr_base(
+    tmp_path, "mobius-os/app-demo", 967, base_branch="main",
+  )
+  assert result == "rejected"
+  assert "invalid" in error.lower()
+
+
+def test_merged_parent_successor_plan_leaves_ordinary_update_path_untouched():
+  """An ordinary reviewed ``pr_update`` restack never enters the successor claim."""
+  from app.github_contributions import _merged_parent_successor_plan
+
+  with pytest.raises(ContributionSubmitError):
+    _merged_parent_successor_plan({
+      "branch": "feat/existing-review",
+      "plan": {"action": "pr_update", "branch": "feat/existing-review"},
+    })

--- a/frontend/src/components/ChatView/ChatDiffViewer.jsx
+++ b/frontend/src/components/ChatView/ChatDiffViewer.jsx
@@ -25,6 +25,7 @@ import {
   publicationAction,
   publicationFailureOwner,
   publicationItemsAction,
+  publicationItemsMutations,
   reviewItems,
   refreshedReviewItems,
   sendBlocker,
@@ -320,7 +321,9 @@ export default function ChatDiffViewer({
   const workState = contributionWorkState(work)
   const workContext = contributionWorkContext(overview)
   const workActive = workState === 'active'
-  const publicationPending = overview.counts.submitting > 0
+  const publicationPending = overview.stages.prepared.some(
+    record => record?.status === 'submitting' && record?.successor !== true,
+  )
   const dialogRef = useRef(null)
   const closeRef = useRef(null)
   const expansionSequenceRef = useRef(0)
@@ -432,6 +435,7 @@ export default function ChatDiffViewer({
       ? preparedPrimaryAction
       : lifecycleAction
   const confirmingAction = confirming ? publicationItemsAction(confirming) : null
+  const confirmingMutations = confirming ? publicationItemsMutations(confirming) : []
 
   function consume(record) {
     setAccepted(current => new Set(current).add(recordRevision(record)))
@@ -680,6 +684,7 @@ export default function ChatDiffViewer({
     const canOpenPr = typeof record?.url === 'string' && record.url.startsWith('https://github.com/')
     const action = publicationAction(record)
     const publicationPending = record?.status === 'submitting'
+      && record?.successor !== true
     const attentionMessage = attention
       ? String(record?.attention?.message
         || record?.last_submit_error
@@ -885,6 +890,7 @@ export default function ChatDiffViewer({
                 const pending = stack
                   ? selectedPreparedItem.records.some(record => record?.status === 'submitting')
                   : representative?.status === 'submitting'
+                    && representative?.successor !== true
                 const records = stack ? selectedPreparedItem.records : [representative]
                 return (
                   <article className="chat-work__review-detail">
@@ -1003,6 +1009,11 @@ export default function ChatDiffViewer({
               <span className={confirmationNotice ? 'is-attention' : ''}>
                 {confirmationNotice || 'GitHub will receive only these exact reviewed heads. Nothing will be merged.'}
               </span>
+              {confirmingMutations.length > 1 ? (
+                <ul className="chat-work__confirm-mutations">
+                  {confirmingMutations.map(mutation => <li key={mutation}>{mutation}</li>)}
+                </ul>
+              ) : null}
             </div>
             <div>
               <button type="button" disabled={helperStarting || Boolean(publishPhase)} onClick={() => {

--- a/frontend/src/components/ChatView/__tests__/chatContributionIntent.test.js
+++ b/frontend/src/components/ChatView/__tests__/chatContributionIntent.test.js
@@ -107,6 +107,22 @@ test('prepared work resolves to one direct top action', () => {
   assert.equal(preparedChangesPrimaryAction([
     { ...send, status: 'submitting' }, update,
   ], { connected: true }), null)
+  const successor = {
+    ...update,
+    status: 'submitting',
+    successor: true,
+    last_submit_error: 'GitHub did not confirm the base retarget.',
+    last_submit_error_code: 'update_unconfirmed',
+  }
+  assert.deepEqual(
+    preparedChangesPrimaryAction([successor], { connected: true }),
+    {
+      kind: 'publish-items',
+      items: [{ kind: 'record', id: 'update', record: successor }],
+      label: 'Resume update',
+      description: 'Complete this exact reviewed GitHub action.',
+    },
+  )
   assert.equal(preparedChangesPrimaryAction([
     { ...send, review: { state: 'needs_refresh' } }, update,
   ], { connected: true }).label, 'Fix and review all 2')

--- a/frontend/src/components/ChatView/__tests__/contributionReviewModel.test.js
+++ b/frontend/src/components/ChatView/__tests__/contributionReviewModel.test.js
@@ -6,10 +6,13 @@ import {
   contributeAppId,
   contributionReviewIntent,
   currentReviewItems,
+  isUpdateAction,
   refreshedReviewItems,
   publicationAction,
   publicationFailureOwner,
   publicationItemsAction,
+  publicationItemsMutations,
+  publicationMutations,
   publicationStackAction,
   reviewActionKey,
   reviewItems,
@@ -23,6 +26,24 @@ const publicationSrc = readFileSync(new URL('../chatContributionPublication.js',
 const clientSrc = readFileSync(new URL('../../../api/client.js', import.meta.url), 'utf8')
 const PLATFORM_REPO = 'mobius-os/mobius'
 const APPS = [{ id: 3, slug: 'other' }, { id: 8, slug: 'contribute' }]
+
+test('a merged-parent successor exposes both public mutations and remains resumable', () => {
+  const successor = {
+    id: 'child', status: 'prepared', action: 'pr_update', successor: true,
+    quality_review_ready: true, review: { state: 'ready' },
+  }
+  assert.equal(isUpdateAction('pr_update'), true)
+  assert.equal(publicationMutations(successor).length, 2)
+  assert.deepEqual(
+    publicationItemsMutations([{ kind: 'record', record: successor }]),
+    publicationMutations(successor),
+  )
+  assert.deepEqual(publicationAction({ ...successor, status: 'submitting' }), {
+    label: 'Resume update', busyLabel: 'Resuming update',
+  })
+  assert.equal(sendBlocker({ ...successor, status: 'submitting' }), null)
+  assert.match(sendBlocker({ ...successor, status: 'submitting', successor: false }), /still being confirmed/)
+})
 
 test('the ledger owner is resolved by slug', () => {
   assert.equal(contributeAppId(APPS), 8)
@@ -239,7 +260,8 @@ test('helper progress and recovery stay inside Changes', () => {
 })
 
 test('durable submitting state is visible but never offers a duplicate action', () => {
-  assert.match(changesSrc, /const publicationPending = overview\.counts\.submitting > 0/)
+  assert.match(changesSrc, /const publicationPending = overview\.stages\.prepared\.some\(/)
+  assert.match(changesSrc, /record => record\?\.status === 'submitting' && record\?\.successor !== true/)
   assert.match(changesSrc, /publicationPending \? \(/)
   assert.match(
     changesSrc,

--- a/frontend/src/components/ChatView/chatChangesLifecycle.js
+++ b/frontend/src/components/ChatView/chatChangesLifecycle.js
@@ -36,6 +36,9 @@ export function contributionStage(record) {
 
 export function contributionNeedsAttention(record) {
   if (SETTLED.has(record?.status)) return false
+  if (record?.status === 'submitting' && record?.successor === true) {
+    return record?.review?.state === 'needs_refresh'
+  }
   return record?.needs_attention === true
     || Boolean(String(record?.last_submit_error || '').trim())
     || record?.review?.state === 'needs_refresh'

--- a/frontend/src/components/ChatView/chatContributionIntent.js
+++ b/frontend/src/components/ChatView/chatContributionIntent.js
@@ -1,6 +1,7 @@
 /* Typed chat-owned requests for one compact attached contribution worker. */
 
 import {
+  isUpdateAction,
   publicationAction,
   publicationStackAction,
   sendBlocker,
@@ -151,7 +152,9 @@ export function preparedChangesPrimaryAction(values, { connected } = {}) {
   if (items.length === 0) return null
   if (items.some(item => item.kind === 'stack'
     ? item.records?.some(record => record?.status === 'submitting')
-    : item.record?.status === 'submitting')) return null
+    : item.record?.status === 'submitting' && item.record?.successor !== true)) {
+    return null
+  }
   const ready = items.every(item => item.kind === 'stack'
     ? !stackSendBlocker(item, { connected })
     : !sendBlocker(item.record, { connected }))
@@ -172,7 +175,7 @@ export function preparedChangesPrimaryAction(values, { connected } = {}) {
     }
     const allUpdates = items.every(item => item.kind === 'stack'
       ? publicationStackAction(item).updating
-      : item.record?.action === 'pr_update')
+      : isUpdateAction(item.record?.action))
     const allStacks = items.every(item => item.kind === 'stack')
     return {
       kind: 'publish-items',

--- a/frontend/src/components/ChatView/contributionReviewModel.js
+++ b/frontend/src/components/ChatView/contributionReviewModel.js
@@ -40,11 +40,15 @@ function isTrackingRecord(record) {
 
 /** Why direct publication is unavailable, or null when the exact review can send. */
 export function sendBlocker(record, { connected } = {}) {
-  if (record?.status === 'submitting') {
+  const resumableSuccessor = record?.status === 'submitting'
+    && record?.successor === true
+  if (record?.status === 'submitting' && !resumableSuccessor) {
     return 'This GitHub action is still being confirmed.'
   }
-  if (!record || record.status !== 'prepared') return null
-  if (typeof record.last_submit_error === 'string' && record.last_submit_error.trim()) {
+  if (!record || (record.status !== 'prepared' && !resumableSuccessor)) return null
+  if (!resumableSuccessor
+    && typeof record.last_submit_error === 'string'
+    && record.last_submit_error.trim()) {
     return 'This contribution needs a fresh check before it can continue.'
   }
   if (record.stack || record.is_stack) {
@@ -59,11 +63,31 @@ export function sendBlocker(record, { connected } = {}) {
     || 'Refresh this review in Contribute before sending.'
 }
 
+export function isUpdateAction(action) {
+  return action === 'pr_update'
+}
+
 /** Copy for the one public action represented by this prepared record. */
 export function publicationAction(record) {
-  return record?.action === 'pr_update'
+  if (record?.status === 'submitting' && record?.successor === true) {
+    return { label: 'Resume update', busyLabel: 'Resuming update' }
+  }
+  return isUpdateAction(record?.action)
     ? { label: 'Update PR', busyLabel: 'Updating PR' }
     : { label: 'Send PR', busyLabel: 'Sending PR' }
+}
+
+export function publicationMutations(record) {
+  if (record?.successor === true) {
+    return [
+      'Force-update the pull request branch to the reviewed successor commit',
+      'Retarget the pull request base branch to the surviving branch',
+    ]
+  }
+  if (isUpdateAction(record?.action)) {
+    return ['Update the pull request branch with the reviewed commit']
+  }
+  return ['Open a new pull request for the reviewed branch']
 }
 
 /** Why one complete reviewed stack cannot use its guarded public action yet. */
@@ -120,7 +144,7 @@ export function publicationItemsAction(items) {
       : [item?.record].filter(Boolean)
   ))
   const updating = records.length > 0
-    && records.every(record => record?.action === 'pr_update')
+    && records.every(record => isUpdateAction(record?.action))
   const verb = updating ? 'Update' : 'Send'
   return {
     count: records.length,
@@ -128,6 +152,15 @@ export function publicationItemsAction(items) {
     promptLabel: `${verb} ${records.length} reviewed pull ${records.length === 1 ? 'request' : 'requests'}?`,
     confirmLabel: `${verb} ${records.length} ${records.length === 1 ? 'PR' : 'PRs'}`,
   }
+}
+
+export function publicationItemsMutations(items) {
+  const records = (Array.isArray(items) ? items : []).flatMap(item => (
+    item?.kind === 'stack'
+      ? (item.records || []).filter(record => record?.status === 'prepared')
+      : [item?.record].filter(Boolean)
+  ))
+  return [...new Set(records.flatMap(publicationMutations))]
 }
 
 const RECORD_ID = /^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$/


### PR DESCRIPTION
## Summary
- safely move a reviewed child pull request onto the surviving target branch after its parent is squash- or queue-merged
- pin the branch rewrite, parent equivalence, target-base commit, and pull-request retarget to exact reviewed and live public states
- preserve one resumable claim across restarts, lost responses, and unexpected failures without repeating a mutation before re-reading GitHub
- enumerate both the force-with-lease branch update and base retarget in the owner confirmation while leaving ordinary pull-request updates unchanged

## Testing
- GitHub contribution route suite: 228 passed
- frontend library suite: 2,909 passed
- frontend hook suite: 95 passed
- focused successor and confirmation regressions: 27 passed
- Python Ruff and compile checks passed
- changed frontend ESLint checks and exact dependency-tree validation passed
- production build, runtime checks, offline/PWA checks, push worker, and packaged workers passed
- canonical full-index diff, direct-main merge tree, attribution, and privacy review passed

## Security and maintenance review
Every transition is derived from the live pull request's exact head and base, never from the writable ledger alone. The branch update uses a force-with-lease against the reviewed old head; the target branch must still resolve to the reviewed commit; and an advanced target must contain a tree-equivalent merged parent. Ambiguous or unexpected outcomes remain resumable under the original exact approval, and a later attempt re-reads the public state before deciding whether it may push, retarget, or only settle local bookkeeping.