### PR TITLE
Keep app crash reports actionable without a message

### DIFF
--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -69,6 +69,7 @@ import {
   ACTIVATE_FOREGROUND,
 } from './workspacePlacement.js'
 import {
+  appCrashReportDraft,
   appUpdateStaleMessage,
   findAppStoreApp,
 } from '../../lib/appRecovery.js'
@@ -2522,7 +2523,7 @@ export default function Shell({ onInitialVisualReady }) {
   const handleAppError = useCallback((appId, error, chatId) => {
     const appEntry = appsRef.current.find(a => String(a.id) === String(appId))
     const appName = appEntry?.name || `app ${appId}`
-    const report = `The app "${appName}" crashed with this error:\n\`\`\`\n${error}\n\`\`\`\nPlease investigate and fix.`
+    const report = appCrashReportDraft(appName, error)
     const buildingChatId = appEntry?.chat_id || chatId || null
     const buildingChat = buildingChatId
       && chatsRef.current.find(c => c.id === buildingChatId)

--- a/frontend/src/lib/__tests__/appRecovery.test.js
+++ b/frontend/src/lib/__tests__/appRecovery.test.js
@@ -2,6 +2,7 @@ import test from 'node:test'
 import assert from 'node:assert/strict'
 
 import {
+  appCrashReportDraft,
   appUpdateStaleMessage,
   findAppStoreApp,
 } from '../appRecovery.js'
@@ -10,6 +11,17 @@ test('explains how to recover a stale update without alarming about live state',
   assert.equal(
     appUpdateStaleMessage({ appName: 'Reflection' }),
     'The pending update for Reflection changed upstream. Review the latest update and start again. The previous version is still running.',
+  )
+})
+
+test('crash report drafts never leave an empty error fence', () => {
+  assert.equal(
+    appCrashReportDraft('Notes', '   '),
+    'The app "Notes" crashed with this error:\n```\nUnknown app error (no message reached the shell)\n```\nPlease investigate and fix.',
+  )
+  assert.equal(
+    appCrashReportDraft('Notes', 'TypeError: unavailable'),
+    'The app "Notes" crashed with this error:\n```\nTypeError: unavailable\n```\nPlease investigate and fix.',
   )
 })
 

--- a/frontend/src/lib/appRecovery.js
+++ b/frontend/src/lib/appRecovery.js
@@ -15,6 +15,12 @@ export function appUpdateStaleMessage(event) {
     + `Review the latest update and start again. ${REASSURANCE}`
 }
 
+export function appCrashReportDraft(name, error) {
+  const detail = String(error ?? '').trim()
+    || 'Unknown app error (no message reached the shell)'
+  return `The app "${name}" crashed with this error:\n\`\`\`\n${detail}\n\`\`\`\nPlease investigate and fix.`
+}
+
 export function findAppStoreApp(apps) {
   let nameFallback = null
   for (const app of Array.isArray(apps) ? apps : []) {


### PR DESCRIPTION
## Summary
- format app-crash drafts through the existing recovery helper
- supply a clear fallback when the failing frame provides no error message
- cover both empty and ordinary error details with a focused regression

## Why
Cross-origin script failures and thrown non-Error values can reach the shell without a message. The recovery draft previously rendered an empty code fence, leaving the next repair turn without useful context.

## Testing
- focused app-recovery unit tests: 3 passed
- changed-file ESLint: 0 errors
- production frontend and offline/PWA build
- canonical diff, attribution, privacy, topology, and installed-source provenance checks