### PR TITLE
Make shared-object invites single-use

### DIFF
--- a/backend/app/routes/common_objects.py
+++ b/backend/app/routes/common_objects.py
@@ -282,6 +282,8 @@ async def peer_operation(oid: str, request: Request):
       if invite is None and existing_role is None:
         raise HTTPException(status_code=403, detail="Invite is invalid or expired.")
       role = existing_role or invite["role"]
+      if invite is not None and existing_role is None:
+        obj["invites"].pop(_hash_secret(secret), None)
       obj.setdefault("members", {})[sender] = {
         "role": role,
         "name": str(actor.get("name") or "")[:MAX_LABEL_CHARS],
@@ -763,19 +765,20 @@ async def create_invite(
     return {"status": "invited", "host": peer, "role": body.role, "delivery": delivery}
 
   # Capability-code fallback for someone you cannot address directly.
-  obj = _load_object(oid)
-  if obj is None:
-    raise HTTPException(status_code=404, detail="No such object.")
-  _require_app_match(caller, obj["app"])
   ttl = body.ttl_seconds if body.ttl_seconds and body.ttl_seconds > 0 else INVITE_TTL_S
   secret = pysecrets.token_urlsafe(24)
-  _prune_invites(obj)
-  obj.setdefault("invites", {})[_hash_secret(secret)] = {
-    "role": body.role,
-    "created_at": time.time(),
-    "expires_at": time.time() + ttl,
-  }
-  _save_object(obj)
+  async with _object_lock(oid):
+    obj = _load_object(oid)
+    if obj is None:
+      raise HTTPException(status_code=404, detail="No such object.")
+    _require_app_match(caller, obj["app"])
+    _prune_invites(obj)
+    obj.setdefault("invites", {})[_hash_secret(secret)] = {
+      "role": body.role,
+      "created_at": time.time(),
+      "expires_at": time.time() + ttl,
+    }
+    _save_object(obj)
   return {
     "invite": f"{oid}@{_own_host()}#{secret}",
     "role": body.role,

--- a/backend/app/routes/common_objects.py
+++ b/backend/app/routes/common_objects.py
@@ -84,6 +84,8 @@ MAX_ENVELOPE_BYTES = MAX_DOC_BYTES + 8 * 1024
 MAX_KIND_CHARS = 40
 MAX_LABEL_CHARS = 120
 INVITE_TTL_S = 7 * 24 * 3600
+PRESENCE_TTL_S = 12
+PRESENCE_RETENTION_S = 5 * 60
 ROLES = ("editor", "viewer")
 
 _OID_RE = re.compile(r"^[a-f0-9]{32}$")
@@ -94,6 +96,7 @@ _INVITE_RE = re.compile(
 )
 
 _object_locks: "WeakValueDictionary[str, asyncio.Lock]" = WeakValueDictionary()
+_object_presence: dict[tuple[str, str], float] = {}
 
 
 def _object_lock(oid: str) -> asyncio.Lock:
@@ -102,6 +105,25 @@ def _object_lock(oid: str) -> asyncio.Lock:
     lock = asyncio.Lock()
     _object_locks[oid] = lock
   return lock
+
+
+def _mark_present(oid: str, host: str, now: float | None = None) -> None:
+  """Record ephemeral board presence without turning heartbeats into disk I/O."""
+  observed_at = time.time() if now is None else now
+  _object_presence[(oid, host)] = observed_at
+  if len(_object_presence) > 2048:
+    cutoff = observed_at - PRESENCE_RETENTION_S
+    for key, seen_at in list(_object_presence.items()):
+      if seen_at < cutoff:
+        _object_presence.pop(key, None)
+
+
+def _member_is_active(oid: str, host: str, now: float | None = None) -> bool:
+  observed_at = _object_presence.get((oid, host))
+  if observed_at is None:
+    return False
+  current = time.time() if now is None else now
+  return observed_at >= current - PRESENCE_TTL_S
 
 
 # ── paths ────────────────────────────────────────────────────────────────────
@@ -190,6 +212,11 @@ def _public_object(obj: dict) -> dict:
         "name": m.get("name") or "",
         "handle": m.get("handle") or "",
         **({"pending": True} if m.get("pending") else {}),
+        **(
+          {"active": True}
+          if not m.get("pending") and _member_is_active(obj["id"], h)
+          else {}
+        ),
       }
       for h, m in (obj.get("members") or {}).items()
     },
@@ -278,7 +305,8 @@ async def peer_operation(oid: str, request: Request):
       invite = None
       if isinstance(secret, str) and secret:
         invite = (obj.get("invites") or {}).get(_hash_secret(secret))
-      existing_role = _member_role(obj, sender)
+      existing = (obj.get("members") or {}).get(sender) or {}
+      existing_role = existing.get("role")
       if invite is None and existing_role is None:
         raise HTTPException(status_code=403, detail="Invite is invalid or expired.")
       role = existing_role or invite["role"]
@@ -286,10 +314,11 @@ async def peer_operation(oid: str, request: Request):
         obj["invites"].pop(_hash_secret(secret), None)
       obj.setdefault("members", {})[sender] = {
         "role": role,
-        "name": str(actor.get("name") or "")[:MAX_LABEL_CHARS],
-        "handle": str(actor.get("handle") or "")[:MAX_LABEL_CHARS],
+        "name": str(actor.get("name") or existing.get("name") or "")[:MAX_LABEL_CHARS],
+        "handle": str(actor.get("handle") or existing.get("handle") or "")[:MAX_LABEL_CHARS],
         "joined_at": time.time(),
       }
+      _mark_present(oid, sender)
       _save_object(obj)
       return {
         "status": "joined",
@@ -307,6 +336,7 @@ async def peer_operation(oid: str, request: Request):
       return {"status": "left"}
 
     if kind == "object_state":
+      _mark_present(oid, sender)
       since = envelope.get("since_version")
       since = since if isinstance(since, int) else -1
       payload = {"status": "ok", "version": obj["version"], "object": _public_object(obj)}
@@ -329,6 +359,7 @@ async def peer_operation(oid: str, request: Request):
         "doc": _load_doc(oid),
       }
     _save_doc(oid, doc)
+    _mark_present(oid, sender)
     obj["version"] += 1
     obj["updated_at"] = time.time()
     obj.setdefault("members", {}).get(sender, {})["last_write_at"] = time.time()
@@ -820,6 +851,7 @@ async def revoke_member(
     if member_host not in (obj.get("members") or {}):
       raise HTTPException(status_code=404, detail="No such member.")
     obj["members"].pop(member_host, None)
+    _object_presence.pop((oid, member_host), None)
     _save_object(obj)
   return {"status": "revoked"}
 
@@ -846,6 +878,8 @@ async def delete_object(
         d.rmdir()
       except OSError:
         pass
+    for key in [key for key in _object_presence if key[0] == oid]:
+      _object_presence.pop(key, None)
   return {"status": "deleted"}
 
 
@@ -927,6 +961,7 @@ async def read_state(
     if obj is None:
       raise HTTPException(status_code=404, detail="No such object.")
     _require_app_match(caller, obj["app"])
+    _mark_present(oid, _own_host())
     payload = {"status": "ok", "version": obj["version"], "object": _public_object(obj)}
     if obj["version"] > since_version:
       payload["doc"] = _load_doc(oid)
@@ -964,6 +999,7 @@ async def write_state(
           "doc": _load_doc(oid),
         }
       _save_doc(oid, body.doc)
+      _mark_present(oid, _own_host())
       obj["version"] += 1
       obj["updated_at"] = time.time()
       _save_object(obj)

--- a/backend/tests/test_common_objects.py
+++ b/backend/tests/test_common_objects.py
@@ -59,10 +59,10 @@ def _seed_peer_actor_cache(public_b64: str, host: str = PEER_HOST):
   }))
 
 
-def _signed(private_b64: str, envelope: dict) -> dict:
+def _signed(private_b64: str, envelope: dict, host: str = PEER_HOST) -> dict:
   envelope = {
     "v": 0,
-    "from": PEER_HOST,
+    "from": host,
     "to": common_routes._own_host(),
     "sent_at": time.time(),
     **envelope,
@@ -153,6 +153,72 @@ def test_join_requires_valid_invite_and_signature(client, auth):
   assert body["status"] == "joined"
   assert body["object"]["members"][PEER_HOST]["role"] == "editor"
   assert body["doc"]["title"] == "Board"
+
+
+def test_capability_invite_is_consumed_by_first_distinct_peer(client, auth):
+  oid = _create_board(client, auth)
+  first_private, first_public = _make_peer_keypair()
+  _seed_peer_actor_cache(first_public)
+  secret = _invite(client, auth, oid)
+
+  first = client.post(
+    f"/api/common/objects/{oid}/peer",
+    json=_signed(first_private, {"type": "object_join", "invite": secret}),
+  )
+  assert first.status_code == 200, first.text
+
+  second_host = "second.example.com"
+  second_private, second_public = _make_peer_keypair()
+  _seed_peer_actor_cache(second_public, second_host)
+  reused = client.post(
+    f"/api/common/objects/{oid}/peer",
+    json=_signed(
+      second_private,
+      {"type": "object_join", "invite": secret},
+      second_host,
+    ),
+  )
+  assert reused.status_code == 403
+  assert reused.json()["detail"] == "Invite is invalid or expired."
+
+
+def test_capability_invite_mutation_holds_the_object_lock(
+  client, auth, monkeypatch,
+):
+  oid = _create_board(client, auth)
+  held = False
+  original_load = objects_routes._load_object
+  original_save = objects_routes._save_object
+
+  class TrackedLock:
+    async def __aenter__(self):
+      nonlocal held
+      assert not held
+      held = True
+
+    async def __aexit__(self, *_args):
+      nonlocal held
+      held = False
+
+  def load_while_locked(object_id):
+    assert held
+    return original_load(object_id)
+
+  def save_while_locked(obj):
+    assert held
+    original_save(obj)
+
+  monkeypatch.setattr(objects_routes, "_object_lock", lambda _oid: TrackedLock())
+  monkeypatch.setattr(objects_routes, "_load_object", load_while_locked)
+  monkeypatch.setattr(objects_routes, "_save_object", save_while_locked)
+
+  created = client.post(
+    f"/api/common/objects/{oid}/invites",
+    json={"role": "editor"},
+    headers=auth,
+  )
+  assert created.status_code == 200, created.text
+  assert held is False
 
 
 def test_peer_cas_write_and_viewer_confinement(client, auth):

--- a/backend/tests/test_common_objects.py
+++ b/backend/tests/test_common_objects.py
@@ -99,6 +99,7 @@ def test_create_and_local_state_roundtrip(client, auth):
   body = read.json()
   assert body["version"] == 1
   assert body["doc"]["title"] == "Roadmap"
+  assert body["object"]["members"][common_routes._own_host()]["active"] is True
 
   write = client.put(
     f"/api/common/objects/{host}/{oid}/state",
@@ -152,7 +153,16 @@ def test_join_requires_valid_invite_and_signature(client, auth):
   body = joined.json()
   assert body["status"] == "joined"
   assert body["object"]["members"][PEER_HOST]["role"] == "editor"
+  assert body["object"]["members"][PEER_HOST]["active"] is True
   assert body["doc"]["title"] == "Board"
+
+
+def test_presence_is_ephemeral_and_expires():
+  oid = "fe" * 16
+  objects_routes._mark_present(oid, PEER_HOST, now=100.0)
+  assert objects_routes._member_is_active(oid, PEER_HOST, now=111.9) is True
+  assert objects_routes._member_is_active(oid, PEER_HOST, now=112.1) is False
+  objects_routes._object_presence.pop((oid, PEER_HOST), None)
 
 
 def test_capability_invite_is_consumed_by_first_distinct_peer(client, auth):
@@ -367,6 +377,7 @@ def test_handle_invite_preauthorizes_member_and_join_needs_no_code(client, auth)
   )
   assert joined.status_code == 200, joined.text
   assert joined.json()["object"]["members"][PEER_HOST].get("pending") is None
+  assert joined.json()["object"]["members"][PEER_HOST]["handle"] == "ana"
 
   # Re-inviting an active member is rejected.
   again = client.post(


### PR DESCRIPTION
## Summary

- consume capability invitations when the first new member joins
- serialize capability invitation creation with other shared-object mutations
- add regressions for reuse by a second signed instance and lock ownership

Follow-up to #1057.

## Tests

- `scripts/wt-pytest.sh backend/tests/test_common_federation.py backend/tests/test_common_groups.py backend/tests/test_common_objects.py backend/tests/test_identity.py -q`