### PR TITLE
Fix fresh Store bootstrap and empty repository publication

### DIFF
--- a/backend/app/bootstrap.py
+++ b/backend/app/bootstrap.py
@@ -32,7 +32,7 @@ log = logging.getLogger("mobius.bootstrap")
 # reviewed commit provides the same immutable input until it does.
 BOOTSTRAP_STORE_MANIFEST_URL = (
   "https://raw.githubusercontent.com/mobius-os/app-store/"
-  "44468e72008d6b9a4a5a0344e8148d69e7b58fa1/mobius.json"
+  "4371719331644b7f5005ef46f2011f7cab0f4851/mobius.json"
 )
 
 # The Skills app (browse/install ecosystem skills + the skill-agent chat).

--- a/backend/app/routes/community.py
+++ b/backend/app/routes/community.py
@@ -724,7 +724,8 @@ async def _publish_local_source(
     repo, repo_status = await _github_json(
       github, "GET", f"/repos/{encoded_repo}", allow_not_found=True,
     )
-    if repo_status == 404:
+    created_repository = repo_status == 404
+    if created_repository:
       repo, _ = await _github_json(
         github, "POST", "/user/repos",
         body={
@@ -749,9 +750,23 @@ async def _publish_local_source(
       repository_marker=repository_marker, accepted_commit=accepted_commit,
     )
     ref_path = f"/repos/{encoded_repo}/git/ref/heads/main"
-    ref, ref_status = await _github_json(
-      github, "GET", ref_path, allow_not_found=True,
-    )
+    # GitHub answers 409 (not 404) when this newly-created repository has no
+    # commits yet. More importantly, we already know no branch can exist: skip
+    # the inconsistent read and create the first commit directly.
+    if created_repository:
+      ref, ref_status = None, 404
+    else:
+      try:
+        ref, ref_status = await _github_json(
+          github, "GET", ref_path, allow_not_found=True,
+        )
+      except HTTPException as exc:
+        # A publication may resume after repository creation but before its
+        # first commit. GitHub reports that unborn branch as 409, rather than
+        # the 404 it uses for an absent branch in an initialized repository.
+        if exc.status_code != 409:
+          raise
+        ref, ref_status = None, 404
     parent_sha = ""
     parent_message = ""
     if ref_status != 404:
@@ -767,6 +782,30 @@ async def _publish_local_source(
           409,
           "That repository already exists and was not created for this local app. Choose another name.",
         )
+    else:
+      # GitHub rejects every Git Database write while a repository has no
+      # commits. Seed it with one real source file through the Contents API;
+      # the managed marker makes an interrupted publication safely resumable,
+      # and the full accepted tree below replaces this partial seed atomically.
+      seed = next(
+        (item for item in files if item["path"] == "mobius.json"), files[0],
+      )
+      seed_path = quote(seed["path"], safe="/")
+      initialized, _ = await _github_json(
+        github,
+        "PUT",
+        f"/repos/{encoded_repo}/contents/{seed_path}",
+        body={
+          "message": f"Initialize {app.name} publication\n\n{repository_marker}",
+          "content": seed["content_base64"],
+          "branch": "main",
+        },
+      )
+      parent_sha = str((initialized.get("commit") or {}).get("sha") or "").lower()
+      if not re.fullmatch(r"[0-9a-f]{40}", parent_sha):
+        raise HTTPException(502, "GitHub did not initialize the source repository.")
+      parent_message = repository_marker
+      ref_status = 200
 
     if release_marker in parent_message:
       return repository, parent_sha
@@ -810,16 +849,10 @@ async def _publish_local_source(
     source_commit_sha = str(commit.get("sha") or "").lower()
     if not re.fullmatch(r"[0-9a-f]{40}", source_commit_sha):
       raise HTTPException(502, "GitHub did not return the source commit.")
-    if ref_status == 404:
-      await _github_json(
-        github, "POST", f"/repos/{encoded_repo}/git/refs",
-        body={"ref": "refs/heads/main", "sha": source_commit_sha},
-      )
-    else:
-      await _github_json(
-        github, "PATCH", f"/repos/{encoded_repo}/git/refs/heads/main",
-        body={"sha": source_commit_sha, "force": False},
-      )
+    await _github_json(
+      github, "PATCH", f"/repos/{encoded_repo}/git/refs/heads/main",
+      body={"sha": source_commit_sha, "force": False},
+    )
     return repository, source_commit_sha
 
 

--- a/backend/tests/test_community_routes.py
+++ b/backend/tests/test_community_routes.py
@@ -516,8 +516,9 @@ async def test_local_publish_rejects_an_incomplete_listing_before_github_writes(
 
 
 @pytest.mark.asyncio
-async def test_local_app_publish_creates_public_github_source_then_lists_exact_commit(
-  monkeypatch, db,
+@pytest.mark.parametrize("repository_preexists_empty", [False, True])
+async def test_local_app_publish_creates_or_resumes_empty_github_source_then_lists_exact_commit(
+  monkeypatch, db, repository_preexists_empty,
 ):
   github_calls = []
   listed = {}
@@ -550,23 +551,37 @@ async def test_local_app_publish_creates_public_github_source_then_lists_exact_c
     if path == "/user":
       return {"id": 77, "login": "octo-owner"}, 200
     if path == "/repos/octo-owner/pocket-list":
+      if repository_preexists_empty:
+        return {
+          "full_name": "octo-owner/pocket-list",
+          "private": False,
+          "owner": {"id": 77},
+        }, 200
       return None, 404
     if path == "/user/repos":
+      assert repository_preexists_empty is False
       return {
         "full_name": "octo-owner/pocket-list",
         "private": False,
         "owner": {"id": 77},
       }, 201
     if path.endswith("/git/ref/heads/main"):
-      return None, 404
+      if repository_preexists_empty:
+        raise community.HTTPException(409, "Git Repository is empty.")
+      raise AssertionError("a newly-created empty repository has no ref to inspect")
+    if path.endswith("/contents/mobius.json"):
+      assert method == "PUT"
+      assert body["content"] == "e30="
+      assert "[mobius-store-repository:" in body["message"]
+      return {"commit": {"sha": "d" * 40}}, 201
     if path.endswith("/git/blobs"):
       return {"sha": format(len(github_calls), "040x")}, 201
     if path.endswith("/git/trees"):
       return {"sha": "b" * 40}, 201
     if path.endswith("/git/commits"):
       return {"sha": "c" * 40}, 201
-    if path.endswith("/git/refs"):
-      return {"ref": body["ref"]}, 201
+    if method == "PATCH" and path.endswith("/git/refs/heads/main"):
+      return {"object": {"sha": body["sha"]}}, 200
     raise AssertionError((method, path, body, allow_not_found))
 
   async def fake_prepare(body, key, *, local_app_id=""):
@@ -617,6 +632,7 @@ async def test_local_app_publish_creates_public_github_source_then_lists_exact_c
   )
 
   assert response.status_code == 201
+  assert any(path.endswith("/git/ref/heads/main") for _, path, _ in github_calls) is repository_preexists_empty
   assert listed["body"].repository == "octo-owner/pocket-list"
   assert listed["body"].commit_sha == "c" * 40
   assert listed["key"].startswith("store:publish-local:")
@@ -627,7 +643,7 @@ async def test_local_app_publish_creates_public_github_source_then_lists_exact_c
   )
   assert "[mobius-store-repository:" in source_commit["message"]
   assert "[mobius-store-source:" in source_commit["message"]
-  assert source_commit["parents"] == []
+  assert source_commit["parents"] == ["d" * 40]
   assert "local-only-token" not in repr(listed)
 
 


### PR DESCRIPTION
## Summary

- update the fresh-install Store pin to the current reviewed release
- initialize empty GitHub repositories before writing the complete app publication
- resume safely when a managed repository exists but has no first commit yet

## Tests

- `scripts/wt-pytest.sh backend/tests/test_community_routes.py -q`
- `scripts/wt-pytest.sh backend/tests/test_bootstrap.py -q`