### PR TITLE
Let owners explicitly accept local Store packages

### DIFF
--- a/backend/app/app_apply.py
+++ b/backend/app/app_apply.py
@@ -16,6 +16,7 @@ import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
+from urllib.parse import parse_qs, urlsplit
 
 from fastapi import HTTPException
 from sqlalchemy.orm import Session
@@ -23,6 +24,7 @@ from sqlalchemy.orm import Session
 from app import app_git, icon_assets, models, timeutil
 from app.app_capabilities import (
   contract_from_app_state,
+  contract_from_manifest,
   local_manifest_runtime_fields,
 )
 from app.compiler import (
@@ -59,6 +61,10 @@ _STATIC_ASSETS_MANIFEST = ".mobius-static-assets.json"
 _STATIC_ASSETS_BACKUP_SUFFIX = ".mobius-static-bak"
 _STATIC_ASSETS_BACKUP_ASSET_PREFIX = "assets"
 _STATIC_ASSETS_BACKUP_METADATA_PREFIX = "metadata"
+_LOCAL_PACKAGE_WARNING = (
+  "Local package declarations are active, including permissions, schedules, "
+  "and skills; a future reviewed Store update may replace them."
+)
 
 
 @dataclass(frozen=True)
@@ -264,8 +270,9 @@ async def _sync_accepted_app_side_effects(
 ) -> tuple[str, ...]:
   """Converge post-commit declarations for one accepted local revision.
 
-  The caller holds the app source lock. Store-managed worktrees have no local
-  manifest authority, so their reviewed schedule remains installer-owned.
+  The caller holds the app source lock. Store-managed worktrees normally have
+  no local manifest authority; the explicit local-package path supplies the
+  validated manifest when the owner deliberately accepts that package.
   """
   warnings: list[str] = []
   if manifest is not None:
@@ -424,12 +431,21 @@ def retire_integrated_app_provenance(db: Session) -> tuple[int, list[str]]:
   return retired, warnings
 
 
-def _validate_local_identity(source_dir: Path, manifest: dict) -> None:
-  if manifest["id"] != source_dir.name:
+def _validate_local_identity(
+  source_dir: Path, manifest: dict, app: models.App | None = None,
+) -> None:
+  accepted_ids = {source_dir.name}
+  if app is not None and app.manifest_url:
+    accepted_ids.update(
+      value for value in parse_qs(urlsplit(app.manifest_url).fragment).get(
+        "manifest-id", []
+      ) if value
+    )
+  if manifest["id"] not in accepted_ids:
     raise AppApplyError(
       "manifest_id_mismatch",
       "For a local app, mobius.json `id` must match the source-directory "
-      f"name ({source_dir.name!r}).",
+      f"name or its installed package identity ({sorted(accepted_ids)!r}).",
     )
   if len(manifest["id"]) > 128:
     raise AppApplyError(
@@ -442,12 +458,102 @@ def _validate_local_identity(source_dir: Path, manifest: dict) -> None:
     )
 
 
+def _apply_explicit_package_runtime(
+  app: models.App, manifest: dict, *, package_icon: bytes | None,
+) -> None:
+  """Persist every live field owned by an explicitly accepted Store package.
+
+  Store installation and local-source acceptance are two entry points into
+  the same App row. Keep their runtime projection aligned so accepting a local
+  package cannot compile successfully while silently dropping permissions,
+  project templates, offline metadata, or other declarations.
+  """
+  from app import install
+
+  runtime_fields = local_manifest_runtime_fields(manifest)
+  permissions = manifest.get("permissions") or {}
+  app.name = manifest["name"]
+  app.description = manifest["description"]
+  app.version = str(manifest.get("version", "")).strip() or None
+  app.theme_color = install._manifest_color(manifest.get("theme_color"))
+  app.background_color = (
+    install._manifest_color(manifest.get("background_color"))
+    or app.theme_color
+  )
+  app.display = install._manifest_display(manifest.get("display"))
+  app.icon_png = package_icon
+  app.cross_app_access = permissions.get("cross_app_access", "none")
+  app.share_with_apps = permissions.get("share_with_apps", "none")
+  app.chat_log_access = permissions.get("chat_log_access", "none")
+  # Privileged grants are opt-in on every explicitly accepted package;
+  # omission revokes them just as a reviewed Store update does.
+  app.manage_apps = bool(permissions.get("manage_apps", False))
+  app.manage_skills = bool(permissions.get("manage_skills", False))
+  app.github_access = bool(permissions.get("github_access", False))
+  app.github_connect = bool(permissions.get("github_connect", False))
+  app.filesystem_access = bool(permissions.get("filesystem_access", False))
+  app.connections_manage = bool(permissions.get("connections_manage", False))
+  app.connect_manage = bool(permissions.get("connect_manage", False))
+  if "offline_capable" in runtime_fields:
+    app.offline_capable = runtime_fields["offline_capable"]
+  if "embeds_agent" in manifest:
+    app.embeds_agent = bool(manifest["embeds_agent"])
+  app.offline_contract = manifest.get("offline") or None
+  app.system_prompt_file = manifest.get("system_prompt") or None
+  app.system_app = bool(manifest.get("system_app", False))
+  app.project_templates_json = manifest.get("project_templates") or None
+  effective_manifest = dict(manifest)
+  # The reviewed Store updater preserves these two live fields when an older
+  # manifest omits them. Normalize the accepted local package against the same
+  # effective state so its durable contract cannot disagree with its App row.
+  effective_manifest.setdefault("offline_capable", app.offline_capable)
+  effective_manifest.setdefault("embeds_agent", app.embeds_agent)
+  app.capability_contract = contract_from_manifest(effective_manifest)
+
+
+def _live_runtime_state(app: models.App) -> tuple:
+  """Return fields whose manifest-driven changes make an apply non-empty."""
+  return (
+    app.name,
+    app.description,
+    app.version,
+    app.theme_color,
+    app.background_color,
+    app.display,
+    app.cross_app_access,
+    app.share_with_apps,
+    app.chat_log_access,
+    app.manage_apps,
+    app.manage_skills,
+    app.github_access,
+    app.github_connect,
+    app.filesystem_access,
+    app.connections_manage,
+    app.connect_manage,
+    app.offline_capable,
+    app.embeds_agent,
+    app.offline_contract,
+    app.system_prompt_file,
+    app.system_app,
+    app.project_templates_json,
+    app.capability_contract,
+    app.chat_id,
+    app.jsx_source,
+    app.compiled_path,
+    app.source_commit,
+    app.icon_png,
+    app.icon_override_png,
+    app.published_manifest_url,
+  )
+
+
 async def apply_source_revision(
   db: Session,
   *,
   source_dir: str,
   app: models.App | None,
   chat_id: str | None,
+  accept_local_package: bool = False,
 ) -> ApplyResult:
   """Compile, accept, and publish one source revision.
 
@@ -478,6 +584,14 @@ async def apply_source_revision(
         "resolve_app_update.py instead of applying an ordinary edit.",
         status_code=409,
       )
+  if accept_local_package and (
+    app is None or app.manifest_url is None
+  ):
+    raise AppApplyError(
+      "local_package_requires_store_app",
+      "--accept-local-package is only valid for an installed Store app; "
+      "ordinary local apps keep their owner-managed permission settings.",
+    )
 
   candidate = await _git_operation(
     "snapshot", app_git.snapshot_worktree, source_path,
@@ -502,18 +616,21 @@ async def apply_source_revision(
         snapshot_dir,
       )
       store_managed = app is not None and app.manifest_url is not None
-      manifest = None if store_managed else _read_manifest(snapshot_dir)
+      manifest = (
+        _read_manifest(snapshot_dir)
+        if not store_managed or accept_local_package
+        else None
+      )
       if manifest is not None:
-        _validate_local_identity(source_path, manifest)
+        _validate_local_identity(source_path, manifest, app)
       static_assets = (
         _snapshot_static_assets(snapshot_dir, source_path, manifest)
         if manifest is not None
         else {}
       )
-      # Store-installed source trees intentionally exclude reviewed package
-      # metadata. Their App row owns that identity; the editable source
-      # contract has one fixed entry. Local apps retain the strict manifest
-      # reader and its declared entry.
+      # Ordinary Store edits intentionally exclude reviewed package metadata.
+      # Only the explicit local-package mode reads that manifest; local apps
+      # always retain the strict manifest reader and its declared entry.
       entry_relative = "index.jsx" if store_managed else manifest["entry"]
       source = _entry_source(snapshot_dir, entry_relative)
       package_icon = (
@@ -540,19 +657,8 @@ async def apply_source_revision(
           offline_capable=False,
         )
       assert app is not None
-      previous_state = (
-        app.name,
-        app.description,
-        app.offline_capable,
-        app.capability_contract,
-        app.chat_id,
-        app.jsx_source,
-        app.compiled_path,
-        app.source_commit,
-        app.published_manifest_url,
-        app.icon_png,
-        app.icon_override_png,
-      )
+      previous_state = _live_runtime_state(app)
+      previous_source_commit = app.source_commit
 
       # Explicit apply is serialized by the lifecycle lock, so it can compile
       # under one shared, non-servable name before a new row has a numeric id.
@@ -578,20 +684,27 @@ async def apply_source_revision(
 
       if manifest is not None:
         _validate_static_asset_publish_paths(source_path, static_assets)
-
-      if app.manifest_url is None:
-        runtime_fields = local_manifest_runtime_fields(manifest)
-        app.name = manifest["name"]
-        app.description = manifest["description"]
-        app.icon_png = package_icon
-        if "offline_capable" in runtime_fields:
-          app.offline_capable = runtime_fields["offline_capable"]
-        app.capability_contract = contract_from_app_state(
-          app,
-          capabilities=runtime_fields["capabilities"],
-          public_access=runtime_fields["public_access"],
-          contract_permissions=manifest.get("permissions") or {},
-        )
+        if store_managed and accept_local_package:
+          _apply_explicit_package_runtime(
+            app, manifest, package_icon=package_icon,
+          )
+        else:
+          # Ordinary owner-authored app source does not grant server
+          # permissions from source. Those live row fields remain under the
+          # explicit settings/update contract; the manifest owns only the
+          # app's display metadata and host-mediated runtime declarations.
+          runtime_fields = local_manifest_runtime_fields(manifest)
+          app.name = manifest["name"]
+          app.description = manifest["description"]
+          app.icon_png = package_icon
+          if "offline_capable" in runtime_fields:
+            app.offline_capable = runtime_fields["offline_capable"]
+          app.capability_contract = contract_from_app_state(
+            app,
+            capabilities=runtime_fields["capabilities"],
+            public_access=runtime_fields["public_access"],
+            contract_permissions=manifest.get("permissions") or {},
+          )
       if chat_id is not None:
         app.chat_id = chat_id
 
@@ -627,7 +740,7 @@ async def apply_source_revision(
           ) from exc
       if (
         app.manifest_url is None
-        and app.source_commit != previous_state[7]
+        and app.source_commit != previous_source_commit
       ):
         # A distribution manifest is a statement about one exact accepted package. Once
         # local source advances, require publication verification again rather
@@ -652,19 +765,7 @@ async def apply_source_revision(
       changed = (
         created
         or committed is not None
-        or previous_state != (
-          app.name,
-          app.description,
-          app.offline_capable,
-          app.capability_contract,
-          app.chat_id,
-          source,
-          str(published),
-          app.source_commit,
-          app.published_manifest_url,
-          app.icon_png,
-          app.icon_override_png,
-        )
+        or previous_state != _live_runtime_state(app)
       )
       if not changed:
         db.rollback()
@@ -677,6 +778,8 @@ async def apply_source_revision(
         )
         _finish_static_assets(static_commit)
         static_materialized = False
+        if store_managed and accept_local_package:
+          warnings = (*warnings, _LOCAL_PACKAGE_WARNING)
         return ApplyResult(app=app, mode="unchanged", warnings=warnings)
 
       app.jsx_source = source
@@ -698,6 +801,8 @@ async def apply_source_revision(
       warnings = await _sync_accepted_app_side_effects(
         db, app, manifest, drop_prior_cron=not created,
       )
+      if store_managed and accept_local_package:
+        warnings = (*warnings, _LOCAL_PACKAGE_WARNING)
       return ApplyResult(
         app=app,
         mode="created" if created else "updated",

--- a/backend/app/routes/apps.py
+++ b/backend/app/routes/apps.py
@@ -1538,6 +1538,7 @@ async def apply_app_source(
         source_dir=source_dir,
         app=app,
         chat_id=body.chat_id,
+        accept_local_package=body.accept_local_package,
       )
     except app_apply.AppApplyError as exc:
       raise HTTPException(

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -98,6 +98,10 @@ class AppApply(BaseModel):
 
   source_dir: str = Field(min_length=1, max_length=512)
   chat_id: str | None = Field(default=None, max_length=64)
+  # Store-installed apps normally preserve reviewed package metadata while
+  # accepting local UI source. This explicit opt-in accepts the local manifest
+  # as the package authority for this revision without discarding provenance.
+  accept_local_package: bool = False
 
 
 class AppResolveUpdate(BaseModel):

--- a/backend/scripts/apply_app.py
+++ b/backend/scripts/apply_app.py
@@ -10,7 +10,10 @@ import urllib.request
 
 
 def _usage() -> None:
-  print("Usage: apply_app.py <source-dir>", file=sys.stderr)
+  print(
+    "Usage: apply_app.py [--accept-local-package] <source-dir>",
+    file=sys.stderr,
+  )
 
 
 def _receipt(result: dict) -> dict:
@@ -32,11 +35,16 @@ def _receipt(result: dict) -> dict:
 
 
 def main() -> None:
-  if len(sys.argv) != 2:
+  args = sys.argv[1:]
+  accept_local_package = False
+  if "--accept-local-package" in args:
+    accept_local_package = True
+    args.remove("--accept-local-package")
+  if len(args) != 1 or any(value.startswith("-") for value in args):
     _usage()
     raise SystemExit(2)
   try:
-    source_dir = str(Path(sys.argv[1]).resolve(strict=True))
+    source_dir = str(Path(args[0]).resolve(strict=True))
   except (OSError, RuntimeError) as exc:
     print(f"Cannot resolve app source directory: {exc}", file=sys.stderr)
     raise SystemExit(1) from exc
@@ -52,6 +60,7 @@ def main() -> None:
   payload = {
     "source_dir": source_dir,
     "chat_id": os.environ.get("CHAT_ID") or None,
+    "accept_local_package": accept_local_package,
   }
   request = urllib.request.Request(
     f"{base}/api/apps/apply",

--- a/backend/scripts/seed-skills/building-apps-quickstart.md
+++ b/backend/scripts/seed-skills/building-apps-quickstart.md
@@ -156,6 +156,23 @@ As soon as the first slice compiles and contains one real feature:
 python "$SCRIPTS_DIR/apply_app.py" /data/apps/<slug>
 ```
 
+For a Store-installed app, ordinary apply deliberately accepts local UI source
+while preserving the Store-reviewed manifest, skills, permissions, schedules,
+and project templates. If—and only if—the partner explicitly chose to make the
+local package manifest authoritative for this revision, use the deliberate
+variant:
+
+```bash
+python "$SCRIPTS_DIR/apply_app.py" --accept-local-package /data/apps/<slug>
+```
+
+This keeps the app's Store provenance while accepting the validated local
+runtime declarations, permissions, project templates, skills and schedules,
+icon, and static assets. It does not import installer-owned storage seeds. The
+receipt warns that a future reviewed Store update may replace the accepted
+declarations. Never use it merely to make an ordinary source edit take effect
+or to work around a manifest/permission guard.
+
 The helper validates the manifest and complete source tree, compiles and
 commits that exact revision, returns a compact receipt with `app_id`,
 `preview_path`, and `open_path`, and emits one live-preview action tied to this

--- a/backend/tests/test_app_apply.py
+++ b/backend/tests/test_app_apply.py
@@ -32,10 +32,15 @@ def _source(slug: str = "demo") -> Path:
   return root
 
 
-def _apply(client, auth, source: Path, chat_id: str | None = None):
+def _apply(
+  client, auth, source: Path, chat_id: str | None = None,
+  *, accept_local_package: bool = False,
+):
   body = {"source_dir": str(source)}
   if chat_id is not None:
     body["chat_id"] = chat_id
+  if accept_local_package:
+    body["accept_local_package"] = True
   return client.post("/api/apps/apply", json=body, headers=auth)
 
 
@@ -991,6 +996,54 @@ def test_local_apply_updates_runtime_capabilities_with_source(
   assert app_git._run(source, "status", "--porcelain").stdout == ""
 
 
+def test_local_manifest_does_not_grant_live_server_permissions(
+  client, auth, db,
+):
+  source = _source()
+  manifest = json.loads((source / "mobius.json").read_text())
+  manifest["permissions"] = {
+    "cross_app_access": "read",
+    "share_with_apps": "write",
+    "chat_log_access": "summary_with_deleted",
+    "manage_apps": True,
+    "manage_skills": True,
+    "github_access": True,
+    "github_connect": True,
+    "filesystem_access": True,
+    "connections_manage": True,
+    "connect_manage": True,
+  }
+  (source / "mobius.json").write_text(json.dumps(manifest))
+
+  created = _apply(client, auth, source)
+
+  assert created.status_code == 200, created.text
+  app_id = created.json()["app"]["id"]
+  row = db.query(models.App).populate_existing().filter_by(id=app_id).one()
+  assert row.cross_app_access == "none"
+  assert row.share_with_apps == "none"
+  assert row.chat_log_access == "none"
+  assert row.manage_apps is False
+  assert row.manage_skills is False
+  assert row.github_access is False
+  assert row.github_connect is False
+  assert row.filesystem_access is False
+  assert row.connections_manage is False
+  assert row.connect_manage is False
+
+
+def test_local_package_flag_requires_an_installed_store_app(client, auth, db):
+  source = _source()
+
+  rejected = _apply(client, auth, source, accept_local_package=True)
+
+  assert rejected.status_code == 422
+  assert rejected.json()["detail"]["code"] == (
+    "local_package_requires_store_app"
+  )
+  assert db.query(models.App).filter_by(source_dir=str(source)).first() is None
+
+
 def test_store_local_apply_preserves_reviewed_manifest_authority(
   client, auth, db,
 ):
@@ -1028,6 +1081,172 @@ def test_store_local_apply_preserves_reviewed_manifest_authority(
   assert row.offline_capable is True
   assert row.capability_contract == reviewed_contract
   assert app_git._run(source, "status", "--porcelain").stdout == ""
+
+
+def test_store_local_package_apply_explicitly_accepts_manifest_authority(
+  client, auth, db,
+):
+  source = _source()
+  created = _apply(client, auth, source)
+  app_id = created.json()["app"]["id"]
+  row = db.query(models.App).populate_existing().filter_by(id=app_id).one()
+  store_manifest_url = "https://store.example/demo/mobius.json"
+  row.manifest_url = store_manifest_url
+  row.name = "Reviewed name"
+  row.description = "Reviewed description"
+  row.project_templates_json = None
+  db.commit()
+
+  manifest = json.loads((source / "mobius.json").read_text())
+  manifest["name"] = "Local package name"
+  manifest["description"] = "Local package description"
+  manifest["version"] = "2.3.4"
+  manifest["theme_color"] = "#223344"
+  manifest["background_color"] = "#101820"
+  manifest["display"] = "fullscreen"
+  manifest["embeds_agent"] = True
+  manifest["permissions"] = {
+    "cross_app_access": "read",
+    "share_with_apps": "write",
+    "shared_memory": "write",
+    "chat_log_access": "summary",
+    "manage_apps": True,
+    "manage_skills": True,
+    "github_access": True,
+    "github_connect": True,
+    "filesystem_access": True,
+    "connections_manage": True,
+    "connect_manage": True,
+  }
+  manifest["skills"] = ["guide.md"]
+  manifest["source_files"] = ["guide.md"]
+  manifest["schedule"] = {
+    "default": "*/10 * * * *",
+    "user_configurable": False,
+    "job": "job.sh",
+  }
+  manifest["project_templates"] = [{
+    "id": "document", "name": "Document", "files": {},
+  }]
+  (source / "mobius.json").write_text(json.dumps(manifest))
+  (source / "guide.md").write_text("# Local package guidance\n")
+  job = source / "job.sh"
+  job.write_text("#!/bin/sh\nexit 0\n")
+  job.chmod(0o755)
+  (source / "index.jsx").write_text(
+    "export default function App() { return <div>local package</div> }\n"
+  )
+
+  with patch("app.app_cron.register_cron"):
+    updated = _apply(
+      client, auth, source, accept_local_package=True,
+    )
+
+  assert updated.status_code == 200, updated.text
+  assert updated.json()["app"]["name"] == "Local package name"
+  assert updated.json()["warnings"] == [
+    "Local package declarations are active, including permissions, schedules, "
+    "and skills; a future reviewed Store update may replace them."
+  ]
+  row = db.query(models.App).populate_existing().filter_by(id=app_id).one()
+  assert row.manifest_url == store_manifest_url
+  assert row.description == "Local package description"
+  assert row.version == "2.3.4"
+  assert row.theme_color == "#223344"
+  assert row.background_color == "#101820"
+  assert row.display == "fullscreen"
+  assert row.embeds_agent is True
+  assert row.cross_app_access == "read"
+  assert row.share_with_apps == "write"
+  assert row.chat_log_access == "summary"
+  assert row.manage_apps is True
+  assert row.manage_skills is True
+  assert row.github_access is True
+  assert row.github_connect is True
+  assert row.filesystem_access is True
+  assert row.connections_manage is True
+  assert row.connect_manage is True
+  assert row.capability_contract["data"]["shared_memory"] == "write"
+  assert row.capability_contract["agent"]["skills"] == ["guide.md"]
+  assert row.capability_contract["background"]["job"] == "job.sh"
+  assert row.capability_contract["background"]["cron"] == "*/10 * * * *"
+  assert row.project_templates_json == [{
+    "id": "document", "name": "Document", "files": {},
+  }]
+  assert "local package" in row.jsx_source
+
+  with patch("app.app_cron.register_cron"):
+    repeated = _apply(client, auth, source, accept_local_package=True)
+
+  assert repeated.status_code == 200, repeated.text
+  assert repeated.json()["mode"] == "unchanged"
+  assert repeated.json()["warnings"] == [
+    "Local package declarations are active, including permissions, schedules, "
+    "and skills; a future reviewed Store update may replace them."
+  ]
+
+
+def test_store_local_package_revokes_omitted_privileged_permissions(
+  client, auth, db,
+):
+  source = _source()
+  created = _apply(client, auth, source)
+  app_id = created.json()["app"]["id"]
+  row = db.query(models.App).populate_existing().filter_by(id=app_id).one()
+  row.manifest_url = "https://store.example/demo/mobius.json"
+  row.manage_apps = True
+  row.manage_skills = True
+  row.github_access = True
+  row.github_connect = True
+  row.filesystem_access = True
+  row.connections_manage = True
+  row.connect_manage = True
+  row.capability_contract = {
+    "schema": 2,
+    "data": {"shared_memory": "write"},
+  }
+  db.commit()
+
+  updated = _apply(client, auth, source, accept_local_package=True)
+
+  assert updated.status_code == 200, updated.text
+  assert updated.json()["mode"] == "updated"
+  row = db.query(models.App).populate_existing().filter_by(id=app_id).one()
+  assert row.manage_apps is False
+  assert row.manage_skills is False
+  assert row.github_access is False
+  assert row.github_connect is False
+  assert row.filesystem_access is False
+  assert row.connections_manage is False
+  assert row.connect_manage is False
+  assert row.capability_contract["data"]["shared_memory"] == "none"
+
+
+def test_store_local_package_apply_accepts_its_installed_package_identity(
+  client, auth, db,
+):
+  source = _source("app-store")
+  created = _apply(client, auth, source)
+  app_id = created.json()["app"]["id"]
+  row = db.query(models.App).populate_existing().filter_by(id=app_id).one()
+  row.manifest_url = (
+    "https://raw.githubusercontent.com/mobius-os/app-store/main"
+    "#manifest-id=store&channel=stable"
+  )
+  db.commit()
+
+  manifest = json.loads((source / "mobius.json").read_text())
+  manifest["id"] = "store"
+  manifest["permissions"] = {"manage_apps": True, "github_access": True}
+  (source / "mobius.json").write_text(json.dumps(manifest))
+
+  updated = _apply(client, auth, source, accept_local_package=True)
+
+  assert updated.status_code == 200, updated.text
+  row = db.query(models.App).populate_existing().filter_by(id=app_id).one()
+  assert row.slug == "app-store"
+  assert row.github_access is True
+  assert row.manifest_url.endswith("#manifest-id=store&channel=stable")
 
 
 def test_store_local_apply_accepts_installer_managed_tree_without_manifest(

--- a/backend/tests/test_apply_app_script.py
+++ b/backend/tests/test_apply_app_script.py
@@ -75,6 +75,36 @@ def test_apply_prints_compact_reusable_identity_receipt(
   }
 
 
+def test_apply_forwards_explicit_local_package_acceptance(
+  monkeypatch, capsys, tmp_path,
+):
+  module = _load()
+  source = tmp_path / "store-app"
+  source.mkdir()
+  monkeypatch.setattr(sys, "argv", [
+    "apply_app.py", "--accept-local-package", str(source),
+  ])
+  monkeypatch.setenv("AGENT_TOKEN", "agent-token")
+  captured = {}
+
+  def urlopen(request, timeout):
+    captured["payload"] = json.loads(request.data)
+    return _Response({
+      "mode": "updated", "warnings": [],
+      "app": {
+        "id": 9, "name": "Store app", "slug": "store-app",
+        "source_dir": str(source.resolve()), "chat_id": None,
+      },
+    })
+
+  monkeypatch.setattr(module.urllib.request, "urlopen", urlopen)
+
+  module.main()
+
+  assert captured["payload"]["accept_local_package"] is True
+  assert json.loads(capsys.readouterr().out)["mode"] == "updated"
+
+
 def test_apply_fails_loudly_when_response_loses_numeric_identity(
   monkeypatch, capsys, tmp_path,
 ):


### PR DESCRIPTION
## Summary

- add an explicit owner opt-in for accepting a Store-installed app's local package declarations while preserving its Store provenance and installed slug
- validate the manifest against either the source directory or canonical installed package identity, then persist the accepted runtime declarations, permissions, project templates, metadata, schedules, skills, icon, and static assets
- keep ordinary local and Store-app source apply authority unchanged; only the explicit Store path may grant package permissions, and omitted privileged grants are revoked
- return an owner-visible warning that a later reviewed Store update may replace the accepted declarations; installer-owned storage seeds remain outside this path

## Testing

- `scripts/wt-pytest.sh backend/tests/test_app_apply.py backend/tests/test_apply_app_script.py backend/tests/test_app_capabilities.py backend/tests/test_app_system_prompt.py backend/tests/test_identity.py -q` (92 passed)
- focused Store-only flag, ordinary-local authority, explicit-package, unchanged-reapply, installed-identity, skills/schedule contract, permission grant, and omission-revocation regressions
- Ruff and Python compilation checks on every changed Python file
- canonical full-index diff, direct-main merge tree, attribution, privacy, and complete current-head review

## Safety

Ordinary app source apply remains unable to grant live server permissions from source. The new path requires an explicit owner-only flag on an existing Store app, retains the Store origin and stable app identity, validates the manifest before publication, shares the existing source/static-asset/database rollback boundary, and makes replacement semantics visible in the receipt. It accepts runtime declarations and their side effects but deliberately does not import installer-owned storage seeds.