### PR TITLE
Update agent CLIs and clarify container rebuilds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,8 @@ RUN useradd -m -s /bin/bash mobius
 # agent-browser looks by default).
 # Discard npm's download cache in each layer: installed packages are the
 # runtime artifact; registry tarballs only make the production image larger.
-ARG CLAUDE_CODE_VERSION=2.1.251
+ARG CLAUDE_CODE_VERSION=2.1.258
+ARG CODEX_VERSION=0.152.1
 ARG AGENT_BROWSER_VERSION=0.35.1
 RUN apt-get update && apt-get install -y --no-install-recommends \
     age ca-certificates cron curl git jq procps ripgrep sqlite3 sudo unzip util-linux \
@@ -51,9 +52,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libxfixes3 libxrandr2 libgbm1 libpango-1.0-0 libcairo2 libasound2t64 \
     fonts-liberation fonts-noto-color-emoji \
     && npm install -g --engine-strict --strict-allow-scripts \
-      --allow-scripts="@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION},agent-browser@${AGENT_BROWSER_VERSION}" \
+      --allow-scripts="@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION},@openai/codex@${CODEX_VERSION},agent-browser@${AGENT_BROWSER_VERSION}" \
       "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
-      @openai/codex@0.150.1 \
+      "@openai/codex@${CODEX_VERSION}" \
       "agent-browser@${AGENT_BROWSER_VERSION}" \
     && agent-browser install \
     && mv /root/.agent-browser /opt/agent-browser \
@@ -143,8 +144,8 @@ RUN pip install --no-cache-dir --require-hashes -r requirements.lock \
 # lockstep npm CLI. This preserves the external SDK contract without storing a
 # second ~350 MB runtime or running a second protocol version.
 # Pinned to commit SHA (not tag) for full reproducibility — tags are
-# mutable on GitHub. SHA corresponds to refs/tags/rust-v0.150.1
-# as of 2026-08-27, and is kept in lockstep with the npm @openai/codex
+# mutable on GitHub. SHA corresponds to refs/tags/rust-v0.152.1
+# as of 2026-09-01, and is kept in lockstep with the npm @openai/codex
 # binary above (the SDK spawns it via codex_bin=shutil.which("codex")).
 # We moved from rust-v0.144.5 to this tag because the 0.144.x generated
 # ReasoningEffort enum was strict (none/minimal/low/medium/high/xhigh)
@@ -152,14 +153,14 @@ RUN pip install --no-cache-dir --require-hashes -r requirements.lock \
 # codex.models() and ThreadResumeResponse validation failed and broke a
 # real chat resume. alpha.13 turned ReasoningEffort into a forgiving
 # `str, Enum` with a `_missing_` hook that accepts any effort string;
-# 0.150.1 is the latest stable tag published to BOTH the git repo and npm, so
+# 0.152.1 is the latest stable tag published to BOTH the git repo and npm, so
 # binary and schema stay matched. The SDK exposes the request bridge as a
 # public `approval_handler` constructor argument on
 # `openai_codex.client.CodexClient`; `AsyncCodex` still does not forward
 # it, so codex_sdk_runner.py installs the handler on the wrapped sync
 # client's `_approval_handler`.
 RUN pip install --no-cache-dir --no-deps \
-      'openai-codex @ git+https://github.com/openai/codex.git@90854393966b21e9ebfd21b122334eb09a20c93d#subdirectory=sdk/python' \
+      'openai-codex @ git+https://github.com/openai/codex.git@5adb68a49933ae446bf11935662c83dba55a0804#subdirectory=sdk/python' \
     && pip install --no-cache-dir 'openai-codex-cli-bin==0.147.0' \
     && _codex_cli_bin="$(python -c \
       'from pathlib import Path; import codex_cli_bin; print(Path(codex_cli_bin.__file__).parent)')" \

--- a/backend/app/deployment_control.py
+++ b/backend/app/deployment_control.py
@@ -1,4 +1,4 @@
-"""Container replacement control for Settings.
+"""Container rebuild control for Settings.
 
 The browser can request only one fixed operation: replace this installation's
 app container with the official image for its applied upstream revision.
@@ -307,7 +307,7 @@ def _read_host_status() -> dict[str, Any]:
       return {
         "state": "queued",
         "expected_sha": expected,
-        "message": "Container replacement queued.",
+        "message": "Container rebuild queued.",
         "handoff": value.get("handoff"),
         "runtime_overlay": value.get("runtime_overlay"),
       }
