### PR TITLE
Identify managed deployment requests

### DIFF
--- a/backend/app/deployment_control.py
+++ b/backend/app/deployment_control.py
@@ -64,6 +64,7 @@ _KNOWN_STATES = {
 _ACTIVE_STATES = {"queued", "preparing", "replacing", "verifying"}
 _HANDOFF_VERSION = "external-cutover-v1"
 _RUNTIME_OVERLAY_VERSION = "active-runtime-v1"
+_MANAGED_USER_AGENT = "mobius-managed-deployment/1"
 _managed_recovery_tasks: set[asyncio.Task[None]] = set()
 _UPGRADE_MESSAGE = (
   "The Host replacement helper predates safe active-runtime carry-forward. "
@@ -183,6 +184,9 @@ def _managed_headers() -> dict[str, str]:
     "Authorization": f"Bearer {settings.mobius_sso_client_secret}",
     "X-Mobius-Instance-Id": settings.mobius_sso_instance_id,
     "Accept": "application/json",
+    # Browser-oriented edge checks reject Python's default urllib signature.
+    # Identify this authenticated machine-to-machine client explicitly instead.
+    "User-Agent": _MANAGED_USER_AGENT,
   }
 
 

--- a/backend/tests/test_deployment_control.py
+++ b/backend/tests/test_deployment_control.py
@@ -35,6 +35,30 @@ def _install_managed_cutover_marker(tmp_path, monkeypatch, boot_id="boot-test"):
   monkeypatch.setenv("MOBIUS_BOOT_ID", boot_id)
 
 
+def test_managed_request_identifies_the_machine_client(monkeypatch):
+  settings = SimpleNamespace(
+    mobius_account_origin="https://account.example",
+    mobius_sso_enabled=True,
+    mobius_sso_client_secret="secret",
+    mobius_sso_instance_id="instance",
+  )
+  captured = []
+
+  def open_request(request, **_kwargs):
+    captured.append(request)
+    return io.BytesIO(b"{}")
+
+  opener = SimpleNamespace(open=open_request)
+  monkeypatch.setattr(dc, "get_settings", lambda: settings)
+  monkeypatch.setattr(dc.urllib.request, "build_opener", lambda *_args: opener)
+
+  assert dc._managed_request("GET", "status") == {}
+  headers = {name.lower(): value for name, value in captured[0].header_items()}
+  assert headers["user-agent"] == "mobius-managed-deployment/1"
+  assert headers["authorization"] == "Bearer secret"
+  assert headers["x-mobius-instance-id"] == "instance"
+
+
 @pytest.mark.parametrize("status", [400, 409])
 def test_managed_request_recognizes_only_structured_client_rejections(
   monkeypatch, status,


### PR DESCRIPTION
## Summary
- send an explicit Möbius user agent on authenticated managed-deployment requests
- keep the existing bearer and instance identity headers unchanged
- cover the full generated request header set

Browser-oriented edge checks may reject Python’s default `urllib` signature even when the request is authenticated. Naming this platform-owned machine client keeps those trusted control calls distinguishable without weakening the edge policy.

## Verification
- `scripts/wt-pytest.sh backend/tests/test_deployment_control.py -q` (29 passed)
