### PR TITLE
Prevent font swaps during shell and app reveal

### DIFF
--- a/backend/scripts/probe-font-handoff.mjs
+++ b/backend/scripts/probe-font-handoff.mjs
@@ -1,0 +1,295 @@
+/** Probe a live Möbius shell/app launch for text revealed before owned fonts settle. */
+
+import process from 'node:process'
+import { chromium } from '@playwright/test'
+
+const HELP = `Usage: npm run probe:font-handoff -- --app <id> [options]
+
+Opens a fresh browser with service workers disabled, delays Möbius's bundled
+font responses, and fails if shell or app title geometry changes after reveal.
+
+Options:
+  --app <id>          App id to open (required)
+  --delay-ms <ms>     Artificial delay per bundled font request (default: 350)
+  --settle-ms <ms>    Observation time after app reveal (default: 1500)
+  --selector <css>    Extra app text selector to observe
+  --json              Print only the machine-readable result
+  --help              Show this help
+
+Environment:
+  API_BASE_URL        Möbius origin (default: http://localhost:8000)
+  AGENT_TOKEN         Owner-scoped bearer token (required)
+  VIEWPORT_WIDTH      Browser width (default: 1280)
+  VIEWPORT_HEIGHT     Browser height (default: 800)
+`
+
+function parseArgs(argv) {
+  const options = {
+    app: '',
+    delayMs: 350,
+    settleMs: 1500,
+    selector: '',
+    json: false,
+  }
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    if (arg === '--help') {
+      process.stdout.write(HELP)
+      process.exit(0)
+    }
+    if (arg === '--json') {
+      options.json = true
+      continue
+    }
+    const key = {
+      '--app': 'app',
+      '--delay-ms': 'delayMs',
+      '--settle-ms': 'settleMs',
+      '--selector': 'selector',
+    }[arg]
+    if (!key || index + 1 >= argv.length) {
+      throw new Error(`Unknown or incomplete option: ${arg}`)
+    }
+    options[key] = argv[index + 1]
+    index += 1
+  }
+  if (!/^\d+$/.test(String(options.app))) {
+    throw new Error('--app must be a numeric app id')
+  }
+  for (const key of ['delayMs', 'settleMs']) {
+    options[key] = Number(options[key])
+    if (!Number.isFinite(options[key]) || options[key] < 0) {
+      throw new Error(`--${key === 'delayMs' ? 'delay-ms' : 'settle-ms'} must be non-negative`)
+    }
+  }
+  return options
+}
+
+function positiveInteger(value, fallback) {
+  const parsed = Number.parseInt(String(value || ''), 10)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
+}
+
+function targetShifts(records, revealAt, frameKind) {
+  const history = new Map()
+  for (const record of records) {
+    if (record.kind !== 'sample' || record.at < revealAt) continue
+    if (frameKind === 'shell' && !record.top) continue
+    if (frameKind === 'app' && record.top) continue
+    for (const target of record.targets || []) {
+      const entries = history.get(target.key) || []
+      const signature = `${target.family}|${target.weight}|${target.size}|${target.width}|${target.height}`
+      if (!entries.some((entry) => entry.signature === signature)) {
+        entries.push({ at: record.at, signature })
+        history.set(target.key, entries)
+      }
+    }
+  }
+  return [...history.entries()]
+    .filter(([, entries]) => entries.length > 1)
+    .map(([target, entries]) => ({ target, states: entries }))
+}
+
+function summarize(records, fontRequests, delayMs, probeStartAt) {
+  const shellSamples = records.filter((record) => (
+    record.kind === 'sample' && record.top && record.at >= probeStartAt
+  ))
+  const shellReveal = shellSamples.find((record) => (
+    record.shellPresent && !record.splashVisible
+  ))
+  const appReveal = shellSamples.find((record) => (
+    record.shellPresent && record.framePresent
+      && !record.splashVisible && !record.coverPresent
+  ))
+  const appSamples = records.filter((record) => (
+    record.kind === 'sample' && !record.top && record.path.includes('/frame')
+      && (record.targets || []).length > 0
+  ))
+  const firstVisibleAppText = appReveal
+    ? appSamples.find((record) => record.at >= appReveal.at)
+    : null
+  const shellShifts = shellReveal
+    ? targetShifts(records, shellReveal.at, 'shell')
+    : []
+  const appShifts = appReveal
+    ? targetShifts(records, appReveal.at, 'app')
+    : []
+  const failures = []
+  if (!shellReveal) failures.push('shell never revealed')
+  if (!appReveal) failures.push('app never revealed')
+  if (!firstVisibleAppText) failures.push('no visible app title text was observed')
+  if (firstVisibleAppText && !firstVisibleAppText.ownedFontsSettled) {
+    failures.push('app text became visible before Möbius-owned fonts settled')
+  }
+  if (shellShifts.length) failures.push('shell text geometry changed after reveal')
+  if (appShifts.length) failures.push('app text geometry changed after reveal')
+
+  return {
+    ok: failures.length === 0,
+    artificialFontDelayMs: delayMs,
+    bundledFontRequests: fontRequests,
+    shellRevealAt: shellReveal?.at || null,
+    appRevealAt: appReveal?.at || null,
+    firstVisibleAppTextAt: firstVisibleAppText?.at || null,
+    firstVisibleAppTextFontStatus: firstVisibleAppText?.fontStatus || null,
+    firstVisibleAppOwnedFonts: firstVisibleAppText?.ownedFonts || [],
+    firstVisibleAppTargets: firstVisibleAppText?.targets || [],
+    shellShifts,
+    appShifts,
+    failures,
+    observedPaths: [...new Set(records
+      .filter((record) => record.at >= probeStartAt)
+      .map((record) => record.path))],
+  }
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2))
+  const token = process.env.AGENT_TOKEN || ''
+  if (!token) throw new Error('AGENT_TOKEN is required')
+  const baseUrl = new URL(process.env.API_BASE_URL || 'http://localhost:8000')
+  const browser = await chromium.launch({ headless: true })
+  const context = await browser.newContext({
+    serviceWorkers: 'block',
+    ignoreHTTPSErrors: true,
+    viewport: {
+      width: positiveInteger(process.env.VIEWPORT_WIDTH, 1280),
+      height: positiveInteger(process.env.VIEWPORT_HEIGHT, 800),
+    },
+  })
+  const records = []
+  const fontRequests = []
+  const page = await context.newPage()
+  let probeStartAt = Date.now()
+
+  try {
+    await context.route('**/vendor/fonts/*.woff2', async (route) => {
+      fontRequests.push(new URL(route.request().url()).pathname)
+      if (options.delayMs) {
+        await new Promise((resolve) => setTimeout(resolve, options.delayMs))
+      }
+      await route.continue()
+    })
+    await page.exposeBinding('__mobiusFontProbeRecord', (source, record) => {
+      records.push({ ...record, frameUrl: source.frame?.url() || '' })
+    })
+    await page.addInitScript((value) => localStorage.setItem('token', value), token)
+    await page.addInitScript(({ extraSelector }) => {
+      const selectors = [
+        '.shell__wordmark',
+        'h1',
+        'h2',
+        'h3',
+        '[class*="title" i]',
+        extraSelector,
+      ].filter(Boolean).join(',')
+      const visible = (element) => {
+        const style = getComputedStyle(element)
+        const rect = element.getBoundingClientRect()
+        return style.visibility !== 'hidden' && style.display !== 'none'
+          && Number(style.opacity) !== 0 && rect.width > 0 && rect.height > 0
+      }
+      const overlayVisible = (element) => element ? visible(element) : false
+      const sample = () => {
+        const ownedFonts = [...(document.fonts || [])]
+          .filter((face) => ['Inter', 'JetBrains Mono'].includes(
+            String(face.family || '').replace(/^['"]|['"]$/g, ''),
+          ))
+          .map((face) => ({
+            family: String(face.family || '').replace(/^['"]|['"]$/g, ''),
+            weight: face.weight,
+            style: face.style,
+            status: face.status,
+          }))
+        const targets = [...document.querySelectorAll(selectors)]
+          .filter(visible)
+          .slice(0, 24)
+          .map((element) => {
+            const style = getComputedStyle(element)
+            const rect = element.getBoundingClientRect()
+            const text = (element.textContent || '').trim().replace(/\s+/g, ' ').slice(0, 80)
+            return {
+              key: `${element.tagName.toLowerCase()}.${String(element.className).slice(0, 80)}|${text}`,
+              family: style.fontFamily,
+              weight: style.fontWeight,
+              size: style.fontSize,
+              width: Number(rect.width.toFixed(2)),
+              height: Number(rect.height.toFixed(2)),
+            }
+          })
+        window.__mobiusFontProbeRecord({
+          kind: 'sample',
+          at: Date.now(),
+          top: window === window.top,
+          path: location.pathname,
+          fontStatus: document.fonts?.status || 'unsupported',
+          ownedFonts,
+          ownedFontsSettled: ownedFonts.length > 0
+            && ownedFonts.every((face) => ['loaded', 'error'].includes(face.status)),
+          shellPresent: Boolean(document.querySelector('.shell')),
+          framePresent: Boolean(document.querySelector('iframe[src*="/frame"]')),
+          splashVisible: overlayVisible(document.getElementById('splash')),
+          coverPresent: Boolean(document.querySelector('.canvas-loading')),
+          targets,
+        })
+      }
+      document.fonts?.addEventListener('loading', () => {
+        window.__mobiusFontProbeRecord({
+          kind: 'font-loading', at: Date.now(), top: window === window.top,
+          path: location.pathname,
+        })
+      })
+      document.fonts?.addEventListener('loadingdone', () => {
+        window.__mobiusFontProbeRecord({
+          kind: 'font-loaded', at: Date.now(), top: window === window.top,
+          path: location.pathname,
+        })
+      })
+      const observer = new MutationObserver(sample)
+      observer.observe(document, { childList: true, subtree: true, attributes: true })
+      const timer = setInterval(sample, 16)
+      addEventListener('pagehide', () => {
+        clearInterval(timer)
+        observer.disconnect()
+      }, { once: true })
+      sample()
+    }, { extraSelector: options.selector })
+
+    probeStartAt = Date.now()
+    const appUrl = new URL(`/app/${options.app}?font-probe=${Date.now()}`, baseUrl)
+    await page.goto(appUrl.toString(), {
+      waitUntil: 'domcontentloaded',
+    })
+    await page.waitForFunction(() => {
+      const splash = document.getElementById('splash')
+      const cover = document.querySelector('.canvas-loading')
+      const hidden = (element) => !element
+        || getComputedStyle(element).display === 'none'
+        || getComputedStyle(element).visibility === 'hidden'
+        || Number(getComputedStyle(element).opacity) === 0
+      return document.querySelector('.shell')
+        && document.querySelector('iframe[src*="/frame"]')
+        && hidden(splash) && !cover
+    }, { timeout: 15_000 })
+    await page.waitForTimeout(options.settleMs)
+  } finally {
+    await context.close()
+    await browser.close()
+  }
+
+  const result = summarize(records, fontRequests, options.delayMs, probeStartAt)
+  if (options.json) {
+    process.stdout.write(`${JSON.stringify(result)}\n`)
+  } else {
+    process.stdout.write(`${result.ok ? 'PASS' : 'FAIL'} font handoff: `
+      + `${result.bundledFontRequests.length} delayed font requests, `
+      + `${result.appShifts.length + result.shellShifts.length} post-reveal shifts\n`)
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`)
+  }
+  if (!result.ok) process.exitCode = 1
+}
+
+main().catch((error) => {
+  process.stderr.write(`font handoff probe: ${error.message}\n`)
+  process.exitCode = 1
+})

--- a/backend/tests/test_frame_mount_guard.py
+++ b/backend/tests/test_frame_mount_guard.py
@@ -90,12 +90,20 @@ def test_mounted_flag_is_set_by_a_commit_ref():
   )
 
 
-def test_font_check_is_requested_separately_from_app_mount():
+def test_owned_fonts_settle_before_commit_without_moving_the_commit_signal():
   html = _frame_html()
   mount_signal = html[
     html.index("function MountSignal"):
     html.index("// Immersive safe-area passthrough")
   ]
   assert "__mobiusFontReadiness" not in mount_signal
+  assert "async function settleOwnedFontsBeforeMount" in html
+  load_module = html[
+    html.index("async function loadModule"):
+    html.index("window.addEventListener('message', (e) =>", html.index("async function loadModule"))
+  ]
+  assert load_module.index("await settleOwnedFontsBeforeMount()") < load_module.index(
+    "mountedRoot = createRoot"
+  )
   assert "msg.type === 'moebius:frame-font-check'" in html
   assert "type: 'moebius:frame-font-check-result'" in html

--- a/backend/tests/test_vendor_fallback.py
+++ b/backend/tests/test_vendor_fallback.py
@@ -7,6 +7,7 @@ cache-first service worker — the failure mode behind the missing
 404 on a miss instead of falling through to HTML.
 """
 
+import json
 from pathlib import Path
 
 import pytest
@@ -37,7 +38,37 @@ def test_shell_and_frame_share_source_owned_font_contract():
   assert "font-family: 'JetBrains Mono'" in fonts
   assert "doc.fonts.load" in readiness
   assert "face.family === family" in readiness
+  assert "settleOwnedDocument" in readiness
   assert "moebius:frame-font-check" in readiness
+
+
+def test_shell_launch_cover_waits_for_owned_rendered_faces():
+  frontend = Path(__file__).resolve().parents[2] / "frontend"
+  app = (frontend / "src" / "App.jsx").read_text(encoding="utf-8")
+
+  assert "void removeSplashWhenOwnedFontsReady()" in app
+  helper_start = app.index("function removeSplashWhenOwnedFontsReady()")
+  helper_end = app.index("\nfunction removeSplash()", helper_start)
+  helper = app[helper_start:helper_end]
+  assert "settleOwnedDocument" in helper
+  assert ".then(() => removeSplash())" in helper
+
+
+def test_live_font_handoff_probe_stresses_cold_owned_fonts():
+  platform = Path(__file__).resolve().parents[2]
+  package = json.loads((platform / "package.json").read_text(encoding="utf-8"))
+  probe = (
+    platform / "backend" / "scripts" / "probe-font-handoff.mjs"
+  ).read_text(encoding="utf-8")
+
+  assert package["scripts"]["probe:font-handoff"].endswith(
+    "probe-font-handoff.mjs"
+  )
+  assert "serviceWorkers: 'block'" in probe
+  assert "**/vendor/fonts/*.woff2" in probe
+  assert "ownedFontsSettled" in probe
+  assert "shellShifts" in probe
+  assert "appShifts" in probe
 
 
 def test_classifies_module_and_asset_paths_as_static():

--- a/frontend/public/app-frame.html
+++ b/frontend/public/app-frame.html
@@ -542,7 +542,10 @@
     //      parent. The controlled shell can read the versioned service-worker
     //      cache offline; this opaque frame cannot. The parent transfers only
     //      the exact source-attributed app/version bytes back.
-    //   4. iframe imports those bytes from a short-lived blob URL and mounts.
+    //   4. iframe imports those bytes from a short-lived blob URL, settles every
+    //      platform-owned font face, and mounts. Font settlement happens before
+    //      React's first commit so the visible frame never swaps typefaces after
+    //      promotion and MountSignal keeps its capability-ordering guarantee.
     //   5. iframe posts {type:'moebius:frame-mounted', appId} as the first
     //      render COMMITS (MountSignal's stable ref, not render()-returned).
     //      Ref attachment precedes app layout effects, so their mount-time host
@@ -1054,6 +1057,31 @@
       );
     }
 
+    const OWNED_FONT_FAMILIES = new Set(['Inter', 'JetBrains Mono']);
+
+    async function settleOwnedFontsBeforeMount() {
+      if (!document.fonts) return true;
+      const specs = new Set();
+      for (const face of document.fonts) {
+        const family = String(face.family || '').replace(/^['"]|['"]$/g, '');
+        if (!OWNED_FONT_FAMILIES.has(family)) continue;
+        specs.add([
+          face.style || 'normal', face.weight || '400', '14px', JSON.stringify(family)
+        ].join(' '));
+      }
+      try {
+        const groups = await Promise.all(
+          [...specs].map((font) => document.fonts.load(font, 'Möbius 0123456789'))
+        );
+        await document.fonts.ready;
+        return groups.flat().every((face) => face.status === 'loaded');
+      } catch (_) {
+        // A failed face cannot swap in later, so the browser's stable fallback
+        // is safe to reveal. Only a still-loading face may change geometry.
+        return false;
+      }
+    }
+
     function tokenExpiresSoon(token, skewMs = 60000) {
       try {
         const encoded = String(token || '').split('.')[1];
@@ -1369,6 +1397,7 @@
           showErr('Module error', 'The app module has no default export.');
           return;
         }
+        await settleOwnedFontsBeforeMount();
         mountedRoot = createRoot(document.getElementById('root'));
         mountedComponent = Component;
         renderMountedComponent();

--- a/frontend/public/vendor/fonts/mobius-font-readiness.js
+++ b/frontend/public/vendor/fonts/mobius-font-readiness.js
@@ -3,8 +3,10 @@
   const OWNED_FAMILIES = new Set(['Inter', 'JetBrains Mono'])
   const FRAME_CHECK_TIMEOUT_MS = 4000
 
-  async function settleDocument(doc) {
-    if (!doc?.fonts || !doc.body) return true
+  function renderedFontRequirements(doc, ownedOnly) {
+    const specs = new Set()
+    const requiredFamilies = new Set()
+    if (!doc?.fonts || !doc.body) return { specs, requiredFamilies }
 
     const elements = new Set([doc.body])
     const walker = doc.createTreeWalker(doc.body, NodeFilter.SHOW_TEXT)
@@ -13,17 +15,23 @@
       if (node.textContent.trim() && node.parentElement) elements.add(node.parentElement)
     }
 
-    const specs = new Set()
-    const requiredFamilies = new Set()
     for (const element of elements) {
       if (!element.getClientRects().length) continue
       const style = doc.defaultView.getComputedStyle(element)
       const family = style.fontFamily.split(',')[0].trim().replace(/^['"]|['"]$/g, '')
+      const owned = OWNED_FAMILIES.has(family)
+      if (ownedOnly && !owned) continue
       specs.add([
         style.fontStyle, style.fontWeight, style.fontSize, JSON.stringify(family),
       ].join(' '))
-      if (OWNED_FAMILIES.has(family)) requiredFamilies.add(family)
+      if (owned) requiredFamilies.add(family)
     }
+    return { specs, requiredFamilies }
+  }
+
+  async function settleRenderedFonts(doc, ownedOnly) {
+    if (!doc?.fonts || !doc.body) return true
+    const { specs, requiredFamilies } = renderedFontRequirements(doc, ownedOnly)
 
     try {
       const groups = await Promise.all([...specs].map((font) => doc.fonts.load(font)))
@@ -35,6 +43,17 @@
     } catch {
       return false
     }
+  }
+
+  function settleDocument(doc) {
+    return settleRenderedFonts(doc, false)
+  }
+
+  // Production launch covers only wait on faces Möbius ships itself. External
+  // theme fonts remain an owner-controlled network dependency and must never
+  // hold the shell hostage; exact screenshots still use settleDocument above.
+  function settleOwnedDocument(doc) {
+    return settleRenderedFonts(doc, true)
   }
 
   function isPainted(element, view) {
@@ -102,5 +121,7 @@
     return true
   }
 
-  scope.__mobiusFontReadiness = { settleDocument, settleCapture }
+  scope.__mobiusFontReadiness = {
+    settleDocument, settleOwnedDocument, settleCapture,
+  }
 })(globalThis)

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -289,7 +289,7 @@ function AppRoot() {
     const showingDegradedNotice = !STANDALONE_APP
       && servedVersionQuery.data?.serving_source === 'baked'
     if (STANDALONE_APP || shellVisualReady || showingDegradedNotice) {
-      removeSplash()
+      void removeSplashWhenOwnedFontsReady()
     }
   }, [hasToken, isRestoring, shellVisualReady, status, servedVersionQuery.data])
 
@@ -383,6 +383,17 @@ function StartupError({ title, message, retrying = false, onRetry }) {
       </section>
     </div>
   )
+}
+
+let ownedFontSplashRemoval = null
+
+function removeSplashWhenOwnedFontsReady() {
+  if (ownedFontSplashRemoval) return ownedFontSplashRemoval
+  const settle = globalThis.__mobiusFontReadiness?.settleOwnedDocument
+  ownedFontSplashRemoval = Promise.resolve(
+    typeof settle === 'function' ? settle(document) : true,
+  ).catch(() => false).then(() => removeSplash())
+  return ownedFontSplashRemoval
 }
 
 function removeSplash() {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "scripts": {
+    "probe:font-handoff": "node backend/scripts/probe-font-handoff.mjs",
     "test:e2e-harness": "node --test tests/chat-fixture-registry.test.mjs tests/mock-accepted-messages.test.mjs",
     "test:packager": "node --test scripts/package-static-app.test.mjs"
   },


### PR DESCRIPTION
## Summary
- wait for bundled Möbius fonts before removing the shell launch cover
- settle the same font faces before an app frame's first React commit while preserving capability ordering
- add a cold-font probe that delays font requests and flags post-reveal text shifts

## Verification
- `scripts/wt-pytest.sh tests/test_frame_mount_guard.py tests/test_vendor_fallback.py --tb=short -q`
- `node --test frontend/src/lib/__tests__/capabilityBrokerContract.test.js frontend/src/components/AppCanvas/__tests__/previewSwapState.test.js`
- delayed-font probe against a live mini-app: all bundled faces settled and zero post-reveal shifts