### PR TITLE
Show wake-enabled helpers as a truthful Waiting handoff

### DIFF
--- a/backend/app/delegations.py
+++ b/backend/app/delegations.py
@@ -1026,8 +1026,97 @@ WAKE_ELIGIBLE_RUN_STATUSES = frozenset({"completed", "failed"})
 _WAKE_RESULT_MAX = 3000
 WAKE_RECOVERY_BATCH_SIZE = 16
 WAKE_NOTICE_DELEGATION_LIMIT = 16
+BACKGROUND_HELPER_ITEM_LIMIT = 16
 WAKE_PARENT_DELIVERY_TIMEOUT_SECS = 40.0
 _LOG = logging.getLogger("moebius.delegations")
+
+
+def _self_resuming_helper_rows(
+  db: Session, parent_chat_ids: set[str],
+) -> list[tuple[models.Delegation, str]]:
+  """Wake-enabled helper rows that still own a future parent continuation."""
+  if not parent_chat_ids:
+    return []
+  candidate_run_statuses = tuple(
+    set(models.NONTERMINAL_RUN_STATUSES) | WAKE_ELIGIBLE_RUN_STATUSES
+  )
+  rows = (
+    db.query(models.Delegation)
+    .outerjoin(models.ChatRun, models.ChatRun.id == _latest_child_run_id())
+    .filter(
+      models.Delegation.parent_chat_id.in_(parent_chat_ids),
+      models.Delegation.notify_parent_on_complete.is_(True),
+      models.Delegation.source_work_id.is_(None),
+      models.Delegation.cancelled_at.is_(None),
+      models.Delegation.parent_woken_at.is_(None),
+      or_(
+        models.ChatRun.status.in_(candidate_run_statuses),
+        and_(
+          models.ChatRun.id.is_(None),
+          models.Delegation.startup_prompt.is_not(None),
+        ),
+      ),
+    )
+    .order_by(models.Delegation.created_at.asc(), models.Delegation.id.asc())
+    .all()
+  )
+  waiting_statuses = ACTIVE_DELEGATION_STATUSES | WAKE_ELIGIBLE_STATUSES
+  projected = []
+  for row in rows:
+    status, _run, _result = derived_status(db, row, load_result=False)
+    if status in waiting_statuses:
+      projected.append((row, status))
+  return projected
+
+
+def background_helper_chat_ids(db: Session, parent_chat_ids) -> set[str]:
+  """Chats that are idle while wake-enabled helpers own their next move."""
+  requested = {str(chat_id) for chat_id in parent_chat_ids if chat_id}
+  return {
+    row.parent_chat_id
+    for row, _status in _self_resuming_helper_rows(db, requested)
+  }
+
+
+def background_helper_goal_ids(db: Session, parent_chat_id: str) -> set[str]:
+  """Logical Goal/root identities owned by this chat's waking helpers."""
+  return {
+    row.parent_root_run_id
+    for row, _status in _self_resuming_helper_rows(db, {parent_chat_id})
+  }
+
+
+def serialize_background_helpers(db: Session, parent_chat_id: str) -> dict:
+  """Compact owner-facing helper summary; child transcripts stay private."""
+  rows = _self_resuming_helper_rows(db, {parent_chat_id})
+  return {
+    "count": len(rows),
+    "items": [
+      {
+        "id": row.id,
+        "task_key": row.task_key,
+        "provider": row.provider,
+        "status": status,
+      }
+      for row, status in rows[:BACKGROUND_HELPER_ITEM_LIMIT]
+    ],
+  }
+
+
+def publish_parent_waiting_changed(parent_chat_id: str) -> None:
+  """Reconcile every owner surface that projects self-resuming idle work."""
+  if not parent_chat_id:
+    return
+  try:
+    from app.broadcast import get_system_broadcast
+
+    get_system_broadcast().publish({
+      "type": "chat_wait_changed",
+      "chatId": parent_chat_id,
+      "source": "background_helpers",
+    })
+  except Exception:
+    _LOG.debug("background helper wait broadcast failed", exc_info=True)
 
 
 @dataclass(frozen=True)
