### PR TITLE
Bridge current Railway deployment adoption

### DIFF
--- a/backend/app/routes/identity.py
+++ b/backend/app/routes/identity.py
@@ -790,6 +790,21 @@ async def create_railway_deployment(
   )
 
 
+@router.post("/railway/deployments/adopt-current", status_code=202)
+async def adopt_current_railway_deployment(
+  owner: models.Owner = Depends(get_owner_or_app_with_railway_manage),
+  db: Session = Depends(get_db),
+):
+  # The account host derives the deployment address from the signed link grant.
+  # Deliberately accept no browser-supplied Railway ids or domain here.
+  return await _railway_mutation(
+    db,
+    owner.id,
+    "POST",
+    "/instances/adopt-current",
+  )
+
+
 @router.post("/railway/connect/start")
 async def start_railway_connection(
   body: RailwayConnectStart | None = None,

--- a/backend/tests/test_identity.py
+++ b/backend/tests/test_identity.py
@@ -231,6 +231,9 @@ def test_linked_railway_mutations_use_the_scoped_server_bridge(
     },
     headers=granted,
   )
+  adopted = client.post(
+    "/api/identity/railway/deployments/adopt-current", headers=granted,
+  )
   deleted = client.delete(
     "/api/identity/railway/deployments/mob_example", headers=granted,
   )
@@ -243,6 +246,7 @@ def test_linked_railway_mutations_use_the_scoped_server_bridge(
   assert connect.status_code == 200
   assert connect.json()["authorization_url"].startswith("https://www.mobius.you/")
   assert created.status_code == 202
+  assert adopted.status_code == 202
   assert deleted.status_code == 202
   assert storage.status_code == 200
   assert calls == [
@@ -256,6 +260,11 @@ def test_linked_railway_mutations_use_the_scoped_server_bridge(
         "memory_mb": None,
         "volume_mb": None,
       },
+    ),
+    (
+      "POST",
+      "https://www.mobius.you/api/account/v1/railway/instances/adopt-current",
+      None,
     ),
     (
       "DELETE",


### PR DESCRIPTION
## Summary
- add the scoped Identity bridge action for current Railway deployment adoption
- accept no browser-supplied provider identifiers
- cover the exact account-service request and response path

This follows #849 by extending the portable Identity bridge with the verified current-deployment adoption action.

## Verification
- `scripts/wt-pytest.sh backend/tests/test_identity.py -q`
