### PR TITLE
Preserve iOS shell sign-in across installation

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -24,6 +24,7 @@ from sqlalchemy import (
 from sqlalchemy.orm import column_property, validates
 
 from app.database import Base
+from app.shell_install_pass import ShellInstallPassGrant
 from app.timeutil import now_naive_utc
 from app.tool_output_storage import CompressedToolOutputText
 

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -32,8 +32,10 @@ from app.deps import (
   require_chat_embed_operation,
 )
 from app.timeutil import now_naive_utc
+from app.routes.shell_install_pass import router as shell_install_pass_router
 
 router = APIRouter(prefix="/api/auth", tags=["auth"])
+router.include_router(shell_install_pass_router)
 _limiter = Limiter(key_func=get_remote_address)
 log = logging.getLogger("moebius.auth")
 

--- a/backend/app/routes/shell_install_pass.py
+++ b/backend/app/routes/shell_install_pass.py
@@ -1,0 +1,160 @@
+"""One-use owner-session handoff for a newly installed iOS PWA shell."""
+
+import secrets
+
+from fastapi import APIRouter, Depends, HTTPException, Request, Response
+from fastapi.responses import JSONResponse
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app import auth, models
+from app.config import get_settings
+from app.database import get_db
+from app.deps import get_current_owner, reject_cross_site
+from app.shell_install_pass import (
+  COOKIE_NAME,
+  COOKIE_PATH,
+  GRANT_TTL,
+  SESSION_TTL,
+  ShellInstallPassGrant,
+  hash_secret,
+)
+from app.timeutil import now_naive_utc
+
+
+router = APIRouter(tags=["auth"])
+
+
+def _cookie_secure() -> bool:
+  return get_settings().frontend_origin.startswith("https://")
+
+
+def _failure() -> JSONResponse:
+  response = JSONResponse(
+    {"detail": "This installation sign-in has expired."}, status_code=401,
+  )
+  response.delete_cookie(COOKIE_NAME, path=COOKIE_PATH)
+  response.headers["Cache-Control"] = "no-store"
+  response.headers["Referrer-Policy"] = "no-referrer"
+  return response
+
+
+@router.post(
+  "/shell-install-pass",
+  status_code=204,
+  dependencies=[Depends(reject_cross_site)],
+)
+def prepare_shell_install_pass(
+  owner: models.Owner = Depends(get_current_owner),
+  db: Session = Depends(get_db),
+):
+  """Prepare the owner session iOS copies into a new Home Screen shell."""
+  now = now_naive_utc()
+  db.query(ShellInstallPassGrant).filter(
+    ShellInstallPassGrant.expires_at <= now,
+  ).delete(synchronize_session=False)
+  secret = ""
+  for _attempt in range(3):
+    secret = secrets.token_urlsafe(32)
+    db.add(ShellInstallPassGrant(
+      token_hash=hash_secret(secret),
+      owner_id=owner.id,
+      owner_epoch=owner.token_epoch,
+      expires_at=now + GRANT_TTL,
+    ))
+    try:
+      db.commit()
+      break
+    except IntegrityError:
+      db.rollback()
+  else:
+    raise HTTPException(
+      status_code=503, detail="Could not create a sign-in handoff.",
+    )
+  response = Response(status_code=204)
+  response.set_cookie(
+    COOKIE_NAME,
+    secret,
+    httponly=True,
+    secure=_cookie_secure(),
+    samesite="strict",
+    max_age=int(GRANT_TTL.total_seconds()),
+    path=COOKIE_PATH,
+  )
+  response.headers["Cache-Control"] = "no-store"
+  response.headers["Referrer-Policy"] = "no-referrer"
+  return response
+
+
+@router.post(
+  "/shell-install-pass/revoke",
+  status_code=204,
+  dependencies=[Depends(reject_cross_site)],
+)
+def revoke_shell_install_passes(
+  owner: models.Owner = Depends(get_current_owner),
+  db: Session = Depends(get_db),
+):
+  """Revoke copied-but-unspent shell handoffs before explicit sign-out."""
+  now = now_naive_utc()
+  db.query(ShellInstallPassGrant).filter(
+    ShellInstallPassGrant.owner_id == owner.id,
+    ShellInstallPassGrant.consumed_at.is_(None),
+  ).update(
+    {ShellInstallPassGrant.consumed_at: now},
+    synchronize_session=False,
+  )
+  db.commit()
+  response = Response(status_code=204)
+  response.delete_cookie(COOKIE_NAME, path=COOKIE_PATH)
+  response.headers["Cache-Control"] = "no-store"
+  response.headers["Referrer-Policy"] = "no-referrer"
+  return response
+
+
+@router.post(
+  "/shell-install-pass/redeem",
+  dependencies=[Depends(reject_cross_site)],
+)
+def redeem_shell_install_pass(
+  request: Request,
+  db: Session = Depends(get_db),
+):
+  """Atomically exchange the copied install cookie for an owner session."""
+  secret = request.cookies.get(COOKIE_NAME, "")
+  now = now_naive_utc()
+  grant = db.query(ShellInstallPassGrant).filter(
+    ShellInstallPassGrant.token_hash == hash_secret(secret),
+  ).first() if secret else None
+  if grant is None or grant.consumed_at is not None or grant.expires_at <= now:
+    return _failure()
+
+  owner = db.query(models.Owner).filter(models.Owner.id == grant.owner_id).first()
+  if owner is None or owner.token_epoch != grant.owner_epoch:
+    return _failure()
+
+  consumed = db.query(ShellInstallPassGrant).filter(
+    ShellInstallPassGrant.id == grant.id,
+    ShellInstallPassGrant.consumed_at.is_(None),
+    ShellInstallPassGrant.expires_at > now,
+  ).update(
+    {ShellInstallPassGrant.consumed_at: now},
+    synchronize_session=False,
+  )
+  if consumed != 1:
+    db.rollback()
+    return _failure()
+  db.commit()
+
+  access_token = auth.create_access_token(
+    {"sub": owner.username},
+    token_epoch=owner.token_epoch,
+    expires_delta=SESSION_TTL,
+  )
+  response = JSONResponse(
+    {"access_token": access_token, "token_type": "bearer"},
+  )
+  response.delete_cookie(COOKIE_NAME, path=COOKIE_PATH)
+  response.headers["Cache-Control"] = "no-store"
+  response.headers["Referrer-Policy"] = "no-referrer"
+  return response

--- a/backend/app/shell_install_pass.py
+++ b/backend/app/shell_install_pass.py
@@ -1,0 +1,40 @@
+"""Durable data contract for the iOS Home Screen shell sign-in handoff."""
+
+import hashlib
+from datetime import timedelta
+
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, String
+
+from app.database import Base
+from app.timeutil import now_naive_utc
+
+
+COOKIE_NAME = "mobius_shell_install"
+COOKIE_PATH = "/api/auth/shell-install-pass/redeem"
+GRANT_TTL = timedelta(minutes=30)
+SESSION_TTL = timedelta(days=30)
+
+
+def hash_secret(secret: str) -> str:
+  """Hash the browser-visible opaque secret before durable storage."""
+  return hashlib.sha256(secret.encode("utf-8")).hexdigest()
+
+
+class ShellInstallPassGrant(Base):
+  """Opaque one-use session copied into a newly installed iOS shell.
+
+  This protocol has its own table so neither its raw opaque cookie nor a
+  mobius.you handoff ``jti`` can ever be interpreted by the other redemption
+  path. ``create_all`` adds the table to existing installations without an
+  in-place column migration.
+  """
+
+  __tablename__ = "shell_install_pass_grants"
+
+  id = Column(Integer, primary_key=True, autoincrement=True)
+  token_hash = Column(String(64), nullable=False, unique=True, index=True)
+  owner_id = Column(Integer, ForeignKey("owner.id"), nullable=False, index=True)
+  owner_epoch = Column(Integer, nullable=False)
+  created_at = Column(DateTime, nullable=False, default=now_naive_utc)
+  expires_at = Column(DateTime, nullable=False, index=True)
+  consumed_at = Column(DateTime, nullable=True, default=None, index=True)

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -61,6 +61,19 @@ def test_setup_creates_owner(client):
   assert "access_token" in r.json()
 
 
+def test_managed_sso_handoff_cannot_cross_into_shell_install_protocol(client):
+  from app import auth as auth_service
+
+  handoff = auth_service.create_access_token({"scope": "mobius_sso_handoff"})
+  client.cookies.set(
+    "mobius_shell_install",
+    handoff,
+    path="/api/auth/shell-install-pass/redeem",
+  )
+
+  assert client.post("/api/auth/shell-install-pass/redeem").status_code == 401
+
+
 def test_self_hosted_setup_status_stays_local(client):
   status = client.get("/api/auth/setup/status")
 

--- a/backend/tests/test_install_pass.py
+++ b/backend/tests/test_install_pass.py
@@ -11,7 +11,9 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 from app import auth as auth_lib, models
+from app.shell_install_pass import hash_secret as _shell_install_hash
 import app.routes.standalone as standalone_routes
+from app.routes.auth import _install_pass_hash
 from app.timeutil import now_naive_utc
 from test_app_fixtures import create_local_app
 
@@ -200,3 +202,105 @@ def test_manifest_never_mints_a_pass_for_an_anonymous_fetch(client, auth):
   app_row = _create_app(client, auth)
   body = client.get(f"/apps/{app_row['slug']}/manifest.json").json()
   assert "pass" not in body["start_url"]
+
+
+def test_shell_install_cookie_is_opaque_copied_and_durably_one_use(
+  client, auth, db,
+):
+  prepared = client.post("/api/auth/shell-install-pass", headers=auth)
+  assert prepared.status_code == 204
+  assert prepared.headers["cache-control"] == "no-store"
+  set_cookie = prepared.headers["set-cookie"]
+  assert "mobius_shell_install=" in set_cookie
+  assert "HttpOnly" in set_cookie
+  assert "SameSite=strict" in set_cookie
+  assert "Path=/api/auth/shell-install-pass/redeem" in set_cookie
+
+  secret = client.cookies.get("mobius_shell_install")
+  assert secret
+  assert auth_lib.decode_access_token(secret) is None
+  digest = _shell_install_hash(secret)
+  grant = db.query(models.ShellInstallPassGrant).filter(
+    models.ShellInstallPassGrant.token_hash == digest,
+  ).one()
+  assert grant.token_hash != secret
+
+  blocked = client.post(
+    "/api/auth/shell-install-pass/redeem",
+    headers={"Sec-Fetch-Site": "cross-site"},
+  )
+  assert blocked.status_code == 403
+
+  redeemed = client.post("/api/auth/shell-install-pass/redeem")
+  assert redeemed.status_code == 200
+  payload = auth_lib.decode_access_token(redeemed.json()["access_token"])
+  assert payload["sub"] == "test"
+  assert datetime.fromtimestamp(payload["exp"], UTC) >= (
+    datetime.now(UTC) + timedelta(days=29)
+  )
+  db.expire_all()
+  assert grant.consumed_at is not None
+
+  client.cookies.set(
+    "mobius_shell_install",
+    secret,
+    path="/api/auth/shell-install-pass/redeem",
+  )
+  assert client.post("/api/auth/shell-install-pass/redeem").status_code == 401
+
+
+def test_shell_install_preparation_requires_owner_session(client):
+  assert client.post("/api/auth/shell-install-pass").status_code == 401
+
+
+def test_shell_install_logout_revokes_a_cookie_already_copied_to_an_app(
+  client, auth, db,
+):
+  prepared = client.post("/api/auth/shell-install-pass", headers=auth)
+  assert prepared.status_code == 204
+  copied_secret = client.cookies.get("mobius_shell_install")
+  grant = db.query(models.ShellInstallPassGrant).filter(
+    models.ShellInstallPassGrant.token_hash == _shell_install_hash(copied_secret),
+  ).one()
+
+  revoked = client.post("/api/auth/shell-install-pass/revoke", headers=auth)
+  assert revoked.status_code == 204
+  assert revoked.headers["cache-control"] == "no-store"
+  assert "mobius_shell_install=" in revoked.headers["set-cookie"]
+  assert "Max-Age=0" in revoked.headers["set-cookie"]
+  assert "Path=/api/auth/shell-install-pass/redeem" in revoked.headers["set-cookie"]
+  db.expire_all()
+  assert grant.consumed_at is not None
+
+  # The Home Screen container may already hold its own copied cookie when the
+  # browser signs out. Restoring that copy must not restore the owner session.
+  client.cookies.set(
+    "mobius_shell_install",
+    copied_secret,
+    path="/api/auth/shell-install-pass/redeem",
+  )
+  assert client.post("/api/auth/shell-install-pass/redeem").status_code == 401
+
+
+def test_shell_install_logout_requires_auth_and_same_site_request(
+  client, auth, db,
+):
+  client.post("/api/auth/shell-install-pass", headers=auth)
+  grant = db.query(models.ShellInstallPassGrant).one()
+
+  assert client.post("/api/auth/shell-install-pass/revoke").status_code == 401
+  blocked = client.post(
+    "/api/auth/shell-install-pass/revoke",
+    headers={**auth, "Sec-Fetch-Site": "cross-site"},
+  )
+  assert blocked.status_code == 403
+  db.expire_all()
+  assert grant.consumed_at is None
+
+
+def test_shell_install_honors_owner_epoch(client, auth, db):
+  client.post("/api/auth/shell-install-pass", headers=auth)
+  owner = db.query(models.Owner).one()
+  owner.token_epoch += 1
+  db.commit()
+  assert client.post("/api/auth/shell-install-pass/redeem").status_code == 401

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -136,7 +136,7 @@ export function clearToken() {
 // uses the default and removes it too. Returns
 // a promise so callers can `await` it before reloading the page
 // (otherwise the browser would abort the in-flight delete).
-export function clearQueryCache({ preserveChatOutbox = false } = {}) {
+function clearOwnerClientState({ preserveChatOutbox }) {
   // Owner-scoped in-memory state: the AppCanvas token latch holds resolved
   // app/owner tokens across iframe remounts; drop it on logout so a remount
   // after the session ends can't reuse the previous owner's token.
@@ -160,6 +160,23 @@ export function clearQueryCache({ preserveChatOutbox = false } = {}) {
     delDatabase('mobius-signals', 'signal queue').catch(() => {}),
     wipeSwCaches().catch(() => {}),
   ])
+}
+
+/** Remove every browser-local trace owned by the current signed-in owner. */
+export function clearQueryCache() {
+  return clearOwnerClientState({ preserveChatOutbox: false })
+}
+
+/**
+ * Retire an expired credential while retaining only intent that is already
+ * partitioned by owner and epoch. The same owner may replay that intent after
+ * signing in again; an explicit logout still uses clearQueryCache() and wipes
+ * it with the rest of the owner-scoped browser state.
+ */
+export async function clearExpiredOwnerSession() {
+  clearToken()
+  try { sessionStorage.setItem('auth_expired', '1') } catch {}
+  await clearOwnerClientState({ preserveChatOutbox: true })
 }
 
 // Remove browser-local queues and mirrors after an explicit app-data wipe.
@@ -286,15 +303,13 @@ export async function apiFetch(path, options = {}) {
       window.dispatchEvent(new CustomEvent('mobius:chat-embed-auth-expired'))
       throw new Error('EMBED_AUTH_EXPIRED')
     }
-    clearToken()
-    try { sessionStorage.setItem('auth_expired', '1') } catch {}
     // Await the cache wipe before reloading. Without this, the page
     // reload aborts the IndexedDB delete and the next owner could see
     // stale chats/messages from the cached query data.
     // Keep accepted chat intent through an expired credential. Each record is
     // partitioned by owner+epoch and can only replay after a matching login;
     // explicit Settings logout still uses the default full wipe.
-    await clearQueryCache({ preserveChatOutbox: true })
+    await clearExpiredOwnerSession()
     // Defer reload one tick and throw a typed error so callers'
     // try/catch/finally blocks run (stopping spinners) before the
     // page goes away. Previously we returned a never-resolving

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -16,7 +16,9 @@ import {
 } from '../lib/connectivityStore.js'
 import { SHELL_DATA_CACHE } from '../sw-cache-policy.js'
 
-export const BASE = (import.meta.env.BASE_URL || '/').replace(/\/$/, '')
+export const BASE = (import.meta.env?.BASE_URL || '/').replace(/\/$/, '')
+export const SHELL_INSTALL_PASS_TIMEOUT_MS = 5000
+export const OWNER_TOKEN_CHANGED_EVENT = 'mobius:owner-token-changed'
 
 // The opaque embedded-chat document must never read or receive the owner's
 // browser token. App.jsx enables this mode before ChatEmbed mounts; the only
@@ -84,6 +86,7 @@ export function getAuthHeaders(extra = {}) {
 
 export function setToken(token) {
   try { localStorage.setItem('token', token) } catch {}
+  try { window.dispatchEvent(new Event(OWNER_TOKEN_CHANGED_EVENT)) } catch {}
 }
 
 export function clearToken() {
@@ -92,6 +95,7 @@ export function clearToken() {
     return
   }
   try { localStorage.removeItem('token') } catch {}
+  try { window.dispatchEvent(new Event(OWNER_TOKEN_CHANGED_EVENT)) } catch {}
   // Setup-wizard resume state assumes an active token. If the token
   // is gone (logout / expiry), clear the resume key + in-progress
   // flag so the user doesn't get bounced back into the wizard after
@@ -236,14 +240,26 @@ export async function apiFetch(path, options = {}) {
   const { timeoutMs, ...fetchOptions } = options
   let signal = fetchOptions.signal
   let timeoutTimer
+  let removeCallerAbort
   if (timeoutMs) {
     const ctrl = new AbortController()
+    if (signal) {
+      const callerSignal = signal
+      const relayCallerAbort = () => ctrl.abort(callerSignal.reason)
+      if (callerSignal.aborted) relayCallerAbort()
+      else {
+        callerSignal.addEventListener('abort', relayCallerAbort, { once: true })
+        removeCallerAbort = () => {
+          callerSignal.removeEventListener('abort', relayCallerAbort)
+        }
+      }
+    }
     timeoutTimer = setTimeout(() => {
       const error = new Error('Request timed out')
       error.name = 'TimeoutError'
       ctrl.abort(error)
     }, timeoutMs)
-    signal = signal ? AbortSignal.any([signal, ctrl.signal]) : ctrl.signal
+    signal = ctrl.signal
   }
 
   let res
@@ -260,6 +276,7 @@ export async function apiFetch(path, options = {}) {
     throw error
   } finally {
     if (timeoutTimer) clearTimeout(timeoutTimer)
+    removeCallerAbort?.()
   }
 
   if (res.status === 401 && sentCredential && !setupSession.isInProgress()) {
@@ -436,6 +453,20 @@ export const api = {
         method: 'POST',
         body: JSON.stringify({ install_pass: installPass, slug }),
       }),
+    },
+    // iOS copies cookies, but not localStorage, into a newly installed Home
+    // Screen web app. Prepare places only an opaque one-use reference in an
+    // HttpOnly cookie; the installed shell exchanges it for its own session.
+    shellInstallPass: {
+      prepare: ({ signal, timeoutMs = SHELL_INSTALL_PASS_TIMEOUT_MS } = {}) => (
+        apiFetch('/auth/shell-install-pass', { method: 'POST', signal, timeoutMs })
+      ),
+      redeem: ({ signal, timeoutMs = SHELL_INSTALL_PASS_TIMEOUT_MS } = {}) => (
+        apiFetch('/auth/shell-install-pass/redeem', { method: 'POST', signal, timeoutMs })
+      ),
+      revoke: ({ signal, timeoutMs = SHELL_INSTALL_PASS_TIMEOUT_MS } = {}) => (
+        apiFetch('/auth/shell-install-pass/revoke', { method: 'POST', signal, timeoutMs })
+      ),
     },
     setup: {
       status: () => apiFetch('/auth/setup/status'),

--- a/frontend/src/components/ChatView/__tests__/offlineFooter.test.js
+++ b/frontend/src/components/ChatView/__tests__/offlineFooter.test.js
@@ -9,9 +9,6 @@ const connectionStatus = readFileSync(new URL('../ConnectionStatus.jsx', import.
 const chatCss = readFileSync(new URL('../ChatView.css', import.meta.url), 'utf8')
 const scrollMode = readFileSync(new URL('../useScrollMode.js', import.meta.url), 'utf8')
 const shell = readFileSync(new URL('../../Shell/Shell.jsx', import.meta.url), 'utf8')
-const apiClient = readFileSync(new URL('../../../api/client.js', import.meta.url), 'utf8')
-const systemStream = readFileSync(new URL('../../../hooks/useSystemEventStream.js', import.meta.url), 'utf8')
-const settingsView = readFileSync(new URL('../../SettingsView/SettingsView.jsx', import.meta.url), 'utf8')
 
 test('only transient nudges float above the measured rail → connection → queued → composer stack', () => {
   const footStart = chatView.indexOf('<div ref={footRef} className="chat__foot">')
@@ -111,31 +108,6 @@ test('the composer accepts an offline send for the durable chat outbox', () => {
     streamConnection,
     /outboxRetained = await enqueueIntent\([\s\S]*?err\.outboxRetained = true/,
     'automatic-replay copy must be gated by the successful durable write',
-  )
-})
-
-test('credential expiry preserves principal-bound intent while explicit logout wipes it', () => {
-  assert.match(
-    apiClient,
-    /clearQueryCache\(\{ preserveChatOutbox = false \} = \{\}\)/,
-  )
-  assert.match(
-    apiClient,
-    /preserveChatOutbox[\s\S]*?\? \[\][\s\S]*?: \[clearChatOutbox\(\)\]/,
-    'explicit cleanup must clear through the live outbox store, not a blocked deleteDatabase',
-  )
-  assert.match(
-    apiClient,
-    /status === 401[\s\S]*?clearQueryCache\(\{ preserveChatOutbox: true \}\)/,
-  )
-  assert.match(
-    systemStream,
-    /res\.status === 401[\s\S]*?clearQueryCache\(\{ preserveChatOutbox: true \}\)/,
-  )
-  assert.match(
-    settingsView,
-    /clearToken\(\)[\s\S]{0,300}?await clearQueryCache\(\)/,
-    'owner-invoked logout must use the default full outbox wipe',
   )
 })
 

--- a/frontend/src/components/SettingsView/SettingsView.jsx
+++ b/frontend/src/components/SettingsView/SettingsView.jsx
@@ -18,6 +18,8 @@ import {
   platformUpdateStatusLabel,
 } from '../../lib/platformUpdateState.js'
 import { settleBackgroundAgentSave } from '../../lib/backgroundAgentSave.js'
+import { clearExplicitOwnerSession } from '../../lib/explicitLogout.js'
+import { stopShellInstallPassPreparation } from '../../lib/shellInstallPass.js'
 import { captureLayoutSpace, clientLengthToLayout } from '../../lib/layoutSpace.js'
 import {
   PROVIDER_AVAILABILITY_PHASE,
@@ -1120,9 +1122,16 @@ export default function SettingsView({
   async function signOut() {
     if (signingOut) return
     setSigningOut(true)
-    clearToken()
-    await clearQueryCache()
-    window.location.reload()
+    try {
+      await clearExplicitOwnerSession({
+        stopInstallHandoffPreparation: stopShellInstallPassPreparation,
+        revokeInstallHandoffs: () => api.auth.shellInstallPass.revoke(),
+        dropCredential: clearToken,
+        clearOwnerCache: clearQueryCache,
+      })
+    } finally {
+      window.location.reload()
+    }
   }
 
   // Refresh both Möbius update signals on demand: the service worker cache and

--- a/frontend/src/components/Shell/__tests__/chatHandoff.test.js
+++ b/frontend/src/components/Shell/__tests__/chatHandoff.test.js
@@ -151,8 +151,13 @@ test('a staging chat cannot leave the outgoing transcript held on a wedged reque
   )
   assert.match(chatView, /initialLoadController\.abort\(\)/,
     'hiding or unmounting a staging chat must release its request immediately')
-  assert.match(apiClient, /AbortSignal\.any\(\[signal, ctrl\.signal\]\)/,
-    'apiFetch must compose lifecycle cancellation with its deadline')
+  assert.match(
+    apiClient,
+    /relayCallerAbort = \(\) => ctrl\.abort\(callerSignal\.reason\)[\s\S]*signal = ctrl\.signal/,
+    'apiFetch must compose lifecycle cancellation with its deadline',
+  )
+  assert.doesNotMatch(apiClient, /AbortSignal\.any/,
+    'the bounded lifecycle path must work on the original iOS 17.2 handoff floor')
   assert.match(apiClient, /error\.name = 'TimeoutError'\s*ctrl\.abort\(error\)/,
     'a deadline remains distinguishable from routine lifecycle cancellation')
   assert.match(apiClient, /if \(error\?\.name !== 'AbortError'\) void verifyConnectivity\(\)/,

--- a/frontend/src/components/Walkthrough/WalkthroughOverlay.jsx
+++ b/frontend/src/components/Walkthrough/WalkthroughOverlay.jsx
@@ -8,6 +8,7 @@ import {
   requestInstall,
   subscribeInstallPrompt,
 } from '../../lib/installPrompt.js'
+import { prepareShellInstallPass } from '../../lib/shellInstallPass.js'
 import {
   detectInstallPlatform,
   installCopyForPlatform,
@@ -17,6 +18,7 @@ import './WalkthroughOverlay.css'
 export default function WalkthroughOverlay({ onDone, onOpenSettings, onExploreApps }) {
   const queryClient = useQueryClient()
   const closingRef = useRef(false)
+  const installAbortRef = useRef(null)
   const [platform] = useState(() => detectInstallPlatform())
   const [installCopy] = useState(() => installCopyForPlatform(platform))
   const [showInstallHelp, setShowInstallHelp] = useState(false)
@@ -47,6 +49,17 @@ export default function WalkthroughOverlay({ onDone, onOpenSettings, onExploreAp
 
   async function handleInstall() {
     setInstallFeedback('')
+    if (platform.ios) {
+      const controller = new AbortController()
+      installAbortRef.current = controller
+      setInstallBusy(true)
+      // Best effort: installing still works if the short sign-in handoff
+      // cannot be refreshed; the new app will simply show normal login.
+      await prepareShellInstallPass({ force: true, signal: controller.signal })
+      if (controller.signal.aborted) return
+      installAbortRef.current = null
+      setInstallBusy(false)
+    }
     if (installState !== 'ready') {
       setShowInstallHelp((visible) => !visible)
       return
@@ -73,6 +86,10 @@ export default function WalkthroughOverlay({ onDone, onOpenSettings, onExploreAp
     // The event can arrive after mount; finish is guarded across rerenders.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [installState])
+
+  useEffect(() => () => {
+    installAbortRef.current?.abort()
+  }, [])
 
   const nativeInstallReady = installState === 'ready'
   const installButtonLabel = installBusy

--- a/frontend/src/hooks/useSystemEventStream.js
+++ b/frontend/src/hooks/useSystemEventStream.js
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react'
 import {
   BASE, getToken, getAuthHeaders, isEphemeralAuth,
-  clearToken, clearQueryCache,
+  clearExpiredOwnerSession,
 } from '../api/client.js'
 import * as setupSession from '../lib/setupSession.js'
 import {
@@ -75,11 +75,9 @@ export default function useSystemEventStream(
           // credentials and reload so the auth boundary takes over.
           // (Guard against the setup-wizard flow where 401s are expected.)
           if (!setupSession.isInProgress()) {
-            clearToken()
-            try { sessionStorage.setItem('auth_expired', '1') } catch {}
             // Match apiFetch: preserve only principal-partitioned accepted chat
             // intent across credential renewal. Explicit logout still wipes it.
-            await clearQueryCache({ preserveChatOutbox: true })
+            await clearExpiredOwnerSession()
             setTimeout(() => window.location.reload(), 100)
           }
           // Stop the reconnect loop regardless — either the page is

--- a/frontend/src/lib/__tests__/explicitLogout.test.js
+++ b/frontend/src/lib/__tests__/explicitLogout.test.js
@@ -1,7 +1,99 @@
-import test from 'node:test'
+import { after, before, beforeEach, test } from 'node:test'
 import assert from 'node:assert/strict'
+import { IDBFactory } from 'fake-indexeddb'
 
+import {
+  clearExpiredOwnerSession,
+  clearQueryCache,
+  getToken,
+  setToken,
+} from '../../api/client.js'
+import {
+  clearOutboxForTests,
+  enqueueIntent,
+  listIntents,
+  outboxPrincipalKey,
+} from '../../components/ChatView/chatOutbox.js'
 import { clearExplicitOwnerSession } from '../explicitLogout.js'
+
+const originalGlobals = {
+  caches: globalThis.caches,
+  indexedDB: globalThis.indexedDB,
+  localStorage: globalThis.localStorage,
+  sessionStorage: globalThis.sessionStorage,
+  window: globalThis.window,
+}
+const localValues = new Map()
+const sessionValues = new Map()
+
+function storage(values) {
+  return {
+    get length() { return values.size },
+    getItem: key => values.get(key) ?? null,
+    key: index => [...values.keys()][index] ?? null,
+    removeItem: key => { values.delete(key) },
+    setItem: (key, value) => { values.set(key, String(value)) },
+  }
+}
+
+function ownerToken() {
+  const payload = Buffer.from(JSON.stringify({ sub: 'owner', epoch: 3 }))
+    .toString('base64url')
+  return `stub.${payload}.stub`
+}
+
+function principalKey() {
+  return outboxPrincipalKey(getToken())
+}
+
+async function queueOwnerIntent(cid) {
+  await enqueueIntent({
+    chatId: 'chat-1',
+    cid,
+    type: 'message',
+    principalKey: principalKey(),
+    body: { content: 'keep my accepted intent', cid },
+  })
+}
+
+before(() => {
+  globalThis.indexedDB = new IDBFactory()
+  globalThis.localStorage = storage(localValues)
+  globalThis.sessionStorage = storage(sessionValues)
+  globalThis.window = globalThis
+  globalThis.caches = { keys: async () => [], delete: async () => true }
+})
+
+beforeEach(async () => {
+  localValues.clear()
+  sessionValues.clear()
+  setToken(ownerToken())
+  await clearOutboxForTests()
+})
+
+after(() => {
+  Object.assign(globalThis, originalGlobals)
+})
+
+test('credential expiry preserves principal-bound intent for the same owner', async () => {
+  const owner = principalKey()
+  await queueOwnerIntent('renew-me')
+
+  await clearExpiredOwnerSession()
+
+  assert.equal(getToken(), null)
+  assert.equal(sessionStorage.getItem('auth_expired'), '1')
+  assert.equal((await listIntents(owner)).length, 1)
+})
+
+test('explicit cleanup wipes principal-bound intent from the live outbox store', async () => {
+  const owner = principalKey()
+  await queueOwnerIntent('forget-me')
+
+  await clearQueryCache()
+
+  assert.equal((await listIntents(owner)).length, 0)
+})
 
 test('explicit logout revokes copied handoffs before local owner state', async () => {
   const calls = []

--- a/frontend/src/lib/__tests__/explicitLogout.test.js
+++ b/frontend/src/lib/__tests__/explicitLogout.test.js
@@ -1,0 +1,46 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { clearExplicitOwnerSession } from '../explicitLogout.js'
+
+test('explicit logout revokes copied handoffs before local owner state', async () => {
+  const calls = []
+  await clearExplicitOwnerSession({
+    stopInstallHandoffPreparation: async () => { calls.push('stop') },
+    revokeInstallHandoffs: async () => { calls.push('revoke') },
+    dropCredential: () => { calls.push('credential') },
+    clearOwnerCache: async () => { calls.push('cache') },
+  })
+
+  assert.deepEqual(calls, ['stop', 'revoke', 'credential', 'cache'])
+})
+
+test('failed handoff revocation never strands ordinary local logout', async () => {
+  const calls = []
+  await clearExplicitOwnerSession({
+    stopInstallHandoffPreparation: async () => { calls.push('stop') },
+    revokeInstallHandoffs: async () => {
+      calls.push('revoke')
+      throw new Error('offline')
+    },
+    dropCredential: () => { calls.push('credential') },
+    clearOwnerCache: async () => { calls.push('cache') },
+  })
+
+  assert.deepEqual(calls, ['stop', 'revoke', 'credential', 'cache'])
+})
+
+test('failed local preparation stop still reaches server revocation', async () => {
+  const calls = []
+  await clearExplicitOwnerSession({
+    stopInstallHandoffPreparation: async () => {
+      calls.push('stop')
+      throw new Error('cancel failed')
+    },
+    revokeInstallHandoffs: async () => { calls.push('revoke') },
+    dropCredential: () => { calls.push('credential') },
+    clearOwnerCache: async () => { calls.push('cache') },
+  })
+
+  assert.deepEqual(calls, ['stop', 'revoke', 'credential', 'cache'])
+})

--- a/frontend/src/lib/__tests__/shellInstallPass.test.js
+++ b/frontend/src/lib/__tests__/shellInstallPass.test.js
@@ -1,0 +1,96 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { createShellInstallPassPreparer } from '../shellInstallPassPreparer.js'
+
+function preparer(overrides = {}) {
+  let calls = 0
+  const prepare = createShellInstallPassPreparer({
+    request: async () => { calls += 1; return { ok: true } },
+    isIos: () => true,
+    isStandalone: () => false,
+    hasToken: () => true,
+    ...overrides,
+  })
+  return { ...prepare, calls: () => calls }
+}
+
+test('prepares once and refreshes only when installation intent is explicit', async () => {
+  const h = preparer()
+  assert.equal(await h.prepare(), true)
+  assert.equal(await h.prepare(), true)
+  assert.equal(h.calls(), 1)
+  assert.equal(await h.prepare({ force: true }), true)
+  assert.equal(h.calls(), 2)
+})
+
+test('shares concurrent preparation and leaves failure retryable', async () => {
+  let release
+  let calls = 0
+  const first = new Promise(resolve => { release = resolve })
+  const h = preparer({
+    request: async () => {
+      calls += 1
+      if (calls === 1) return first
+      return { ok: true }
+    },
+  })
+  const one = h.prepare()
+  const two = h.prepare({ force: true })
+  release({ ok: false })
+  assert.deepEqual(await Promise.all([one, two]), [false, false])
+  assert.equal(await h.prepare(), true)
+  assert.equal(calls, 2)
+})
+
+test('never creates a handoff outside an authenticated iOS browser tab', async () => {
+  for (const overrides of [
+    { isIos: () => false },
+    { isStandalone: () => true },
+    { hasToken: () => false },
+  ]) {
+    const h = preparer(overrides)
+    assert.equal(await h.prepare(), false)
+    assert.equal(h.calls(), 0)
+  }
+})
+
+test('lifecycle stop settles a transport that would otherwise never finish', async () => {
+  let calls = 0
+  const h = preparer({
+    request: ({ signal }) => {
+      calls += 1
+      return new Promise((_resolve, reject) => {
+        if (signal.aborted) {
+          reject(signal.reason)
+          return
+        }
+        signal.addEventListener('abort', () => reject(signal.reason), { once: true })
+      })
+    },
+  })
+  const pending = h.prepare()
+  await h.stop()
+
+  assert.equal(await pending, false)
+  assert.equal(calls, 1)
+  assert.equal(await h.prepare({ force: true }), false)
+  assert.equal(calls, 1)
+})
+
+test('caller cancellation settles a transport that would otherwise never finish', async () => {
+  const h = preparer({
+    request: ({ signal }) => new Promise((_resolve, reject) => {
+      if (signal.aborted) {
+        reject(signal.reason)
+        return
+      }
+      signal.addEventListener('abort', () => reject(signal.reason), { once: true })
+    }),
+  })
+  const controller = new AbortController()
+  const pending = h.prepare({ signal: controller.signal })
+  controller.abort()
+
+  assert.equal(await pending, false)
+})

--- a/frontend/src/lib/__tests__/shellInstallPassApi.test.js
+++ b/frontend/src/lib/__tests__/shellInstallPassApi.test.js
@@ -1,0 +1,48 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  api,
+  SHELL_INSTALL_PASS_TIMEOUT_MS,
+} from '../../api/client.js'
+
+function neverSettlingFetch(_url, { signal }) {
+  return new Promise((_resolve, reject) => {
+    if (signal.aborted) {
+      reject(signal.reason)
+      return
+    }
+    signal.addEventListener('abort', () => reject(signal.reason), { once: true })
+  })
+}
+
+test('shell handoff requests bound never-settling transports', async (t) => {
+  const originalFetch = globalThis.fetch
+  t.after(() => { globalThis.fetch = originalFetch })
+  globalThis.fetch = neverSettlingFetch
+  assert.equal(SHELL_INSTALL_PASS_TIMEOUT_MS, 5000)
+
+  for (const request of [
+    api.auth.shellInstallPass.prepare,
+    api.auth.shellInstallPass.redeem,
+    api.auth.shellInstallPass.revoke,
+  ]) {
+    await assert.rejects(
+      request({ timeoutMs: 5 }),
+      error => error?.name === 'TimeoutError',
+    )
+  }
+})
+
+test('shell handoff requests honor caller cancellation', async (t) => {
+  const originalFetch = globalThis.fetch
+  t.after(() => { globalThis.fetch = originalFetch })
+  globalThis.fetch = neverSettlingFetch
+  const controller = new AbortController()
+  const pending = api.auth.shellInstallPass.prepare({
+    signal: controller.signal,
+  })
+  controller.abort()
+
+  await assert.rejects(pending, error => error?.name === 'AbortError')
+})

--- a/frontend/src/lib/__tests__/shellInstallSessionRuntime.test.js
+++ b/frontend/src/lib/__tests__/shellInstallSessionRuntime.test.js
@@ -1,0 +1,80 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  redeemInstalledShellSession,
+  startShellInstallSessionLifecycle,
+} from '../shellInstallSessionRuntime.js'
+
+
+function eventTarget(extra = {}) {
+  const listeners = new Map()
+  return {
+    ...extra,
+    addEventListener(type, listener) {
+      const current = listeners.get(type) || new Set()
+      current.add(listener)
+      listeners.set(type, current)
+    },
+    removeEventListener(type, listener) {
+      listeners.get(type)?.delete(listener)
+    },
+    dispatch(type) {
+      for (const listener of listeners.get(type) || []) listener()
+    },
+  }
+}
+
+
+test('redeems an installed shell before startup only when it lacks a session', async () => {
+  const saved = []
+  const result = await redeemInstalledShellSession({
+    standaloneApp: () => false,
+    standaloneShell: () => true,
+    hasToken: () => false,
+    redeem: async () => ({
+      ok: true,
+      json: async () => ({ access_token: 'installed-owner-session' }),
+    }),
+    saveToken: token => saved.push(token),
+  })
+  assert.equal(result, true)
+  assert.deepEqual(saved, ['installed-owner-session'])
+
+  let calls = 0
+  assert.equal(await redeemInstalledShellSession({
+    standaloneApp: () => false,
+    standaloneShell: () => true,
+    hasToken: () => true,
+    redeem: async () => { calls += 1 },
+  }), false)
+  assert.equal(calls, 0)
+})
+
+
+test('browser lifecycle prepares on sign-in and aborts cleanly on teardown', () => {
+  const windowTarget = eventTarget()
+  const documentTarget = eventTarget({ visibilityState: 'visible' })
+  let signedIn = false
+  const calls = []
+  const stop = startShellInstallSessionLifecycle({
+    standaloneApp: () => false,
+    standaloneShell: () => false,
+    hasToken: () => signedIn,
+    prepare: options => { calls.push(options); return Promise.resolve(true) },
+    windowTarget,
+    documentTarget,
+  })
+  assert.equal(calls.length, 0)
+
+  signedIn = true
+  windowTarget.dispatch('mobius:owner-token-changed')
+  documentTarget.dispatch('visibilitychange')
+  assert.deepEqual(calls.map(call => call.force), [true, true])
+  assert.equal(calls[0].signal.aborted, false)
+
+  stop()
+  assert.equal(calls[0].signal.aborted, true)
+  windowTarget.dispatch('pageshow')
+  assert.equal(calls.length, 2)
+})

--- a/frontend/src/lib/explicitLogout.js
+++ b/frontend/src/lib/explicitLogout.js
@@ -1,0 +1,25 @@
+/**
+ * Revoke installation handoffs while the owner credential still exists, then
+ * remove every local owner-scoped trace. Revocation is best effort so a broken
+ * or offline transport can delay logout only until its request deadline; it
+ * can never strand the ordinary local sign-out path.
+ */
+export async function clearExplicitOwnerSession({
+  stopInstallHandoffPreparation,
+  revokeInstallHandoffs,
+  dropCredential,
+  clearOwnerCache,
+}) {
+  try {
+    await stopInstallHandoffPreparation()
+  } catch {
+    // Continue to the server-owned invalidation boundary.
+  }
+  try {
+    await revokeInstallHandoffs()
+  } catch {
+    // Local privacy cleanup and sign-out remain authoritative when offline.
+  }
+  dropCredential()
+  await clearOwnerCache()
+}

--- a/frontend/src/lib/shellInstallPass.js
+++ b/frontend/src/lib/shellInstallPass.js
@@ -1,0 +1,13 @@
+import { api, getToken } from '../api/client.js'
+import { detectInstallPlatform, isStandaloneDisplay } from '../utils/installPlatform.js'
+import { createShellInstallPassPreparer } from './shellInstallPassPreparer.js'
+
+const shellInstallPassPreparer = createShellInstallPassPreparer({
+  request: (options) => api.auth.shellInstallPass.prepare(options),
+  isIos: () => detectInstallPlatform().ios,
+  isStandalone: () => isStandaloneDisplay(),
+  hasToken: () => Boolean(getToken()),
+})
+
+export const prepareShellInstallPass = shellInstallPassPreparer.prepare
+export const stopShellInstallPassPreparation = shellInstallPassPreparer.stop

--- a/frontend/src/lib/shellInstallPassPreparer.js
+++ b/frontend/src/lib/shellInstallPassPreparer.js
@@ -1,0 +1,66 @@
+/**
+ * Build one process-wide preparer for the shell's iOS installation handoff.
+ *
+ * A normal browser tab prepares once. A real lifecycle return or an explicit
+ * install action may force a fresh one because an installed copy could have
+ * consumed the previous grant while Safari was away. Concurrent signals share
+ * one request; failure remains retryable and never blocks installation.
+ */
+export function createShellInstallPassPreparer({
+  request,
+  isIos,
+  isStandalone,
+  hasToken,
+}) {
+  let prepared = false
+  let pending = null
+  let activeController = null
+  let stopped = false
+
+  async function prepare({ force = false, signal } = {}) {
+    if (stopped) return false
+    if (!isIos() || isStandalone() || !hasToken()) return false
+    if (prepared && !force) return true
+    if (pending) return pending
+
+    activeController = new AbortController()
+    const requestController = activeController
+    let removeCallerAbort
+    if (signal) {
+      const relayCallerAbort = () => requestController.abort(signal.reason)
+      if (signal.aborted) relayCallerAbort()
+      else {
+        signal.addEventListener('abort', relayCallerAbort, { once: true })
+        removeCallerAbort = () => {
+          signal.removeEventListener('abort', relayCallerAbort)
+        }
+      }
+    }
+    pending = Promise.resolve()
+      .then(() => request({ signal: requestController.signal }))
+      .then((response) => {
+        prepared = Boolean(response?.ok)
+        return prepared
+      })
+      .catch(() => {
+        prepared = false
+        return false
+      })
+      .finally(() => {
+        removeCallerAbort?.()
+        pending = null
+        activeController = null
+      })
+    return pending
+  }
+
+  async function stop() {
+    stopped = true
+    prepared = false
+    const inFlight = pending
+    activeController?.abort()
+    if (inFlight) await inFlight
+  }
+
+  return { prepare, stop }
+}

--- a/frontend/src/lib/shellInstallSessionRuntime.js
+++ b/frontend/src/lib/shellInstallSessionRuntime.js
@@ -1,0 +1,70 @@
+import {
+  api,
+  getToken,
+  OWNER_TOKEN_CHANGED_EVENT,
+  setToken,
+} from '../api/client.js'
+import { isStandaloneDisplay } from '../utils/installPlatform.js'
+import { readStandaloneBoot } from './standaloneBoot.js'
+import { prepareShellInstallPass } from './shellInstallPass.js'
+
+
+/** Redeem the copied iOS cookie before React chooses setup, login, or shell. */
+export async function redeemInstalledShellSession({
+  standaloneApp = () => Boolean(readStandaloneBoot()),
+  standaloneShell = isStandaloneDisplay,
+  hasToken = () => Boolean(getToken()),
+  redeem = options => api.auth.shellInstallPass.redeem(options),
+  saveToken = setToken,
+} = {}) {
+  if (standaloneApp() || !standaloneShell() || hasToken()) return false
+  try {
+    const response = await redeem()
+    if (!response.ok) return false
+    const data = await response.json()
+    if (!data?.access_token) return false
+    saveToken(data.access_token)
+    return true
+  } catch {
+    return false
+  }
+}
+
+
+/** Keep one copied-cookie grant ready in an authenticated iOS browser tab. */
+export function startShellInstallSessionLifecycle({
+  standaloneApp = () => Boolean(readStandaloneBoot()),
+  standaloneShell = isStandaloneDisplay,
+  hasToken = () => Boolean(getToken()),
+  prepare = prepareShellInstallPass,
+  windowTarget = window,
+  documentTarget = document,
+} = {}) {
+  if (standaloneApp() || standaloneShell()) return () => {}
+
+  const controller = new AbortController()
+  let stopped = false
+  function refresh({ force = false } = {}) {
+    if (stopped || !hasToken()) return
+    void prepare({ force, signal: controller.signal })
+  }
+  function refreshWhenVisible() {
+    if (documentTarget.visibilityState === 'visible') refresh({ force: true })
+  }
+  function refreshAfterSignIn() {
+    refresh({ force: true })
+  }
+
+  windowTarget.addEventListener('pageshow', refreshAfterSignIn)
+  windowTarget.addEventListener(OWNER_TOKEN_CHANGED_EVENT, refreshAfterSignIn)
+  documentTarget.addEventListener('visibilitychange', refreshWhenVisible)
+  refresh()
+
+  return () => {
+    stopped = true
+    controller.abort()
+    windowTarget.removeEventListener('pageshow', refreshAfterSignIn)
+    windowTarget.removeEventListener(OWNER_TOKEN_CHANGED_EVENT, refreshAfterSignIn)
+    documentTarget.removeEventListener('visibilitychange', refreshWhenVisible)
+  }
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -10,6 +10,10 @@ import App from './App.jsx'
 import { installGlobalErrorHandlers } from './lib/errorLog.js'
 import { installPerfProbe } from './lib/perfProbe.js'
 import { SHELL_BUILD } from './lib/buildInfo.js'
+import {
+  redeemInstalledShellSession,
+  startShellInstallSessionLifecycle,
+} from './lib/shellInstallSessionRuntime.js'
 import './index.css'
 
 // Capture errors React's ErrorBoundary can't see (async/event-handler throws,
@@ -27,8 +31,16 @@ installPerfProbe()
 // whole job is to move the entry bundle's content hash (see buildInfo.js).
 console.info(`Mobius shell build: ${SHELL_BUILD}`)
 
-ReactDOM.createRoot(document.getElementById('root')).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
-)
+async function mount() {
+  // iOS copies cookies but not localStorage into a new Home Screen shell.
+  // Settle that bounded one-use exchange before App chooses setup or login.
+  await redeemInstalledShellSession()
+  startShellInstallSessionLifecycle()
+  ReactDOM.createRoot(document.getElementById('root')).render(
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>
+  )
+}
+
+void mount()


### PR DESCRIPTION
## Summary
- keep the owner signed in when Safari installs Möbius to the iOS Home Screen
- exchange an opaque, short-lived, one-use HttpOnly cookie for an isolated owner session before the shell chooses login or setup
- keep the handoff current across Safari lifecycle returns and revoke unused handoffs before explicit sign-out

## Security
- never place bearer credentials in URLs or cookies
- hash stored handoff secrets, bind them to the owner session epoch, expire them after 30 minutes, and consume them atomically
- reject cross-site prepare, redeem, and revoke requests, and bound browser requests to five seconds
- keep ordinary local sign-out authoritative when offline

## Testing
- `scripts/wt-pytest.sh backend/tests/test_install_pass.py backend/tests/test_auth.py -q` (49 passed)
- focused frontend install-session, logout, and handoff tests (21 passed)
- `npm run lint` (0 errors)
- `npm run build` (production and service-worker builds passed)

## Device coverage
- Physical-device iOS installation remains to be exercised; the protocol, lifecycle, timeout, replay, revocation, and cross-protocol boundaries are covered locally.
