### PR TITLE
Add App Store feedback and hosted Spotlight broker

### DIFF
--- a/backend/app/community_broker.py
+++ b/backend/app/community_broker.py
@@ -74,7 +74,7 @@ class CommunityBrokerClient:
     method = method.upper()
     if not path.startswith(COMMUNITY_PREFIX + "/") and path != "/identity":
       raise ValueError("community broker path is outside its allow-list")
-    if method not in {"GET", "POST"}:
+    if method not in {"GET", "POST", "PUT"}:
       raise ValueError("community broker method is not allowed")
     if method != "GET" and path != "/identity":
       if not _IDEMPOTENCY_KEY.fullmatch(str(idempotency_key or "")):

--- a/backend/app/routes/community.py
+++ b/backend/app/routes/community.py
@@ -114,6 +114,23 @@ class CommentIn(BaseModel):
   public_identity: _PUBLIC_IDENTITY = "anonymous"
 
 
+class EditorialAssetIn(BaseModel):
+  mime_type: Literal["image/png", "image/jpeg", "image/webp", "image/avif"]
+  data_base64: str = Field(min_length=4, max_length=1_850_000)
+
+
+class EditorialSpotlightItemIn(BaseModel):
+  app_id: str = Field(pattern=r"^[a-z0-9][a-z0-9-]{0,63}$")
+  artwork_asset: str | None = Field(
+    default=None,
+    pattern=r"^[0-9a-f]{64}\.(?:png|jpg|webp|avif)$",
+  )
+
+
+class EditorialSpotlightIn(BaseModel):
+  items: list[EditorialSpotlightItemIn] = Field(min_length=1, max_length=8)
+
+
 def _idempotency(value: str | None) -> str:
   key = str(value or "")
   if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._:-]{15,127}", key):
