### PR TITLE
Prevent unfinished Goals from settling without an owner

### DIFF
--- a/backend/app/chat.py
+++ b/backend/app/chat.py
@@ -2685,6 +2685,121 @@ async def _drain_and_release(
   )
 
 
+def _goal_handoff_is_owned(
+  db: Session,
+  chat_id: str,
+  goal_id: str,
+  sink: "_ChatEventSink | None" = None,
+) -> bool:
+  """Whether a durable actor already owns an unfinished Goal's next move."""
+  chat = (
+    db.query(
+      models.Chat.pending_messages,
+      models.Chat.pending_question_id,
+    )
+    .filter(models.Chat.id == chat_id)
+    .first()
+  )
+  if chat is None:
+    return True
+  if chat.pending_messages or chat.pending_question_id is not None:
+    return True
+  if questions.is_waiting(chat_id):
+    return True
+  if sink is not None and any(
+    isinstance(block, dict)
+    and block.get("type") == "question"
+    and not block.get("answers")
+    for block in sink.assistant_blocks
+  ):
+    return True
+
+  from app.chat_waits import armed_waits_for_chat
+  wait_run_ids = {
+    wait.created_by_run_id
+    for wait in armed_waits_for_chat(db, chat_id)
+    if wait.created_by_run_id
+  }
+  if wait_run_ids and db.query(models.ChatRun.id).filter(
+    models.ChatRun.id.in_(wait_run_ids),
+    models.ChatRun.goal_id == goal_id,
+  ).first() is not None:
+    return True
+  from app.delegations import background_helper_goal_ids
+  return goal_id in background_helper_goal_ids(db, chat_id)
+
+
+def _prepare_goal_handoff(
+  db: Session,
+  chat_id: str,
+  ending_run_token: str,
+  sink: "_ChatEventSink",
+) -> run_state.GoalSettlementTarget | None:
+  """Return a correction target, or persistently mark an exhausted handoff."""
+  target = run_state.goal_settlement_target(db, chat_id, ending_run_token)
+  if target is None or _goal_handoff_is_owned(
+    db, chat_id, target.goal_id, sink,
+  ):
+    return None
+  if target.retry_allowed:
+    return target
+  sink.publish(_pause_note(
+    "This Goal paused repeatedly without a visible owner for the next "
+    "action. Resume it to continue; before pausing again, use a question "
+    "card, a durable wait, or a wake-enabled helper."
+  ))
+  return None
+
+
+async def _maybe_enqueue_goal_handoff(
+  db: Session,
+  chat_id: str,
+  ending_run_token: str,
+  target: run_state.GoalSettlementTarget,
+  sink: "_ChatEventSink | None" = None,
+) -> None:
+  """Queue one corrective turn when an unfinished Goal has no next owner.
+
+  The marker flows through the ordinary append/drain/promote path, so it gains
+  the same durable run identity and recovery semantics as every continuation.
+  Re-checking ownership immediately before append lets a real queued message,
+  question, wait, or waking helper that arrived during finalization win.
+  """
+  if _goal_handoff_is_owned(db, chat_id, target.goal_id, sink):
+    return
+  current = run_state.goal_settlement_target(db, chat_id, ending_run_token)
+  if (
+    current is None
+    or current.goal_id != target.goal_id
+    or not current.retry_allowed
+  ):
+    return
+  await _await_ack(get_writer().submit(
+    AppendPending(
+      chat_id=chat_id,
+      run_token="",
+      user_msg={
+        "role": "user",
+        "content": (
+          "This Goal is still unfinished, but the last turn ended without "
+          "assigning who or what will advance it. Continue the work now. "
+          "Before ending again, either complete or update the Goal, ask "
+          "through the clarifying-question tool if only the partner can act, "
+          "declare a durable wait for an observable external condition, or "
+          "leave a wake-enabled helper as the next owner. Do not stop on a "
+          "prose-only request for user action."
+        ),
+        "ts": int(time.time() * 1000),
+        "kind": "continuation",
+        "continuation_reason": run_state.GOAL_HANDOFF_REASON,
+        "goal_id": target.goal_id,
+        # One correction per finishing run; an ambiguous retry cannot double-send.
+        "cid": f"goal-handoff-{ending_run_token}",
+      },
+    )
+  ))
+
+
 _BROWSER_CLOSE_CREATE_TIMEOUT = 5.0
 _BROWSER_CLOSE_WAIT_TIMEOUT = 5.0
 _BROWSER_CLOSE_KILL_GRACE = 1.0