@@ -1294,6 +1383,7 @@ async def _deliver_parent_wake_once(
         synchronize_session=False,
       )
       db.commit()
+    publish_parent_waiting_changed(parent_chat_id)
     return True
 
 
@@ -1320,6 +1410,7 @@ async def wake_parent_after_child_settled(child_chat_id: str) -> None:
       if row is not None:
         from app.goal_plans import publish_plan_for_delegation
         publish_plan_for_delegation(db, row)
+        publish_parent_waiting_changed(row.parent_chat_id)
       if (
         row is None
         or not row.notify_parent_on_complete

--- a/backend/app/goal_plans.py
+++ b/backend/app/goal_plans.py
@@ -629,16 +629,18 @@ def _goal_wait_kind(
       models.ChatWait.created_by_run_id.isnot(None),
     ).all()
   ]
-  if not wait_run_ids:
-    return None
-  wait_owners = db.query(models.ChatRun).filter(
-    models.ChatRun.chat_id == physical.chat_id,
-    models.ChatRun.id.in_(wait_run_ids),
-  ).all()
-  if any(
-    (owner.goal_id or owner.root_run_id or owner.id) == goal_id
-    for owner in wait_owners
-  ):
+  if wait_run_ids:
+    wait_owners = db.query(models.ChatRun).filter(
+      models.ChatRun.chat_id == physical.chat_id,
+      models.ChatRun.id.in_(wait_run_ids),
+    ).all()
+    if any(
+      (owner.goal_id or owner.root_run_id or owner.id) == goal_id
+      for owner in wait_owners
+    ):
+      return "monitor"
+  from app.delegations import background_helper_goal_ids
+  if goal_id in background_helper_goal_ids(db, physical.chat_id):
     return "monitor"
   return None
 

--- a/backend/app/routes/chats.py
+++ b/backend/app/routes/chats.py
@@ -46,6 +46,7 @@ from app.chat_titles import (
   renamed_event,
 )
 from app.database import get_db
+from app.delegations import background_helper_chat_ids, serialize_background_helpers
 from app.goal_plans import presented_goal
 from app.memory_observability import record_memory_checkpoint_once
 from app.owner_input import OwnerInputKind
@@ -653,6 +654,10 @@ def _chat_detail_response(
     "waits": [
       serialize_wait(row) for row in armed_waits_for_chat(db, chat.id)
     ] if expose_session else [],
+    "background_helpers": (
+      serialize_background_helpers(db, chat.id)
+      if expose_session else {"count": 0, "items": []}
+    ),
   }
   if requested_anchor_found is not None:
     response["requested_anchor_found"] = requested_anchor_found