@@ -495,6 +512,13 @@ async def list_community_publications(
   return _response(
     _merge_publication_state(payload, local_items), status, headers,
   )
+
+
+@router.get("/editorial/spotlight")
+async def get_editorial_spotlight(
+  _: models.Owner = Depends(get_owner_or_app_with_manage_apps),
+) -> JSONResponse:
+  return await _request("GET", f"{COMMUNITY_PREFIX}/editorial/spotlight")
 
 
 @router.get("/apps/{app_id}")
@@ -1084,5 +1108,35 @@ async def add_community_comment(
     "POST",
     f"{COMMUNITY_PREFIX}/apps/{_safe_public_id(app_id, 'App id')}"
     f"/revisions/{_safe_public_id(revision_id, 'Revision id')}/comments",
+    body=body.model_dump(), idempotency_key=_idempotency(idempotency_key),
+  )
+
+
+@router.post(
+  "/editorial/assets",
+  dependencies=[Depends(reject_cross_site)],
+)
+async def upload_editorial_asset(
+  body: EditorialAssetIn,
+  _: models.Owner = Depends(_store_github_owner),
+  idempotency_key: str | None = Header(default=None, alias="Idempotency-Key"),
+) -> JSONResponse:
+  return await _request(
+    "POST", f"{COMMUNITY_PREFIX}/editorial/assets",
+    body=body.model_dump(), idempotency_key=_idempotency(idempotency_key),
+  )
+
+
+@router.put(
+  "/editorial/spotlight",
+  dependencies=[Depends(reject_cross_site)],
+)
+async def publish_editorial_spotlight(
+  body: EditorialSpotlightIn,
+  _: models.Owner = Depends(_store_github_owner),
+  idempotency_key: str | None = Header(default=None, alias="Idempotency-Key"),
+) -> JSONResponse:
+  return await _request(
+    "PUT", f"{COMMUNITY_PREFIX}/editorial/spotlight",
     body=body.model_dump(), idempotency_key=_idempotency(idempotency_key),
   )

--- a/backend/app/routes/community.py
+++ b/backend/app/routes/community.py
@@ -95,11 +95,23 @@ class ExistingGitHubRevisionIn(BaseModel):
   contribution_id: str = Field(default="", max_length=200)
 
 
+class RatingIn(BaseModel):
+  value: int = Field(ge=1, le=5)
+  revision_id: str = Field(
+    min_length=8, max_length=200, pattern=r"^[A-Za-z0-9_:-]+$",
+  )
+
+
 class InstallReceiptIn(BaseModel):
   local_app_id: str = Field(
     min_length=1, max_length=128,
     pattern=r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$",
   )
+
+
+class CommentIn(BaseModel):
+  body: str = Field(min_length=1, max_length=4000)
+  public_identity: _PUBLIC_IDENTITY = "anonymous"
 
 
 def _idempotency(value: str | None) -> str:
@@ -1037,5 +1049,40 @@ async def record_community_install(
     "POST",
     f"{COMMUNITY_PREFIX}/apps/{safe_app_id}/revisions/"
     f"{safe_revision_id}/installs",
+    body=body.model_dump(), idempotency_key=_idempotency(idempotency_key),
+  )
+
+
+@router.put(
+  "/apps/{app_id}/rating",
+  dependencies=[Depends(reject_cross_site)],
+)
+async def set_community_rating(
+  app_id: str,
+  body: RatingIn,
+  _: models.Owner = Depends(get_owner_or_app_with_manage_apps),
+  idempotency_key: str | None = Header(default=None, alias="Idempotency-Key"),
+) -> JSONResponse:
+  return await _request(
+    "PUT", f"{COMMUNITY_PREFIX}/apps/{_safe_public_id(app_id, 'App id')}/rating",
+    body=body.model_dump(), idempotency_key=_idempotency(idempotency_key),
+  )
+
+
+@router.post(
+  "/apps/{app_id}/revisions/{revision_id}/comments",
+  dependencies=[Depends(reject_cross_site)],
+)
+async def add_community_comment(
+  app_id: str,
+  revision_id: str,
+  body: CommentIn,
+  _: models.Owner = Depends(get_owner_or_app_with_manage_apps),
+  idempotency_key: str | None = Header(default=None, alias="Idempotency-Key"),
+) -> JSONResponse:
+  return await _request(
+    "POST",
+    f"{COMMUNITY_PREFIX}/apps/{_safe_public_id(app_id, 'App id')}"
+    f"/revisions/{_safe_public_id(revision_id, 'Revision id')}/comments",
     body=body.model_dump(), idempotency_key=_idempotency(idempotency_key),
   )

--- a/backend/runtime/identity_broker.py
+++ b/backend/runtime/identity_broker.py
@@ -99,6 +99,19 @@ _COMMUNITY_ROUTES = (
     ),
     "community:install",
   ),
+  (
+    "PUT",
+    re.compile(r"/v1/community/apps/[A-Za-z0-9_:-]{8,200}/rating"),
+    "community:rate",
+  ),
+  (
+    "POST",
+    re.compile(
+      r"/v1/community/apps/[A-Za-z0-9_:-]{8,200}/revisions/"
+      r"[A-Za-z0-9_:-]{8,200}/comments"
+    ),
+    "community:comment",
+  ),
 )
 
 
@@ -768,6 +781,7 @@ class _Handler(BaseHTTPRequestHandler):
 
   do_GET = _handle
   do_POST = _handle
+  do_PUT = _handle
 
 
 class _UnixServer(socketserver.ThreadingMixIn, socketserver.UnixStreamServer):