@@ -3347,6 +3462,24 @@ async def _complete_turn(
     db.close()
     return chat_queue.TerminalDisposition.STALE_NO_ACTION
 
+  # A platform-promoted Goal has no provider-native stop hook. Before a clean
+  # turn can settle, require a truthful next owner: a queued message, an open
+  # question, a durable monitor, or a wake-enabled helper. With no owner, one
+  # progress-bounded corrective continuation gets queued after finalization.
+  # If the agent repeats the unowned handoff without plan progress, publish a
+  # resumable failure NOW so the same terminal snapshot makes the stop visible
+  # and durable rather than leaving the Goal looking benignly paused.
+  goal_handoff_target = None
+  if (
+    we_own_gen
+    and not stop_handoff_successor
+    and not limit_reached
+    and not sink._last_error
+  ):
+    goal_handoff_target = _prepare_goal_handoff(
+      db, chat_id, sink.run_token or "", sink,
+    )
+
   # Lost-reply backstop (defense-in-depth behind the runner-side fixes). A
   # normally-owned run that reached a CLEAN provider terminal (no error, no
   # limit/park) yet produced ZERO renderable content is a genuine dropped reply
@@ -3480,6 +3613,16 @@ async def _complete_turn(
       await _close_browser_session(chat_id)
     db.close()
     return chat_queue.TerminalDisposition.LIMIT_PARKED
+  # A clean, unfinished auto-promoted Goal with no durable owner gets its one
+  # bounded correction through the same queue path as every other continuation.
+  if ending_status == "completed" and goal_handoff_target is not None:
+    await _maybe_enqueue_goal_handoff(
+      db,
+      chat_id,
+      sink.run_token or "",
+      goal_handoff_target,
+      sink,
+    )
   # The continuation is a fresh turn — give it its own run_token. The
   # turn-end drain's PromotePending sets the next turn's run marker under
   # this token, and _schedule_continuation hands the SAME token to the

--- a/backend/app/run_state.py
+++ b/backend/app/run_state.py
@@ -7,6 +7,7 @@ reconstructed from a second per-chat marker.
 """
 
 from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
 from typing import Any
 import json
 import uuid
@@ -135,8 +136,10 @@ def goal_identity_for_run_start(
   return None, None
 
 
-def _goal_plan_is_unfinished(db: Session, chat_id: str, goal_id: str) -> bool:
-  """Whether a stable Goal identity owns a plan with unsettled work."""
+def _goal_plan_tasks(
+  db: Session, chat_id: str, goal_id: str,
+) -> list[dict[str, Any]] | None:
+  """Return one stable Goal's validated task list, if it owns a plan."""
   owner = (
     db.query(models.ChatRun.goal_plan_json)
     .filter(
@@ -148,17 +151,153 @@ def _goal_plan_is_unfinished(db: Session, chat_id: str, goal_id: str) -> bool:
     .first()
   )
   if owner is None:
-    return False
+    return None
   raw = owner[0]
   try:
     plan = json.loads(raw) if isinstance(raw, str) else raw
   except (TypeError, json.JSONDecodeError):
-    return False
+    return None
   tasks = (plan or {}).get("tasks") if isinstance(plan, dict) else None
+  return tasks if isinstance(tasks, list) and tasks else None
+
+
+def _goal_plan_is_unfinished(db: Session, chat_id: str, goal_id: str) -> bool:
+  """Whether a stable Goal identity owns a plan with unsettled work."""
+  tasks = _goal_plan_tasks(db, chat_id, goal_id)
   return bool(tasks) and any(
     isinstance(task, dict)
     and task.get("status") not in ("completed", "cancelled")
     for task in tasks
+  )
+
+
+# --- Owned settlement for auto-promoted Goals -------------------------------
+
+# Explicit ``/goal`` starts already have a provider-owned continuation loop.
+# A Goal promoted during an ordinary turn has no such owner, so a clean turn
+# end must either leave a durable handoff or receive one bounded corrective
+# continuation. Each newly settled plan task earns one further correction;
+# lack of progress then becomes a visible resumable failure instead of an
+# unbounded provider loop or a Goal that silently looks paused.
+GOAL_HANDOFF_REASON = "goal_handoff"
+
+
+@dataclass(frozen=True)
+class GoalSettlementTarget:
+  """An unfinished auto-promoted Goal reaching a clean physical turn end."""
+
+  goal_id: str
+  retry_allowed: bool
+
+
+def _goal_started_explicitly(
+  db: Session,
+  chat_id: str,
+  messages: Any,
+  run: models.ChatRun,
+) -> bool:
+  """Whether this Goal belongs to the provider-native ``/goal`` path.
+
+  Current explicit starts mint a Goal id distinct from their original logical
+  root, while mid-turn promotion deliberately adopts that root as its id. A
+  later wait/helper wake may itself have a fresh physical root, so classify
+  from the Goal's earliest run rather than the turn that happens to be ending.
+  Historical rows predate the id distinction; for those inspect only the owner
+  message that opened the exact original assistant segment. Never scan for an
+  unrelated ``/goal`` elsewhere in a long-lived chat.
+  """
+  origin = (
+    db.query(models.ChatRun)
+    .filter(
+      models.ChatRun.chat_id == chat_id,
+      models.ChatRun.goal_id == run.goal_id,
+    )
+    .order_by(models.ChatRun.started_at.asc(), models.ChatRun.id.asc())
+    .first()
+  )
+  if origin is None:
+    return True
+  logical_root = origin.root_run_id or origin.id
+  if origin.goal_id != logical_root:
+    return True
+
+  from app.goal_commands import is_goal_command
+
+  rows = list(messages or [])
+  for index, message in enumerate(rows):
+    if not (
+      isinstance(message, dict)
+      and message.get("role") == "assistant"
+      and message.get("id") == logical_root
+    ):
+      continue
+    for prior in reversed(rows[:index]):
+      if not isinstance(prior, dict) or prior.get("role") != "user":
+        continue
+      return is_goal_command(str(prior.get("content") or ""))
+    return False
+  return False
+
+
+def _goal_handoff_attempt_count(messages: Any, goal_id: str) -> int:
+  """Count this Goal's already-promoted corrective continuation markers."""
+  return sum(
+    1
+    for message in (messages or [])
+    if isinstance(message, dict)
+    and message.get("role") == "user"
+    and message.get("continuation_reason") == GOAL_HANDOFF_REASON
+    and message.get("goal_id") == goal_id
+  )
+
+
+def goal_settlement_target(
+  db: Session, chat_id: str, ending_run_token: str | None,
+) -> GoalSettlementTarget | None:
+  """Describe an unfinished auto-promoted Goal at clean turn settlement.
+
+  Explicit ``/goal`` paths stay under their existing Claude/Codex continuation
+  owners. Auto-promoted Goals get one baseline corrective continuation and one
+  additional attempt per task that has become completed/cancelled. The caller
+  turns an exhausted target into a visible failure rather than silently doing
+  nothing.
+  """
+  if not ending_run_token:
+    return None
+  run = (
+    db.query(models.ChatRun)
+    .filter(
+      models.ChatRun.id == ending_run_token,
+      models.ChatRun.chat_id == chat_id,
+    )
+    .first()
+  )
+  if run is None or run.goal_objective is None or run.goal_id is None:
+    return None
+  chat_row = (
+    db.query(models.Chat.messages)
+    .filter(models.Chat.id == chat_id)
+    .first()
+  )
+  messages = chat_row[0] if chat_row is not None else []
+  if _goal_started_explicitly(db, chat_id, messages, run):
+    return None
+  tasks = _goal_plan_tasks(db, chat_id, run.goal_id)
+  if not tasks or not any(
+    isinstance(task, dict)
+    and task.get("status") not in ("completed", "cancelled")
+    for task in tasks
+  ):
+    return None
+  completed = sum(
+    1
+    for task in tasks
+    if isinstance(task, dict) and task.get("status") in ("completed", "cancelled")
+  )
+  attempts = _goal_handoff_attempt_count(messages, run.goal_id)
+  return GoalSettlementTarget(
+    goal_id=run.goal_id,
+    retry_allowed=attempts < 1 + completed,
   )
 
 

--- a/backend/tests/test_goal_owned_settlement.py
+++ b/backend/tests/test_goal_owned_settlement.py
@@ -1,0 +1,351 @@
+"""Owned settlement for platform-promoted Goals.
+
+An unfinished Goal promoted during an ordinary agent turn cannot settle with
+no actor responsible for the next move. One progress-bounded corrective turn
+is allowed; a repeat without plan progress becomes a visible resumable error.
+Explicit ``/goal`` starts retain their native provider continuation owners.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from app import models
+from app.run_state import (
+  GOAL_HANDOFF_REASON,
+  GoalSettlementTarget,
+  goal_settlement_target,
+)
+
+
+UNFINISHED = {"tasks": [
+  {"id": "a", "status": "completed"},
+  {"id": "b", "status": "running"},
+]}
+STUCK = {"tasks": [{"id": "a", "status": "running"}]}
+SETTLED = {"tasks": [
+  {"id": "a", "status": "completed"},
+  {"id": "b", "status": "cancelled"},
+]}
+
+
+def _add_run(
+  db,
+  chat_id,
+  run_id,
+  *,
+  goal_objective="Ship it",
+  goal_id=None,
+  root_run_id=None,
+  status="completed",
+  provider="codex",
+  plan=None,
+):
+  root = root_run_id or run_id
+  db.add(models.ChatRun(
+    id=run_id,
+    root_run_id=root,
+    chat_id=chat_id,
+    status=status,
+    provider=provider,
+    goal_objective=goal_objective,
+    goal_id=goal_id if goal_id is not None else root,
+    goal_plan_json=plan,
+  ))
+  db.commit()
+
+
+def _target(db, chat, run_id="run-a"):
+  return goal_settlement_target(db, chat.id, run_id)
+
+
+def _correction(goal_id, index=1):
+  return {
+    "role": "user",
+    "content": "correct the handoff",
+    "kind": "continuation",
+    "continuation_reason": GOAL_HANDOFF_REASON,
+    "goal_id": goal_id,
+    "cid": f"correction-{index}",
+  }
+
+
+# --- exact Goal classification ---------------------------------------------
+
+
+def test_auto_promoted_unfinished_plan_returns_target(db, chat):
+  _add_run(db, chat.id, "run-a", plan=UNFINISHED)
+  assert _target(db, chat) == GoalSettlementTarget(
+    goal_id="run-a", retry_allowed=True,
+  )
+
+
+def test_settled_unplanned_and_non_goal_runs_are_not_guarded(db, chat):
+  _add_run(db, chat.id, "settled", plan=SETTLED)
+  assert _target(db, chat, "settled") is None
+
+  _add_run(db, chat.id, "unplanned", plan=None)
+  assert _target(db, chat, "unplanned") is None
+
+  _add_run(
+    db, chat.id, "ordinary", goal_objective=None, goal_id=None, plan=None,
+  )
+  assert _target(db, chat, "ordinary") is None
+
+
+def test_current_explicit_goal_identity_is_excluded(db, chat):
+  _add_run(
+    db,
+    chat.id,
+    "run-a",
+    root_run_id="run-a",
+    goal_id="explicit-goal-uuid",
+    plan=UNFINISHED,
+  )
+  assert _target(db, chat) is None
+
+
+def test_historical_explicit_goal_is_excluded_by_its_exact_root_message(db, chat):
+  chat.messages = [
+    {"role": "user", "content": "/goal Ship it"},
+    {"role": "assistant", "id": "run-a", "content": "working"},
+  ]
+  db.commit()
+  # Historical migration used root_run_id as goal_id for every old Goal.
+  _add_run(db, chat.id, "run-a", goal_id="run-a", plan=UNFINISHED)
+  assert _target(db, chat) is None
+
+
+def test_unrelated_earlier_goal_command_does_not_exclude_new_auto_goal(db, chat):
+  chat.messages = [
+    {"role": "user", "content": "/goal Old work"},
+    {"role": "assistant", "id": "old-root", "content": "done"},
+    {"role": "user", "content": "Please ship this ordinary request"},
+    {"role": "assistant", "id": "run-a", "content": "working"},
+  ]
+  db.commit()
+  _add_run(db, chat.id, "run-a", plan=UNFINISHED)
+  assert _target(db, chat) is not None
+
+
+def test_wait_or_helper_wake_keeps_auto_goal_classification(db, chat):
+  _add_run(db, chat.id, "a-origin", plan=UNFINISHED)
+  # A durable wait/helper wake can start a new physical root while inheriting
+  # the original Goal identity. Classification must follow the Goal origin.
+  _add_run(
+    db,
+    chat.id,
+    "z-wake",
+    root_run_id="z-wake",
+    goal_id="a-origin",
+    plan=None,
+  )
+  target = _target(db, chat, "z-wake")
+  assert target is not None
+  assert target.goal_id == "a-origin"
+
+
+def test_missing_or_unknown_run_token_returns_none(db, chat):
+  assert goal_settlement_target(db, chat.id, "") is None
+  assert goal_settlement_target(db, chat.id, "missing") is None
+
+
+# --- one baseline correction plus one per settled task ---------------------
+
+
+def test_one_correction_is_allowed_before_any_plan_progress(db, chat):
+  _add_run(db, chat.id, "run-a", plan=STUCK)
+  assert _target(db, chat).retry_allowed is True
+
+
+def test_repeat_without_progress_exhausts_the_guard(db, chat):
+  chat.messages = [_correction("run-a")]
+  db.commit()
+  _add_run(db, chat.id, "run-a", plan=STUCK)
+  assert _target(db, chat).retry_allowed is False
+
+
+def test_settled_task_earns_one_further_correction(db, chat):
+  chat.messages = [_correction("run-a")]
+  db.commit()
+  _add_run(db, chat.id, "run-a", plan=UNFINISHED)
+  assert _target(db, chat).retry_allowed is True
+
+
+def test_other_goals_corrections_do_not_consume_this_goal_budget(db, chat):
+  chat.messages = [_correction("another-goal")]
+  db.commit()
+  _add_run(db, chat.id, "run-a", plan=STUCK)
+  assert _target(db, chat).retry_allowed is True
+
+
+# --- truthful next-owner classification ------------------------------------
+
+
+class _Sink:
+  def __init__(self, blocks=None):
+    self.assistant_blocks = list(blocks or [])
+    self.published = []
+    self._last_error = None
+
+  def publish(self, event):
+    self.published.append(event)
+    if event.get("type") == "error":
+      self._last_error = event.get("message")
+
+
+def test_pending_owner_message_satisfies_handoff(db, chat):
+  from app.chat import _goal_handoff_is_owned
+
+  chat.pending_messages = [{"role": "user", "content": "real follow-up"}]
+  db.commit()
+  assert _goal_handoff_is_owned(db, chat.id, "run-a", _Sink()) is True
+
+
+def test_pending_question_marker_or_open_question_block_satisfies_handoff(db, chat):
+  from app.chat import _goal_handoff_is_owned
+
+  chat.pending_question_id = "q1"
+  db.commit()
+  assert _goal_handoff_is_owned(db, chat.id, "run-a", _Sink()) is True
+
+  chat.pending_question_id = None
+  db.commit()
+  sink = _Sink([{"type": "question", "question_id": "q2"}])
+  assert _goal_handoff_is_owned(db, chat.id, "run-a", sink) is True
+
+
+def test_armed_wait_or_waking_helper_satisfies_handoff(db, chat, monkeypatch):
+  from app.chat import _goal_handoff_is_owned
+
+  _add_run(db, chat.id, "run-a", plan=STUCK)
+  monkeypatch.setattr(
+    "app.chat_waits.armed_waits_for_chat",
+    lambda *_args: [SimpleNamespace(created_by_run_id="run-a")],
+  )
+  monkeypatch.setattr(
+    "app.delegations.background_helper_goal_ids", lambda *_args: set(),
+  )
+  assert _goal_handoff_is_owned(db, chat.id, "run-a", _Sink()) is True
+
+  monkeypatch.setattr(
+    "app.chat_waits.armed_waits_for_chat", lambda *_args: [],
+  )
+  monkeypatch.setattr(
+    "app.delegations.background_helper_goal_ids",
+    lambda *_args: {"run-a"},
+  )
+  assert _goal_handoff_is_owned(db, chat.id, "run-a", _Sink()) is True
+
+
+def test_unrelated_wait_or_helper_does_not_own_this_goal(db, chat, monkeypatch):
+  from app.chat import _goal_handoff_is_owned
+
+  _add_run(db, chat.id, "run-a", plan=STUCK)
+  _add_run(db, chat.id, "other-run", plan=STUCK)
+  monkeypatch.setattr(
+    "app.chat_waits.armed_waits_for_chat",
+    lambda *_args: [SimpleNamespace(created_by_run_id="other-run")],
+  )
+  monkeypatch.setattr(
+    "app.delegations.background_helper_goal_ids",
+    lambda *_args: {"other-run"},
+  )
+  assert _goal_handoff_is_owned(db, chat.id, "run-a", _Sink()) is False
+
+
+def test_unowned_exhausted_goal_gets_visible_resumable_failure(db, chat):
+  from app.chat import _prepare_goal_handoff
+
+  chat.messages = [_correction("run-a")]
+  db.commit()
+  _add_run(db, chat.id, "run-a", plan=STUCK)
+  sink = _Sink()
+
+  assert _prepare_goal_handoff(db, chat.id, "run-a", sink) is None
+  assert len(sink.published) == 1
+  assert sink.published[0]["type"] == "error"
+  assert sink.published[0]["resumable"] is True
+  assert "without a visible owner" in sink.published[0]["message"]
+  assert sink._last_error == sink.published[0]["message"]
+
+
+def test_unowned_goal_with_budget_returns_correction_target(db, chat):
+  from app.chat import _prepare_goal_handoff
+
+  _add_run(db, chat.id, "run-a", plan=STUCK)
+  sink = _Sink()
+
+  assert _prepare_goal_handoff(db, chat.id, "run-a", sink) == _target(db, chat)
+  assert sink.published == []
+
+
+def test_owned_exhausted_goal_does_not_publish_failure(db, chat):
+  from app.chat import _prepare_goal_handoff
+
+  chat.messages = [_correction("run-a")]
+  chat.pending_messages = [{"role": "user", "content": "I answered"}]
+  db.commit()
+  _add_run(db, chat.id, "run-a", plan=STUCK)
+  sink = _Sink()
+
+  assert _prepare_goal_handoff(db, chat.id, "run-a", sink) is None
+  assert sink.published == []
+
+
+# --- correction message shape and re-check ---------------------------------
+
+
+class _FakeWriter:
+  def __init__(self):
+    self.submitted = []
+
+  def submit(self, cmd):
+    self.submitted.append(cmd)
+    return "ack"
+
+
+@pytest.mark.asyncio
+async def test_enqueue_appends_actionable_continuation(db, chat, monkeypatch):
+  from app.chat import _maybe_enqueue_goal_handoff
+  from app.chat_writer import AppendPending
+
+  _add_run(db, chat.id, "run-a", plan=STUCK)
+  target = _target(db, chat)
+  writer = _FakeWriter()
+
+  async def _fake_await_ack(_ack):
+    return None
+
+  monkeypatch.setattr("app.chat.get_writer", lambda: writer)
+  monkeypatch.setattr("app.chat._await_ack", _fake_await_ack)
+  await _maybe_enqueue_goal_handoff(
+    db, chat.id, "run-a", target, SimpleNamespace(assistant_blocks=[]),
+  )
+
+  assert len(writer.submitted) == 1
+  cmd = writer.submitted[0]
+  assert isinstance(cmd, AppendPending)
+  assert cmd.user_msg["kind"] == "continuation"
+  assert cmd.user_msg["continuation_reason"] == GOAL_HANDOFF_REASON
+  assert cmd.user_msg["goal_id"] == "run-a"
+  assert cmd.user_msg["cid"] == "goal-handoff-run-a"
+  assert "clarifying-question tool" in cmd.user_msg["content"]
+  assert "prose-only request" in cmd.user_msg["content"]
+
+
+@pytest.mark.asyncio
+async def test_enqueue_recheck_yields_to_real_queued_work(db, chat, monkeypatch):
+  from app.chat import _maybe_enqueue_goal_handoff
+
+  _add_run(db, chat.id, "run-a", plan=STUCK)
+  target = _target(db, chat)
+  chat.pending_messages = [{"role": "user", "content": "owner work"}]
+  db.commit()
+  writer = _FakeWriter()
+  monkeypatch.setattr("app.chat.get_writer", lambda: writer)
+
+  await _maybe_enqueue_goal_handoff(
+    db, chat.id, "run-a", target, SimpleNamespace(assistant_blocks=[]),
+  )
+  assert writer.submitted == []


### PR DESCRIPTION
## Summary
- guard only platform-promoted Goals; explicit `/goal` runs keep their existing provider-owned continuation loops
- recognize queued work, a question, an exact-Goal durable wait, or a wake-enabled helper as a truthful next owner
- otherwise queue one progress-bounded corrective turn, then surface a resumable failure instead of silently settling again without progress
- preserve Goal origin across wait/helper wakes and historical `/goal` transcripts

## Testing
- focused Goal, wait, delegation, and terminal tests (159 passed)
- `scripts/test.sh --fast` (97 passed)
- Ruff and Python compile checks