@@ -720,7 +725,9 @@ def list_chats(
     # owner conversation into the drawer by setting owner_visible at creation.
     chats = [c for c in chats if _visible_in_owner_drawer(c)]
   durable_running = running_chat_ids(db, (chat.id for chat in chats))
-  durable_waiting = armed_wait_chat_ids(db)
+  durable_waiting = armed_wait_chat_ids(db) | background_helper_chat_ids(
+    db, (chat.id for chat in chats)
+  )
   secure_input_chats = secure_inputs.pending_chat_ids()
   record_memory_checkpoint_once(
     "shell_chat_list_first_response",
@@ -1497,6 +1504,10 @@ def get_chat_runtime(
     "waits": [
       serialize_wait(row) for row in armed_waits_for_chat(db, chat.id)
     ] if principal.scope != "chat_embed" else [],
+    "background_helpers": (
+      serialize_background_helpers(db, chat.id)
+      if principal.scope != "chat_embed" else {"count": 0, "items": []}
+    ),
   }
 
 

--- a/backend/app/routes/delegations.py
+++ b/backend/app/routes/delegations.py
@@ -26,6 +26,7 @@ from app.delegations import (
   MAX_DELEGATION_DEPTH,
   normalize_cwd,
   parent_root_run_id,
+  publish_parent_waiting_changed,
   serialize_delegation,
 )
 from app.deps import Principal, get_delegation_principal, reject_cross_site
@@ -269,6 +270,7 @@ async def submit_or_attach(
     await _ensure_started(db, row, body.prompt)
     from app.goal_plans import publish_plan_for_delegation
     publish_plan_for_delegation(db, row)
+    publish_parent_waiting_changed(row.parent_chat_id)
   payload = serialize_delegation(db, row)
   payload["attached"] = attached
   return payload
@@ -384,6 +386,7 @@ async def cancel_delegation(
   payload = serialize_delegation(db, row)
   from app.goal_plans import publish_plan_for_delegation
   publish_plan_for_delegation(db, row)
+  publish_parent_waiting_changed(row.parent_chat_id)
   return payload
 
 
@@ -401,4 +404,6 @@ async def cancel_active_for_parent(db: Session, parent_chat_id: str) -> list[str
     if await cancel_delegation_execution(row.id):
       cancelled.append(row.id)
   db.rollback()
+  if cancelled:
+    publish_parent_waiting_changed(parent_chat_id)
   return cancelled

--- a/backend/tests/test_delegations.py
+++ b/backend/tests/test_delegations.py
@@ -10,11 +10,14 @@ from app.codex_sdk_runner import _codex_config_overrides
 from app.claude_sdk_runner import _guarded_subagent_bash
 from app.delegations import (
   RunPolicy,
+  background_helper_chat_ids,
+  background_helper_goal_ids,
   delegation_execution_token,
   derived_status,
   mark_cancelled,
   parent_root_run_id,
   policy_for_chat,
+  serialize_background_helpers,
 )
 from test_app_fixtures import create_local_app
 
@@ -656,6 +659,86 @@ def _seed_delegation(
   return parent_id, child_id, delegation_id
 
 
+def test_background_helper_projection_owns_waiting_until_parent_wake(
+  client, owner_token, db,
+):
+  parent_id, _child_id, delegation_id = _seed_delegation(
+    db, suffix="waiting-owner", child_status="running",
+  )
+  _seed_delegation(
+    db,
+    suffix="detached-owner",
+    parent_id=parent_id,
+    child_status="running",
+    notify=False,
+  )
+
+  assert background_helper_chat_ids(db, [parent_id]) == {parent_id}
+  assert background_helper_goal_ids(db, parent_id) == {"root-waiting-owner"}
+  summary = serialize_background_helpers(db, parent_id)
+  assert summary == {
+    "count": 1,
+    "items": [{
+      "id": delegation_id,
+      "task_key": "task-waiting-owner",
+      "provider": "claude",
+      "status": "running",
+    }],
+  }
+
+  auth_headers = {"Authorization": f"Bearer {owner_token}"}
+  chats = client.get("/api/chats", headers=auth_headers)
+  assert chats.status_code == 200, chats.text
+  parent_summary = next(row for row in chats.json() if row["id"] == parent_id)
+  assert parent_summary["waiting"] is True
+
+  detail = client.get(f"/api/chats/{parent_id}", headers=auth_headers)
+  assert detail.status_code == 200, detail.text
+  assert detail.json()["background_helpers"] == summary
+  runtime = client.get(f"/api/chats/{parent_id}/runtime", headers=auth_headers)
+  assert runtime.status_code == 200, runtime.text
+  assert runtime.json()["background_helpers"] == summary
+
+  child_run = db.get(models.ChatRun, "child-run-waiting-owner")
+  child_run.status = "completed"
+  db.commit()
+  assert serialize_background_helpers(db, parent_id)["count"] == 1
+
+  delegation = db.get(models.Delegation, delegation_id)
+  delegation.parent_woken_at = now_naive_utc()
+  db.commit()
+  assert background_helper_chat_ids(db, [parent_id]) == set()
+  assert background_helper_goal_ids(db, parent_id) == set()
+  assert serialize_background_helpers(db, parent_id) == {"count": 0, "items": []}
+
+
+def test_background_helper_wait_event_is_parent_scoped_and_best_effort(
+  monkeypatch,
+):
+  events = []
+
+  class Broadcast:
+    def publish(self, event):
+      events.append(event)
+
+  monkeypatch.setattr("app.broadcast.get_system_broadcast", lambda: Broadcast())
+  delegations_mod.publish_parent_waiting_changed("parent-visible")
+  assert events == [{
+    "type": "chat_wait_changed",
+    "chatId": "parent-visible",
+    "source": "background_helpers",
+  }]
+
+  class BrokenBroadcast:
+    def publish(self, _event):
+      raise RuntimeError("socket is already closed")
+
+  monkeypatch.setattr(
+    "app.broadcast.get_system_broadcast", lambda: BrokenBroadcast(),
+  )
+  delegations_mod.publish_parent_waiting_changed("parent-visible")
+
+
 def _capture_starts(monkeypatch, *, running=False):
   """Stub start_programmatic_chat_turn + is_chat_running; return the start log."""
   starts = []
@@ -690,6 +773,18 @@ def test_child_completion_wakes_idle_parent_once(db, monkeypatch):
     result_blocks=[{"type": "text", "content": "All 3 checks passed."}],
   )
   starts = _capture_starts(monkeypatch, running=False)
+  waiting_counts = []
+
+  def capture_waiting_change(changed_parent_id):
+    assert changed_parent_id == parent_id
+    db.expire_all()
+    waiting_counts.append(
+      serialize_background_helpers(db, changed_parent_id)["count"]
+    )
+
+  monkeypatch.setattr(
+    delegations_mod, "publish_parent_waiting_changed", capture_waiting_change,
+  )
 
   asyncio.run(delegations_mod.wake_parent_after_child_settled(child_id))
 
@@ -703,6 +798,7 @@ def test_child_completion_wakes_idle_parent_once(db, monkeypatch):
   assert starts[0]["source_work_id"] == "root-idle"
   db.expire_all()
   assert db.get(models.Delegation, delegation_id).parent_woken_at is not None
+  assert waiting_counts[:2] == [1, 0]
 
   # Second settle is a no-op — the latch holds.
   asyncio.run(delegations_mod.wake_parent_after_child_settled(child_id))

--- a/backend/tests/test_goal_plans.py
+++ b/backend/tests/test_goal_plans.py
@@ -470,6 +470,32 @@ def test_goal_wait_ownership_excludes_a_later_ordinary_turn(db, chat):
   assert presented_goal(db, chat.id)["wait_kind"] == "monitor"
 
 
+def test_goal_wait_ownership_includes_only_its_waking_helpers(
+  db, chat, monkeypatch,
+):
+  from app.goal_plans import presented_goal
+
+  goal_run = models.ChatRun(
+    id="helper-goal-run", root_run_id="helper-goal-run", chat_id=chat.id,
+    status="parked", provider="codex", goal_objective="Wait on helper",
+    goal_id="helper-goal-id", started_at=datetime.now(UTC),
+  )
+  db.add(goal_run)
+  db.commit()
+
+  monkeypatch.setattr(
+    "app.delegations.background_helper_goal_ids",
+    lambda _db, _chat_id: {"different-goal"},
+  )
+  assert "wait_kind" not in presented_goal(db, chat.id)
+
+  monkeypatch.setattr(
+    "app.delegations.background_helper_goal_ids",
+    lambda _db, _chat_id: {"helper-goal-id"},
+  )
+  assert presented_goal(db, chat.id)["wait_kind"] == "monitor"
+
+
 def test_legacy_queued_goal_clear_is_retired_without_opening_a_turn(db, chat):
   from app.chat_writer import PromotePending, get_writer
 

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -124,7 +124,11 @@ import {
   shouldApplyComposerFocusRequest,
 } from './composerFocusPolicy.js'
 import { shouldDismissComposerKeyboardOnSubmit } from './composerKeyboardPolicy.js'
-import { updateChatRuntimeCache } from './chatRuntimeCache.js'
+import {
+  chatHasSelfResumingHandoff,
+  normalizeBackgroundHelpers,
+  updateChatRuntimeCache,
+} from './chatRuntimeCache.js'
 import {
   assistantAnchorKey,
   chatCacheEntryState,
@@ -656,6 +660,9 @@ export default function ChatView({
   // trigger those reads, so declare and resume both refresh this without a
   // dedicated event channel.
   const [armedWaits, setArmedWaits] = useState(() => cached?.waits || [])
+  const [backgroundHelpers, setBackgroundHelpers] = useState(() => (
+    normalizeBackgroundHelpers(cached?.background_helpers)
+  ))
   const handleCancelWait = useCallback(async (waitId) => {
     setArmedWaits(prev => {
       const next = prev.filter(wait => wait.id !== waitId)
@@ -739,6 +746,7 @@ export default function ChatView({
     // destination's cached waits immediately so the previous chat's promise
     // never flashes while the authoritative detail read catches up.
     setArmedWaits(Array.isArray(runtime?.waits) ? runtime.waits : [])
+    setBackgroundHelpers(normalizeBackgroundHelpers(runtime?.background_helpers))
   }, [chatId, queryClient, setGoalPresentationLocalState])
 
   useEffect(() => {
@@ -1341,6 +1349,7 @@ export default function ChatView({
       }
       setLiveQuestionId(data.pending_question_id || null)
       if (Array.isArray(data.waits)) setArmedWaits(data.waits)
+      setBackgroundHelpers(normalizeBackgroundHelpers(data.background_helpers))
       updateChatRuntimeCache(queryClient, chatMessagesQueryKey(chatId), {
         running: !!data.running,
         goal: runtimeGoal,
@@ -1353,6 +1362,7 @@ export default function ChatView({
           activeAssistantMessageId: data.active_assistant_message_id || null,
         } : {}),
         waits: data.waits || [],
+        background_helpers: normalizeBackgroundHelpers(data.background_helpers),
         chatInfo: refreshedChatInfo,
       })
       // Reconcile pending queue against authoritative server state.
@@ -1526,6 +1536,7 @@ export default function ChatView({
       const pendingQuestionId = runtime.pendingQuestionId
       setLiveQuestionId(pendingQuestionId)
       if (Array.isArray(data.waits)) setArmedWaits(data.waits)
+      setBackgroundHelpers(normalizeBackgroundHelpers(data.background_helpers))
       updateChatRuntimeCache(queryClient, chatMessagesQueryKey(chatId), {
         running: !!data.running,
         goal: runtimeGoal,
@@ -1538,6 +1549,7 @@ export default function ChatView({
           activeAssistantMessageId: runtime.activeAssistantMessageId,
         } : {}),
         waits: data.waits || [],
+        background_helpers: normalizeBackgroundHelpers(data.background_helpers),
       })
       // Don't let the fallback poll add/clobber the queue while a turn is live
       // (localAuthoritative, above) — the optimistic queue + confirmQueued
@@ -2392,6 +2404,8 @@ export default function ChatView({
       ))
       hadMessagesRef.current = visibleMessages.length > 0
       setLiveQuestionId(runtime.pending_question_id || null)
+      setArmedWaits(Array.isArray(runtime.waits) ? runtime.waits : [])
+      setBackgroundHelpers(normalizeBackgroundHelpers(runtime.background_helpers))
       setBridgeMountInputs({
         runningAtMount: running,
         lastMsgAtMount: visibleMessages.length > 0
@@ -2510,6 +2524,10 @@ export default function ChatView({
             : '',
           pending_messages: runtime.pending_messages || [],
           pending_question_id: runtime.pending_question_id || null,
+          waits: runtime.waits || [],
+          background_helpers: normalizeBackgroundHelpers(
+            runtime.background_helpers,
+          ),
         })
         applyMessagesToView(msgs, detailCache.offset)
         settleRuntime(runtime, msgs)
@@ -5210,6 +5228,11 @@ export default function ChatView({
         : {}),
     }
   })
+  const showWaitingHandoff = chatHasSelfResumingHandoff({
+    turnActive,
+    waits: armedWaits,
+    backgroundHelpers,
+  })
   // A `/goal ` composer draft keeps the goal visual open while the objective is
   // still being typed (null once the draft is no longer a goal command).
   const draftGoal = draftGoalObjective(input)
@@ -5653,8 +5676,12 @@ export default function ChatView({
           onActionItem={handleGoalRailAction}
         />
         {draftGoal !== null && <GoalDraftChip objective={draftGoal} />}
-        {!turnActive && armedWaits.length > 0 && (
-          <WaitingChip waits={armedWaits} onCancel={handleCancelWait} />
+        {showWaitingHandoff && (
+          <WaitingChip
+            waits={armedWaits}
+            backgroundHelpers={backgroundHelpers}
+            onCancel={handleCancelWait}
+          />
         )}
         <ConnectionStatus
           error={connectionError}

--- a/frontend/src/components/ChatView/WaitingChip.jsx
+++ b/frontend/src/components/ChatView/WaitingChip.jsx
@@ -1,8 +1,6 @@
-/* WaitingChip renders a chat's armed durable waits: the visible form of "the
-   agent is waiting for X and will resume on its own". One chip per wait, shown
-   only while no turn is active — during a live turn the run surface already
-   owns the status area. Cancel is immediate and local-first; the durable row
-   is cancelled through the platform. */
+/* WaitingChip renders every self-resuming chat handoff: declared monitors and
+   wake-enabled background helpers. It is shown only while no parent turn is
+   active; during a live turn the run surface already owns the status area. */
 
 function intervalLabel(wait) {
   if (wait.kind === 'timer') {
@@ -17,10 +15,35 @@ function intervalLabel(wait) {
   return minutes <= 1 ? 'checking every minute' : `checking every ${minutes} min`
 }
 
-export default function WaitingChip({ waits, onCancel }) {
-  if (!waits?.length) return null
+function helperTaskLabel(taskKey) {
+  return String(taskKey || '')
+    .replace(/[._-]+/g, ' ')
+    .replace(/^./, letter => letter.toUpperCase())
+}
+
+export default function WaitingChip({ waits = [], backgroundHelpers, onCancel }) {
+  const helperCount = Number(backgroundHelpers?.count) || 0
+  if (!waits.length && helperCount === 0) return null
+  const helperTasks = (backgroundHelpers?.items || [])
+    .map(item => helperTaskLabel(item?.task_key))
+    .filter(Boolean)
   return (
     <div className="chat__waits" role="status" aria-live="polite">
+      {helperCount > 0 && (
+        <div className="chat__wait-chip">
+          <span className="chat__wait-tag" aria-hidden="true">
+            <span className="chat__wait-pulse" />
+            Waiting
+          </span>
+          <span
+            className="chat__wait-text"
+            title={helperTasks.length ? helperTasks.join(', ') : undefined}
+          >
+            Waiting on {helperCount} {helperCount === 1 ? 'helper' : 'helpers'}
+          </span>
+          <span className="chat__wait-meta">resumes automatically</span>
+        </div>
+      )}
       {waits.map(wait => (
         <div key={wait.id} className="chat__wait-chip">
           <span className="chat__wait-tag" aria-hidden="true">

--- a/frontend/src/components/ChatView/__tests__/backgroundHelpers.test.js
+++ b/frontend/src/components/ChatView/__tests__/backgroundHelpers.test.js
@@ -1,0 +1,30 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+import WaitingChip from '../WaitingChip.jsx'
+import { chatHasSelfResumingHandoff } from '../chatRuntimeCache.js'
+
+test('idle waking helpers own one visible automatic Waiting handoff', () => {
+  const helpers = {
+    count: 2,
+    items: [{ task_key: 'review_copy' }, { task_key: 'verify-build' }],
+  }
+  assert.equal(chatHasSelfResumingHandoff({ backgroundHelpers: helpers }), true)
+  const html = renderToStaticMarkup(createElement(WaitingChip, {
+    backgroundHelpers: helpers,
+  }))
+  assert.match(html, /Waiting on 2 helpers/)
+  assert.match(html, /resumes automatically/)
+  assert.match(html, /Review copy, Verify build/)
+})
+
+test('live parent work suppresses the helper handoff without erasing it', () => {
+  const backgroundHelpers = { count: 1, items: [] }
+  assert.equal(chatHasSelfResumingHandoff({ backgroundHelpers }), true)
+  assert.equal(chatHasSelfResumingHandoff({
+    turnActive: true,
+    backgroundHelpers,
+  }), false)
+})

--- a/frontend/src/components/ChatView/__tests__/chatDetailCache.test.js
+++ b/frontend/src/components/ChatView/__tests__/chatDetailCache.test.js
@@ -103,6 +103,11 @@ test('prefetched chat detail matches the synchronous ChatView cache contract', (
     },
     pending_messages: [{ id: 'queued' }],
     pending_question_id: 'question-1',
+    waits: [{ id: 'wait-1', description: 'CI finishes', status: 'armed' }],
+    background_helpers: {
+      count: 1,
+      items: [{ id: 'helper-1', task_key: 'audit', status: 'running' }],
+    },
     provider: 'codex',
     session_id: 'thread-current',
     created_by_app_id: 7,
@@ -123,6 +128,8 @@ test('prefetched chat detail matches the synchronous ChatView cache contract', (
   assert.equal(cached.activeGoalObjective, 'Finish the migration')
   assert.deepEqual(cached.goal, source.goal)
   assert.equal(cached.pending_question_id, 'question-1')
+  assert.deepEqual(cached.waits, source.waits)
+  assert.deepEqual(cached.background_helpers, source.background_helpers)
   assert.deepEqual(cached.chatInfo, {
     provider: 'codex',
     session_id: 'thread-current',

--- a/frontend/src/components/ChatView/__tests__/chatRuntimeCache.test.js
+++ b/frontend/src/components/ChatView/__tests__/chatRuntimeCache.test.js
@@ -1,7 +1,10 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
 
-import { updateChatRuntimeCache } from '../chatRuntimeCache.js'
+import {
+  normalizeBackgroundHelpers,
+  updateChatRuntimeCache,
+} from '../chatRuntimeCache.js'
 
 function cacheHarness(initial) {
   let value = initial
@@ -66,6 +69,34 @@ test('unchanged durable waits do not republish the persisted chat cache', () => 
 
   assert.equal(cache.updates(), 0)
   assert.equal(cache.value().waits, waits)
+})
+
+test('unchanged background helpers do not republish the persisted chat cache', () => {
+  const helpers = {
+    count: 1,
+    items: [{ id: 'helper-1', task_key: 'audit', status: 'running' }],
+  }
+  const cache = cacheHarness({ messages: [], background_helpers: helpers })
+
+  updateChatRuntimeCache(
+    cache.queryClient,
+    ['chat-messages', 'chat-1'],
+    { background_helpers: structuredClone(helpers) },
+  )
+
+  assert.equal(cache.updates(), 0)
+  assert.equal(cache.value().background_helpers, helpers)
+})
+
+test('background helper summaries normalize missing and truncated detail', () => {
+  assert.deepEqual(normalizeBackgroundHelpers(null), { count: 0, items: [] })
+  assert.deepEqual(normalizeBackgroundHelpers({
+    count: 1,
+    items: [{ id: 'one' }, { id: 'two' }],
+  }), {
+    count: 2,
+    items: [{ id: 'one' }, { id: 'two' }],
+  })
 })
 
 test('unchanged settled chat metadata does not republish the persisted cache', () => {

--- a/frontend/src/components/ChatView/chatRuntimeCache.js
+++ b/frontend/src/components/ChatView/chatRuntimeCache.js
@@ -9,13 +9,46 @@ function samePendingMessages(current, next) {
   return true
 }
 
+export const EMPTY_BACKGROUND_HELPERS = Object.freeze({
+  count: 0,
+  items: Object.freeze([]),
+})
+
+export function normalizeBackgroundHelpers(value) {
+  if (!value || typeof value !== 'object') return EMPTY_BACKGROUND_HELPERS
+  const items = Array.isArray(value.items) ? value.items : []
+  const count = Number.isInteger(value.count) && value.count >= items.length
+    ? value.count
+    : items.length
+  if (count === 0 && items.length === 0) return EMPTY_BACKGROUND_HELPERS
+  return { count, items }
+}
+
+export function chatHasSelfResumingHandoff({
+  turnActive = false,
+  waits = [],
+  backgroundHelpers = null,
+} = {}) {
+  const helpers = normalizeBackgroundHelpers(backgroundHelpers)
+  return !turnActive && (
+    (Array.isArray(waits) && waits.length > 0) || helpers.count > 0
+  )
+}
+
 function runtimeFieldMatches(current, field, value) {
   if (field === 'pending_messages') {
     return samePendingMessages(current?.pending_messages || [], value || [])
   }
-  if (field === 'goal' || field === 'chatInfo') {
-    const currentValue = current?.[field] || null
-    const nextValue = value || null
+  if (
+    field === 'goal'
+    || field === 'chatInfo'
+    || field === 'background_helpers'
+  ) {
+    const empty = field === 'background_helpers'
+      ? EMPTY_BACKGROUND_HELPERS
+      : null
+    const currentValue = current?.[field] || empty
+    const nextValue = value || empty
     if (currentValue === nextValue) return true
     return JSON.stringify(currentValue) === JSON.stringify(nextValue)
   }

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -2955,10 +2955,9 @@ export default function Shell({ onInitialVisualReady }) {
       }
     } else if (ev.type === 'chat_wait_changed') {
       if (ev.chatId) {
-        // Waits are durable chat state, not a running turn. Reconcile the
-        // visible ChatView immediately so its chip cannot depend on a later
-        // run-finished refresh, and refresh the compact list projection so
-        // Recents shows the same state across tabs and reconnects.
+        // Self-resuming handoffs are durable chat state, not a running turn.
+        // Reconcile ChatView immediately and refresh the compact list so its
+        // Waiting card and Recents marker agree across tabs and reconnects.
         markChatRunReconcile(ev.chatId)
         void invalidateShellListCache('chats').then(refreshChats)
       }

--- a/frontend/src/lib/chatDetailCache.js
+++ b/frontend/src/lib/chatDetailCache.js
@@ -190,6 +190,11 @@ export function chatDetailCacheValue(data = {}) {
       ? data.pending_messages
       : [],
     pending_question_id: data.pending_question_id || null,
+    waits: Array.isArray(data.waits) ? data.waits : [],
+    background_helpers: data.background_helpers
+      && typeof data.background_helpers === 'object'
+      ? data.background_helpers
+      : { count: 0, items: [] },
     chatInfo: {
       provider: data.provider || 'claude',
       session_id: data.session_id || null,


### PR DESCRIPTION
## Summary
- keep a parent chat visibly Waiting while a wake-enabled background helper owns its next continuation
- keep chat detail, Recents, and cached runtime state synchronized without exposing child transcripts
- preserve exact Goal ownership so an unrelated helper cannot claim this Goal's wait

## Testing
- `scripts/wt-pytest.sh backend/tests/test_delegations.py backend/tests/test_goal_plans.py -q` (61 passed)
- targeted frontend tests (50 passed)
- `npm test` (2,910 library tests and 95 hook tests passed)
- `npm run lint` (0 errors; 21 existing warnings)
- `npm run build`