@@ -327,7 +327,7 @@ def _write_request(expected_sha: str) -> None:
   if request.exists():
     raise DeploymentControlError(
       "already_running",
-      "A container replacement request is already queued.",
+      "A container rebuild request is already queued.",
       status_code=409,
     )
   temp = inbox / f".request-{secrets.token_hex(12)}.tmp"
@@ -344,7 +344,7 @@ def _write_request(expected_sha: str) -> None:
   except FileExistsError as exc:
     raise DeploymentControlError(
       "already_running",
-      "A container replacement request is already queued.",
+      "A container rebuild request is already queued.",
       status_code=409,
     ) from exc
   except OSError as exc:
@@ -415,7 +415,7 @@ async def read_rebuild_status() -> RebuildStatus:
         code="controller_upgrade_required",
         message=(
           "This Railway installation needs one managed upgrade before it can "
-          "replace containers safely."
+          "rebuild containers safely."
         ),
       )
     raw = await asyncio.to_thread(_managed_request, "GET", "status")
@@ -462,7 +462,7 @@ async def request_rebuild() -> RebuildStatus:
     if current["state"] in _ACTIVE_STATES:
       raise DeploymentControlError(
         "already_running",
-        "A container replacement is already running.",
+        "A container rebuild is already running.",
         status_code=409,
       )
   expected_sha = _expected_upstream_sha()
@@ -484,7 +484,7 @@ async def request_rebuild() -> RebuildStatus:
       "local_runtime_changes",
       "The official image cannot preserve these local image inputs: "
       f"{visible}. Commit them upstream, rebuild locally, or remove them "
-      "before replacing this container.",
+      "before rebuilding this container.",
       status_code=409,
     )
   if deployment == "railway":
@@ -495,7 +495,7 @@ async def request_rebuild() -> RebuildStatus:
   return _normalize_status({
     "state": "queued",
     "expected_sha": expected_sha,
-    "message": "Container replacement queued.",
+    "message": "Container rebuild queued.",
   }, expected_sha=expected_sha)
 
 
@@ -505,7 +505,7 @@ async def _request_managed_rebuild(expected_sha: str) -> RebuildStatus:
   if not managed_cutover_ready():
     raise DeploymentControlError(
       "controller_upgrade_required",
-      "Install the current Möbius image once to enable managed container replacement.",
+      "Install the current Möbius image once to enable managed container rebuilds.",
       status_code=409,
     )
   prepared = await asyncio.to_thread(

--- a/backend/tests/test_verify_test_runtime.py
+++ b/backend/tests/test_verify_test_runtime.py
@@ -150,6 +150,7 @@ def test_node_runtime_satisfies_the_pinned_agent_browser_engine():
   assert "FROM node:24-trixie-slim AS node-runtime" in dockerfile
   pinned_script_packages = {
     "@anthropic-ai/claude-code": "CLAUDE_CODE_VERSION",
+    "@openai/codex": "CODEX_VERSION",
     "agent-browser": "AGENT_BROWSER_VERSION",
   }
   for version_argument in pinned_script_packages.values():

--- a/frontend/src/components/SettingsView/SettingsView.css
+++ b/frontend/src/components/SettingsView/SettingsView.css
@@ -64,6 +64,66 @@
   gap: 8px;
 }
 