--- a/backend/runtime/identity_broker.py
+++ b/backend/runtime/identity_broker.py
@@ -81,6 +81,11 @@ INFERENCE_ROUTES = {
 _COMMUNITY_ROUTES = (
   ("GET", re.compile(r"/v1/community/apps"), "community:read"),
   ("GET", re.compile(r"/v1/community/publications"), "community:read"),
+  (
+    "GET",
+    re.compile(r"/v1/community/editorial/spotlight"),
+    "community:read",
+  ),
   ("GET", re.compile(r"/v1/community/apps/[A-Za-z0-9_:-]{8,200}"), "community:read"),
   (
     "GET",
@@ -111,6 +116,16 @@ _COMMUNITY_ROUTES = (
       r"[A-Za-z0-9_:-]{8,200}/comments"
     ),
     "community:comment",
+  ),
+  (
+    "POST",
+    re.compile(r"/v1/community/editorial/assets"),
+    "community:editorial",
+  ),
+  (
+    "PUT",
+    re.compile(r"/v1/community/editorial/spotlight"),
+    "community:editorial",
   ),
 )
 

--- a/backend/tests/test_community_broker.py
+++ b/backend/tests/test_community_broker.py
@@ -35,6 +35,33 @@ async def test_mutation_binds_exact_body_path_and_idempotency_key():
 
 
 @pytest.mark.asyncio
+async def test_rating_put_is_forwarded_with_exact_idempotent_body():
+  seen = {}
+
+  async def handler(request: httpx.Request) -> httpx.Response:
+    seen["method"] = request.method
+    seen["url"] = str(request.url)
+    seen["body"] = await request.aread()
+    seen["headers"] = dict(request.headers)
+    return httpx.Response(200, json={"rating_average": 5, "rating_count": 1})
+
+  client = CommunityBrokerClient(transport=httpx.MockTransport(handler))
+  payload, status, _ = await client.request(
+    "PUT",
+    "/v1/community/apps/app_12345678/rating",
+    body={"revision_id": "rev_12345678", "value": 5},
+    idempotency_key="rating-request-0001",
+  )
+
+  assert status == 200
+  assert payload == {"rating_average": 5, "rating_count": 1}
+  assert seen["method"] == "PUT"
+  assert seen["url"].endswith("/v1/community/apps/app_12345678/rating")
+  assert seen["body"] == b'{"revision_id":"rev_12345678","value":5}'
+  assert seen["headers"]["idempotency-key"] == "rating-request-0001"
+
+
+@pytest.mark.asyncio
 async def test_read_preserves_bounded_query_for_broker_binding():
   seen = {}
 

--- a/backend/tests/test_community_routes.py
+++ b/backend/tests/test_community_routes.py
@@ -225,6 +225,51 @@ async def test_publication_lifecycle_reads_through_identity_broker(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_feedback_mutations_forward_only_exact_revision_bound_payloads(
+  monkeypatch,
+):
+  calls = []
+
+  async def fake_request(method, path, **kwargs):
+    calls.append((method, path, kwargs))
+    return SimpleNamespace(status_code=200)
+
+  monkeypatch.setattr(community, "_request", fake_request)
+  owner = SimpleNamespace()
+  rating = community.RatingIn(value=5, revision_id="rev_12345678")
+  comment = community.CommentIn(
+    body="Clear and useful.", public_identity="github",
+  )
+
+  await community.set_community_rating(
+    "app_12345678", rating, owner, "rating:1234567890abcdef",
+  )
+  await community.add_community_comment(
+    "app_12345678", "rev_12345678", comment, owner,
+    "comment:1234567890abcdef",
+  )
+
+  assert calls == [
+    (
+      "PUT",
+      "/v1/community/apps/app_12345678/rating",
+      {
+        "body": {"value": 5, "revision_id": "rev_12345678"},
+        "idempotency_key": "rating:1234567890abcdef",
+      },
+    ),
+    (
+      "POST",
+      "/v1/community/apps/app_12345678/revisions/rev_12345678/comments",
+      {
+        "body": {"body": "Clear and useful.", "public_identity": "github"},
+        "idempotency_key": "comment:1234567890abcdef",
+      },
+    ),
+  ]
+
+
+@pytest.mark.asyncio
 async def test_authoritative_live_state_reconciles_only_an_older_local_journal(
   monkeypatch,
 ):

--- a/backend/tests/test_community_routes.py
+++ b/backend/tests/test_community_routes.py
@@ -270,6 +270,57 @@ async def test_feedback_mutations_forward_only_exact_revision_bound_payloads(
 
 
 @pytest.mark.asyncio
+async def test_editorial_routes_forward_bounded_hosted_feed_contract(monkeypatch):
+  calls = []
+
+  async def fake_request(method, path, **kwargs):
+    calls.append((method, path, kwargs))
+    return SimpleNamespace(status_code=200)
+
+  monkeypatch.setattr(community, "_request", fake_request)
+  owner = SimpleNamespace()
+  await community.get_editorial_spotlight(owner)
+  await community.upload_editorial_asset(
+    community.EditorialAssetIn(
+      mime_type="image/png", data_base64="iVBORw0KGgo=",
+    ),
+    owner,
+    "editorial:asset:12345678",
+  )
+  await community.publish_editorial_spotlight(
+    community.EditorialSpotlightIn(items=[
+      community.EditorialSpotlightItemIn(
+        app_id="voice", artwork_asset="a" * 64 + ".png",
+      ),
+      community.EditorialSpotlightItemIn(app_id="maps"),
+    ]),
+    owner,
+    "editorial:feed:12345678",
+  )
+
+  assert calls == [
+    ("GET", "/v1/community/editorial/spotlight", {}),
+    (
+      "POST", "/v1/community/editorial/assets",
+      {
+        "body": {"mime_type": "image/png", "data_base64": "iVBORw0KGgo="},
+        "idempotency_key": "editorial:asset:12345678",
+      },
+    ),
+    (
+      "PUT", "/v1/community/editorial/spotlight",
+      {
+        "body": {"items": [
+          {"app_id": "voice", "artwork_asset": "a" * 64 + ".png"},
+          {"app_id": "maps", "artwork_asset": None},
+        ]},
+        "idempotency_key": "editorial:feed:12345678",
+      },
+    ),
+  ]
+
+
+@pytest.mark.asyncio
 async def test_authoritative_live_state_reconciles_only_an_older_local_journal(
   monkeypatch,
 ):

--- a/backend/tests/test_identity_broker.py
+++ b/backend/tests/test_identity_broker.py
@@ -466,7 +466,7 @@ def test_handler_supports_allowlisted_local_service_http_methods():
   handler = broker_module._Handler
   assert handler.do_GET is handler._handle
   assert handler.do_POST is handler._handle
-  assert not hasattr(handler, "do_PUT")
+  assert handler.do_PUT is handler._handle
   assert not hasattr(handler, "do_DELETE")
 
 
@@ -546,20 +546,61 @@ def test_community_mutations_require_and_forward_idempotency(broker, monkeypatch
 
   broker.client.close()
   broker.client = FakeClient()
-  monkeypatch.setattr(broker, "_capability", lambda **_kwargs: "one-use")
-  path = "/v1/community/apps"
+  capabilities = []
+  monkeypatch.setattr(
+    broker, "_capability",
+    lambda **kwargs: capabilities.append(kwargs) or "one-use",
+  )
+  publish_path = "/v1/community/apps"
   with pytest.raises(ValueError, match="idempotency key is required"):
     broker.proxy(
-      method="POST", path=path, body=b'{"github":{}}', headers={},
+      method="POST", path=publish_path, body=b'{"github":{}}', headers={},
       allow_privileged_routes=True,
     )
-  response = broker.proxy(
-    method="POST", path=path, body=b'{"github":{}}',
+  broker.proxy(
+    method="POST", path=publish_path, body=b'{"github":{}}',
     headers={"idempotency-key": "publish:1234567890abcdef"},
     allow_privileged_routes=True,
-  )
-  response.close()
+  ).close()
   assert seen["headers"]["Idempotency-Key"] == "publish:1234567890abcdef"
+
+  install_path = (
+    "/v1/community/apps/app_12345678/revisions/"
+    "rev_12345678/installs"
+  )
+  broker.proxy(
+    method="POST", path=install_path, body=b'{}',
+    headers={"idempotency-key": "install:1234567890abcdef"},
+    allow_privileged_routes=True,
+  ).close()
+  rating_path = "/v1/community/apps/app_12345678/rating"
+  broker.proxy(
+    method="PUT", path=rating_path, body=b'{"value":5}',
+    headers={"idempotency-key": "rating:1234567890abcdef"},
+    allow_privileged_routes=True,
+  ).close()
+  comment_path = (
+    "/v1/community/apps/app_12345678/revisions/"
+    "rev_12345678/comments"
+  )
+  broker.proxy(
+    method="POST", path=comment_path, body=b'{"body":"Useful"}',
+    headers={"idempotency-key": "comment:1234567890abcdef"},
+    allow_privileged_routes=True,
+  ).close()
+
+  assert [item["scope"] for item in capabilities] == [
+    "community:publish",
+    "community:install",
+    "community:rate",
+    "community:comment",
+  ]
+  assert [item["path"] for item in capabilities] == [
+    publish_path,
+    install_path,
+    rating_path,
+    comment_path,
+  ]
 
 
 def test_contribution_proxy_is_uds_only_and_binds_exact_requests(
@@ -669,7 +710,7 @@ def test_large_body_exception_is_only_for_exact_contribution_mutations():
     ) == broker_module.MAX_BODY
 
 
-def test_unix_handler_rejects_identity_queries_and_forwards_inference():
+def test_unix_handler_rejects_identity_queries_and_forwards_allowlisted_routes():
   # AF_UNIX paths are capped at roughly 108 bytes on Linux; long worktree
   # paths can make pytest's ordinary tmp_path exceed that.
   socket_dir = tempfile.TemporaryDirectory(prefix="mobius-broker-")
@@ -683,7 +724,7 @@ def test_unix_handler_rejects_identity_queries_and_forwards_inference():
     def proxy(
       self, *, method, path, body, headers, allow_privileged_routes=False,
     ):
-      seen.append((method, path, body))
+      seen.append((method, path, body, allow_privileged_routes))
       request = httpx.Request(method, "https://central.test" + path)
       payload = json.dumps({"method": method}).encode()
       return httpx.Response(
@@ -704,8 +745,20 @@ def test_unix_handler_rejects_identity_queries_and_forwards_inference():
       assert client.get("/identity").json() == {"linked": True}
       assert client.get("/identity?subject=user_other").status_code == 404
       models = client.get("/v1/models")
+      rating = client.put(
+        "/v1/community/apps/app_12345678/rating",
+        content=b'{"value":4}',
+        headers={"Idempotency-Key": "rating:1234567890abcdef"},
+      )
     assert models.json() == {"method": "GET"}
-    assert seen == [("GET", "/v1/models", b"")]
+    assert rating.json() == {"method": "PUT"}
+    assert seen == [
+      ("GET", "/v1/models", b"", True),
+      (
+        "PUT", "/v1/community/apps/app_12345678/rating",
+        b'{"value":4}', True,
+      ),
+    ]
   finally:
     server.shutdown()
     server.server_close()

--- a/backend/tests/test_identity_broker.py
+++ b/backend/tests/test_identity_broker.py
@@ -588,18 +588,34 @@ def test_community_mutations_require_and_forward_idempotency(broker, monkeypatch
     headers={"idempotency-key": "comment:1234567890abcdef"},
     allow_privileged_routes=True,
   ).close()
+  editorial_asset_path = "/v1/community/editorial/assets"
+  broker.proxy(
+    method="POST", path=editorial_asset_path, body=b'{"data_base64":"abcd"}',
+    headers={"idempotency-key": "editorial:1234567890abcdef"},
+    allow_privileged_routes=True,
+  ).close()
+  editorial_feed_path = "/v1/community/editorial/spotlight"
+  broker.proxy(
+    method="PUT", path=editorial_feed_path, body=b'{"items":[]}',
+    headers={"idempotency-key": "editorial:feed:12345678"},
+    allow_privileged_routes=True,
+  ).close()
 
   assert [item["scope"] for item in capabilities] == [
     "community:publish",
     "community:install",
     "community:rate",
     "community:comment",
+    "community:editorial",
+    "community:editorial",
   ]
   assert [item["path"] for item in capabilities] == [
     publish_path,
     install_path,
     rating_path,
     comment_path,
+    editorial_asset_path,
+    editorial_feed_path,
   ]
 
 


### PR DESCRIPTION
## Summary

- add validated, revision-bound rating and written-review routes to the community broker
- add hosted Spotlight reads, artwork uploads, and feed publication through exact broker routes
- require idempotency for every feedback and editorial mutation and grant only the narrow capability for its exact method and path
- build on the community publication and listing foundations in #992 and #1020

## Testing

- focused community broker, route, and identity suite: 46 passed, 1 skipped
- canonical diff, attribution, privacy, and whitespace checks passed

## Security review

Every mutation is bound to an exact method and full path, requires an idempotency key, and carries only `community:rate`, `community:comment`, or `community:editorial` as appropriate. Payloads are validated and bounded at the backend boundary, and Unix-socket forwarding preserves the same method, path, body, and idempotency contract.