### PR TITLE
Preserve platform update safety across replacements and conflicts

### DIFF
--- a/backend/app/platform_update.py
+++ b/backend/app/platform_update.py
@@ -354,6 +354,11 @@ class ReconcileResult:
   new_sha: str | None
   target_sha: str | None
   conflict_paths: list[str] = field(default_factory=list)
+  # Proven semantic merge base for a ``conflict`` result: the equivalence
+  # engine's tree that already eliminates changes proven to have landed
+  # upstream. Callers that rewrite the conflict flag must carry it forward so
+  # the resolver preserves every proven elimination.
+  merge_base: str | None = None
   error: str | None = None
   # Exact reviewed release/upstream commit captured while RECONCILE_LOCK is
   # still held. Hook refresh reads every allowlisted blob from this immutable
@@ -984,24 +989,38 @@ def container_replacement_blockers(
   pending = list(marker["paths"]) if marker else []
 
   # Activation markers record intended work, not the bytes actually mounted at
-  # /app/runtime. When the caller supplies the official replacement target,
-  # verify deployed parity directly and prove that target contains every stale
-  # path. This catches lost markers without blocking a replacement whose exact
-  # official image will repair the drift.
+  # /app/runtime or the commits an agent made directly.  When the caller
+  # supplies the official replacement target, verify parity against the
+  # histories themselves: deployed protected-runtime bytes, plus every path
+  # whose desired local content differs from the official target (local
+  # Dockerfile, dependency-lock, bootstrap-script, or seeded-skill commits
+  # never write a marker, yet the official image would silently replace
+  # them).  This catches lost/cleared/stale markers without blocking a
+  # replacement whose exact official image will repair the drift.  A failed
+  # diff (e.g. an unfetched target) adds nothing here; the replacement
+  # controller independently fails closed on unverifiable provenance.
+  head = _rev(repo, _local_branch(repo)) if expected_sha else None
+  # Paths pending for a reason git parity cannot verify (an unreadable
+  # deployed runtime) must stay blockers even when source matches the target.
+  unverifiable: set[str] = set()
   if expected_sha:
     runtime = _protected_runtime_status(repo)
     if runtime["state"] == "unavailable":
       pending.append("backend/runtime")
+      unverifiable.add("backend/runtime")
     else:
-      runtime_paths = runtime_provenance.activation_paths(runtime)
-      pending.extend(runtime_paths)
-      head = _rev(repo, _local_branch(repo))
-      if head:
-        covered.update(_paths_matching_upstream(
-          repo, head, expected_sha, runtime_paths,
-        ))
+      pending.extend(runtime_provenance.activation_paths(runtime))
+    if head:
+      drift = _git(
+        "diff", "--name-only", "--no-renames", expected_sha, head,
+        repo=repo, check=False,
+      )
+      if drift.returncode == 0:
+        pending.extend(
+          line.strip() for line in drift.stdout.splitlines() if line.strip()
+        )
 
-  blockers: list[str] = []
+  image_pending: list[str] = []
   for path in sorted(set(pending)):
     if preserve_active_runtime and (
       path == "backend/runtime" or path.startswith("backend/runtime/")
@@ -1013,10 +1032,18 @@ def container_replacement_blockers(
     if (
       impact["level"]
       == platform_activation.ActivationLevel.IMAGE_REBUILD.value
-      and path not in covered
     ):
-      blockers.append(path)
-  return sorted(blockers)
+      image_pending.append(path)
+
+  # Actual content parity with the target is authoritative whenever both
+  # revisions are known; a marker's recorded coverage must not excuse a path
+  # that drifted after the marker was written.  Without a verifiable head the
+  # marker's own upstream coverage remains the fallback.
+  if expected_sha and head:
+    covered = set(_paths_matching_upstream(
+      repo, head, expected_sha, image_pending,
+    )) - unverifiable
+  return sorted(path for path in image_pending if path not in covered)
 
 
 def _write_activation_marker(
@@ -1670,6 +1697,7 @@ def reconcile_clone(
           return ReconcileResult(
             "conflict", pre, pre, target,
             conflict_paths=conflict_paths,
+            merge_base=merge_base,
             reconciliation=(
               equivalent.reconciliation
               if equivalent is not None
@@ -2253,7 +2281,10 @@ async def apply_platform_update(
       elif res.status == "conflict":
         # Keep the resolver gated behind the owner's next click. A conflict pass
         # rewrites the flag with target + paths, so preserve a previously opened
-        # chat only when it belongs to this same target.
+        # chat only when it belongs to this same target — and carry the proven
+        # semantic merge base forward so the resolver keeps every elimination
+        # the equivalence engine already proved (falling back to a same-target
+        # base recorded by an earlier pass).
         target = res.target_sha or existing_conflict.get("upstream")
         existing_chat_id = (
           existing_conflict.get("chat_id")
@@ -2265,6 +2296,11 @@ async def apply_platform_update(
           target,
           res.conflict_paths or existing_conflict.get("paths") or [],
           existing_chat_id,
+          merge_base=res.merge_base or (
+            existing_conflict.get("merge_base")
+            if target and existing_conflict.get("upstream") == target
+            else None
+          ),
         )
         state = PlatformUpdateState.CONFLICT
       elif res.status == "rolled_back":

--- a/backend/tests/test_platform_update.py
+++ b/backend/tests/test_platform_update.py
@@ -19,6 +19,7 @@ is still cleaned up because an update can cross this implementation boundary.
 """
 
 import hashlib
+import json
 import os
 import subprocess
 import stat
@@ -1148,6 +1149,37 @@ async def test_apply_conflict_waits_for_owner_before_opening_chat(
   flag = pu._read_conflict_flag()
   assert flag["upstream"] == target
   assert flag["paths"] == ["backend/app/main.py"]
+
+
+@pytest.mark.asyncio
+async def test_apply_conflict_preserves_proven_merge_base(
+  monkeypatch, clone_env,
+):
+  """The apply-path conflict rewrite must carry the equivalence engine's
+  proven semantic base into the flag, or the resolver chat re-surfaces
+  conflicts already proven to have landed upstream."""
+  origin, platform = clone_env
+  target = _advance_origin(origin, edits={"backend/app/main.py":
+    _MAIN_PY.replace("LINE_A = 1", "LINE_A = 'UPSTREAM'")})
+  merge_base = "b" * 40
+
+  monkeypatch.setattr(pu, "_reconcile_under_lock", lambda repo, at_boot, **kwargs: (
+    pu.ReconcileResult(
+      "conflict", _served_sha(platform), _served_sha(platform), target,
+      ["backend/app/main.py"],
+      merge_base=merge_base,
+    )
+  ))
+
+  current = _served_sha(platform)
+  res = await pu.apply_platform_update(
+    SimpleNamespace(), **_apply_plan(current, target, platform),
+  )
+
+  assert res["state"] == pu.PlatformUpdateState.CONFLICT.value
+  flag = pu._read_conflict_flag()
+  assert flag["upstream"] == target
+  assert flag["merge_base"] == merge_base
   assert flag["chat_id"] is None
 
 
@@ -1412,6 +1444,92 @@ def test_replacement_blocks_when_desired_runtime_cannot_be_verified(
 
   assert pu.container_replacement_blockers(official, platform) == [
     "backend/runtime",
+  ]
+
+
+def test_replacement_blocks_unmarked_local_image_input_drift(
+  clone_env, monkeypatch,
+):
+  """Direct local commits to image inputs never write an activation marker,
+  yet the official image would silently replace them; the blockers check must
+  derive that drift from the histories themselves."""
+  _, platform = clone_env
+  official = _git(platform, "rev-parse", "HEAD").stdout.strip()
+  monkeypatch.setattr(
+    pu,
+    "_protected_runtime_status",
+    lambda _repo: {
+      "state": "current",
+      "source_sha256": "match",
+      "deployed_sha256": "match",
+      "mismatched_paths": [],
+    },
+  )
+
+  assert pu.container_replacement_blockers(official, platform) == []
+
+  _local_commit(platform, edits={"Dockerfile": "FROM local-only\n"})
+  assert pu.container_replacement_blockers(official, platform) == [
+    "Dockerfile",
+  ]
+
+
+def test_replacement_blocks_image_input_renamed_out_of_its_owned_path(
+  clone_env, monkeypatch,
+):
+  """Rename detection must not hide the removed image-owned source path."""
+  _, platform = clone_env
+  official = _local_commit(
+    platform, edits={"Dockerfile": "FROM official\n"}, msg="add image input",
+  )
+  monkeypatch.setattr(
+    pu,
+    "_protected_runtime_status",
+    lambda _repo: {
+      "state": "current",
+      "source_sha256": "match",
+      "deployed_sha256": "match",
+      "mismatched_paths": [],
+    },
+  )
+
+  (platform / "docs").mkdir()
+  _git(platform, "mv", "Dockerfile", "docs/Dockerfile")
+  _git(platform, "commit", "-q", "-m", "move image input out")
+
+  assert pu.container_replacement_blockers(official, platform) == [
+    "Dockerfile",
+  ]
+
+
+def test_stale_marker_coverage_cannot_excuse_newer_image_input_drift(
+  clone_env, monkeypatch,
+):
+  """A marker recorded content parity at Apply time; a later local commit to
+  the same image input must still block the replacement."""
+  _, platform = clone_env
+  official = _git(platform, "rev-parse", "HEAD").stdout.strip()
+  monkeypatch.setattr(
+    pu,
+    "_protected_runtime_status",
+    lambda _repo: {
+      "state": "current",
+      "source_sha256": "match",
+      "deployed_sha256": "match",
+      "mismatched_paths": [],
+    },
+  )
+  pu.RESTART_NEEDED_FLAG.write_text(json.dumps({
+    "version": 2,
+    "target_sha": official,
+    "upstream_sha": official,
+    "paths": ["Dockerfile"],
+    "image_paths": ["Dockerfile"],
+  }), encoding="utf-8")
+
+  _local_commit(platform, edits={"Dockerfile": "FROM drifted-later\n"})
+  assert pu.container_replacement_blockers(official, platform) == [
+    "Dockerfile",
   ]
 
 


### PR DESCRIPTION
## Summary
- derive replacement blockers from exact local-versus-official history so unmarked image inputs cannot be silently replaced
- surface both sides of renamed image inputs so moving a Dockerfile or other owned input cannot evade the blocker
- treat exact target parity as authoritative over stale marker coverage while keeping unverifiable runtime state fail-closed
- preserve the equivalence-proven semantic merge base when Apply rewrites a conflict handoff

## Prior work
This builds on the protected-runtime provenance from #1023 and the reduced-conflict reconciliation from #377. It is also related to #990, but does not add local image builds; it prevents existing local image-input drift from being silently lost during an official replacement.

## Testing
- focused platform update suite (91 passed)