+.settings__info-button {
+  display: inline-grid;
+  place-items: center;
+  width: 32px;
+  height: 32px;
+  margin: -7px 0;
+  padding: 0;
+  border: 0;
+  border-radius: 50%;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+}
+
+.settings__info-anchor {
+  position: relative;
+}
+
+.settings__info-bubble {
+  position: absolute;
+  z-index: 20;
+  bottom: calc(100% + 10px);
+  left: 0;
+  width: min(320px, calc(100vw - 40px));
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--surface);
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.24);
+  color: var(--text);
+  font-size: 13px;
+  font-weight: 400;
+  line-height: 1.45;
+}
+
+.settings__info-bubble::after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: calc(100% - 26px);
+  width: 10px;
+  height: 10px;
+  border-right: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  background: var(--surface);
+  transform: translateY(-5px) rotate(45deg);
+}
+
+.settings__info-button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .settings__info-button:hover {
+    color: var(--text);
+    background: var(--surface2);
+  }
+}
+
 /* "Configured" indicator now uses the shared <StatusDot> component
    (frontend/src/components/ui/StatusDot.jsx) — both this badge
    AND the provider-row "Connected" / "Not connected" status pull
@@ -322,6 +382,14 @@
   font-size: 12px;
   letter-spacing: 0;
   color: var(--muted);
+}
+
+.settings__build-kind {
+  display: inline-block;
+  min-width: 70px;
+  margin-right: 8px;
+  color: var(--muted);
+  font-family: var(--font);
 }
 
 .settings__btn--nowrap { white-space: nowrap; }

--- a/frontend/src/components/SettingsView/SettingsView.jsx
+++ b/frontend/src/components/SettingsView/SettingsView.jsx
@@ -1,11 +1,14 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { Alert } from '@openai/apps-sdk-ui/components/Alert'
-import { ChevronDown, Moon, Sun } from '@openai/apps-sdk-ui/components/Icon'
+import { ChevronDown, Info, Moon, Sun } from '@openai/apps-sdk-ui/components/Icon'
 import GripVertical from 'lucide-react/dist/esm/icons/grip-vertical.mjs'
 import { api, clearQueryCache, clearToken } from '../../api/client.js'
 import { authQueries, modelQueries, settingsQueries, themeQueries, versionQueries } from '../../hooks/queries.js'
-import { platformVersionIdentity } from '../../lib/platformVersionIdentity.js'
+import {
+  containerVersionIdentity,
+  platformVersionIdentity,
+} from '../../lib/platformVersionIdentity.js'
 import { formatUpstreamCommitDate } from '../../lib/platformProvenance.js'
 import {
   rebuildIsActive,
@@ -120,6 +123,61 @@ function PlanUsageToggle({ provider, label, expanded, onToggle }) {
 
 function providerFromSettings(settings) {
   return isKnownProvider(settings?.provider) ? settings.provider : 'claude'
+}
+
+function SettingsInfoLabel({
+  label,
+  infoId,
+  expanded,
+  onToggle,
+  onDismiss,
+  children,
+}) {
+  const anchorRef = useRef(null)
+  const buttonRef = useRef(null)
+
+  useEffect(() => {
+    if (!expanded) return undefined
+
+    const dismissOnOutsidePress = (event) => {
+      if (!anchorRef.current?.contains(event.target)) onDismiss()
+    }
+    const dismissOnEscape = (event) => {
+      if (event.key !== 'Escape') return
+      onDismiss()
+      buttonRef.current?.focus()
+    }
+
+    document.addEventListener('pointerdown', dismissOnOutsidePress)
+    document.addEventListener('keydown', dismissOnEscape)
+    return () => {
+      document.removeEventListener('pointerdown', dismissOnOutsidePress)
+      document.removeEventListener('keydown', dismissOnEscape)
+    }
+  }, [expanded, onDismiss])
+
+  return (
+    <span ref={anchorRef} className="settings__label settings__info-anchor">
+      <span>{label}</span>
+      <button
+        ref={buttonRef}
+        className="settings__info-button"
+        type="button"
+        aria-label={`About ${label}`}
+        aria-controls={infoId}
+        aria-describedby={expanded ? infoId : undefined}
+        aria-expanded={expanded}
+        onClick={onToggle}
+      >
+        <Info width={16} height={16} aria-hidden="true" />
+      </button>
+      {expanded && (
+        <span id={infoId} className="settings__info-bubble" role="tooltip">
+          {children}
+        </span>
+      )}
+    </span>
+  )
 }
 
 function normalizeBackgroundAgents(backgroundAgents, defaultProvider = 'claude') {
@@ -394,6 +452,7 @@ export default function SettingsView({
   const [rebuildError, setRebuildError] = useState('')
   const [rebuildRequesting, setRebuildRequesting] = useState(false)
   const [rebuildStartedHere, setRebuildStartedHere] = useState(false)
+  const [serverInfo, setServerInfo] = useState(null)
   const rebuildPreviousBootIdRef = useRef('')
   const rebuildInitiatedHereRef = useRef(false)
   const rebuildReconnectStartedRef = useRef(false)
@@ -1017,7 +1076,7 @@ export default function SettingsView({
         setRebuildStatus({
           supported: false,
           state: 'idle',
-          message: 'Container replacement is not available yet.',
+          message: 'Container rebuilds are not available yet.',
         })
         return null
       }
@@ -1067,7 +1126,7 @@ export default function SettingsView({
         rebuildReconnectStartedRef.current = false
         setRebuildError(freshServerSeen
           ? 'The container changed, but Möbius couldn’t reload the shell. Refresh the page.'
-          : 'Möbius still can’t confirm the replacement. Use your deployment’s Recovery action if it is unavailable.')
+          : 'Möbius still can’t confirm the rebuild. Use your deployment’s Recovery action if it is unavailable.')
       },
     })
   }, [rebuildStatus?.state])
@@ -1078,7 +1137,7 @@ export default function SettingsView({
     setRebuildConfirm(false)
     if (state === 'failed') {
       setRebuildError(
-        rebuildStatus?.message || 'The container could not be replaced.',
+        rebuildStatus?.message || 'The container could not be rebuilt.',
       )
     }
   }, [rebuildStatus?.state, rebuildStatus?.message])
@@ -1111,7 +1170,7 @@ export default function SettingsView({
       setRebuildConfirm(false)
       returnToSettingsAfterReload()
     } catch (err) {
-      setRebuildError(err?.message || 'The container could not be replaced.')
+      setRebuildError(err?.message || 'The container could not be rebuilt.')
     } finally {
       setRebuildRequesting(false)
     }
@@ -1490,11 +1549,10 @@ export default function SettingsView({
   // origin/main; keep that identity as a secondary diagnostic instead of
   // presenting it as the published Möbius version.
   const mobiusVersion = platformVersionIdentity(platform, version)
-  // The commit date (YYYY-MM-DD) baked at build time, shown next to the sha as
-  // a human "version · date". Null on a dev build that didn't stamp it.
-  const buildDate = version?.build_date && version.build_date !== 'unknown'
-    ? version.build_date
-    : null
+  const containerVersion = containerVersionIdentity(version)
+  // The commit date baked at image-build time, formatted independently from
+  // the mutable platform checkout's upstream commit date below.
+  const buildDate = formatUpstreamCommitDate(version?.build_date) || null
   const upstreamCommitDate = formatUpstreamCommitDate(
     platform?.contained_upstream_committed_at,
   )
@@ -1852,6 +1910,7 @@ export default function SettingsView({
               </StatusDot>
               {mobiusVersion.primarySha && (
                 <p className="settings__build">
+                  <span className="settings__build-kind">Möbius</span>
                   {mobiusVersion.synced && upstreamCommitDate
                     ? `${upstreamCommitDate} (`
                     : !mobiusVersion.synced
@@ -1863,6 +1922,14 @@ export default function SettingsView({
                     : !mobiusVersion.synced && buildDate
                       ? ` · ${buildDate}`
                       : ''}
+                </p>
+              )}
+              {containerVersion.sha && (
+                <p className="settings__build">
+                  <span className="settings__build-kind">Container</span>
+                  {buildDate ? `${buildDate} (` : ''}
+                  <span className="settings__standard-highlight">{containerVersion.sha}</span>
+                  {buildDate ? ')' : ''}
                 </p>
               )}
             </div>
@@ -2034,7 +2101,19 @@ export default function SettingsView({
         <section className="settings__section settings__section--compact settings__section--server">
           <h2 className="settings__section-title">Server</h2>
           <div className="settings__row">
-            <span className="settings__label">Restart</span>
+            <SettingsInfoLabel
+              label="Restart"
+              infoId="settings-restart-info"
+              expanded={serverInfo === 'restart'}
+              onToggle={() => setServerInfo((value) => (
+                value === 'restart' ? null : 'restart'
+              ))}
+              onDismiss={() => setServerInfo(null)}
+            >
+              Restarts Möbius inside the current container. This reloads server
+              changes and briefly interrupts active responses, but does not
+              install a newer container image.
+            </SettingsInfoLabel>
             {restartConfirm ? (
               <div className="settings__confirm">
                 <button
@@ -2085,9 +2164,19 @@ export default function SettingsView({
             />
           )}
           <div className="settings__row">
-            <span className="settings__label">
-              {rebuildBootstrap ? 'Container updates' : 'Replace container'}
-            </span>
+            <SettingsInfoLabel
+              label={rebuildBootstrap ? 'Container updates' : 'Rebuild container'}
+              infoId="settings-rebuild-info"
+              expanded={serverInfo === 'rebuild'}
+              onToggle={() => setServerInfo((value) => (
+                value === 'rebuild' ? null : 'rebuild'
+              ))}
+              onDismiss={() => setServerInfo(null)}
+            >
+              {rebuildBootstrap
+                ? 'Enables safe container rebuilds on this Railway deployment with one managed upgrade.'
+                : 'Creates a fresh container from the newest official image for your applied update, while keeping your chats, apps, settings, and other saved data.'}
+            </SettingsInfoLabel>
             {rebuildConfirm ? (
               <div className="settings__confirm">
                 <button
@@ -2105,8 +2194,8 @@ export default function SettingsView({
                   disabled={rebuildRequesting || rebuildIsActive(rebuildStatus)}
                 >
                   {rebuildRequesting || rebuildIsActive(rebuildStatus)
-                    ? (rebuildBootstrap ? 'Enabling…' : 'Replacing…')
-                    : (rebuildBootstrap ? 'Enable now' : 'Replace now')}
+                    ? (rebuildBootstrap ? 'Enabling…' : 'Rebuilding…')
+                    : (rebuildBootstrap ? 'Enable now' : 'Rebuild now')}
                 </button>
               </div>
             ) : (
@@ -2123,7 +2212,7 @@ export default function SettingsView({
               >
                 {rebuildBootstrap
                   ? 'Enable'
-                  : (rebuildStatus?.supported === false ? 'Not set up' : 'Replace')}
+                  : (rebuildStatus?.supported === false ? 'Not set up' : 'Rebuild')}
               </button>
             )}
           </div>
@@ -2134,15 +2223,16 @@ export default function SettingsView({
                 update controller. Finish active responses first; Railway restores
                 the previous container if the upgrade is unhealthy.</>
               ) : (
-                <>Deploys the official image for your applied update. Local-only
-                runtime changes recorded by Möbius block replacement; undeclared
+                <>Rebuilds the container from the official image for your applied
+                update. Local-only runtime changes recorded by Möbius block the
+                rebuild; undeclared
                 container changes are lost. Active chats continue afterward.</>
               )}
             </p>
           )}
           {rebuildStatus?.supported === false && (
             <p className="settings__subtext settings__subtext--tight">
-              {rebuildStatus.message || 'Container replacement is not set up on this installation.'}
+              {rebuildStatus.message || 'Container rebuilds are not set up on this installation.'}
             </p>
           )}
           {(rebuildIsActive(rebuildStatus) || (rebuildStartedHere && [

--- a/frontend/src/lib/__tests__/containerRebuild.test.js
+++ b/frontend/src/lib/__tests__/containerRebuild.test.js
@@ -8,7 +8,7 @@ import {
   rebuildProgressMessage,
 } from '../containerRebuild.js'
 
-test('container replacement active states are exactly the controller phases', () => {
+test('container rebuild active states are exactly the controller phases', () => {
   for (const state of [
     'queued', 'preparing', 'replacing', 'verifying',
   ]) {
@@ -30,17 +30,17 @@ test('legacy Railway status exposes the one-time bootstrap action', () => {
   )
 })
 
-test('container replacement polling survives transient status failures', () => {
+test('container rebuild polling survives transient status failures', () => {
   assert.equal(rebuildPollShouldContinue(null), true)
   assert.equal(rebuildPollShouldContinue({ state: 'replacing' }), true)
   assert.equal(rebuildPollShouldContinue({ state: 'succeeded' }), false)
   assert.equal(rebuildPollShouldContinue({ state: 'failed' }), false)
 })
 
-test('container replacement progress copy stays factual', () => {
+test('container rebuild progress copy stays factual', () => {
   assert.equal(
     rebuildProgressMessage({ state: 'succeeded' }),
-    'Container replaced successfully.',
+    'Container rebuilt successfully.',
   )
   assert.equal(
     rebuildProgressMessage({ state: 'needs_recovery' }),

--- a/frontend/src/lib/__tests__/platformVersionIdentity.test.js
+++ b/frontend/src/lib/__tests__/platformVersionIdentity.test.js
@@ -1,7 +1,10 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 
-import { platformVersionIdentity } from '../platformVersionIdentity.js'
+import {
+  containerVersionIdentity,
+  platformVersionIdentity,
+} from '../platformVersionIdentity.js'
 
 test('the recorded origin commit is the primary synced identity', () => {
   assert.deepEqual(platformVersionIdentity(
@@ -35,4 +38,12 @@ test('served or image identity remains a fallback for untracked builds', () => {
   assert.deepEqual(platformVersionIdentity({}, { sha: 'def567890' }), {
     primarySha: 'def5678', synced: false, localSha: null,
   })
+})
+
+test('container identity stays distinct from the mutable served platform', () => {
+  assert.deepEqual(containerVersionIdentity({
+    sha: '86ff104100cab779d5040fd81dd8dd3c81f372b5',
+    served_sha: 'ec7024a8dcc3654aedafad2d5533e8241ed02c9a',
+  }), { sha: '86ff104' })
+  assert.deepEqual(containerVersionIdentity({ sha: 'unknown' }), { sha: null })
 })

--- a/frontend/src/lib/__tests__/settingsViewAppearance.test.js
+++ b/frontend/src/lib/__tests__/settingsViewAppearance.test.js
@@ -28,10 +28,26 @@ test('model and concise synced version use the same normal-weight standard highl
   assert.match(view, /Last model: <span className="settings__standard-highlight">/)
   assert.match(view, /upstreamCommitDate[\s\S]*settings__standard-highlight/)
   assert.match(view, /contained_upstream_committed_at/)
+  assert.match(view, /containerVersionIdentity\(version\)/)
+  assert.match(view, /settings__build-kind">Möbius/)
+  assert.match(view, /settings__build-kind">Container/)
   assert.doesNotMatch(view, /Current with upstream|Last checked|upstream_checked_at|settings__update-check/)
   assert.doesNotMatch(view, /Serving local \{mobiusVersion\.localSha\}/)
   assert.match(css, /\.settings__last-model\s*\{[^}]*color:\s*var\(--muted\);[^}]*font-weight:\s*400;/s)
   assert.match(css, /\.settings__standard-highlight\s*\{[^}]*color:\s*var\(--green\);[^}]*font-weight:\s*inherit;/s)
+})
+
+test('restart and rebuild explain their distinct container effects on demand', () => {
+  assert.match(view, /SettingsInfoLabel[\s\S]*aria-expanded=\{expanded\}/)
+  assert.match(view, /settings__info-bubble[\s\S]*role="tooltip"/)
+  assert.match(view, /dismissOnOutsidePress[\s\S]*dismissOnEscape/)
+  assert.match(view, /label="Restart"[\s\S]*settings-restart-info/)
+  assert.match(view, /label=\{rebuildBootstrap \? 'Container updates' : 'Rebuild container'\}/)
+  assert.match(view, /does not[\s\S]*install a newer container image/)
+  assert.match(view, /Creates a fresh container from the newest official image/)
+  assert.doesNotMatch(view, /Replace container|Replace now|Replacing…/)
+  assert.match(css, /\.settings__info-button\s*\{[^}]*width:\s*32px;[^}]*height:\s*32px;/s)
+  assert.match(css, /\.settings__info-bubble\s*\{[^}]*position:\s*absolute;[^}]*bottom:\s*calc\(100% \+ 10px\);/s)
 })
 
 test('background agents are always draggable without reorder chrome or a trailing caret', () => {

--- a/frontend/src/lib/containerRebuild.js
+++ b/frontend/src/lib/containerRebuild.js
@@ -1,4 +1,4 @@
-/** Pure projection of the durable container-replacement job into Settings UI. */
+/** Pure projection of the durable container-rebuild job into Settings UI. */
 
 export const ACTIVE_REBUILD_STATES = new Set([
   'queued', 'preparing', 'replacing', 'verifying',
@@ -41,15 +41,15 @@ export function rebuildProgressMessage(status) {
     case 'preparing':
       return 'Preparing the new container…'
     case 'replacing':
-      return 'Replacing the container…'
+      return 'Rebuilding the container…'
     case 'verifying':
       return 'Checking that Möbius came back…'
     case 'succeeded':
-      return 'Container replaced successfully.'
+      return 'Container rebuilt successfully.'
     case 'no_change':
       return 'This container is already current.'
     case 'rolled_back':
-      return 'The replacement failed, so the previous container was restored.'
+      return 'The rebuild failed, so the previous container was restored.'
     case 'needs_recovery':
       return 'The container could not be restored. Use your deployment’s Recovery action.'
     default:

--- a/frontend/src/lib/platformVersionIdentity.js
+++ b/frontend/src/lib/platformVersionIdentity.js
@@ -13,3 +13,9 @@ export function platformVersionIdentity(platform, version) {
     localSha: syncedSha && servedSha && syncedSha !== servedSha ? servedSha : null,
   }
 }
+
+export function containerVersionIdentity(version) {
+  return {
+    sha: shortSha(version?.sha),
+  }
+}

--- a/scripts/install-rebuild-helper.sh
+++ b/scripts/install-rebuild-helper.sh
@@ -173,7 +173,7 @@ ExecStopPost=/usr/local/libexec/mobius-rebuild-host reconcile
 EOF
 cat >/etc/systemd/system/mobius-rebuild.path <<EOF
 [Unit]
-Description=Watch for a Möbius container replacement request
+Description=Watch for a Möbius container rebuild request
 
 [Path]
 PathExists=$DATA_SOURCE/mobius-rebuild/inbox/request.json
@@ -184,7 +184,7 @@ WantedBy=multi-user.target
 EOF
 cat >/etc/systemd/system/mobius-rebuild-reconcile.service <<'EOF'
 [Unit]
-Description=Reconcile interrupted Möbius container replacement state
+Description=Reconcile interrupted Möbius container rebuild state
 After=docker.service
 Requires=docker.service
 Before=mobius-rebuild.path
@@ -204,6 +204,6 @@ systemctl daemon-reload
 systemctl enable mobius-rebuild-reconcile.service
 systemctl enable --now mobius-rebuild.path
 
-echo "Container replacement installed for Compose project '$PROJECT'."
+echo "Container rebuild support installed for Compose project '$PROJECT'."
 echo "Topology: ${FILES[*]:-$FROZEN_SOURCE}"
 echo "Rerun this installer after an intentional Compose topology change."

--- a/scripts/mobius-rebuild-host.py
+++ b/scripts/mobius-rebuild-host.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Root-owned controller for one fixed Möbius container replacement."""
+"""Root-owned controller for one fixed Möbius container rebuild."""
 
 from __future__ import annotations
 
@@ -1158,7 +1158,7 @@ def run() -> int:
                 raise ValueError("invalid replacement target")
             write_status(config_value, operation_id=operation, state="queued",
                          expected_sha=expected, code=None,
-                         message="Container replacement queued.")
+                         message="Container rebuild queued.")
             cid, previous = app_container(config_value)
             image_ref = f"{IMAGE}:sha-{expected}"
             require_pull_space(previous)
@@ -1214,7 +1214,7 @@ def run() -> int:
             request_drain(config_value, operation, cid)
             write_status(config_value, operation_id=operation, state="replacing",
                          expected_sha=expected, code=None,
-                         message="Replacing the container.")
+                         message="Rebuilding the container.")
             replacement_started = True
             compose(config_value, "up", "-d", "--no-build", "--no-deps",
                     "--force-recreate", "app", image=image_ref,
@@ -1250,15 +1250,15 @@ def run() -> int:
                 status_code = None
                 if prepared_runtime.carried_paths:
                     message = (
-                        "Container replaced successfully; the active local "
+                        "Container rebuilt successfully; the active local "
                         "runtime overlay was carried forward."
                     )
                 else:
-                    message = "Container replaced successfully."
+                    message = "Container rebuilt successfully."
             else:
                 status_code = "handoff_finalize_failed"
                 message = (
-                    "Container replaced successfully, but the Host could not "
+                    "Container rebuilt successfully, but the Host could not "
                     "verify and retire the exact chat handoff receipt. Check "
                     "the affected chats."
                 )
@@ -1269,7 +1269,7 @@ def run() -> int:
     except BlockingIOError:
         write_status(config_value, operation_id=operation, state="failed",
                      expected_sha=expected, code="already_running",
-                     message="Another replacement is already running.")
+                     message="Another container rebuild is already running.")
         return 1
     except Exception as exc:
         detail = str(exc)[:300]


### PR DESCRIPTION
## Summary

- update Claude Code to 2.1.258 and Codex to 0.152.1, including the matching Codex SDK pin
- rename the container operation to Rebuild container and explain Restart and Rebuild in anchored, dismissible popovers
- show the container build date and commit separately from the applied Möbius source revision

## Testing

- focused frontend, backend, and Codex SDK contract tests
- `npm run build`
- `npm run lint -- --quiet`