### PR TITLE
Pin Railway rebuilds to exact published images

### DIFF
--- a/backend/app/chat.py
+++ b/backend/app/chat.py
@@ -39,6 +39,7 @@ from app.broadcast import (
   create_broadcast,
   get_broadcast,
   get_system_broadcast,
+  has_running_chat_broadcast,
   set_active_broadcast,
 )
 from app.chat_event_sink import (
@@ -199,7 +200,29 @@ PAUSED_FOR_RESTART_MESSAGE = "Paused for a platform update."
 def begin_drain() -> None:
   """Set the process-wide drain gate. Idempotent."""
   global draining
+  registry.close_admission()
   draining = True
+
+
+def begin_idle_drain() -> bool:
+  """Close admission only if no runner can already own the cutover boundary.
+
+  The registry check and reservation gate are one critical section. A send that
+  already reserved a runner makes this fail; a send that has not reserved yet
+  is forced into the durable pending queue when it reaches ``mark_starting``.
+  """
+  global draining
+  if draining or not registry.close_admission_if_idle():
+    return False
+  # A provider handle unregisters before terminal transcript persistence has
+  # fully settled. Its broadcast remains running through that ownership window.
+  # Admission stays closed while checking it, so no fresh reservation or
+  # broadcast can appear between the idle proof and setting the drain flag.
+  if has_running_chat_broadcast():
+    registry.reopen_admission()
+    return False
+  draining = True
+  return True
 
 
 def cancel_idle_drain() -> bool:
@@ -214,6 +237,7 @@ def cancel_idle_drain() -> bool:
   if registry.all_alive_chat_ids() or _restart_draining_chats:
     return False
   draining = False
+  registry.reopen_admission()
   return True
 
 

--- a/backend/app/deployment_control.py
+++ b/backend/app/deployment_control.py
@@ -1,10 +1,11 @@
 """Container rebuild control for Settings.
 
-The browser can request only one fixed operation: replace this installation's
-app container with the official image for its applied upstream revision.
-Self-hosting crosses the /data mount to a narrow host helper; managed Railway
-uses its account service, while the root-owned restart ledger preserves chat
-continuation across either cutover.
+The browser can request only fixed official-image operations. Managed Railway
+discovers the newest completely published GHCR release, then pins its immutable
+revision and digest; a reviewed image-owned update carries that same identity.
+Self-hosting keeps rebuilding the applied upstream revision through its narrow
+host helper. The root-owned restart ledger preserves chat continuation across
+either cutover.
 """
 
 from __future__ import annotations
@@ -40,7 +41,16 @@ class RebuildStatus(TypedDict):
   expected_sha: str | None
   code: str | None
   message: str | None
+  error: str | None
+  image_digest: str | None
+  release_source: Literal["applied", "latest_ghcr"]
   updated_at: str | None
+
+
+class OfficialImageRelease(TypedDict):
+  build_sha: str
+  image_digest: str
+  image_ref: str
 
 
 class DeploymentControlError(RuntimeError):
@@ -56,6 +66,7 @@ class DeploymentControlError(RuntimeError):
 
 
 _SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+_DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 _OPERATION_RE = re.compile(r"^[0-9a-f]{32}$")
 _KNOWN_STATES = {
   "idle", "queued", "preparing", "replacing", "verifying", "succeeded",
@@ -89,6 +100,9 @@ def _empty_status(
     expected_sha=None,
     code=code,
     message=message,
+    error=None,
+    image_digest=None,
+    release_source="applied",
     updated_at=None,
   )
 
@@ -98,6 +112,56 @@ def _schedule_managed_recovery(
 ) -> None:
   """Keep the sole post-rejection restart alive until it settles."""
   task = asyncio.create_task(restart())
+  _managed_recovery_tasks.add(task)
+  task.add_done_callback(_managed_recovery_tasks.discard)
+
+
+async def _reconcile_ambiguous_managed_start(
+  operation_id: str,
+  handoff_nonce: str,
+  recover: Callable[[], Awaitable[None]],
+) -> None:
+  """Recover only when the account atomically cancels an unaccepted Start.
+
+  A timed-out POST may have reached Railway even though this worker saw no
+  response. A read of the old state is not proof that the write will never
+  commit, so the still-running drained worker asks the account service to race
+  Start with one conditional Cancel update against the same handoff state. Only
+  an affirmative Cancel result makes local recovery safe; if Start won, the
+  account service owns the cutover.
+  """
+
+  while True:
+    await asyncio.sleep(2)
+    try:
+      raw = await asyncio.to_thread(
+        _managed_request,
+        "POST",
+        "cancel",
+        {"operation_id": operation_id, "handoff_nonce": handoff_nonce},
+      )
+    except DeploymentControlError:
+      continue
+    if str(raw.get("operation_id") or "") != operation_id:
+      continue
+    cancelled = raw.get("cancelled")
+    if cancelled is True:
+      await recover()
+      return
+    if cancelled is False:
+      return
+
+
+def _schedule_ambiguous_start_reconciliation(
+  operation_id: str,
+  handoff_nonce: str,
+  recover: Callable[[], Awaitable[None]],
+) -> None:
+  """Keep ambiguous Start reconciliation alive after the request returns."""
+
+  task = asyncio.create_task(
+    _reconcile_ambiguous_managed_start(operation_id, handoff_nonce, recover),
+  )
   _managed_recovery_tasks.add(task)
   task.add_done_callback(_managed_recovery_tasks.discard)
 
@@ -167,6 +231,9 @@ def _normalize_status(
     expected_sha=reported_sha or None,
     code=code,
     message=message,
+    error=str(raw.get("error") or "").strip() or None,
+    image_digest=None,
+    release_source="applied",
     updated_at=updated_at,
   )
 
@@ -256,6 +323,8 @@ def _managed_request(method: str, suffix: str, payload: dict[str, str] | None = 
 
 def _normalize_managed_status(
   raw: dict[str, Any], *, bootstrap_available: bool = False,
+  release_source: Literal["applied", "latest_ghcr"] = "latest_ghcr",
+  image_digest: str | None = None,
 ) -> RebuildStatus:
   remote_state = str(raw.get("state") or "idle").lower()
   states: dict[str, RebuildState] = {
@@ -270,6 +339,7 @@ def _normalize_managed_status(
       "controller_invalid_response", "The account service returned an unknown state."
     )
   expected = str(raw.get("expected_sha") or "").lower()
+  digest = str(raw.get("image_digest") or image_digest or "").lower()
   return RebuildStatus(
     supported=not bootstrap_available,
     bootstrap_available=bootstrap_available,
@@ -279,7 +349,34 @@ def _normalize_managed_status(
     expected_sha=expected if _SHA_RE.fullmatch(expected) else None,
     code=None,
     message=str(raw.get("message") or "")[:360] or None,
+    error=str(raw.get("error") or "")[:1000] or None,
+    image_digest=digest if _DIGEST_RE.fullmatch(digest) else None,
+    release_source=release_source,
     updated_at=str(raw.get("updated_at") or "") or None,
+  )
+
+
+async def latest_official_release() -> OfficialImageRelease:
+  """Discover the newest fully published official Railway image from GHCR.
+
+  The account service cross-checks mutable ``main`` against its immutable SHA
+  tag. This method accepts only the resulting commit+digest identity; callers
+  then pass both back to prepare, which prevents a moved tag from changing the
+  reviewed bytes.
+  """
+  raw = await asyncio.to_thread(_managed_request, "GET", "release")
+  build_sha = str(raw.get("build_sha") or "").strip().lower()
+  image_digest = str(raw.get("image_digest") or "").strip().lower()
+  image_ref = str(raw.get("image_ref") or "").strip()
+  if not _SHA_RE.fullmatch(build_sha) or not _DIGEST_RE.fullmatch(image_digest):
+    raise DeploymentControlError(
+      "controller_invalid_response",
+      "The account service returned an invalid official image identity.",
+    )
+  return OfficialImageRelease(
+    build_sha=build_sha,
+    image_digest=image_digest,
+    image_ref=image_ref,
   )
 
 
@@ -465,32 +562,54 @@ async def request_rebuild() -> RebuildStatus:
         "A container rebuild is already running.",
         status_code=409,
       )
-  expected_sha = _expected_upstream_sha()
+  release: OfficialImageRelease | None = None
+  if deployment == "railway":
+    # Railway's deployable release authority is GHCR, not the persisted source
+    # checkout. `main` is used only to discover a verified commit+digest pair;
+    # prepare below pins the immutable SHA tag and that exact digest.
+    release = await latest_official_release()
+    expected_sha = release["build_sha"]
+  else:
+    expected_sha = _expected_upstream_sha()
   if not expected_sha:
     raise DeploymentControlError(
       "target_unavailable",
       "Möbius cannot identify the official version to deploy.",
       status_code=409,
     )
-  blockers = platform_update.container_replacement_blockers(
-    expected_sha,
-    preserve_active_runtime=deployment == "self_hosted",
-  )
-  if blockers:
-    visible = ", ".join(blockers[:5])
-    if len(blockers) > 5:
-      visible += f", and {len(blockers) - 5} more"
-    raise DeploymentControlError(
-      "local_runtime_changes",
-      "The official image cannot preserve these local image inputs: "
-      f"{visible}. Commit them upstream, rebuild locally, or remove them "
-      "before rebuilding this container.",
-      status_code=409,
-    )
+  def validate_image_inputs() -> None:
+    try:
+      blockers = (
+        platform_update.official_image_rebuild_blockers(expected_sha)
+        if deployment == "railway"
+        else platform_update.container_replacement_blockers(
+          expected_sha,
+          preserve_active_runtime=True,
+        )
+      )
+    except platform_update.PlatformUpdateError as exc:
+      raise DeploymentControlError(
+        "target_unavailable",
+        "Möbius found the latest official image but could not verify its source revision.",
+        status_code=409,
+      ) from exc
+    if blockers:
+      _raise_local_runtime_blockers(blockers)
+
+  # Railway verification may fetch the target revision from Git. Keep that
+  # bounded network/filesystem work off the backend event loop.
+  await asyncio.to_thread(validate_image_inputs)
   if deployment == "railway":
+    assert release is not None
     if not managed_cutover_ready():
-      return await _request_managed_bootstrap(expected_sha)
-    return await _request_managed_rebuild(expected_sha)
+      return await _request_managed_bootstrap(
+        expected_sha, release["image_digest"],
+      )
+    return await _request_managed_rebuild(
+      expected_sha,
+      release["image_digest"],
+      final_check=validate_image_inputs,
+    )
   await asyncio.to_thread(_write_request, expected_sha)
   return _normalize_status({
     "state": "queued",
@@ -499,7 +618,105 @@ async def request_rebuild() -> RebuildStatus:
   }, expected_sha=expected_sha)
 
 
-async def _request_managed_rebuild(expected_sha: str) -> RebuildStatus:
+async def request_reviewed_rebuild(
+  *,
+  plan_id: str,
+  current_sha: str,
+  target_sha: str,
+  image_digest: str,
+) -> RebuildStatus:
+  """Cut over Railway to the exact GHCR image bound into an owner review."""
+  if platform_activation.deployment_kind() != "railway":
+    raise DeploymentControlError(
+      "unsupported_deployment",
+      "Reviewed image updates are available on Railway deployments.",
+      status_code=409,
+  )
+  def validate_reviewed_release() -> None:
+    try:
+      reviewed = platform_update.reviewed_container_rebuild_plan(
+        plan_id=plan_id,
+        current_sha=current_sha,
+        target_sha=target_sha,
+        image_digest=image_digest,
+      )
+    except platform_update.PlatformUpdateError as exc:
+      code = str(exc)
+      messages = {
+        "update_plan_stale": (
+          "Möbius changed since this preview. Refresh and review the update again."
+        ),
+        "update_plan_invalid": (
+          "This update review is no longer valid. Refresh it and try again."
+        ),
+        "update_plan_target_missing": (
+          "The reviewed release source is unavailable. Refresh and try again shortly."
+        ),
+      }
+      raise DeploymentControlError(
+        code,
+        messages.get(
+          code,
+          "This update could not be verified. Refresh it and try again.",
+        ),
+        status_code=409,
+      ) from exc
+    if reviewed["activation"]["level"] != (
+      platform_activation.ActivationLevel.IMAGE_REBUILD.value
+    ):
+      raise DeploymentControlError(
+        "activation_changed",
+        "This update no longer requires a container rebuild. Refresh the review.",
+        status_code=409,
+      )
+    if reviewed["blockers"]:
+      _raise_local_runtime_blockers(reviewed["blockers"])
+
+  await asyncio.to_thread(validate_reviewed_release)
+  # The SHA tag and digest are immutable. A newer `main` publication must not
+  # invalidate an already reviewed release, so prepare proves this exact pair
+  # rather than consulting the moving discovery tag again.
+  return await _request_managed_rebuild(
+    target_sha,
+    image_digest,
+    final_check=validate_reviewed_release,
+  )
+
+
+def _raise_local_runtime_blockers(blockers: list[str]) -> None:
+  visible = ", ".join(blockers[:5])
+  if len(blockers) > 5:
+    visible += f", and {len(blockers) - 5} more"
+  raise DeploymentControlError(
+    "local_runtime_changes",
+    "The official image cannot preserve these local image inputs: "
+    f"{visible}. Commit them upstream, rebuild locally, or remove them "
+    "before rebuilding this container.",
+    status_code=409,
+  )
+
+
+def _verify_managed_release_echo(
+  raw: dict[str, Any],
+  expected_sha: str,
+  expected_digest: str,
+) -> None:
+  """Require the account service to echo the exact immutable release pair."""
+  reported_sha = str(raw.get("expected_sha") or "").strip().lower()
+  reported_digest = str(raw.get("image_digest") or "").strip().lower()
+  if reported_sha != expected_sha or reported_digest != expected_digest:
+    raise DeploymentControlError(
+      "controller_invalid_response",
+      "The account service did not confirm the exact reviewed image.",
+    )
+
+
+async def _request_managed_rebuild(
+  expected_sha: str,
+  expected_digest: str,
+  *,
+  final_check: Callable[[], None] | None = None,
+) -> RebuildStatus:
   from app import restart_ledger, restart_util
 
   if not managed_cutover_ready():
@@ -509,10 +726,16 @@ async def _request_managed_rebuild(expected_sha: str) -> RebuildStatus:
       status_code=409,
     )
   prepared = await asyncio.to_thread(
-    _managed_request, "POST", "prepare", {"expected_sha": expected_sha},
+    _managed_request,
+    "POST",
+    "prepare",
+    {"expected_sha": expected_sha, "expected_digest": expected_digest},
   )
+  _verify_managed_release_echo(prepared, expected_sha, expected_digest)
   if prepared.get("state") == "no_change":
-    return _normalize_managed_status(prepared)
+    return _normalize_managed_status(
+      prepared, image_digest=expected_digest,
+    )
   operation_id = str(prepared.get("operation_id") or "")
   handoff_nonce = str(prepared.get("handoff_nonce") or "")
   boot_id = restart_ledger.current_boot_id()
@@ -544,6 +767,11 @@ async def _request_managed_rebuild(expected_sha: str) -> RebuildStatus:
           "controller_unavailable", "The container could not finish the Railway handoff."
         )
       await asyncio.sleep(0.25)
+    # Commits do not take the reconcile lock, so validation performed before
+    # chat drain can become stale. Re-check the exact plan and image-owned
+    # blockers at the last locally-owned boundary before Railway starts.
+    if final_check is not None:
+      await asyncio.to_thread(final_check)
     provider_start_attempted = True
     started = await asyncio.to_thread(
       _managed_request,
@@ -551,19 +779,37 @@ async def _request_managed_rebuild(expected_sha: str) -> RebuildStatus:
       "start",
       {"operation_id": operation_id, "handoff_nonce": handoff_nonce},
     )
-    return _normalize_managed_status(started)
-  except DeploymentControlError as exc:
+    _verify_managed_release_echo(started, expected_sha, expected_digest)
+    return _normalize_managed_status(
+      started, image_digest=expected_digest,
+    )
+  except Exception as exc:
+    code = exc.code if isinstance(exc, DeploymentControlError) else None
     if drained and (
-      not provider_start_attempted or exc.code == "controller_rejected"
+      not provider_start_attempted or code == "controller_rejected"
     ):
       # Before the start request, the provider cannot own the transition. After
       # it, only a definitive rejection proves local recovery cannot race an
       # accepted Railway cutover.
       _schedule_managed_recovery(restart_util.restart_this_worker)
-    raise
+    elif drained and provider_start_attempted and code != "controller_rejected":
+      _schedule_ambiguous_start_reconciliation(
+        operation_id,
+        handoff_nonce,
+        restart_util.restart_this_worker,
+      )
+    if isinstance(exc, DeploymentControlError):
+      raise
+    raise DeploymentControlError(
+      "controller_unavailable",
+      "The final container replacement check could not complete.",
+    ) from exc
 
 
-async def _request_managed_bootstrap(expected_sha: str) -> RebuildStatus:
+async def _request_managed_bootstrap(
+  expected_sha: str,
+  expected_digest: str,
+) -> RebuildStatus:
   """Move one legacy Railway image onto the root-owned handoff protocol.
 
   The account service validates and owns the Railway mutation. The old image
@@ -573,34 +819,58 @@ async def _request_managed_bootstrap(expected_sha: str) -> RebuildStatus:
   the durable queue for the new worker.
   """
   from app import chat
-  from app.runner_registry import registry
 
   prepared = await asyncio.to_thread(
-    _managed_request, "POST", "bootstrap/prepare", {"expected_sha": expected_sha},
+    _managed_request,
+    "POST",
+    "bootstrap/prepare",
+    {"expected_sha": expected_sha, "expected_digest": expected_digest},
   )
+  _verify_managed_release_echo(prepared, expected_sha, expected_digest)
   operation_id = str(prepared.get("operation_id") or "")
   handoff_nonce = str(prepared.get("handoff_nonce") or "")
   if not operation_id or not handoff_nonce:
     raise DeploymentControlError(
       "controller_invalid_response", "The managed upgrade handoff is incomplete."
     )
-  if registry.all_alive_chat_ids():
+  if not chat.begin_idle_drain():
     raise DeploymentControlError(
       "active_chats",
       "Finish active chat responses, then enable container updates again.",
       status_code=409,
     )
 
-  chat.begin_drain()
+  provider_start_attempted = False
   try:
+    provider_start_attempted = True
     started = await asyncio.to_thread(
       _managed_request,
       "POST",
       "bootstrap/start",
       {"operation_id": operation_id, "handoff_nonce": handoff_nonce},
     )
-  except DeploymentControlError as exc:
-    if exc.code == "controller_rejected":
+    _verify_managed_release_echo(started, expected_sha, expected_digest)
+  except Exception as exc:
+    code = exc.code if isinstance(exc, DeploymentControlError) else None
+    if code == "controller_rejected" or not provider_start_attempted:
       chat.cancel_idle_drain()
-    raise
-  return _normalize_managed_status(started, bootstrap_available=True)
+    else:
+      async def recover_idle_drain() -> None:
+        chat.cancel_idle_drain()
+
+      _schedule_ambiguous_start_reconciliation(
+        operation_id,
+        handoff_nonce,
+        recover_idle_drain,
+      )
+    if isinstance(exc, DeploymentControlError):
+      raise
+    raise DeploymentControlError(
+      "controller_unavailable",
+      "The managed container upgrade could not finish its handoff.",
+    ) from exc
+  return _normalize_managed_status(
+    started,
+    bootstrap_available=True,
+    image_digest=expected_digest,
+  )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -944,7 +944,10 @@ def ready(response: Response):
   return {"ready": False, "reason": reason}
 
 
-def _served_platform_identity(data_dir: str) -> dict:
+def _served_platform_identity(
+  data_dir: str,
+  image_build_sha: str = "unknown",
+) -> dict:
   """The ACTUALLY-SERVED backend identity, distinct from the image ``build_sha``.
 
   The served backend is normally ``/data/platform/app``, which persists across
@@ -958,7 +961,8 @@ def _served_platform_identity(data_dir: str) -> dict:
   import subprocess
 
   out = {"serving_source": "unknown", "served_sha": None, "platform_sha": None,
-         "platform_dirty": None, "baked_sha": None}
+         "platform_dirty": None, "applied_upstream_sha": None,
+         "image_build_applied": False, "baked_sha": None}
   try:
     sentinel = Path(
       os.environ.get("MOBIUS_SERVING_SOURCE_FILE", "/tmp/serving-source")
@@ -992,6 +996,17 @@ def _served_platform_identity(data_dir: str) -> dict:
         head = _git("rev-parse", "HEAD")
         if head.returncode == 0:
           out["platform_sha"] = head.stdout.strip() or None
+      upstream = _git("rev-parse", "refs/heads/upstream")
+      if upstream.returncode == 0:
+        value = upstream.stdout.strip()
+        if re.fullmatch(r"[0-9a-f]{40}", value):
+          out["applied_upstream_sha"] = value
+          normalized_build = str(image_build_sha or "").strip().lower()
+          if re.fullmatch(r"[0-9a-f]{40}", normalized_build):
+            contains_build = _git(
+              "merge-base", "--is-ancestor", normalized_build, value,
+            )
+            out["image_build_applied"] = contains_build.returncode == 0
       # dirty filters .baked-sha churn + untracked dotfiles, mirroring step-3b.
       st = _git("-c", "core.fileMode=false", "status", "--porcelain")
       if st.returncode == 0:
@@ -1065,7 +1080,7 @@ def version():
           # can parse one stable scalar without reimplementing JSON traversal.
           "protected_runtime_state": protected_runtime["state"],
           "protected_runtime": protected_runtime,
-          **_served_platform_identity(settings.data_dir),
+          **_served_platform_identity(settings.data_dir, settings.build_sha),
           **_served_frontend_identity()}
 
 

--- a/backend/app/platform_activation.py
+++ b/backend/app/platform_activation.py
@@ -259,13 +259,13 @@ def _guidance(level: ActivationLevel, deployment: DeploymentKind) -> str:
   if deployment == "railway":
     if level is ActivationLevel.CONTAINER_RECREATE:
       return (
-        "Trigger a Railway deployment; an in-product restart cannot apply "
-        "deployment configuration."
+        "Apply updates the checkout, but finish this change in Railway: an "
+        "in-product restart or image rebuild cannot apply deployment configuration."
       )
     if level is ActivationLevel.IMAGE_REBUILD:
       return (
-        "Trigger a Railway image rebuild and deployment; Restart cannot "
-        "install dependencies or baked tools."
+        "Möbius will rebuild Railway to this pinned GHCR image and restore "
+        "the previous container if verification fails."
       )
   else:
     if level is ActivationLevel.PROXY_RELOAD:

--- a/backend/app/platform_update.py
+++ b/backend/app/platform_update.py
@@ -1071,13 +1071,28 @@ def container_replacement_blockers(
       image_pending.append(path)
 
   # Actual content parity with the target is authoritative whenever both
-  # revisions are known; a marker's recorded coverage must not excuse a path
-  # that drifted after the marker was written.  Without a verifiable head the
-  # marker's own upstream coverage remains the fallback.
+  # revisions are known. A newer official image may legitimately advance a
+  # marker-covered path, though, so preserve that coverage when the current
+  # local bytes still match the marker's official upstream and the replacement
+  # target descends from it. This distinguishes incoming official changes from
+  # real local drift without letting stale marker coverage excuse either an
+  # unrelated release or unverifiable runtime bytes.
   if expected_sha and head:
-    covered = set(_paths_matching_upstream(
+    exact_target_coverage = set(_paths_matching_upstream(
       repo, head, expected_sha, image_pending,
-    )) - unverifiable
+    ))
+    marker_upstream = marker["upstream_sha"] if marker else None
+    carried_marker_coverage: set[str] = set()
+    if marker_upstream and _is_ancestor(repo, marker_upstream, expected_sha):
+      carried_marker_coverage.update(_paths_matching_upstream(
+        repo,
+        head,
+        marker_upstream,
+        [path for path in image_pending if path in covered],
+      ))
+    covered = (
+      exact_target_coverage | carried_marker_coverage
+    ) - unverifiable
   return sorted(path for path in image_pending if path not in covered)
 
 

--- a/backend/app/platform_update.py
+++ b/backend/app/platform_update.py
@@ -247,6 +247,8 @@ class PlatformStatus(TypedDict):
   # backlog is reviewed once and resolved once, instead of one resolve per
   # release. Fetch-free like the rest of status: reflects the last fetch.
   newer_updates_available: bool
+  rollback_target_sha: str | None
+  rollback_error: str | None
 
 
 class PlatformApplyResult(TypedDict):
@@ -261,6 +263,17 @@ class PlatformApplyResult(TypedDict):
   chat_id: str | None
   phase: str
   reconciliation: dict[str, list[str]]
+  error: str | None
+
+
+class PlatformReviewedRebuild(TypedDict):
+  """Validated exact target for a reviewed Railway image cutover."""
+
+  target_sha: str
+  image_digest: str
+  local_base_sha: str
+  activation: PlatformActivationImpact
+  blockers: list[str]
 
 
 class _ActivationMarker(TypedDict):
@@ -323,6 +336,10 @@ class PlatformUpdatePreview(TypedDict):
   # and rejects a changed local tip or substituted target instead of silently
   # installing bytes other than the ones represented by this preview.
   plan_id: str | None
+  # Present for a Railway image-owned release. The review binds both the
+  # source revision and the immutable GHCR manifest, so a moving `main` tag can
+  # never substitute different bytes after the owner reviews the diff.
+  image_digest: str | None
   activation: PlatformActivationImpact
   total_commits: int
   commits_truncated: bool
@@ -428,9 +445,18 @@ def _set_update_progress(
     )
 
 
-def _update_plan_id(current_sha: str, target_sha: str) -> str:
+def _update_plan_id(
+  current_sha: str,
+  target_sha: str,
+  image_digest: str | None = None,
+) -> str:
   """Deterministic identity for the exact local tip + reviewed release pair."""
-  material = f"mobius-platform-update-v1\0{current_sha}\0{target_sha}".encode()
+  if image_digest:
+    material = (
+      f"mobius-platform-update-v2\0{current_sha}\0{target_sha}\0{image_digest}"
+    ).encode()
+  else:
+    material = f"mobius-platform-update-v1\0{current_sha}\0{target_sha}".encode()
   return hashlib.sha256(material).hexdigest()
 
 
@@ -440,13 +466,16 @@ def _validate_update_plan(
   plan_id: str,
   current_sha: str,
   target_sha: str,
+  image_digest: str | None = None,
 ) -> None:
   """Reject a stale or substituted preview before reconcile mutates the tree."""
   if not re.fullmatch(r"[0-9a-f]{40,64}", current_sha or ""):
     raise PlatformUpdateError("update_plan_invalid")
   if not re.fullmatch(r"[0-9a-f]{40,64}", target_sha or ""):
     raise PlatformUpdateError("update_plan_invalid")
-  if plan_id != _update_plan_id(current_sha, target_sha):
+  if image_digest is not None and not re.fullmatch(r"sha256:[0-9a-f]{64}", image_digest):
+    raise PlatformUpdateError("update_plan_invalid")
+  if plan_id != _update_plan_id(current_sha, target_sha, image_digest):
     raise PlatformUpdateError("update_plan_invalid")
 
   local = _local_branch(repo)
@@ -970,6 +999,7 @@ def container_replacement_blockers(
   repo: Path = PLATFORM_REPO,
   *,
   preserve_active_runtime: bool = False,
+  local_change_base: str | None = None,
 ) -> list[str]:
   """Return local image/runtime changes absent from the official target.
 
@@ -1011,8 +1041,13 @@ def container_replacement_blockers(
     else:
       pending.extend(runtime_provenance.activation_paths(runtime))
     if head:
+      # A reviewed target may be ahead of the applied tree. Diffing target to
+      # head would mislabel the incoming official Dockerfile/runtime changes as
+      # local drift. The reviewed path supplies the proven merge base so only
+      # the local side is considered; ordinary rebuilds keep expected..head.
+      drift_base = local_change_base or expected_sha
       drift = _git(
-        "diff", "--name-only", "--no-renames", expected_sha, head,
+        "diff", "--name-only", "--no-renames", drift_base, head,
         repo=repo, check=False,
       )
       if drift.returncode == 0:
@@ -1044,6 +1079,78 @@ def container_replacement_blockers(
       repo, head, expected_sha, image_pending,
     )) - unverifiable
   return sorted(path for path in image_pending if path not in covered)
+
+
+def reviewed_container_rebuild_plan(
+  *,
+  plan_id: str,
+  current_sha: str,
+  target_sha: str,
+  image_digest: str,
+  repo: Path = PLATFORM_REPO,
+) -> PlatformReviewedRebuild:
+  """Validate an immutable image review without mutating the served checkout."""
+  with _reconcile_flock():
+    _validate_update_plan(
+      repo,
+      plan_id=plan_id,
+      current_sha=current_sha,
+      target_sha=target_sha,
+      image_digest=image_digest,
+    )
+    base = _git(
+      "merge-base", current_sha, target_sha, repo=repo, check=False,
+    ).stdout.strip() or current_sha
+    paths = _activation_paths_between(repo, base, target_sha)
+    activation = platform_activation.classify_activation(paths)
+    blockers = container_replacement_blockers(
+      target_sha,
+      repo,
+      preserve_active_runtime=True,
+      local_change_base=base,
+    )
+    return PlatformReviewedRebuild(
+      target_sha=target_sha,
+      image_digest=image_digest,
+      local_base_sha=base,
+      activation=activation,
+      blockers=blockers,
+    )
+
+
+def official_image_rebuild_blockers(
+  target_sha: str,
+  repo: Path = PLATFORM_REPO,
+) -> list[str]:
+  """Fetch and compare local image drift against one GHCR release revision.
+
+  GHCR is authoritative for what can be deployed, while Git supplies the trees
+  needed to prove local edits will not be lost. A newly published image may be
+  ahead of this checkout's last fetch, so refresh the canonical ref before
+  computing the local side from the merge base.
+  """
+  if not re.fullmatch(r"[0-9a-f]{40}", target_sha or ""):
+    raise PlatformUpdateError("image_release_invalid")
+  with _reconcile_flock():
+    if _rev(repo, target_sha) != target_sha:
+      if not _has_origin(repo) or not _fetch(
+        repo, refspec=OWNER_UPDATE_FETCH_REFSPEC,
+      ):
+        raise PlatformUpdateError("image_release_source_unavailable")
+    if _rev(repo, target_sha) != target_sha:
+      raise PlatformUpdateError("image_release_source_unavailable")
+    current = _rev(repo, _local_branch(repo))
+    base = _git(
+      "merge-base", current, target_sha, repo=repo, check=False,
+    ).stdout.strip()
+    if not current or not base:
+      raise PlatformUpdateError("image_release_source_unavailable")
+    return container_replacement_blockers(
+      target_sha,
+      repo,
+      preserve_active_runtime=True,
+      local_change_base=base,
+    )
 
 
 def _write_activation_marker(
@@ -1784,6 +1891,7 @@ def _reconcile_under_lock(
   target_ref: str = DEFAULT_TARGET_REF,
   plan_id: str | None = None,
   current_sha: str | None = None,
+  image_digest: str | None = None,
   progress: Callable[[PlatformUpdatePhase], None] | None = None,
   prepare_frontend: bool = False,
 ) -> ReconcileResult:
@@ -1804,6 +1912,7 @@ def _reconcile_under_lock(
         plan_id=plan_id,
         current_sha=current_sha,
         target_sha=target_ref,
+        image_digest=image_digest,
       )
     previous_upstream_sha = _rev(repo, UPSTREAM_BRANCH) or None
     reconcile_kwargs = {
@@ -1936,16 +2045,24 @@ def boot_guard_sync() -> str:
     return boot_guard_clean_served_tree(PLATFORM_REPO)
 
 
-def platform_status(repo: Path = PLATFORM_REPO) -> PlatformStatus:
+def platform_status(
+  repo: Path = PLATFORM_REPO,
+  *,
+  target_sha: str | None = None,
+) -> PlatformStatus:
   """Compute update availability on demand (no daemon, no polling, no fetch).
 
-  Availability is an EXACT ancestry check against ``origin/main``. Conflict and
-  rolled-back states take precedence over a bare "available".
+  Availability is an EXACT ancestry check against the selected release. Generic
+  self-hosted callers use ``origin/main``; managed deployments pass the exact
+  GHCR release SHA so Settings never advertises a Git commit that has no
+  deployable image. Conflict and rolled-back states take precedence over a bare
+  "available".
   """
   image_sha = current_build_sha()
   upstream_sha = recorded_upstream_sha(repo)
   conflict = CONFLICT_FLAG.exists() or _reconcile_in_progress(repo)
   rolled_back = ROLLED_BACK_FLAG.exists()
+  rollback = _read_rolled_back_flag() if rolled_back else None
   activation = _platform_activation_impact(repo)
   activation_state = _state_for_activation(activation)
   restart_needed = activation["level"] in {
@@ -1953,7 +2070,7 @@ def platform_status(repo: Path = PLATFORM_REPO) -> PlatformStatus:
     platform_activation.ActivationLevel.DEPENDENCY_SYNC.value,
   }
   local = _local_branch(repo)
-  target = _rev(repo, DEFAULT_TARGET_REF)
+  target = _rev(repo, target_sha or DEFAULT_TARGET_REF)
   target_contained = bool(target) and _is_ancestor(repo, target, local)
   contained_upstream_sha = target if target_contained else upstream_sha
   contained_upstream_committed_at = _commit_timestamp(
@@ -1983,9 +2100,14 @@ def platform_status(repo: Path = PLATFORM_REPO) -> PlatformStatus:
       seed_required=False,
       conflict_paths=paths, conflict_chat_id=flag.get("chat_id"),
       newer_updates_available=newer_available,
+      rollback_target_sha=None, rollback_error=None,
     )
 
-  available = bool(target) and not target_contained
+  # A freshly published GHCR revision may not yet be in this clone's object
+  # store. Its immutable SHA is still authoritative evidence that a different
+  # release exists; the preview/check path fetches and proves the source object
+  # before it creates an actionable plan.
+  available = bool(target_sha or target) and not target_contained
 
   if rolled_back:
     # An update is available but its last apply failed the import probe.
@@ -2007,10 +2129,16 @@ def platform_status(repo: Path = PLATFORM_REPO) -> PlatformStatus:
     upstream_checked_at=upstream_checked_at,
     seed_required=False, conflict_paths=[], conflict_chat_id=None,
     newer_updates_available=False,
+    rollback_target_sha=(rollback or {}).get("target"),
+    rollback_error=(rollback or {}).get("error"),
   )
 
 
-def check_for_updates(repo: Path = PLATFORM_REPO) -> PlatformStatus:
+def check_for_updates(
+  repo: Path = PLATFORM_REPO,
+  *,
+  target_sha: str | None = None,
+) -> PlatformStatus:
   """Owner-triggered "Check for updates": fetch origin, THEN report availability.
 
   :func:`platform_status` is deliberately fetch-free — it reads
@@ -2032,15 +2160,18 @@ def check_for_updates(repo: Path = PLATFORM_REPO) -> PlatformStatus:
     # have a configured refspec that cannot advance origin/main.
     if not _fetch(repo, refspec=OWNER_UPDATE_FETCH_REFSPEC):
       raise PlatformUpdateError("platform_fetch_failed")
+    if target_sha and _rev(repo, target_sha) != target_sha:
+      raise PlatformUpdateError("image_release_source_unavailable")
     target = _rev(repo, DEFAULT_TARGET_REF)
     local = _local_branch(repo)
     if target and _is_ancestor(repo, target, local):
       _set_upstream(repo, target)
-  return platform_status(repo)
+  return platform_status(repo, target_sha=target_sha)
 
 
 def empty_platform_update_preview(
   *, current_sha: str | None = None, target_sha: str | None = None,
+  image_digest: str | None = None,
 ) -> PlatformUpdatePreview:
   """A preview carrying no incoming changes — the up-to-date / unreadable case.
   The review sheet reads ``available``/``files`` and shows "nothing to review"
@@ -2048,6 +2179,7 @@ def empty_platform_update_preview(
   return PlatformUpdatePreview(
     state=PlatformUpdateState.UP_TO_DATE.value, available=False,
     current_sha=current_sha, target_sha=target_sha, plan_id=None,
+    image_digest=image_digest,
     activation=platform_activation.classify_activation([]),
     total_commits=0, commits_truncated=False,
     commits=[], files=[], diff=None, diff_truncated=False, conflict_paths=[],
@@ -2142,38 +2274,69 @@ def _preview_diff(repo: Path, base: str, target: str) -> tuple[str | None, bool]
   return (text or None), False
 
 
-def platform_update_preview(repo: Path = PLATFORM_REPO) -> PlatformUpdatePreview:
+def platform_update_preview(
+  repo: Path = PLATFORM_REPO,
+  *,
+  target_sha: str | None = None,
+  image_digest: str | None = None,
+) -> PlatformUpdatePreview:
   """Read-only preview of the incoming platform update, for the Settings review
-  step before Apply (fetch-free, never mutates the tree).
+  step before Apply. Generic previews remain fetch-free. When a managed
+  deployment supplies an exact GHCR target, this function may refresh the
+  canonical remote ref solely to obtain and verify that immutable source tree;
+  it never mutates the served branch or working tree.
 
   Shows the upstream-side changes ``origin/main`` brings since the shared merge
   base — local edits are excluded, so the owner reviews exactly what a clean Apply
   would pull. Availability is the same ancestry check :func:`platform_status`
-  uses; an up-to-date instance returns an empty preview. Degrades to an empty
-  preview (never raises) when the clone or ancestry can't be read, so it can never
-  break Settings."""
+  uses; an up-to-date instance returns an empty preview. Generic self-hosted
+  reads degrade to an empty preview when the clone or ancestry cannot be read.
+  An explicit managed-image target instead fails closed when its source tree
+  cannot be verified, so "unavailable" can never masquerade as "up to date."""
   # A missing/non-clone tree has no source snapshot to protect. Return before
   # touching the durable /data lock so read-only diagnostics and recovery
   # surfaces still degrade cleanly when DATA_DIR itself is unavailable.
   # Actual clones take the lock below; the unlocked builder repeats this check
   # after acquisition, which closes a removal/reseed race.
   if not (repo / ".git").exists():
+    if target_sha:
+      raise PlatformUpdateError("image_release_source_unavailable")
     return empty_platform_update_preview()
   with _reconcile_flock():
-    return _platform_update_preview_unlocked(repo)
+    return _platform_update_preview_unlocked(
+      repo,
+      target_sha=target_sha,
+      image_digest=image_digest,
+    )
 
 
-def _platform_update_preview_unlocked(repo: Path) -> PlatformUpdatePreview:
+def _platform_update_preview_unlocked(
+  repo: Path,
+  *,
+  target_sha: str | None = None,
+  image_digest: str | None = None,
+) -> PlatformUpdatePreview:
   """Build one preview while the reconcile lock holds its source snapshot."""
   if not (repo / ".git").exists() or not _has_origin(repo):
+    if target_sha:
+      raise PlatformUpdateError("image_release_source_unavailable")
     return empty_platform_update_preview()
+  if target_sha:
+    if not re.fullmatch(r"[0-9a-f]{40}", target_sha):
+      raise PlatformUpdateError("image_release_invalid")
+    if _rev(repo, target_sha) != target_sha:
+      if not _fetch(repo, refspec=OWNER_UPDATE_FETCH_REFSPEC):
+        raise PlatformUpdateError("image_release_source_unavailable")
+    if _rev(repo, target_sha) != target_sha:
+      raise PlatformUpdateError("image_release_source_unavailable")
   local = _local_branch(repo)
   local_sha = _rev(repo, local) or None
-  target = _rev(repo, DEFAULT_TARGET_REF) or None
+  target = _rev(repo, target_sha or DEFAULT_TARGET_REF) or None
   available = bool(target) and not _is_ancestor(repo, target, local)
   if not target or not available:
     return empty_platform_update_preview(
       current_sha=local_sha, target_sha=target,
+      image_digest=image_digest,
     )
   base = _git(
     "merge-base", local, target, repo=repo, check=False,
@@ -2184,7 +2347,10 @@ def _platform_update_preview_unlocked(repo: Path) -> PlatformUpdatePreview:
     return PlatformUpdatePreview(
       state=PlatformUpdateState.AVAILABLE.value, available=True,
       current_sha=local_sha, target_sha=target,
-      plan_id=_update_plan_id(local_sha, target) if local_sha else None,
+      plan_id=(
+        _update_plan_id(local_sha, target, image_digest) if local_sha else None
+      ),
+      image_digest=image_digest,
       activation=platform_activation.classify_activation(["backend/app"]),
       total_commits=0, commits_truncated=False, commits=[], files=[],
       diff=None, diff_truncated=False, conflict_paths=[],
@@ -2197,7 +2363,10 @@ def _platform_update_preview_unlocked(repo: Path) -> PlatformUpdatePreview:
   return PlatformUpdatePreview(
     state=PlatformUpdateState.AVAILABLE.value, available=True,
     current_sha=local_sha, target_sha=target,
-    plan_id=_update_plan_id(local_sha, target) if local_sha else None,
+    plan_id=(
+      _update_plan_id(local_sha, target, image_digest) if local_sha else None
+    ),
+    image_digest=image_digest,
     activation=platform_activation.classify_activation(activation_paths),
     total_commits=total_commits,
     commits_truncated=total_commits > len(commits),
@@ -2214,6 +2383,7 @@ async def apply_platform_update(
   plan_id: str,
   current_sha: str,
   target_sha: str,
+  image_digest: str | None = None,
   repo: Path = PLATFORM_REPO,
 ) -> PlatformApplyResult:
   """Owner-triggered reconcile with an explicit activation remainder.
@@ -2248,6 +2418,7 @@ async def apply_platform_update(
         target_ref=target_sha,
         plan_id=plan_id,
         current_sha=current_sha,
+        image_digest=image_digest,
         progress=publish_progress,
         prepare_frontend=True,
       )
@@ -2340,6 +2511,7 @@ async def apply_platform_update(
         chat_id=chat_id,
         phase=final_phase.value,
         reconciliation=res.reconciliation.as_dict(),
+        error=res.error if state is PlatformUpdateState.ROLLED_BACK else None,
       )
     except Exception as exc:
       _set_update_progress(

--- a/backend/app/routes/platform.py
+++ b/backend/app/routes/platform.py
@@ -25,7 +25,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 from starlette.background import BackgroundTask
 
-from app import models, platform_activation, platform_update
+from app import deployment_control, models, platform_activation, platform_update
 from app.database import get_db
 from app.deps import get_current_owner, reject_cross_site
 from app.platform_update import (
@@ -39,27 +39,75 @@ log = logging.getLogger("mobius.platform")
 router = APIRouter(prefix="/api/platform", tags=["platform"])
 
 
+_PLAN_ERROR_MESSAGES = {
+  "update_plan_stale": (
+    "Möbius changed since this preview. Refresh and review the update again."
+  ),
+  "update_plan_invalid": (
+    "This update review is no longer valid. Refresh it and try again."
+  ),
+  "update_plan_target_missing": (
+    "The reviewed release source is unavailable. Refresh and try again shortly."
+  ),
+  "image_release_source_unavailable": (
+    "The official image is published, but its source revision could not be "
+    "verified yet. Try again shortly."
+  ),
+  "image_release_invalid": (
+    "The official image returned an invalid release identity. Try again later."
+  ),
+}
+
+
+def _plan_error_detail(exc: PlatformUpdateError) -> dict[str, str]:
+  code = str(exc)
+  return {
+    "code": code,
+    "message": _PLAN_ERROR_MESSAGES.get(
+      code,
+      "This update could not be verified. Refresh it and try again.",
+    ),
+  }
+
+
 class PlatformApplyIn(BaseModel):
   """The immutable update plan returned by ``GET /update-preview``."""
 
   plan_id: str = Field(min_length=64, max_length=64)
   current_sha: str = Field(min_length=40, max_length=64)
   target_sha: str = Field(min_length=40, max_length=64)
+  image_digest: str | None = Field(
+    default=None,
+    pattern=r"^sha256:[0-9a-f]{64}$",
+  )
 
 
 @router.get("/status")
 async def get_platform_status(
   _: models.Owner = Depends(get_current_owner),
 ) -> PlatformStatus:
-  """Cheap, read-only update availability for Settings. Never raises — a git
-  hiccup degrades to "up to date" rather than breaking the page.
+  """Read-only update availability for Settings. Railway resolves its published
+  GHCR release identity; self-hosting remains a cheap local read. A managed
+  release lookup failure is explicit so Settings never calls an unknown release
+  current. Local Git diagnostics still degrade without breaking the page.
 
   Does NOT clear the restart flag here: a restart-needed set by an owner Apply
   must persist (the running uvicorn still has the old code) until an actual boot
   reconcile clears it. Clearing on ancestry alone would drop it in the SAME stale
   process the moment the on-disk tree looks reconciled."""
   try:
+    if platform_activation.deployment_kind() == "railway":
+      release = await deployment_control.latest_official_release()
+      return await asyncio.to_thread(
+        platform_update.platform_status,
+        target_sha=release["build_sha"],
+      )
     return await asyncio.to_thread(platform_update.platform_status)
+  except deployment_control.DeploymentControlError as exc:
+    raise HTTPException(
+      status_code=exc.status_code,
+      detail={"code": exc.code, "message": exc.message},
+    ) from exc
   except Exception as exc:
     log.warning("platform status failed: %r", exc)
     return PlatformStatus(
@@ -71,6 +119,7 @@ async def get_platform_status(
       contained_upstream_committed_at=None, upstream_checked_at=None,
       seed_required=False, conflict_paths=[],
       conflict_chat_id=None, newer_updates_available=False,
+      rollback_target_sha=None, rollback_error=None,
     )
 
 
@@ -83,7 +132,20 @@ async def check_platform_updates(
   refresh. A failed check is a 503 so Settings cannot mistake stale tracking
   data for an authoritative "No updates found" result."""
   try:
+    if platform_activation.deployment_kind() == "railway":
+      release = await deployment_control.latest_official_release()
+      return await asyncio.to_thread(
+        platform_update.check_for_updates,
+        target_sha=release["build_sha"],
+      )
     return await asyncio.to_thread(platform_update.check_for_updates)
+  except deployment_control.DeploymentControlError as exc:
+    raise HTTPException(
+      status_code=exc.status_code,
+      detail={"code": exc.code, "message": exc.message},
+    ) from exc
+  except platform_update.PlatformUpdateError as exc:
+    raise HTTPException(status_code=503, detail=_plan_error_detail(exc)) from exc
   except Exception as exc:
     log.warning("platform check failed: %r", exc)
     raise HTTPException(
@@ -97,11 +159,26 @@ async def get_platform_update_preview(
   _: models.Owner = Depends(get_current_owner),
 ) -> PlatformUpdatePreview:
   """Read-only preview of the incoming platform update, for the Settings review
-  step the owner sees before Apply. Fetch-free and non-mutating like ``/status``.
-  Never raises — a git hiccup degrades to an empty preview so the review sheet
-  shows "nothing to review" rather than breaking the page."""
+  step the owner sees before Apply. Railway may fetch the exact source object
+  named by GHCR, but never mutates the served branch or working tree. Missing
+  managed release source is explicit; generic self-hosted read failures still
+  degrade to an empty preview rather than breaking Settings."""
   try:
+    if platform_activation.deployment_kind() == "railway":
+      release = await deployment_control.latest_official_release()
+      return await asyncio.to_thread(
+        platform_update.platform_update_preview,
+        target_sha=release["build_sha"],
+        image_digest=release["image_digest"],
+      )
     return await asyncio.to_thread(platform_update.platform_update_preview)
+  except deployment_control.DeploymentControlError as exc:
+    raise HTTPException(
+      status_code=exc.status_code,
+      detail={"code": exc.code, "message": exc.message},
+    ) from exc
+  except platform_update.PlatformUpdateError as exc:
+    raise HTTPException(status_code=503, detail=_plan_error_detail(exc)) from exc
   except Exception as exc:
     log.warning("platform update-preview failed: %r", exc)
     return platform_update.empty_platform_update_preview()
@@ -128,11 +205,41 @@ async def apply_platform_update(
       plan_id=request.plan_id,
       current_sha=request.current_sha,
       target_sha=request.target_sha,
+      image_digest=request.image_digest,
     )
   except PlatformUpdateError as exc:
     # A known, recoverable precondition failure (offline fetch, not a clone) —
     # tell the UI plainly; the instance is untouched.
-    raise HTTPException(status_code=409, detail=str(exc)) from exc
+    raise HTTPException(status_code=409, detail=_plan_error_detail(exc)) from exc
+
+
+@router.post(
+  "/rebuild",
+  dependencies=[Depends(reject_cross_site)],
+  status_code=202,
+)
+async def rebuild_reviewed_platform_update(
+  request: PlatformApplyIn,
+  _: models.Owner = Depends(get_current_owner),
+):
+  """Deploy the exact digest-pinned GHCR image represented by the review."""
+  if not request.image_digest:
+    exc = PlatformUpdateError("update_plan_invalid")
+    raise HTTPException(status_code=409, detail=_plan_error_detail(exc))
+  try:
+    return await deployment_control.request_reviewed_rebuild(
+      plan_id=request.plan_id,
+      current_sha=request.current_sha,
+      target_sha=request.target_sha,
+      image_digest=request.image_digest,
+    )
+  except platform_update.PlatformUpdateError as exc:
+    raise HTTPException(status_code=409, detail=_plan_error_detail(exc)) from exc
+  except deployment_control.DeploymentControlError as exc:
+    raise HTTPException(
+      status_code=exc.status_code,
+      detail={"code": exc.code, "message": exc.message},
+    ) from exc
 
 
 @router.post("/conflict-resolver-chat", dependencies=[Depends(reject_cross_site)])

--- a/backend/app/runner_registry.py
+++ b/backend/app/runner_registry.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from enum import Enum
+import threading
 from typing import Protocol, runtime_checkable
 
 
@@ -39,6 +40,11 @@ class RunnerRegistry:
     self._starting: set[str] = set()
     self._handles: dict[tuple[str, RunnerKind], RunnerHandle] = {}
     self._generation: dict[str, int] = {}
+    # The drain gate and a new runner reservation share this lock. A send that
+    # passed the route's early drain check must still fail its final reservation
+    # once a restart closes admission.
+    self._admission_lock = threading.Lock()
+    self._admission_closed = False
     # Chats soft-deleted while a run was in flight. `current_generation`
     # returns +inf for these so a run holding any finite pre-delete run_gen
     # computes `we_own_gen=False` and skips finalize onto the dead row — the
@@ -49,12 +55,31 @@ class RunnerRegistry:
 
   def mark_starting(self, chat_id: str) -> bool:
     """Reserves a spawn slot for a chat if it is currently idle."""
-    if chat_id in self._starting:
-      return False
-    if any(cid == chat_id for cid, _ in self._handles):
-      return False
-    self._starting.add(chat_id)
-    return True
+    with self._admission_lock:
+      if self._admission_closed or chat_id in self._starting:
+        return False
+      if any(cid == chat_id for cid, _ in self._handles):
+        return False
+      self._starting.add(chat_id)
+      return True
+
+  def close_admission(self) -> None:
+    """Prevent future runner reservations until explicitly reopened."""
+    with self._admission_lock:
+      self._admission_closed = True
+
+  def close_admission_if_idle(self) -> bool:
+    """Atomically close admission only when no runner is active or starting."""
+    with self._admission_lock:
+      if self._starting or self._handles:
+        return False
+      self._admission_closed = True
+      return True
+
+  def reopen_admission(self) -> None:
+    """Allow future runner reservations after an idle drain is cancelled."""
+    with self._admission_lock:
+      self._admission_closed = False
 
   def discard_starting(self, chat_id: str) -> None:
     """Clears a chat's starting reservation."""
@@ -181,10 +206,12 @@ class RunnerRegistry:
 
   def reset_for_tests(self) -> None:
     """Clears all registry state between tests."""
-    self._starting.clear()
-    self._handles.clear()
-    self._generation.clear()
-    self._deleted.clear()
+    with self._admission_lock:
+      self._starting.clear()
+      self._handles.clear()
+      self._generation.clear()
+      self._deleted.clear()
+      self._admission_closed = False
 
 
 registry = RunnerRegistry()

--- a/backend/tests/test_deployment_control.py
+++ b/backend/tests/test_deployment_control.py
@@ -5,12 +5,32 @@ from __future__ import annotations
 import asyncio
 import io
 import json
+import threading
 from types import SimpleNamespace
 import urllib.error
 
 import pytest
 
 from app import deployment_control as dc
+
+
+_TEST_DIGEST = "sha256:" + "d" * 64
+
+
+def _install_latest_release(monkeypatch, sha="a" * 40):
+  async def latest():
+    return {
+      "build_sha": sha,
+      "image_digest": _TEST_DIGEST,
+      "image_ref": f"ghcr.io/mobius-os/mobius:sha-{sha}@{_TEST_DIGEST}",
+    }
+
+  monkeypatch.setattr(dc, "latest_official_release", latest)
+  monkeypatch.setattr(
+    dc.platform_update,
+    "official_image_rebuild_blockers",
+    lambda *_args, **_kwargs: [],
+  )
 
 
 def _install_control(tmp_path, monkeypatch):
@@ -108,18 +128,272 @@ def test_normalize_rejects_unknown_controller_state():
 
 
 @pytest.mark.asyncio
+async def test_latest_official_release_requires_verified_sha_and_digest(
+  monkeypatch,
+):
+  monkeypatch.setattr(dc, "_managed_request", lambda *_args: {
+    "build_sha": "b" * 40,
+    "image_digest": "sha256:" + "c" * 64,
+    "image_ref": "immutable-ref",
+  })
+
+  release = await dc.latest_official_release()
+
+  assert release == {
+    "build_sha": "b" * 40,
+    "image_digest": "sha256:" + "c" * 64,
+    "image_ref": "immutable-ref",
+  }
+
+  monkeypatch.setattr(dc, "_managed_request", lambda *_args: {
+    "build_sha": "b" * 40,
+    "image_digest": "mutable",
+  })
+  with pytest.raises(dc.DeploymentControlError) as exc:
+    await dc.latest_official_release()
+  assert exc.value.code == "controller_invalid_response"
+
+
+def test_managed_status_preserves_controller_failure_detail():
+  status = dc._normalize_managed_status({
+    "state": "rolled_back",
+    "expected_sha": "a" * 40,
+    "message": "Previous deployment restored.",
+    "error": "Public URL served the wrong build SHA.",
+  })
+
+  assert status["state"] == "rolled_back"
+  assert status["error"] == "Public URL served the wrong build SHA."
+  assert status["release_source"] == "latest_ghcr"
+
+
+@pytest.mark.asyncio
+async def test_reviewed_rebuild_uses_exact_plan_target_and_digest(monkeypatch):
+  target = "b" * 40
+  digest = "sha256:" + "c" * 64
+  captured = {}
+
+  monkeypatch.setattr(
+    dc.platform_activation, "deployment_kind", lambda: "railway",
+  )
+  monkeypatch.setattr(
+    dc.platform_update,
+    "reviewed_container_rebuild_plan",
+    lambda **plan: {
+      "target_sha": plan["target_sha"],
+      "image_digest": plan["image_digest"],
+      "local_base_sha": plan["current_sha"],
+      "activation": {
+        "level": "image_rebuild", "deployment": "railway",
+        "reasons": [], "guidance": [],
+      },
+      "blockers": [],
+    },
+  )
+
+  async def start(expected_sha, expected_digest, *, final_check):
+    captured.update(sha=expected_sha, digest=expected_digest)
+    final_check()
+    return {"state": "queued"}
+
+  monkeypatch.setattr(dc, "_request_managed_rebuild", start)
+
+  status = await dc.request_reviewed_rebuild(
+    plan_id="a" * 64,
+    current_sha="1" * 40,
+    target_sha=target,
+    image_digest=digest,
+  )
+
+  assert status["state"] == "queued"
+  assert captured == {"sha": target, "digest": digest}
+
+
+@pytest.mark.asyncio
+async def test_reviewed_immutable_plan_does_not_reconsult_moving_ghcr_main(
+  monkeypatch,
+):
+  target = "b" * 40
+  digest = "sha256:" + "c" * 64
+  monkeypatch.setattr(
+    dc.platform_activation, "deployment_kind", lambda: "railway",
+  )
+
+  async def moving_main_must_not_be_read():
+    raise AssertionError("immutable review reconsulted the moving main tag")
+
+  monkeypatch.setattr(dc, "latest_official_release", moving_main_must_not_be_read)
+  monkeypatch.setattr(
+    dc.platform_update,
+    "reviewed_container_rebuild_plan",
+    lambda **plan: {
+      "target_sha": plan["target_sha"],
+      "image_digest": plan["image_digest"],
+      "local_base_sha": plan["current_sha"],
+      "activation": {
+        "level": "image_rebuild", "deployment": "railway",
+        "reasons": [], "guidance": [],
+      },
+      "blockers": [],
+    },
+  )
+
+  async def start(expected_sha, expected_digest, *, final_check):
+    final_check()
+    return {
+      "state": "queued", "expected_sha": expected_sha,
+      "image_digest": expected_digest,
+    }
+
+  monkeypatch.setattr(dc, "_request_managed_rebuild", start)
+
+  result = await dc.request_reviewed_rebuild(
+    plan_id="a" * 64,
+    current_sha="1" * 40,
+    target_sha=target,
+    image_digest=digest,
+  )
+
+  assert result["expected_sha"] == target
+  assert result["image_digest"] == digest
+
+
+@pytest.mark.asyncio
+async def test_managed_prepare_rejects_mismatched_release_echo(
+  tmp_path, monkeypatch,
+):
+  _install_managed_cutover_marker(tmp_path, monkeypatch)
+  monkeypatch.setattr(
+    dc,
+    "get_settings",
+    lambda: type("S", (), {"data_dir": str(tmp_path)})(),
+  )
+
+  def managed_request(_method, suffix, _payload=None):
+    assert suffix == "prepare"
+    return {
+      "state": "awaiting_handoff",
+      "operation_id": "replace_12345678",
+      "handoff_nonce": "nonce-secret",
+      "expected_sha": "a" * 40,
+      "image_digest": "sha256:" + "e" * 64,
+    }
+
+  monkeypatch.setattr(dc, "_managed_request", managed_request)
+
+  with pytest.raises(dc.DeploymentControlError) as exc:
+    await dc._request_managed_rebuild("a" * 40, _TEST_DIGEST)
+
+  assert exc.value.code == "controller_invalid_response"
+
+
+@pytest.mark.asyncio
+async def test_managed_start_rejects_mismatched_release_echo(
+  tmp_path, monkeypatch,
+):
+  from app import restart_ledger, restart_util
+
+  _install_managed_cutover_marker(tmp_path, monkeypatch)
+  monkeypatch.setattr(
+    dc,
+    "get_settings",
+    lambda: type("S", (), {"data_dir": str(tmp_path)})(),
+  )
+
+  def managed_request(_method, suffix, _payload=None):
+    if suffix == "prepare":
+      return {
+        "state": "awaiting_handoff",
+        "operation_id": "replace_12345678",
+        "handoff_nonce": "nonce-secret",
+        "expected_sha": "a" * 40,
+        "image_digest": _TEST_DIGEST,
+      }
+    return {
+      "state": "queued",
+      "operation_id": "replace_12345678",
+      "expected_sha": "b" * 40,
+      "image_digest": _TEST_DIGEST,
+    }
+
+  monkeypatch.setattr(dc, "_managed_request", managed_request)
+  monkeypatch.setattr(restart_ledger, "current_boot_id", lambda: "boot-12345678")
+  monkeypatch.setattr(restart_ledger, "request_managed_cutover", lambda **_kw: None)
+  monkeypatch.setattr(restart_ledger, "authorized_cutover_challenge", lambda _id: True)
+  monkeypatch.setattr(restart_ledger, "accepted_cutover_receipt", lambda _id: True)
+  monkeypatch.setattr(
+    restart_util,
+    "prepare_managed_container_cutover",
+    lambda _id: asyncio.sleep(0),
+  )
+
+  with pytest.raises(dc.DeploymentControlError) as exc:
+    await dc._request_managed_rebuild("a" * 40, _TEST_DIGEST)
+
+  assert exc.value.code == "controller_invalid_response"
+
+
+@pytest.mark.asyncio
+async def test_managed_final_validation_runs_after_drain_and_before_start(
+  tmp_path, monkeypatch,
+):
+  from app import restart_ledger, restart_util
+
+  _install_managed_cutover_marker(tmp_path, monkeypatch)
+  monkeypatch.setattr(
+    dc,
+    "get_settings",
+    lambda: type("S", (), {"data_dir": str(tmp_path)})(),
+  )
+  events = []
+
+  def managed_request(_method, suffix, _payload=None):
+    events.append(suffix)
+    if suffix == "prepare":
+      return {
+        "state": "awaiting_handoff",
+        "operation_id": "replace_12345678",
+        "handoff_nonce": "nonce-secret",
+        "expected_sha": "a" * 40,
+        "image_digest": _TEST_DIGEST,
+      }
+    return {
+      "state": "queued",
+      "operation_id": "replace_12345678",
+      "expected_sha": "a" * 40,
+      "image_digest": _TEST_DIGEST,
+    }
+
+  async def drain(_operation_id):
+    events.append("drain")
+
+  def final_check():
+    events.append("final_check")
+
+  monkeypatch.setattr(dc, "_managed_request", managed_request)
+  monkeypatch.setattr(restart_ledger, "current_boot_id", lambda: "boot-12345678")
+  monkeypatch.setattr(restart_ledger, "request_managed_cutover", lambda **_kw: None)
+  monkeypatch.setattr(restart_ledger, "authorized_cutover_challenge", lambda _id: True)
+  monkeypatch.setattr(restart_ledger, "accepted_cutover_receipt", lambda _id: True)
+  monkeypatch.setattr(restart_util, "prepare_managed_container_cutover", drain)
+
+  result = await dc._request_managed_rebuild(
+    "a" * 40,
+    _TEST_DIGEST,
+    final_check=final_check,
+  )
+
+  assert result["state"] == "queued"
+  assert events == ["prepare", "drain", "final_check", "start"]
+
+
+@pytest.mark.asyncio
 async def test_legacy_railway_image_offers_managed_bootstrap(tmp_path, monkeypatch):
   from app import chat
-  from app.runner_registry import registry
 
   monkeypatch.setattr(dc.platform_activation, "deployment_kind", lambda: "railway")
   monkeypatch.setattr(dc, "get_settings", lambda: type("S", (), {"data_dir": str(tmp_path)})())
-  monkeypatch.setattr(dc, "_expected_upstream_sha", lambda: "a" * 40)
-  monkeypatch.setattr(
-    dc.platform_update,
-    "container_replacement_blockers",
-    lambda *_args, **_kwargs: [],
-  )
+  _install_latest_release(monkeypatch)
   calls = []
 
   def managed_request(method, suffix, payload=None):
@@ -130,16 +404,19 @@ async def test_legacy_railway_image_offers_managed_bootstrap(tmp_path, monkeypat
       return {
         "mode": "bootstrap", "state": "awaiting_bootstrap",
         "operation_id": "bootstrap_123", "handoff_nonce": "nonce",
+        "expected_sha": "a" * 40, "image_digest": _TEST_DIGEST,
       }
     return {
       "mode": "bootstrap", "state": "queued",
       "operation_id": "bootstrap_123", "expected_sha": "a" * 40,
+      "image_digest": _TEST_DIGEST,
     }
 
   monkeypatch.setattr(dc, "_managed_request", managed_request)
-  monkeypatch.setattr(registry, "all_alive_chat_ids", lambda: set())
   began = []
-  monkeypatch.setattr(chat, "begin_drain", lambda: began.append(True))
+  monkeypatch.setattr(
+    chat, "begin_idle_drain", lambda: began.append(True) or True,
+  )
 
   status = await dc.read_rebuild_status()
   assert status["supported"] is False
@@ -152,7 +429,9 @@ async def test_legacy_railway_image_offers_managed_bootstrap(tmp_path, monkeypat
   assert began == [True]
   assert calls == [
     ("GET", "status", None),
-    ("POST", "bootstrap/prepare", {"expected_sha": "a" * 40}),
+    ("POST", "bootstrap/prepare", {
+      "expected_sha": "a" * 40, "expected_digest": _TEST_DIGEST,
+    }),
     ("POST", "bootstrap/start", {
       "operation_id": "bootstrap_123", "handoff_nonce": "nonce",
     }),
@@ -240,16 +519,10 @@ async def test_legacy_railway_bootstrap_does_not_mask_controller_failure(
 @pytest.mark.asyncio
 async def test_legacy_railway_bootstrap_waits_for_idle_chats(tmp_path, monkeypatch):
   from app import chat
-  from app.runner_registry import registry
 
   monkeypatch.setattr(dc.platform_activation, "deployment_kind", lambda: "railway")
   monkeypatch.setattr(dc, "get_settings", lambda: type("S", (), {"data_dir": str(tmp_path)})())
-  monkeypatch.setattr(dc, "_expected_upstream_sha", lambda: "a" * 40)
-  monkeypatch.setattr(
-    dc.platform_update,
-    "container_replacement_blockers",
-    lambda *_args, **_kwargs: [],
-  )
+  _install_latest_release(monkeypatch)
   calls = []
 
   def managed_request(method, suffix, payload=None):
@@ -257,18 +530,20 @@ async def test_legacy_railway_bootstrap_waits_for_idle_chats(tmp_path, monkeypat
     return {
       "mode": "bootstrap", "state": "awaiting_bootstrap",
       "operation_id": "bootstrap_123", "handoff_nonce": "nonce",
+      "expected_sha": "a" * 40, "image_digest": _TEST_DIGEST,
     }
 
   monkeypatch.setattr(dc, "_managed_request", managed_request)
-  monkeypatch.setattr(registry, "all_alive_chat_ids", lambda: {"active-chat"})
   began = []
-  monkeypatch.setattr(chat, "begin_drain", lambda: began.append(True))
+  monkeypatch.setattr(
+    chat, "begin_idle_drain", lambda: began.append(True) or False,
+  )
 
   with pytest.raises(dc.DeploymentControlError) as exc:
     await dc.request_rebuild()
 
   assert exc.value.code == "active_chats"
-  assert began == []
+  assert began == [True]
   assert [suffix for _method, suffix, _payload in calls] == ["bootstrap/prepare"]
 
 
@@ -277,17 +552,20 @@ async def test_legacy_bootstrap_reopens_admission_only_after_definitive_rejectio
   monkeypatch,
 ):
   from app import chat
-  from app.runner_registry import registry
 
-  monkeypatch.setattr(registry, "all_alive_chat_ids", lambda: set())
   began = []
   cancelled = []
-  monkeypatch.setattr(chat, "begin_drain", lambda: began.append(True))
+  monkeypatch.setattr(
+    chat, "begin_idle_drain", lambda: began.append(True) or True,
+  )
   monkeypatch.setattr(chat, "cancel_idle_drain", lambda: cancelled.append(True))
 
   def managed_request(method, suffix, _payload=None):
     if suffix == "bootstrap/prepare":
-      return {"operation_id": "bootstrap_123", "handoff_nonce": "nonce"}
+      return {
+        "operation_id": "bootstrap_123", "handoff_nonce": "nonce",
+        "expected_sha": "a" * 40, "image_digest": _TEST_DIGEST,
+      }
     raise dc.DeploymentControlError(
       "controller_rejected", "The managed upgrade was rejected.", status_code=409,
     )
@@ -295,7 +573,7 @@ async def test_legacy_bootstrap_reopens_admission_only_after_definitive_rejectio
   monkeypatch.setattr(dc, "_managed_request", managed_request)
 
   with pytest.raises(dc.DeploymentControlError):
-    await dc._request_managed_bootstrap("a" * 40)
+    await dc._request_managed_bootstrap("a" * 40, _TEST_DIGEST)
 
   assert began == [True]
   assert cancelled == [True]
@@ -328,17 +606,16 @@ async def test_request_rebuild_selects_managed_railway_handoff(tmp_path, monkeyp
   settings = type("S", (), {"data_dir": str(tmp_path)})()
   monkeypatch.setattr(dc.platform_activation, "deployment_kind", lambda: "railway")
   monkeypatch.setattr(dc, "get_settings", lambda: settings)
-  monkeypatch.setattr(dc, "_expected_upstream_sha", lambda: "a" * 40)
-  blocker_calls = []
+  _install_latest_release(monkeypatch)
+  request_thread = threading.get_ident()
+  blocker_threads = []
 
-  def blockers(expected, *, preserve_active_runtime):
-    blocker_calls.append((expected, preserve_active_runtime))
+  def blockers(*_args, **_kwargs):
+    blocker_threads.append(threading.get_ident())
     return []
 
   monkeypatch.setattr(
-    dc.platform_update,
-    "container_replacement_blockers",
-    blockers,
+    dc.platform_update, "official_image_rebuild_blockers", blockers,
   )
   calls = []
 
@@ -348,10 +625,12 @@ async def test_request_rebuild_selects_managed_railway_handoff(tmp_path, monkeyp
       return {
         "operation_id": "replace_12345678", "handoff_nonce": "nonce-secret",
         "state": "awaiting_handoff", "expected_sha": "a" * 40,
+        "image_digest": _TEST_DIGEST,
       }
     return {
       "operation_id": "replace_12345678", "state": "queued",
-      "expected_sha": "a" * 40, "message": "Replacement queued.",
+      "expected_sha": "a" * 40, "image_digest": _TEST_DIGEST,
+      "message": "Replacement queued.",
     }
 
   async def prepare(cutover_id):
@@ -369,9 +648,12 @@ async def test_request_rebuild_selects_managed_railway_handoff(tmp_path, monkeyp
 
   assert status["deployment"] == "railway"
   assert status["state"] == "queued"
-  assert blocker_calls == [("a" * 40, False)]
+  assert blocker_threads
+  assert all(thread_id != request_thread for thread_id in blocker_threads)
   assert calls == [
-    ("POST", "prepare", {"expected_sha": "a" * 40}),
+    ("POST", "prepare", {
+      "expected_sha": "a" * 40, "expected_digest": _TEST_DIGEST,
+    }),
     ("POST", "start", {
       "operation_id": "replace_12345678", "handoff_nonce": "nonce-secret",
     }),
@@ -380,12 +662,12 @@ async def test_request_rebuild_selects_managed_railway_handoff(tmp_path, monkeyp
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-  ("error_code", "restart_count"),
-  [("controller_rejected", 1), ("controller_unavailable", 0),
-   ("controller_invalid_response", 0)],
+  ("error_code", "restart_count", "reconcile_count"),
+  [("controller_rejected", 1, 0), ("controller_unavailable", 0, 1),
+   ("controller_invalid_response", 0, 1)],
 )
 async def test_managed_start_failure_restarts_only_after_definitive_rejection(
-  tmp_path, monkeypatch, error_code, restart_count,
+  tmp_path, monkeypatch, error_code, restart_count, reconcile_count,
 ):
   from app import restart_ledger, restart_util
 
@@ -394,12 +676,7 @@ async def test_managed_start_failure_restarts_only_after_definitive_rejection(
   settings = type("S", (), {"data_dir": str(tmp_path)})()
   monkeypatch.setattr(dc.platform_activation, "deployment_kind", lambda: "railway")
   monkeypatch.setattr(dc, "get_settings", lambda: settings)
-  monkeypatch.setattr(dc, "_expected_upstream_sha", lambda: "a" * 40)
-  monkeypatch.setattr(
-    dc.platform_update,
-    "container_replacement_blockers",
-    lambda *_args, **_kwargs: [],
-  )
+  _install_latest_release(monkeypatch)
 
   def managed_request(method, suffix, payload=None):
     if suffix == "prepare":
@@ -407,10 +684,13 @@ async def test_managed_start_failure_restarts_only_after_definitive_rejection(
         "state": "prepared",
         "operation_id": "replace_12345678",
         "handoff_nonce": "nonce-secret",
+        "expected_sha": "a" * 40,
+        "image_digest": _TEST_DIGEST,
       }
     raise dc.DeploymentControlError(error_code, "start failed")
 
   restarts = []
+  reconciliations = []
 
   async def restart():
     restarts.append(True)
@@ -422,6 +702,13 @@ async def test_managed_start_failure_restarts_only_after_definitive_rejection(
   monkeypatch.setattr(restart_ledger, "accepted_cutover_receipt", lambda _id: True)
   monkeypatch.setattr(restart_util, "prepare_managed_container_cutover", lambda _id: asyncio.sleep(0))
   monkeypatch.setattr(restart_util, "restart_this_worker", restart)
+  monkeypatch.setattr(
+    dc,
+    "_schedule_ambiguous_start_reconciliation",
+    lambda operation_id, nonce, _restart: reconciliations.append(
+      (operation_id, nonce),
+    ),
+  )
 
   with pytest.raises(dc.DeploymentControlError) as exc:
     await dc.request_rebuild()
@@ -429,6 +716,114 @@ async def test_managed_start_failure_restarts_only_after_definitive_rejection(
 
   assert exc.value.code == error_code
   assert len(restarts) == restart_count
+  assert len(reconciliations) == reconcile_count
+  if reconcile_count:
+    assert reconciliations == [("replace_12345678", "nonce-secret")]
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_start_recovers_only_after_atomic_cancel_wins(
+  monkeypatch,
+):
+  requests = []
+
+  def managed_request(method, suffix, payload=None):
+    requests.append((method, suffix, payload))
+    return {
+      "operation_id": "replace_12345678",
+      "state": "failed",
+      "cancelled": True,
+    }
+
+  monkeypatch.setattr(
+    dc,
+    "_managed_request",
+    managed_request,
+  )
+  async def no_sleep(_seconds):
+    return None
+
+  monkeypatch.setattr(dc.asyncio, "sleep", no_sleep)
+  restarts = []
+
+  async def restart():
+    restarts.append(True)
+
+  await dc._reconcile_ambiguous_managed_start(
+    "replace_12345678", "nonce-secret", restart,
+  )
+
+  assert restarts == [True]
+  assert requests == [(
+    "POST",
+    "cancel",
+    {
+      "operation_id": "replace_12345678",
+      "handoff_nonce": "nonce-secret",
+    },
+  )]
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_start_leaves_accepted_operation_to_account(
+  monkeypatch,
+):
+  monkeypatch.setattr(
+    dc,
+    "_managed_request",
+    lambda method, suffix, payload=None: {
+      "operation_id": "replace_12345678", "state": "queued",
+      "cancelled": False,
+    },
+  )
+  async def no_sleep(_seconds):
+    return None
+
+  monkeypatch.setattr(dc.asyncio, "sleep", no_sleep)
+  restarts = []
+
+  async def restart():
+    restarts.append(True)
+
+  await dc._reconcile_ambiguous_managed_start(
+    "replace_12345678", "nonce-secret", restart,
+  )
+
+  assert restarts == []
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_start_retries_stale_or_malformed_cancel_responses(
+  monkeypatch,
+):
+  responses = iter([
+    {"operation_id": "replace_stale", "cancelled": True},
+    {"operation_id": "replace_12345678", "state": "failed"},
+    {"operation_id": "replace_12345678", "cancelled": True},
+  ])
+  requests = []
+
+  def managed_request(method, suffix, payload=None):
+    requests.append((method, suffix, payload))
+    return next(responses)
+
+  monkeypatch.setattr(dc, "_managed_request", managed_request)
+
+  async def no_sleep(_seconds):
+    return None
+
+  monkeypatch.setattr(dc.asyncio, "sleep", no_sleep)
+  restarts = []
+
+  async def restart():
+    restarts.append(True)
+
+  await dc._reconcile_ambiguous_managed_start(
+    "replace_12345678", "nonce-secret", restart,
+  )
+
+  assert len(requests) == 3
+  assert restarts == [True]
 
 
 @pytest.mark.asyncio
@@ -442,12 +837,7 @@ async def test_pre_start_receipt_timeout_recovers_the_drained_worker(
   settings = type("S", (), {"data_dir": str(tmp_path)})()
   monkeypatch.setattr(dc.platform_activation, "deployment_kind", lambda: "railway")
   monkeypatch.setattr(dc, "get_settings", lambda: settings)
-  monkeypatch.setattr(dc, "_expected_upstream_sha", lambda: "a" * 40)
-  monkeypatch.setattr(
-    dc.platform_update,
-    "container_replacement_blockers",
-    lambda *_args, **_kwargs: [],
-  )
+  _install_latest_release(monkeypatch)
 
   requests = []
 
@@ -457,6 +847,8 @@ async def test_pre_start_receipt_timeout_recovers_the_drained_worker(
       "state": "awaiting_handoff",
       "operation_id": "replace_12345678",
       "handoff_nonce": "nonce-secret",
+      "expected_sha": "a" * 40,
+      "image_digest": _TEST_DIGEST,
     }
 
   restarts = []
@@ -484,7 +876,9 @@ async def test_pre_start_receipt_timeout_recovers_the_drained_worker(
 
   assert exc.value.code == "controller_unavailable"
   assert requests == [(
-    "POST", "prepare", {"expected_sha": "a" * 40},
+    "POST", "prepare", {
+      "expected_sha": "a" * 40, "expected_digest": _TEST_DIGEST,
+    },
   )]
   assert restarts == [True]
 
@@ -500,12 +894,7 @@ async def test_definitive_rejection_owns_recovery_until_restart_settles(
   settings = type("S", (), {"data_dir": str(tmp_path)})()
   monkeypatch.setattr(dc.platform_activation, "deployment_kind", lambda: "railway")
   monkeypatch.setattr(dc, "get_settings", lambda: settings)
-  monkeypatch.setattr(dc, "_expected_upstream_sha", lambda: "a" * 40)
-  monkeypatch.setattr(
-    dc.platform_update,
-    "container_replacement_blockers",
-    lambda *_args, **_kwargs: [],
-  )
+  _install_latest_release(monkeypatch)
 
   def managed_request(method, suffix, _payload=None):
     if suffix == "prepare":
@@ -513,6 +902,8 @@ async def test_definitive_rejection_owns_recovery_until_restart_settles(
         "state": "awaiting_handoff",
         "operation_id": "replace_12345678",
         "handoff_nonce": "nonce-secret",
+        "expected_sha": "a" * 40,
+        "image_digest": _TEST_DIGEST,
       }
     raise dc.DeploymentControlError("controller_rejected", "rejected")
 

--- a/backend/tests/test_drain_for_restart.py
+++ b/backend/tests/test_drain_for_restart.py
@@ -755,6 +755,23 @@ def test_notify_after_reconcile_noop_when_nothing_reconciled(owner_token, monkey
 
 # -- bootstrap rejection may reopen only an idle drain ------------------------
 
+def test_idle_drain_includes_terminal_broadcast_ownership(monkeypatch):
+  monkeypatch.setattr(chat_mod, "has_running_chat_broadcast", lambda: True)
+
+  assert chat_mod.begin_idle_drain() is False
+  # The failed idle proof reopens ordinary admission.
+  assert registry.mark_starting("next-chat") is True
+
+
+def test_idle_drain_blocks_late_runner_reservations(monkeypatch):
+  monkeypatch.setattr(chat_mod, "has_running_chat_broadcast", lambda: False)
+
+  assert chat_mod.begin_idle_drain() is True
+  assert registry.mark_starting("late-chat") is False
+  assert chat_mod.cancel_idle_drain() is True
+  assert registry.mark_starting("after-cancel") is True
+
+
 def test_cancel_idle_drain_keeps_admission_closed_for_a_live_runner():
   chat_mod.begin_drain()
   registry.register(_Handle("bootstrap-live-runner"))

--- a/backend/tests/test_platform_activation.py
+++ b/backend/tests/test_platform_activation.py
@@ -32,6 +32,17 @@ def test_deployment_specific_inputs_share_contract_without_fake_commands():
   assert railway_on_self_hosted["reasons"] == []
 
 
+def test_railway_config_guidance_does_not_promise_an_image_rebuild():
+  impact = activation.classify_activation(
+    ["railway.toml"], deployment="railway",
+  )
+
+  assert impact["level"] == "container_recreate"
+  guidance = " ".join(impact["guidance"])
+  assert "finish this change in Railway" in guidance
+  assert "Möbius will rebuild Railway" not in guidance
+
+
 def test_dependency_and_baked_runtime_never_degrade_to_restart_only():
   # Python deps now apply in place (a rebuild is no longer forced), but they are
   # still MORE than a bare restart. Frontend deps and baked-runtime inputs still

--- a/backend/tests/test_platform_routes.py
+++ b/backend/tests/test_platform_routes.py
@@ -7,6 +7,7 @@ case injects a failure at the route seam, so the test remains hermetic even when
 its runner lives inside a real Möbius installation.
 """
 
+from app import deployment_control
 from app.platform_activation import classify_activation
 
 
@@ -83,6 +84,7 @@ def test_apply_forwards_exact_reviewed_plan(client, auth, monkeypatch):
       "conflict_paths": [],
       "chat_id": None,
       "phase": "complete",
+      "error": None,
       "reconciliation": {
         "proven_present": [],
         "local_only_paths": [],
@@ -106,8 +108,201 @@ def test_apply_forwards_exact_reviewed_plan(client, auth, monkeypatch):
   res = client.post("/api/platform/apply", headers=auth, json=body)
 
   assert res.status_code == 200
-  assert captured == body
+  assert captured == {**body, "image_digest": None}
   assert res.json()["upstream_commit"] == body["target_sha"]
+
+
+def test_reviewed_rebuild_forwards_exact_sha_and_digest(
+  client, auth, monkeypatch,
+):
+  captured = {}
+
+  async def fake_rebuild(**plan):
+    captured.update(plan)
+    return {
+      "supported": True,
+      "bootstrap_available": False,
+      "deployment": "railway",
+      "operation_id": "replace_123",
+      "state": "queued",
+      "expected_sha": plan["target_sha"],
+      "code": None,
+      "message": "Replacement queued.",
+      "error": None,
+      "image_digest": plan["image_digest"],
+      "release_source": "latest_ghcr",
+      "updated_at": None,
+    }
+
+  monkeypatch.setattr(
+    "app.routes.platform.deployment_control.request_reviewed_rebuild",
+    fake_rebuild,
+  )
+  body = {
+    "plan_id": "a" * 64,
+    "current_sha": "1" * 40,
+    "target_sha": "2" * 40,
+    "image_digest": "sha256:" + "d" * 64,
+  }
+
+  response = client.post("/api/platform/rebuild", headers=auth, json=body)
+
+  assert response.status_code == 202
+  assert captured == body
+  assert response.json()["release_source"] == "latest_ghcr"
+
+
+def test_reviewed_rebuild_requires_digest(client, auth):
+  response = client.post("/api/platform/rebuild", headers=auth, json={
+    "plan_id": "a" * 64,
+    "current_sha": "1" * 40,
+    "target_sha": "2" * 40,
+  })
+
+  assert response.status_code == 409
+  assert response.json()["detail"] == {
+    "code": "update_plan_invalid",
+    "message": "This update review is no longer valid. Refresh it and try again.",
+  }
+
+
+def test_railway_preview_uses_latest_verified_ghcr_release(
+  client, auth, monkeypatch,
+):
+  digest = "sha256:" + "e" * 64
+  target = "2" * 40
+  captured = {}
+
+  async def latest():
+    return {
+      "build_sha": target,
+      "image_digest": digest,
+      "image_ref": "immutable",
+    }
+
+  def preview(**kwargs):
+    captured.update(kwargs)
+    return {
+      "state": "available", "available": True,
+      "current_sha": "1" * 40, "target_sha": target,
+      "plan_id": "a" * 64, "image_digest": digest,
+      "activation": classify_activation(
+        ["Dockerfile"], deployment="railway",
+      ),
+      "total_commits": 1, "commits_truncated": False,
+      "commits": [], "files": [], "diff": None,
+      "diff_truncated": False, "conflict_paths": [],
+    }
+
+  monkeypatch.setattr(
+    "app.routes.platform.platform_activation.deployment_kind",
+    lambda: "railway",
+  )
+  monkeypatch.setattr(
+    "app.routes.platform.deployment_control.latest_official_release",
+    latest,
+  )
+  monkeypatch.setattr(
+    "app.routes.platform.platform_update.platform_update_preview",
+    preview,
+  )
+
+  response = client.get("/api/platform/update-preview", headers=auth)
+
+  assert response.status_code == 200
+  assert captured == {"target_sha": target, "image_digest": digest}
+  assert response.json()["image_digest"] == digest
+
+
+def test_railway_status_and_check_use_latest_verified_ghcr_target(
+  client, auth, monkeypatch,
+):
+  target = "2" * 40
+  calls = []
+
+  async def latest():
+    return {
+      "build_sha": target,
+      "image_digest": "sha256:" + "e" * 64,
+      "image_ref": "immutable",
+    }
+
+  def status(*, target_sha):
+    calls.append(("status", target_sha))
+    return {
+      "state": "available", "available": True,
+      "needs_restart": False,
+      "activation": classify_activation([]),
+      "current_build_sha": None,
+      "recorded_upstream_sha": None,
+      "contained_upstream_sha": None,
+      "contained_upstream_committed_at": None,
+      "upstream_checked_at": None,
+      "seed_required": False,
+      "conflict_paths": [], "conflict_chat_id": None,
+      "newer_updates_available": False,
+      "rollback_target_sha": None, "rollback_error": None,
+    }
+
+  def check(*, target_sha):
+    calls.append(("check", target_sha))
+    return status(target_sha=target_sha)
+
+  monkeypatch.setattr(
+    "app.routes.platform.platform_activation.deployment_kind",
+    lambda: "railway",
+  )
+  monkeypatch.setattr(
+    "app.routes.platform.deployment_control.latest_official_release",
+    latest,
+  )
+  monkeypatch.setattr(
+    "app.routes.platform.platform_update.platform_status",
+    status,
+  )
+  monkeypatch.setattr(
+    "app.routes.platform.platform_update.check_for_updates",
+    check,
+  )
+
+  status_response = client.get("/api/platform/status", headers=auth)
+  check_response = client.post("/api/platform/check", headers=auth)
+
+  assert status_response.status_code == 200
+  assert check_response.status_code == 200
+  assert calls == [
+    ("status", target),
+    ("check", target),
+    ("status", target),
+  ]
+
+
+def test_railway_status_does_not_call_unknown_release_current(
+  client, auth, monkeypatch,
+):
+  monkeypatch.setattr(
+    "app.routes.platform.platform_activation.deployment_kind",
+    lambda: "railway",
+  )
+
+  async def unavailable():
+    raise deployment_control.DeploymentControlError(
+      "controller_unavailable",
+      "The official image could not be checked.",
+    )
+
+  monkeypatch.setattr(
+    "app.routes.platform.deployment_control.latest_official_release",
+    unavailable,
+  )
+
+  response = client.get("/api/platform/status", headers=auth)
+
+  assert response.status_code == 503
+  assert response.json()["detail"] == {
+    "code": "controller_unavailable",
+    "message": "The official image could not be checked.",
+  }
 
 
 def test_update_check_reports_fetch_failure(client, auth, monkeypatch):
@@ -120,7 +315,10 @@ def test_update_check_reports_fetch_failure(client, auth, monkeypatch):
                       fail_check)
   res = client.post("/api/platform/check", headers=auth)
   assert res.status_code == 503
-  assert res.json()["detail"] == "Could not reach the platform update source."
+  assert res.json()["detail"] == {
+    "code": "platform_fetch_failed",
+    "message": "This update could not be verified. Refresh it and try again.",
+  }
 
 
 def test_status_failure_does_not_disable_owner_updates(

--- a/backend/tests/test_platform_update.py
+++ b/backend/tests/test_platform_update.py
@@ -1474,6 +1474,121 @@ def test_replacement_blocks_unmarked_local_image_input_drift(
   ]
 
 
+def test_reviewed_image_target_does_not_treat_incoming_dockerfile_as_local(
+  clone_env, monkeypatch,
+):
+  origin, platform = clone_env
+  current = _served_sha(platform)
+  target = _advance_origin(origin, edits={"Dockerfile": "FROM official-new\n"})
+  _git(platform, "fetch", "origin")
+  monkeypatch.setattr(
+    pu,
+    "_protected_runtime_status",
+    lambda _repo: {
+      "state": "current",
+      "source_sha256": "match",
+      "deployed_sha256": "match",
+      "mismatched_paths": [],
+    },
+  )
+
+  assert pu.container_replacement_blockers(
+    target,
+    platform,
+    preserve_active_runtime=True,
+    local_change_base=current,
+  ) == []
+
+  _local_commit(platform, edits={"Dockerfile": "FROM local-divergence\n"})
+  assert pu.container_replacement_blockers(
+    target,
+    platform,
+    preserve_active_runtime=True,
+    local_change_base=current,
+  ) == ["Dockerfile"]
+
+
+def test_reviewed_image_plan_binds_digest_and_preserves_live_tree(
+  clone_env, monkeypatch,
+):
+  origin, platform = clone_env
+  current = _served_sha(platform)
+  target = _advance_origin(origin, edits={"Dockerfile": "FROM official-new\n"})
+  _git(platform, "fetch", "origin")
+  digest = "sha256:" + "d" * 64
+  monkeypatch.setattr(
+    pu,
+    "_protected_runtime_status",
+    lambda _repo: {
+      "state": "current",
+      "source_sha256": "match",
+      "deployed_sha256": "match",
+      "mismatched_paths": [],
+    },
+  )
+
+  preview = pu.platform_update_preview(
+    platform, target_sha=target, image_digest=digest,
+  )
+  reviewed = pu.reviewed_container_rebuild_plan(
+    repo=platform,
+    plan_id=preview["plan_id"],
+    current_sha=current,
+    target_sha=target,
+    image_digest=digest,
+  )
+
+  assert preview["image_digest"] == digest
+  assert preview["plan_id"] == pu._update_plan_id(current, target, digest)
+  assert reviewed["target_sha"] == target
+  assert reviewed["activation"]["level"] == "image_rebuild"
+  assert reviewed["blockers"] == []
+  assert _served_sha(platform) == current
+
+  with pytest.raises(pu.PlatformUpdateError, match="update_plan_invalid"):
+    pu.reviewed_container_rebuild_plan(
+      repo=platform,
+      plan_id=preview["plan_id"],
+      current_sha=current,
+      target_sha=target,
+      image_digest="sha256:" + "e" * 64,
+    )
+
+
+def test_explicit_ghcr_target_is_available_before_source_object_is_fetched(
+  clone_env,
+):
+  _origin, platform = clone_env
+  missing_release = "f" * 40
+
+  status = pu.platform_status(platform, target_sha=missing_release)
+
+  assert status["state"] == pu.PlatformUpdateState.AVAILABLE.value
+  assert status["available"] is True
+  assert _served_sha(platform) != missing_release
+
+
+def test_explicit_ghcr_preview_fails_closed_when_source_fetch_fails(
+  clone_env, monkeypatch,
+):
+  _origin, platform = clone_env
+  served = _served_sha(platform)
+  missing_release = "f" * 40
+  monkeypatch.setattr(pu, "_fetch", lambda *_args, **_kwargs: False)
+
+  with pytest.raises(
+    pu.PlatformUpdateError,
+    match="image_release_source_unavailable",
+  ):
+    pu.platform_update_preview(
+      platform,
+      target_sha=missing_release,
+      image_digest="sha256:" + "d" * 64,
+    )
+
+  assert _served_sha(platform) == served
+
+
 def test_replacement_blocks_image_input_renamed_out_of_its_owned_path(
   clone_env, monkeypatch,
 ):
@@ -2180,6 +2295,7 @@ async def test_frontend_build_failure_rolls_back_source_and_is_not_success(
   assert result["activation"]["level"] == "server_restart"
   assert result["upstream_commit"] == target
   assert result["merge_commit"] is None
+  assert "frontend_build_failed" in result["error"]
   assert _served_sha(platform) == before
   assert pu.recorded_upstream_sha(platform) == previous_upstream
   assert pu.RESTART_NEEDED_FLAG.read_text() == "preexisting-restart"
@@ -2188,6 +2304,9 @@ async def test_frontend_build_failure_rolls_back_source_and_is_not_success(
   assert rollback["target"] == target
   assert "frontend_build_failed" in rollback["error"]
   assert "vite exploded" in rollback["error"]
+  status = pu.platform_status(platform)
+  assert status["rollback_target_sha"] == target
+  assert "vite exploded" in status["rollback_error"]
   progress = pu.platform_update_progress()
   assert progress["phase"] == pu.PlatformUpdatePhase.BLOCKED.value
   assert progress["active"] is False

--- a/backend/tests/test_platform_update.py
+++ b/backend/tests/test_platform_update.py
@@ -1648,6 +1648,75 @@ def test_stale_marker_coverage_cannot_excuse_newer_image_input_drift(
   ]
 
 
+def test_marker_coverage_survives_newer_descendant_official_image(
+  clone_env, monkeypatch,
+):
+  """An official image path applied from one release is not local drift merely
+  because a newer descendant release advances that same path."""
+  origin, platform = clone_env
+  applied = _advance_origin(
+    origin, edits={"Dockerfile": "FROM official-applied\n"}, msg="applied image",
+  )
+  _git(platform, "fetch", "origin")
+  _git(platform, "merge", "--ff-only", applied)
+  pu._write_activation_marker(
+    applied,
+    ["Dockerfile"],
+    upstream_sha=applied,
+    image_paths=["Dockerfile"],
+  )
+  target = _advance_origin(
+    origin, edits={"Dockerfile": "FROM official-newer\n"}, msg="newer image",
+  )
+  _git(platform, "fetch", "origin")
+  monkeypatch.setattr(
+    pu,
+    "_protected_runtime_status",
+    lambda _repo: {
+      "state": "current",
+      "source_sha256": "match",
+      "deployed_sha256": "match",
+      "mismatched_paths": [],
+    },
+  )
+
+  assert pu.container_replacement_blockers(
+    target, platform, local_change_base=applied,
+  ) == []
+
+  _local_commit(platform, edits={"Dockerfile": "FROM local-only\n"})
+  assert pu.container_replacement_blockers(
+    target, platform, local_change_base=applied,
+  ) == ["Dockerfile"]
+
+
+def test_unverifiable_runtime_overrides_descendant_marker_coverage(
+  clone_env, monkeypatch,
+):
+  _, platform = clone_env
+  applied = _git(platform, "rev-parse", "HEAD").stdout.strip()
+  pu._write_activation_marker(
+    applied,
+    ["backend/runtime"],
+    upstream_sha=applied,
+    image_paths=["backend/runtime"],
+  )
+  monkeypatch.setattr(
+    pu,
+    "_protected_runtime_status",
+    lambda _repo: {
+      "state": "unavailable",
+      "source_sha256": None,
+      "deployed_sha256": None,
+      "mismatched_paths": [],
+    },
+  )
+
+  assert pu.container_replacement_blockers(applied, platform) == [
+    "backend/runtime",
+  ]
+
+
 def test_legacy_activation_marker_cannot_claim_official_image_coverage(
   tmp_path, monkeypatch,
 ):

--- a/backend/tests/test_runner_registry.py
+++ b/backend/tests/test_runner_registry.py
@@ -24,6 +24,17 @@ def test_mark_starting_duplicate_returns_false():
   assert registry.mark_starting("chat-1") is False
 
 
+def test_idle_admission_close_and_runner_reservation_are_one_boundary():
+  registry = RunnerRegistry()
+
+  assert registry.close_admission_if_idle() is True
+  assert registry.mark_starting("late-chat") is False
+
+  registry.reopen_admission()
+  assert registry.mark_starting("early-chat") is True
+  assert registry.close_admission_if_idle() is False
+
+
 def test_register_replaces_same_kind_handle():
   registry = RunnerRegistry()
   first = _FakeHandle("chat-1", RunnerKind.CLAUDE_SDK, "first")

--- a/backend/tests/test_version.py
+++ b/backend/tests/test_version.py
@@ -7,6 +7,7 @@ check). These pin the endpoint contract + the config wiring in both directions.
 """
 
 import os
+import subprocess
 
 from app.config import Settings
 
@@ -136,7 +137,10 @@ def test_version_always_includes_served_platform_keys(client):
   # The deploy reads these unconditionally; a missing key would make the
   # extractor return empty and silently disable the served-platform assertion.
   body = client.get("/api/version").json()
-  for key in ("serving_source", "platform_sha", "platform_dirty", "baked_sha"):
+  for key in (
+    "serving_source", "platform_sha", "platform_dirty",
+    "applied_upstream_sha", "baked_sha",
+  ):
     assert key in body
 
 
@@ -220,3 +224,124 @@ def test_served_platform_source_reflects_sentinel(client):
         os.remove(_SENTINEL)
       except OSError:
         pass
+
+
+def test_served_platform_identity_exposes_applied_upstream_sha(
+  tmp_path, monkeypatch,
+):
+  from app.main import _served_platform_identity
+
+  repo = tmp_path / "platform"
+  repo.mkdir()
+  subprocess.run(["git", "init", "-q", str(repo)], check=True)
+  subprocess.run(
+    ["git", "-C", str(repo), "config", "user.email", "test@example.invalid"],
+    check=True,
+  )
+  subprocess.run(
+    ["git", "-C", str(repo), "config", "user.name", "Test"], check=True,
+  )
+  (repo / "README.md").write_text("tested\n", encoding="utf-8")
+  subprocess.run(["git", "-C", str(repo), "add", "README.md"], check=True)
+  subprocess.run(["git", "-C", str(repo), "commit", "-qm", "seed"], check=True)
+  sha = subprocess.run(
+    ["git", "-C", str(repo), "rev-parse", "HEAD"],
+    check=True, capture_output=True, text=True,
+  ).stdout.strip()
+  subprocess.run(
+    ["git", "-C", str(repo), "branch", "upstream", sha], check=True,
+  )
+  source = tmp_path / "serving-source"
+  served = tmp_path / "serving-sha"
+  source.write_text("platform\n", encoding="utf-8")
+  served.write_text(sha + "\n", encoding="utf-8")
+  monkeypatch.setenv("MOBIUS_SERVING_SOURCE_FILE", str(source))
+  monkeypatch.setenv("MOBIUS_SERVING_SHA_FILE", str(served))
+
+  identity = _served_platform_identity(str(tmp_path), sha)
+
+  assert identity["serving_source"] == "platform"
+  assert identity["applied_upstream_sha"] == sha
+  assert identity["image_build_applied"] is True
+
+
+def test_image_build_applied_accepts_descendant_applied_upstream(
+  tmp_path, monkeypatch,
+):
+  from app.main import _served_platform_identity
+
+  repo = tmp_path / "platform"
+  repo.mkdir()
+  subprocess.run(["git", "init", "-q", str(repo)], check=True)
+  subprocess.run(
+    ["git", "-C", str(repo), "config", "user.email", "test@example.invalid"],
+    check=True,
+  )
+  subprocess.run(
+    ["git", "-C", str(repo), "config", "user.name", "Test"], check=True,
+  )
+  (repo / "README.md").write_text("image\n", encoding="utf-8")
+  subprocess.run(["git", "-C", str(repo), "add", "README.md"], check=True)
+  subprocess.run(["git", "-C", str(repo), "commit", "-qm", "image"], check=True)
+  image_sha = subprocess.run(
+    ["git", "-C", str(repo), "rev-parse", "HEAD"],
+    check=True, capture_output=True, text=True,
+  ).stdout.strip()
+  (repo / "README.md").write_text("newer applied source\n", encoding="utf-8")
+  subprocess.run(["git", "-C", str(repo), "commit", "-qam", "newer"], check=True)
+  applied_sha = subprocess.run(
+    ["git", "-C", str(repo), "rev-parse", "HEAD"],
+    check=True, capture_output=True, text=True,
+  ).stdout.strip()
+  subprocess.run(
+    ["git", "-C", str(repo), "branch", "upstream", applied_sha], check=True,
+  )
+  source = tmp_path / "serving-source"
+  source.write_text("platform\n", encoding="utf-8")
+  monkeypatch.setenv("MOBIUS_SERVING_SOURCE_FILE", str(source))
+
+  identity = _served_platform_identity(str(tmp_path), image_sha)
+
+  assert identity["applied_upstream_sha"] == applied_sha
+  assert identity["image_build_applied"] is True
+
+
+def test_image_build_applied_rejects_newer_unapplied_image(
+  tmp_path, monkeypatch,
+):
+  from app.main import _served_platform_identity
+
+  repo = tmp_path / "platform"
+  repo.mkdir()
+  subprocess.run(["git", "init", "-q", str(repo)], check=True)
+  subprocess.run(
+    ["git", "-C", str(repo), "config", "user.email", "test@example.invalid"],
+    check=True,
+  )
+  subprocess.run(
+    ["git", "-C", str(repo), "config", "user.name", "Test"], check=True,
+  )
+  (repo / "README.md").write_text("applied\n", encoding="utf-8")
+  subprocess.run(["git", "-C", str(repo), "add", "README.md"], check=True)
+  subprocess.run(["git", "-C", str(repo), "commit", "-qm", "applied"], check=True)
+  applied_sha = subprocess.run(
+    ["git", "-C", str(repo), "rev-parse", "HEAD"],
+    check=True, capture_output=True, text=True,
+  ).stdout.strip()
+  subprocess.run(
+    ["git", "-C", str(repo), "branch", "upstream", applied_sha], check=True,
+  )
+  (repo / "README.md").write_text("new image\n", encoding="utf-8")
+  subprocess.run(["git", "-C", str(repo), "commit", "-qam", "image"], check=True)
+  image_sha = subprocess.run(
+    ["git", "-C", str(repo), "rev-parse", "HEAD"],
+    check=True, capture_output=True, text=True,
+  ).stdout.strip()
+  source = tmp_path / "serving-source"
+  source.write_text("platform\n", encoding="utf-8")
+  monkeypatch.setenv("MOBIUS_SERVING_SOURCE_FILE", str(source))
+
+  identity = _served_platform_identity(str(tmp_path), image_sha)
+
+  assert identity["applied_upstream_sha"] == applied_sha
+  assert identity["image_build_applied"] is False

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -985,6 +985,10 @@ export const api = {
       method: 'POST',
       body: JSON.stringify(plan),
     }),
+    rebuild: (plan) => apiFetch('/platform/rebuild', {
+      method: 'POST',
+      body: JSON.stringify(plan),
+    }),
     conflictResolverChat: () => apiFetch('/platform/conflict-resolver-chat', {
       method: 'POST',
     }),

--- a/frontend/src/components/SettingsView/SettingsView.jsx
+++ b/frontend/src/components/SettingsView/SettingsView.jsx
@@ -15,9 +15,11 @@ import {
   rebuildNeedsBootstrap,
   rebuildPollShouldContinue,
   rebuildProgressMessage,
+  rebuildRequestOutcome,
 } from '../../lib/containerRebuild.js'
 import {
   platformStatusFromApply,
+  platformStatusUnavailable,
   platformUpdateStatusLabel,
 } from '../../lib/platformUpdateState.js'
 import { settleBackgroundAgentSave } from '../../lib/backgroundAgentSave.js'
@@ -456,6 +458,7 @@ export default function SettingsView({
   const rebuildPreviousBootIdRef = useRef('')
   const rebuildInitiatedHereRef = useRef(false)
   const rebuildReconnectStartedRef = useRef(false)
+  const rebuildReviewedUpdateRef = useRef(false)
   const [signOutConfirm, setSignOutConfirm] = useState(false)
   const [signingOut, setSigningOut] = useState(false)
   // Platform self-update (backend, frontend, and libraries as one release).
@@ -1135,45 +1138,93 @@ export default function SettingsView({
     const state = rebuildStatus?.state
     if (!['failed', 'rolled_back', 'needs_recovery'].includes(state)) return
     setRebuildConfirm(false)
-    if (state === 'failed') {
-      setRebuildError(
-        rebuildStatus?.message || 'The container could not be rebuilt.',
-      )
-    }
-  }, [rebuildStatus?.state, rebuildStatus?.message])
+    const message = rebuildStatus?.error
+      || rebuildStatus?.message
+      || (state === 'needs_recovery'
+        ? 'The previous container could not be restored. Use your deployment’s Recovery action.'
+        : 'The container could not be rebuilt.')
+    if (rebuildReviewedUpdateRef.current) setPlatformError(message)
+    else setRebuildError(message)
+    rebuildReviewedUpdateRef.current = false
+  }, [rebuildStatus?.state, rebuildStatus?.error, rebuildStatus?.message])
 
-  async function rebuildContainer() {
+  async function startContainerRebuild(request, { reviewedUpdate = false } = {}) {
     if (
       rebuildRequesting
       || rebuildIsActive(rebuildStatus)
       || restartPhase === 'restarting'
-    ) return
+      || (reviewedUpdate && platformPhase !== 'idle')
+    ) return { ok: false }
     setRebuildRequesting(true)
+    if (reviewedUpdate) setPlatformPhase('rebuilding')
     setRebuildError('')
+    if (reviewedUpdate) setPlatformError('')
     setRebuildStartedHere(false)
     rebuildInitiatedHereRef.current = false
     rebuildReconnectStartedRef.current = false
+    rebuildReviewedUpdateRef.current = reviewedUpdate
     rebuildPreviousBootIdRef.current = await readRestartBootId()
     try {
-      const response = await api.admin.rebuild()
+      const response = await request()
       let body = null
       try { body = await response.json() } catch {}
       if (!response.ok) {
         const detail = body?.detail
         throw new Error(
-          detail?.message || detail || `Replacement failed (${response.status})`,
+          body?.error || detail?.message || detail
+            || body?.message || `Replacement failed (${response.status})`,
         )
       }
-      rebuildInitiatedHereRef.current = true
-      setRebuildStartedHere(true)
+      const outcome = rebuildRequestOutcome(body, { reviewedUpdate })
+      const state = outcome.state
+      rebuildInitiatedHereRef.current = outcome.cutoverAccepted
+      setRebuildStartedHere(outcome.cutoverAccepted)
       setRebuildStatus(body)
       setRebuildConfirm(false)
-      returnToSettingsAfterReload()
+      if (outcome.cutoverAccepted) returnToSettingsAfterReload()
+      if (outcome.alreadyCurrent) {
+        rebuildReviewedUpdateRef.current = false
+        await refreshPlatform()
+      } else if (reviewedUpdate && outcome.terminalFailure) {
+        const message = body?.error || body?.message
+          || 'The reviewed image could not be started.'
+        setPlatformError(message)
+      }
+      return {
+        ok: outcome.accepted,
+        state,
+        message: body?.error || body?.message || '',
+      }
     } catch (err) {
-      setRebuildError(err?.message || 'The container could not be rebuilt.')
+      const message = err?.message || 'The container could not be rebuilt.'
+      if (reviewedUpdate) setPlatformError(message)
+      else setRebuildError(message)
+      rebuildReviewedUpdateRef.current = false
+      return { ok: false, message }
     } finally {
       setRebuildRequesting(false)
+      if (reviewedUpdate) setPlatformPhase('idle')
     }
+  }
+
+  async function rebuildContainer() {
+    return startContainerRebuild(() => api.admin.rebuild())
+  }
+
+  async function rebuildPlatformUpdate(plan) {
+    if (
+      !plan?.plan_id
+      || !plan?.current_sha
+      || !plan?.target_sha
+      || !plan?.image_digest
+    ) {
+      setPlatformError('The update plan is incomplete. Refresh the preview and try again.')
+      return { ok: false }
+    }
+    return startContainerRebuild(
+      () => api.platform.rebuild(plan),
+      { reviewedUpdate: true },
+    )
   }
 
   const rebuildBootstrap = rebuildNeedsBootstrap(rebuildStatus)
@@ -1219,13 +1270,18 @@ export default function SettingsView({
       }
     })()
     const platformP = (async () => {
-      const res = await api.platform.check()
-      // An HTTP failure must REJECT, not resolve: allSettled treats a
-      // resolved probe as success, so a swallowed !ok let updateCheckOutcome
-      // report "No updates found" on a real 500 (feature 20).
-      if (!res.ok) throw new Error(`platform check failed: ${res.status}`)
-      freshPlatform = await res.json()
-      setPlatform(freshPlatform)
+      try {
+        const res = await api.platform.check()
+        // An HTTP failure must REJECT, not resolve: allSettled treats a
+        // resolved probe as success, so a swallowed !ok let updateCheckOutcome
+        // report "No updates found" on a real 500 (feature 20).
+        if (!res.ok) throw new Error(`platform check failed: ${res.status}`)
+        freshPlatform = await res.json()
+        setPlatform(freshPlatform)
+      } catch (error) {
+        setPlatform(current => platformStatusUnavailable(current))
+        throw error
+      }
     })()
     const results = await Promise.allSettled([frontendP, platformP])
     setUpdatePhase(updateCheckOutcome(results))
@@ -1262,9 +1318,16 @@ export default function SettingsView({
   const refreshPlatform = useCallback(async () => {
     try {
       const res = await api.platform.status()
-      if (res.ok) setPlatform(await res.json())
+      if (!res.ok) throw new Error(`platform status failed: ${res.status}`)
+      const body = await res.json()
+      setPlatform(body)
+      if (body?.state === 'rolled_back' && body?.rollback_error) {
+        setPlatformError(body.rollback_error)
+      }
     } catch {
-      // A status hiccup just leaves the section hidden — never blocks Settings.
+      // Never let an unavailable release authority inherit a cached “current”
+      // or update-available claim. The row stays usable and offers a retry.
+      setPlatform(current => platformStatusUnavailable(current))
     }
   }, [])
   useEffect(() => {
@@ -1342,12 +1405,14 @@ export default function SettingsView({
       try { body = await res.json() } catch {}
       if (!res.ok) {
         const detail = body?.detail || ''
+        const detailCode = typeof detail === 'object' ? detail?.code : detail
+        const detailMessage = typeof detail === 'object' ? detail?.message : detail
         await refreshPlatform()
         setPlatformError(
-          detail === 'update_plan_stale'
+          detailCode === 'update_plan_stale'
             ? 'Möbius changed since this preview. Close it and review the refreshed update before applying.'
-            : detail
-              ? `Update stopped: ${detail}`
+            : detailMessage
+              ? `Update stopped: ${detailMessage}`
               : 'Update stopped before completion. Check the current status before trying again.',
         )
         return { ok: false }
@@ -1361,6 +1426,9 @@ export default function SettingsView({
         return { ok: true, state }
       }
       if (state === 'conflict' || state === 'rolled_back') {
+        if (state === 'rolled_back' && body?.error) {
+          setPlatformError(body.error)
+        }
         return { ok: false, state }
       }
       setPlatformError(
@@ -1572,7 +1640,9 @@ export default function SettingsView({
   )
   const updateAvailable = !!platform?.available
   const mobiusUpdating =
-    platformPhase === 'applying' || updatePhase === 'checking'
+    ['applying', 'rebuilding'].includes(platformPhase)
+    || rebuildIsActive(rebuildStatus)
+    || updatePhase === 'checking'
   const checkUpdatesLabel = updateCheckLabel(updatePhase)
   const effectiveBackgroundDraft = backgroundDraft ||
     normalizeBackgroundAgents(
@@ -2090,8 +2160,10 @@ export default function SettingsView({
           <UpdateReviewModal
             onClose={closeUpdateReview}
             onApply={applyPlatformUpdate}
+            onRebuild={rebuildPlatformUpdate}
             onResolve={resolvePlatformConflict}
             applying={platformPhase === 'applying'}
+            rebuilding={platformPhase === 'rebuilding'}
             resolving={platformPhase === 'resolving'}
             applyError={platformError}
             applyProgress={platformProgress}
@@ -2175,7 +2247,7 @@ export default function SettingsView({
             >
               {rebuildBootstrap
                 ? 'Enables safe container rebuilds on this Railway deployment with one managed upgrade.'
-                : 'Creates a fresh container from the newest official image for your applied update, while keeping your chats, apps, settings, and other saved data.'}
+                : 'On Railway, creates a fresh container from the newest published official image. Self-hosted setups rebuild the applied version. Your chats, apps, settings, and other saved data stay in place.'}
             </SettingsInfoLabel>
             {rebuildConfirm ? (
               <div className="settings__confirm">
@@ -2223,9 +2295,10 @@ export default function SettingsView({
                 update controller. Finish active responses first; Railway restores
                 the previous container if the upgrade is unhealthy.</>
               ) : (
-                <>Rebuilds the container from the official image for your applied
-                update. Local-only runtime changes recorded by Möbius block the
-                rebuild; undeclared
+                <>Rebuilds the container from a pinned official image. Railway
+                first checks the newest image published to GHCR; self-hosted
+                setups use the applied version. Local-only runtime changes
+                recorded by Möbius block the rebuild; undeclared
                 container changes are lost. Active chats continue afterward.</>
               )}
             </p>

--- a/frontend/src/components/SettingsView/SettingsView.jsx
+++ b/frontend/src/components/SettingsView/SettingsView.jsx
@@ -1315,7 +1315,9 @@ export default function SettingsView({
   // agent-authored platform work settled. Settings can remain mounted beside a
   // resolver chat, so mount-only fetching leaves a cleared conflict looking
   // blocked until a full page reload.
-  const refreshPlatform = useCallback(async () => {
+  const refreshPlatform = useCallback(async ({
+    preserveCurrentOnFailure = false,
+  } = {}) => {
     try {
       const res = await api.platform.status()
       if (!res.ok) throw new Error(`platform status failed: ${res.status}`)
@@ -1325,9 +1327,14 @@ export default function SettingsView({
         setPlatformError(body.rollback_error)
       }
     } catch {
-      // Never let an unavailable release authority inherit a cached “current”
-      // or update-available claim. The row stays usable and offers a retry.
-      setPlatform(current => platformStatusUnavailable(current))
+      // A successful mutation response is itself authoritative for the state
+      // it just produced. Its best-effort follow-up read must not erase that
+      // known result merely because the status endpoint is temporarily down.
+      if (!preserveCurrentOnFailure) {
+        // Ordinary reads still fail closed: never let an unavailable release
+        // authority inherit a cached “current” or update-available claim.
+        setPlatform(current => platformStatusUnavailable(current))
+      }
     }
   }, [])
   useEffect(() => {
@@ -1421,7 +1428,7 @@ export default function SettingsView({
       if (PLATFORM_APPLY_STATES.has(state)) {
         setPlatform(current => platformStatusFromApply(current, body))
       }
-      await refreshPlatform()
+      await refreshPlatform({ preserveCurrentOnFailure: true })
       if (state === 'restart_needed' || state === 'activation_needed' || state === 'up_to_date') {
         return { ok: true, state }
       }

--- a/frontend/src/components/SettingsView/UpdateReviewModal.jsx
+++ b/frontend/src/components/SettingsView/UpdateReviewModal.jsx
@@ -29,7 +29,11 @@ import {
   summarizePreview,
   isTrivialUpdate,
 } from '../../lib/platformUpdatePreview.js'
-import { deploymentKindLabel, platformActivationLabel } from '../../lib/platformUpdateState.js'
+import {
+  deploymentKindLabel,
+  platformActivationLabel,
+  reviewedUpdateUsesContainerRebuild,
+} from '../../lib/platformUpdateState.js'
 import UnifiedDiff from '../DiffView/UnifiedDiff.jsx'
 import './UpdateReviewModal.css'
 
@@ -53,15 +57,17 @@ const UPDATE_PHASE_LABELS = {
 export default function UpdateReviewModal({
   onClose,
   onApply,
+  onRebuild,
   onResolve,
   applying,
+  rebuilding,
   resolving,
   applyError,
   applyProgress,
 }) {
   const [preview, setPreview] = useState(null)
   const [loading, setLoading] = useState(true)
-  const [loadError, setLoadError] = useState(false)
+  const [loadError, setLoadError] = useState('')
   const [resultState, setResultState] = useState('')
   const dialogRef = useRef(null)
   const closeRef = useRef(null)
@@ -69,13 +75,23 @@ export default function UpdateReviewModal({
 
   const loadPreview = useCallback(async () => {
     setLoading(true)
-    setLoadError(false)
+    setLoadError('')
     try {
       const res = await api.platform.updatePreview()
-      if (!res.ok) throw new Error(`status ${res.status}`)
-      setPreview(await res.json())
-    } catch {
-      setLoadError(true)
+      let body = null
+      try { body = await res.json() } catch {}
+      if (!res.ok) {
+        const detail = body?.detail
+        throw new Error(
+          detail?.message || (typeof detail === 'string' ? detail : '')
+          || 'Couldn’t verify the official release source.',
+        )
+      }
+      setPreview(body)
+    } catch (error) {
+      setLoadError(
+        error?.message || 'Couldn’t verify the official release source.',
+      )
     } finally {
       setLoading(false)
     }
@@ -84,8 +100,8 @@ export default function UpdateReviewModal({
   useEffect(() => { loadPreview() }, [loadPreview])
 
   const requestClose = useCallback(() => {
-    if (!applying && !resolving) onClose()
-  }, [applying, onClose, resolving])
+    if (!applying && !rebuilding && !resolving) onClose()
+  }, [applying, onClose, rebuilding, resolving])
 
   // Escape and backdrop dismissal remain disabled while an update or resolver
   // request is in flight.
@@ -93,15 +109,18 @@ export default function UpdateReviewModal({
     containerRef: dialogRef,
     initialFocusRef: closeRef,
     onClose: requestClose,
-    closeOnEscape: !applying && !resolving,
+    closeOnEscape: !applying && !rebuilding && !resolving,
   })
 
   const handleApply = useCallback(async () => {
-    const result = await onApply({
+    const plan = {
       plan_id: preview?.plan_id,
       current_sha: preview?.current_sha,
       target_sha: preview?.target_sha,
-    })
+      image_digest: preview?.image_digest,
+    }
+    const rebuildUpdate = reviewedUpdateUsesContainerRebuild(preview)
+    const result = await (rebuildUpdate ? onRebuild(plan) : onApply(plan))
     // A successful request can still mean the update was blocked. Keep the
     // reviewed sheet open and show that honest outcome in place; only a clean
     // apply closes automatically and advances Settings to its next step.
@@ -112,12 +131,20 @@ export default function UpdateReviewModal({
     if (
       result?.ok
       && (
-        result.state === 'restart_needed'
-        || result.state === 'activation_needed'
-        || result.state === 'up_to_date'
+        (rebuildUpdate && [
+          'queued', 'preparing', 'replacing', 'verifying', 'succeeded',
+          // The controller returns no_change only after proving the exact image
+          // and reviewed source are already active, so it is a completed update.
+          'no_change',
+        ].includes(result.state))
+        || (!rebuildUpdate && (
+          result.state === 'restart_needed'
+          || result.state === 'activation_needed'
+          || result.state === 'up_to_date'
+        ))
       )
     ) onClose()
-  }, [onApply, onClose, preview])
+  }, [onApply, onClose, onRebuild, preview])
 
   // Applying replaces the focused Apply button with a result surface. Focus a
   // real action in that surface so both Tab directions remain inside the
@@ -132,6 +159,7 @@ export default function UpdateReviewModal({
   const commits = Array.isArray(preview?.commits) ? preview.commits : []
   const files = Array.isArray(preview?.files) ? preview.files : []
   const activation = preview?.activation
+  const rebuildUpdate = reviewedUpdateUsesContainerRebuild(preview)
   const activationGuidance = Array.isArray(activation?.guidance)
     ? activation.guidance
     : []
@@ -143,13 +171,18 @@ export default function UpdateReviewModal({
   const notAvailable = preview && preview.available === false && !loadError
   const hasResult = resultState === 'conflict' || resultState === 'rolled_back'
   const hasPlan = !!(
-    preview?.plan_id && preview?.current_sha && preview?.target_sha
+    preview?.plan_id
+    && preview?.current_sha
+    && preview?.target_sha
+    && (!rebuildUpdate || preview?.image_digest)
   )
-  const progressLabel = (
-    applyProgress?.plan_id === preview?.plan_id
-      ? UPDATE_PHASE_LABELS[applyProgress?.phase]
-      : null
-  ) || 'Preparing update…'
+  const progressLabel = rebuildUpdate && rebuilding
+    ? 'Starting the exact reviewed official image…'
+    : (
+        applyProgress?.plan_id === preview?.plan_id
+          ? UPDATE_PHASE_LABELS[applyProgress?.phase]
+          : null
+      ) || 'Preparing update…'
   const resultTitle = resultState === 'rolled_back'
     ? 'Update rolled back'
     : 'Update not applied'
@@ -183,7 +216,7 @@ export default function UpdateReviewModal({
             className="urm__close"
             onClick={requestClose}
             aria-label="Close"
-            disabled={applying || resolving}
+            disabled={applying || rebuilding || resolving}
           >×</button>
         </div>
 
@@ -218,12 +251,11 @@ export default function UpdateReviewModal({
 
           {!hasResult && !loading && loadError && (
             <div className="urm__notice" role="status">
-              Couldn’t load the change preview. Try again to create a fresh,
-              immutable update plan.
+              {loadError} Try again to create a fresh, immutable update plan.
             </div>
           )}
 
-          {!hasResult && applying && (
+          {!hasResult && (applying || rebuilding) && (
             <div className="urm__notice" role="status">
               {progressLabel}
             </div>
@@ -314,7 +346,7 @@ export default function UpdateReviewModal({
               type="button"
               className="urm__btn urm__btn--ghost"
               onClick={requestClose}
-              disabled={applying || resolving}
+              disabled={applying || rebuilding || resolving}
             >
               Not now
             </button>
@@ -343,7 +375,7 @@ export default function UpdateReviewModal({
               type="button"
               className="urm__btn"
               onClick={loadPreview}
-              disabled={applying}
+              disabled={applying || rebuilding}
             >
               Try again
             </button>
@@ -352,9 +384,15 @@ export default function UpdateReviewModal({
               type="button"
               className="urm__btn"
               onClick={handleApply}
-              disabled={applying || loading || notAvailable || !hasPlan}
+              disabled={applying || rebuilding || loading || notAvailable || !hasPlan}
             >
-              {applying ? 'Applying…' : 'Apply update'}
+              {rebuilding
+                ? 'Starting rebuild…'
+                : applying
+                  ? 'Applying…'
+                  : rebuildUpdate
+                    ? 'Rebuild to update'
+                    : 'Apply update'}
             </button>
           )}
         </div>

--- a/frontend/src/lib/__tests__/containerRebuild.test.js
+++ b/frontend/src/lib/__tests__/containerRebuild.test.js
@@ -6,6 +6,7 @@ import {
   rebuildNeedsBootstrap,
   rebuildPollShouldContinue,
   rebuildProgressMessage,
+  rebuildRequestOutcome,
 } from '../containerRebuild.js'
 
 test('container rebuild active states are exactly the controller phases', () => {
@@ -19,6 +20,28 @@ test('container rebuild active states are exactly the controller phases', () => 
   ]) {
     assert.equal(rebuildIsActive({ state }), false, state)
   }
+})
+
+test('reviewed no-change is completion while standalone no-change stays informational', () => {
+  assert.deepEqual(
+    rebuildRequestOutcome({ state: 'no_change' }, { reviewedUpdate: true }),
+    {
+      state: 'no_change', accepted: true, cutoverAccepted: false,
+      alreadyCurrent: true, terminalFailure: false,
+    },
+  )
+  assert.deepEqual(
+    rebuildRequestOutcome({ state: 'no_change' }),
+    {
+      state: 'no_change', accepted: false, cutoverAccepted: false,
+      alreadyCurrent: false, terminalFailure: false,
+    },
+  )
+  assert.equal(
+    rebuildRequestOutcome({ state: 'rolled_back' }, { reviewedUpdate: true })
+      .terminalFailure,
+    true,
+  )
 })
 
 test('legacy Railway status exposes the one-time bootstrap action', () => {
@@ -45,5 +68,13 @@ test('container rebuild progress copy stays factual', () => {
   assert.equal(
     rebuildProgressMessage({ state: 'needs_recovery' }),
     'The container could not be restored. Use your deployment’s Recovery action.',
+  )
+  assert.equal(
+    rebuildProgressMessage({ state: 'no_change', release_source: 'applied' }),
+    'This container already matches the applied Möbius version.',
+  )
+  assert.equal(
+    rebuildProgressMessage({ state: 'no_change', release_source: 'latest_ghcr' }),
+    'This container already matches the latest official image.',
   )
 })

--- a/frontend/src/lib/__tests__/platformUpdateState.test.js
+++ b/frontend/src/lib/__tests__/platformUpdateState.test.js
@@ -5,8 +5,25 @@ import {
   deploymentKindLabel,
   platformActivationLabel,
   platformStatusFromApply,
+  platformStatusUnavailable,
   platformUpdateStatusLabel,
+  reviewedUpdateUsesContainerRebuild,
 } from '../platformUpdateState.js'
+
+test('an unavailable release check cannot inherit a cached current claim', () => {
+  const unavailable = platformStatusUnavailable({
+    state: 'up_to_date',
+    available: true,
+    contained_upstream_sha: 'a'.repeat(40),
+  })
+
+  assert.equal(unavailable.state, 'unavailable')
+  assert.equal(unavailable.available, false)
+  assert.equal(unavailable.status_unavailable, true)
+  assert.equal(
+    platformUpdateStatusLabel(unavailable), 'Update status unavailable',
+  )
+})
 
 test('the deployment classifier stays as binary as the backend that emits it', () => {
   assert.equal(deploymentKind({ deployment: 'railway' }), 'railway')
@@ -22,6 +39,19 @@ test('the deployment badge names an unresolved deployment self-hosted', () => {
   assert.equal(deploymentKindLabel({ deployment: 'railway' }), 'Railway')
   assert.equal(deploymentKindLabel({ deployment: 'self_hosted' }), 'Self-hosted')
   assert.equal(deploymentKindLabel(null), 'Self-hosted')
+})
+
+test('only reviewed Railway image updates rebuild directly', () => {
+  assert.equal(reviewedUpdateUsesContainerRebuild({
+    activation: { deployment: 'railway', level: 'image_rebuild' },
+  }), true)
+  assert.equal(reviewedUpdateUsesContainerRebuild({
+    activation: { deployment: 'self_hosted', level: 'image_rebuild' },
+  }), false)
+  assert.equal(reviewedUpdateUsesContainerRebuild({
+    activation: { deployment: 'railway', level: 'server_restart' },
+  }), false)
+  assert.equal(reviewedUpdateUsesContainerRebuild(null), false)
 })
 
 test('a clean apply consumes the reviewed target but preserves restart readiness', () => {

--- a/frontend/src/lib/__tests__/platformUpdateState.test.js
+++ b/frontend/src/lib/__tests__/platformUpdateState.test.js
@@ -59,6 +59,7 @@ test('a clean apply consumes the reviewed target but preserves restart readiness
     {
       state: 'available',
       available: true,
+      status_unavailable: true,
       needs_restart: false,
       current_build_sha: 'served',
       contained_upstream_sha: 'before',
@@ -71,6 +72,7 @@ test('a clean apply consumes the reviewed target but preserves restart readiness
   )
 
   assert.equal(projected.available, false)
+  assert.equal(projected.status_unavailable, false)
   assert.equal(projected.needs_restart, true)
   assert.equal(projected.contained_upstream_sha, 'applied')
 })

--- a/frontend/src/lib/__tests__/settingsViewAppearance.test.js
+++ b/frontend/src/lib/__tests__/settingsViewAppearance.test.js
@@ -44,10 +44,22 @@ test('restart and rebuild explain their distinct container effects on demand', (
   assert.match(view, /label="Restart"[\s\S]*settings-restart-info/)
   assert.match(view, /label=\{rebuildBootstrap \? 'Container updates' : 'Rebuild container'\}/)
   assert.match(view, /does not[\s\S]*install a newer container image/)
-  assert.match(view, /Creates a fresh container from the newest official image/)
+  assert.match(view, /On Railway, creates a fresh container from the newest published official image/)
   assert.doesNotMatch(view, /Replace container|Replace now|Replacing…/)
   assert.match(css, /\.settings__info-button\s*\{[^}]*width:\s*32px;[^}]*height:\s*32px;/s)
   assert.match(css, /\.settings__info-bubble\s*\{[^}]*position:\s*absolute;[^}]*bottom:\s*calc\(100% \+ 10px\);/s)
+})
+
+test('platform status failures replace cached current claims with unknown state', () => {
+  assert.match(view, /platformStatusUnavailable,/)
+  assert.match(
+    view,
+    /const refreshPlatform = useCallback[\s\S]*if \(!res\.ok\) throw new Error[\s\S]*catch \{[\s\S]*setPlatform\(current => platformStatusUnavailable\(current\)\)/,
+  )
+  assert.match(
+    view,
+    /const platformP = \(async \(\) => \{[\s\S]*catch \(error\) \{[\s\S]*setPlatform\(current => platformStatusUnavailable\(current\)\)[\s\S]*throw error/,
+  )
 })
 
 test('background agents are always draggable without reorder chrome or a trailing caret', () => {

--- a/frontend/src/lib/__tests__/updateReviewModal.test.js
+++ b/frontend/src/lib/__tests__/updateReviewModal.test.js
@@ -37,6 +37,28 @@ test('apply outcomes close only for explicit clean states and preserve actionabl
   assert.match(modal, /applyProgress\?\.plan_id === preview\?\.plan_id/)
 })
 
+test('Railway image reviews rebuild the exact immutable image instead of applying in place', () => {
+  assert.match(modal, /reviewedUpdateUsesContainerRebuild\(preview\)/)
+  assert.match(modal, /rebuildUpdate \? onRebuild\(plan\) : onApply\(plan\)/)
+  assert.match(modal, /image_digest: preview\?\.image_digest/)
+  assert.match(modal, /!rebuildUpdate \|\| preview\?\.image_digest/)
+  assert.match(modal, /Rebuild to update/)
+  assert.match(modal, /Starting the exact reviewed official image…/)
+  assert.match(settingsView, /api\.platform\.rebuild\(plan\)/)
+  assert.match(settingsView, /\{ reviewedUpdate: true \}/)
+  assert.match(settingsView, /\|\| rebuildIsActive\(rebuildStatus\)/)
+  assert.match(settingsView, /rebuildRequestOutcome\(body, \{ reviewedUpdate \}\)/)
+  assert.match(settingsView, /rebuildStatus\?\.error[\s\S]*rebuildStatus\?\.message/)
+})
+
+test('an exact no-change completes a reviewed rebuild while failures remain visible', () => {
+  assert.match(modal, /'queued', 'preparing', 'replacing', 'verifying', 'succeeded',[\s\S]*'no_change'/)
+  assert.match(settingsView, /ok: outcome\.accepted/)
+  assert.match(settingsView, /if \(outcome\.alreadyCurrent\) \{[\s\S]*await refreshPlatform\(\)/)
+  assert.doesNotMatch(settingsView, /reviewed image is already running, but this update is still pending/)
+  assert.match(settingsView, /rebuildReviewedUpdateRef\.current = false[\s\S]*return \{ ok: false, message \}/)
+})
+
 test('the apply response is a truthful fallback when status refresh fails', () => {
   assert.match(updateState, /function platformStatusFromApply\(previous, result\)/)
   assert.match(updateState, /available: state === 'rolled_back'/)

--- a/frontend/src/lib/__tests__/updateReviewModal.test.js
+++ b/frontend/src/lib/__tests__/updateReviewModal.test.js
@@ -66,7 +66,11 @@ test('the apply response is a truthful fallback when status refresh fails', () =
   assert.match(updateState, /conflict_chat_id: state === 'conflict' \? \(result\.chat_id \|\| null\) : null/)
   assert.match(
     settingsView,
-    /setPlatform\(current => platformStatusFromApply\(current, body\)\)[\s\S]*await refreshPlatform\(\)/,
+    /setPlatform\(current => platformStatusFromApply\(current, body\)\)[\s\S]*await refreshPlatform\(\{ preserveCurrentOnFailure: true \}\)/,
+  )
+  assert.match(
+    settingsView,
+    /if \(!preserveCurrentOnFailure\) \{[\s\S]*setPlatform\(current => platformStatusUnavailable\(current\)\)/,
   )
 })
 

--- a/frontend/src/lib/containerRebuild.js
+++ b/frontend/src/lib/containerRebuild.js
@@ -16,6 +16,19 @@ export function rebuildPollShouldContinue(status) {
   return status === null || rebuildIsActive(status)
 }
 
+export function rebuildRequestOutcome(status, { reviewedUpdate = false } = {}) {
+  const state = typeof status?.state === 'string' ? status.state : ''
+  const cutoverAccepted = rebuildIsActive(status) || state === 'succeeded'
+  const alreadyCurrent = reviewedUpdate && state === 'no_change'
+  return {
+    state,
+    accepted: cutoverAccepted || alreadyCurrent,
+    cutoverAccepted,
+    alreadyCurrent,
+    terminalFailure: ['failed', 'rolled_back', 'needs_recovery'].includes(state),
+  }
+}
+
 export function rebuildProgressMessage(status) {
   if (rebuildNeedsBootstrap(status)) {
     switch (status?.state) {
@@ -47,7 +60,9 @@ export function rebuildProgressMessage(status) {
     case 'succeeded':
       return 'Container rebuilt successfully.'
     case 'no_change':
-      return 'This container is already current.'
+      return status?.release_source === 'latest_ghcr'
+        ? 'This container already matches the latest official image.'
+        : 'This container already matches the applied Möbius version.'
     case 'rolled_back':
       return 'The rebuild failed, so the previous container was restored.'
     case 'needs_recovery':

--- a/frontend/src/lib/platformUpdateState.js
+++ b/frontend/src/lib/platformUpdateState.js
@@ -20,6 +20,7 @@ export function platformStatusFromApply(previous, result) {
   return {
     ...(previous || {}),
     state,
+    status_unavailable: false,
     // A clean apply consumed the exact reviewed target. Do not briefly carry
     // the OLD `available:true` through the render before the status refresh:
     // the batched-update UI would otherwise offer the update that just applied.

--- a/frontend/src/lib/platformUpdateState.js
+++ b/frontend/src/lib/platformUpdateState.js
@@ -42,6 +42,15 @@ export function platformStatusFromApply(previous, result) {
   }
 }
 
+export function platformStatusUnavailable(previous) {
+  return {
+    ...(previous || {}),
+    state: 'unavailable',
+    available: false,
+    status_unavailable: true,
+  }
+}
+
 export function platformUpdateStatusLabel(platform) {
   const state = platform?.state
   const needsRestart = !!platform?.needs_restart
@@ -50,6 +59,9 @@ export function platformUpdateStatusLabel(platform) {
     needsRestart ? 'server_restart' : 'live'
   )
 
+  if (platform?.status_unavailable || state === 'unavailable') {
+    return 'Update status unavailable'
+  }
   if (state === 'conflict') return 'Update blocked'
   if (state === 'rolled_back') return 'Update needs repair'
   if (activationLevel !== 'live' && available) return 'More updates available'
@@ -82,6 +94,17 @@ export function deploymentKind(activation) {
 
 export function deploymentKindLabel(activation) {
   return deploymentKind(activation) === 'railway' ? 'Railway' : 'Self-hosted'
+}
+
+/**
+ * Railway image updates are activated by replacing the container, not by
+ * mutating the checkout that is still serving the current container.
+ */
+export function reviewedUpdateUsesContainerRebuild(preview) {
+  return (
+    deploymentKind(preview?.activation) === 'railway'
+    && preview?.activation?.level === 'image_rebuild'
+  )
 }
 
 export function platformActivationLabel(activation) {


### PR DESCRIPTION
## Summary
- discover the newest Railway release from GHCR, then bind review and deployment to its immutable commit and digest
- rebuild reviewed image-owned updates directly instead of applying source first
- expose registry, startup, rollback, served-identity, and release-lookup failures instead of reporting a false current state
- keep Git verification off the backend request loop and make ambiguous handoff recovery plus one-time bootstrap chat admission atomic
- keep deployment-configuration guidance honest when an image rebuild cannot apply Railway settings

## Rollout order
Deploy the companion `mobius.you` exact-release controller change before this platform client. This is layer 2 of the platform stack and builds on the image-drift safeguard in the parent PR.

## Testing
- focused platform update, deployment, route, activation, version, admission, and drain suites (219 passed)
- focused Settings update and rebuild tests (36 passed)
- production frontend build
