### PR TITLE
Refine chat scrolling, streaming, and navigation

### DIFF
--- a/frontend/src/components/ChatView/ActiveAssistantSurface.jsx
+++ b/frontend/src/components/ChatView/ActiveAssistantSurface.jsx
@@ -27,6 +27,7 @@ function ActiveAssistantSurface({
   dataKey,
   chatId,
   onAnswer,
+  onAnswerPrepare,
   onResume,
   onInternalNav,
   autoResumeEnabled,
@@ -85,6 +86,7 @@ function ActiveAssistantSurface({
       dataKey={dataKey}
       chatId={chatId}
       onAnswer={onAnswer}
+      onAnswerPrepare={onAnswerPrepare}
       onResume={onResume}
       onInternalNav={onInternalNav}
       autoResumeEnabled={autoResumeEnabled}

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -3289,12 +3289,10 @@ export default function ChatView({
     }
     setSending(true)
     // Close the synchronous re-entry window before React publishes the state
-    // update, then reconcile the completed turn this send follows. The forced
-    // read deliberately uses the local-turn preservation path: it replaces a
-    // stale live assistant projection with its durable settled row while
-    // retaining this optimistic user row and its stable pin.
+    // update. Transcript reconciliation waits for the POST acknowledgement
+    // below: before that boundary an idle compact snapshot can still predate
+    // this turn and must never retire its optimistic row.
     sendingRef.current = true
-    void fetchMessages({ force: true })
     // Pin per the R2 send rule via the funnel: it arms the reservation spacer
     // on every send and, when not pinning, retires any stale PIN to the
     // reader's anchor so their viewport stays fixed. The row carries its final
@@ -3416,6 +3414,12 @@ export default function ChatView({
           return replaceOptimisticWithBatch(prev, cid, startedMessages)
         })
       }
+      // The accepted row is now durable, so the compact read may safely hand
+      // the preceding live assistant projection over to its settled source.
+      // Keep this after the acknowledgement and canonical-row commit: doing
+      // it at optimistic-send time lets an idle pre-ack snapshot erase the
+      // entire visible turn.
+      void fetchMessages({ force: true })
       return true
     } catch (err) {
       const pendingQuestionBlocked = isPendingQuestionSendFailure(err)

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -190,6 +190,7 @@ import {
   stopConfirmedIdle,
   stopRequestSucceeded,
   serverSnapshotBehindLocal,
+  serverSnapshotMissingAcceptedCid,
   shouldFreezeStreamingReturn,
   startedMessagesFromResponse,
   stripInternalUserMessageFields,
@@ -1246,6 +1247,7 @@ export default function ChatView({
     authoritative = false,
     expectedFailedAttempt,
     failedAttemptTerminalOutcome = null,
+    preserveAcceptedCid = null,
   } = {}) => {
     if (sendingRef.current && !force) return
     const gen = fetchGenRef.current
@@ -1279,10 +1281,19 @@ export default function ChatView({
           : expectedFailedAttempt,
         expectedFetchGeneration: gen,
       })
+      const preserveAcceptedTurn = serverSnapshotMissingAcceptedCid(
+        msgs,
+        preserveAcceptedCid,
+      )
       const preserveLocalTurn =
         !authoritative
         && force
-        && (sendingRef.current || isStreamingRef.current || serverRunningRef.current)
+        && (
+          preserveAcceptedTurn
+          || sendingRef.current
+          || isStreamingRef.current
+          || serverRunningRef.current
+        )
       const staleSnapshot =
         !terminal204
         && !preserveLocalTurn
@@ -3419,7 +3430,7 @@ export default function ChatView({
       // Keep this after the acknowledgement and canonical-row commit: doing
       // it at optimistic-send time lets an idle pre-ack snapshot erase the
       // entire visible turn.
-      void fetchMessages({ force: true })
+      void fetchMessages({ force: true, preserveAcceptedCid: cid })
       return true
     } catch (err) {
       const pendingQuestionBlocked = isPendingQuestionSendFailure(err)

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -3288,6 +3288,13 @@ export default function ChatView({
       // comment above for the full rationale.
     }
     setSending(true)
+    // Close the synchronous re-entry window before React publishes the state
+    // update, then reconcile the completed turn this send follows. The forced
+    // read deliberately uses the local-turn preservation path: it replaces a
+    // stale live assistant projection with its durable settled row while
+    // retaining this optimistic user row and its stable pin.
+    sendingRef.current = true
+    void fetchMessages({ force: true })
     // Pin per the R2 send rule via the funnel: it arms the reservation spacer
     // on every send and, when not pinning, retires any stale PIN to the
     // reader's anchor so their viewport stays fixed. The row carries its final

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -3528,7 +3528,9 @@ export default function ChatView({
   // POST /question-answers that could race with the GET on a mid-
   // stream remount, causing answers to disappear on first return
   // and reappear on the second.
-  const doSendSilent = useCallback(async (text, resolvedAnswers, questionId) => {
+  const doSendSilent = useCallback(async (
+    text, resolvedAnswers, questionId, preparedQuestionSubmission = null,
+  ) => {
     // Synchronous re-entrancy guard: flip BEFORE any other logic so a
     // second concurrent call (fast double-tap) bails immediately. This
     // is separate from sendingRef because answer submissions are
@@ -3559,7 +3561,7 @@ export default function ChatView({
     // output. Acceptance alone keeps this hold: the scroll owner may restore
     // prior follow only when the first post-answer activity actually renders.
     const questionSubmission = resolvedAnswers
-      ? freezeQuestionSubmission()
+      ? (preparedQuestionSubmission || freezeQuestionSubmission())
       : null
     const responseQuestionKey = resolvedAnswers
       ? (questionId
@@ -5459,6 +5461,7 @@ export default function ChatView({
                 chatId={chatId}
                 messageKey={dataKey}
                 onQuestionAnswer={doSendSilent}
+                onQuestionAnswerPrepare={freezeQuestionSubmission}
                 onResume={doSend}
                 onInternalNav={internalNav}
                 autoResumeEnabled={
@@ -5502,6 +5505,7 @@ export default function ChatView({
               dataKey={streamingDataKey}
               chatId={chatId}
               onAnswer={doSendSilent}
+              onAnswerPrepare={freezeQuestionSubmission}
               onResume={activeAssistantIsStreaming ? undefined : doSend}
               onInternalNav={internalNav}
               autoResumeEnabled={autoResumeEnabled}

--- a/frontend/src/components/ChatView/MsgContent.jsx
+++ b/frontend/src/components/ChatView/MsgContent.jsx
@@ -93,6 +93,7 @@ function MsgContentInner({
   chatId,
   messageKey,
   onQuestionAnswer,
+  onQuestionAnswerPrepare,
   // Resume a turn paused by a drain-gated restart (or interrupted by a crash):
   // a stable send callback that re-sends a short "continue". Only the tail
   // interrupt note (a resumable error block on the last message) shows the
@@ -302,6 +303,7 @@ function MsgContentInner({
               questionId={block.question_id}
               answeredMap={answers}
               onAnswer={answerable ? onQuestionAnswer : undefined}
+              onAnswerPrepare={answerable ? onQuestionAnswerPrepare : undefined}
               disabled={!answerable && !answers}
               pendingCardRef={answerable ? pendingQuestionRef : undefined}
             />
@@ -509,6 +511,7 @@ export default memo(MsgContentInner, (prev, next) => {
     && prev.chatId === next.chatId
     && prev.messageKey === next.messageKey
     && prev.onQuestionAnswer === next.onQuestionAnswer
+    && prev.onQuestionAnswerPrepare === next.onQuestionAnswerPrepare
     && prev.onResume === next.onResume
     && prev.onInternalNav === next.onInternalNav
     && prev.autoResumeEnabled === next.autoResumeEnabled

--- a/frontend/src/components/ChatView/QuestionCard.jsx
+++ b/frontend/src/components/ChatView/QuestionCard.jsx
@@ -397,7 +397,7 @@ export default function QuestionCard({
           <button
             type="button"
             className="qcard__submit"
-            onPointerDown={(event) => {
+            onPointerDownCapture={(event) => {
               if (event.button === 0 && event.isPrimary !== false) prepareSubmit()
             }}
             onClick={handleSubmit}

--- a/frontend/src/components/ChatView/QuestionCard.jsx
+++ b/frontend/src/components/ChatView/QuestionCard.jsx
@@ -105,6 +105,7 @@ export default function QuestionCard({
   questionId,
   answeredMap,
   onAnswer,
+  onAnswerPrepare,
   disabled,
   // Callback ref that publishes this card's node to the "Möbius asked you
   // something — tap to answer" offscreen observer. Set only by the surface
@@ -126,6 +127,7 @@ export default function QuestionCard({
   const [submitted, setSubmitted] = useState(false)
   const [submitError, setSubmitError] = useState('')
   const pointerSelectionRef = useRef(null)
+  const preparedSubmissionRef = useRef(null)
 
   const answered = submitted || !!answeredMap
   const displayAnswers = answeredMap || {}
@@ -201,7 +203,14 @@ export default function QuestionCard({
     })
   }
 
+  function prepareSubmit() {
+    if (!allAnswered || answered || disabled || submitting) return
+    preparedSubmissionRef.current = onAnswerPrepare?.() || null
+  }
+
   async function handleSubmit() {
+    const preparedSubmission = preparedSubmissionRef.current
+    preparedSubmissionRef.current = null
     if (!allAnswered || answered || disabled || submitting) return
     const resolved = {}
     const lines = questions.map(q => {
@@ -212,7 +221,9 @@ export default function QuestionCard({
     setSubmitError('')
     setSubmitting(true)
     try {
-      const accepted = await onAnswer?.(lines.join('\n'), resolved, questionId)
+      const accepted = await onAnswer?.(
+        lines.join('\n'), resolved, questionId, preparedSubmission,
+      )
       // Only settle (and therefore clear the durable per-tab draft) after the
       // answer endpoint confirms that the transcript write committed.
       if (accepted !== false) setSubmitted(true)
@@ -386,6 +397,9 @@ export default function QuestionCard({
           <button
             type="button"
             className="qcard__submit"
+            onPointerDown={(event) => {
+              if (event.button === 0 && event.isPrimary !== false) prepareSubmit()
+            }}
             onClick={handleSubmit}
             disabled={!allAnswered || disabled || answered || submitting}
           >

--- a/frontend/src/components/ChatView/StreamingMessage.jsx
+++ b/frontend/src/components/ChatView/StreamingMessage.jsx
@@ -13,6 +13,7 @@ export default function StreamingMessage({
   dataKey,
   chatId,
   onAnswer,
+  onAnswerPrepare,
   onResume,
   onInternalNav,
   autoResumeEnabled,
@@ -38,6 +39,7 @@ export default function StreamingMessage({
         chatId={chatId}
         messageKey={dataKey}
         onQuestionAnswer={onAnswer}
+        onQuestionAnswerPrepare={onAnswerPrepare}
         onResume={onResume}
         onInternalNav={onInternalNav}
         autoResumeEnabled={autoResumeEnabled}

--- a/frontend/src/components/ChatView/__tests__/activityGrouping.test.js
+++ b/frontend/src/components/ChatView/__tests__/activityGrouping.test.js
@@ -27,6 +27,18 @@ test('activity grouping handles empty and non-activity-only input', () => {
   assert.deepEqual(groupActivityRuns([question]), [{ single: question }])
 })
 
+test('transparent provider separators do not fragment one activity stretch', () => {
+  const thought = entry('thinking', { content: 'Checking the files' })
+  const command = entry('tool', { name: 'exec_command' })
+
+  for (const content of ['', '\n  ']) {
+    const separator = entry('text', { content })
+    assert.deepEqual(groupActivityRuns([thought, separator, command]), [
+      { group: [thought, command] },
+    ])
+  }
+})
+
 test('context compaction breaks activity stretches instead of joining tools', () => {
   const before = entry('tool', { tool: 'Read' })
   const compaction = entry('context_compaction', { provider: 'codex' })

--- a/frontend/src/components/ChatView/__tests__/chatRuntimeState.test.js
+++ b/frontend/src/components/ChatView/__tests__/chatRuntimeState.test.js
@@ -18,6 +18,7 @@ import {
   previewUpdatedAnnouncement,
   runtimeStreamAttachAction,
   serverSnapshotBehindLocal,
+  serverSnapshotMissingAcceptedCid,
   shouldAttachRunningStream,
   shouldAdoptRuntimeAssistantOwner,
   shouldRetireRestoredQuestionSnapshot,
@@ -423,6 +424,25 @@ test('a local turn refreshes completed history while preserving its optimistic s
   ])
 })
 
+test('an empty pre-publication snapshot cannot erase an accepted local turn', () => {
+  const loaded = [
+    { role: 'user', cid: 'accepted-cid', ts: 3, content: 'Accepted turn' },
+  ]
+  const refreshed = mergeRecentMessagesIntoLoadedWindow({
+    loadedMessages: loaded,
+    loadedOffset: 0,
+    recentMessages: [],
+    recentOffset: 0,
+    preserveLocalSuffix: true,
+  })
+
+  assert.deepEqual(refreshed, {
+    messages: loaded,
+    offset: 0,
+    verified: true,
+  })
+})
+
 test('stripInternalUserMessageFields KEEPS cid and drops the envelope fields', () => {
   const kept = stripInternalUserMessageFields({
     role: 'user', content: 'hi', ts: 7, cid: 'keep-me',
@@ -612,6 +632,21 @@ test('serverSnapshotBehindLocal only preserves explicit unsaved local rows', () 
     ...server,
     { role: 'user', content: 'waiting for canonical ts', ts: 6, serverTs: false },
   ]), true)
+})
+
+test('accepted fresh send remains local until the compact snapshot contains its cid', () => {
+  const oldSnapshot = [
+    { role: 'user', content: 'Earlier turn', cid: 'old-cid', ts: 1 },
+  ]
+  assert.equal(
+    serverSnapshotMissingAcceptedCid(oldSnapshot, 'accepted-cid'),
+    true,
+  )
+  assert.equal(serverSnapshotMissingAcceptedCid([
+    ...oldSnapshot,
+    { role: 'user', content: 'Accepted turn', cid: 'accepted-cid', ts: 2 },
+  ], 'accepted-cid'), false)
+  assert.equal(serverSnapshotMissingAcceptedCid(oldSnapshot, null), false)
 })
 
 test('stopRequestSucceeded requires a confirmed backend stop', () => {

--- a/frontend/src/components/ChatView/__tests__/composerSubmission.test.js
+++ b/frontend/src/components/ChatView/__tests__/composerSubmission.test.js
@@ -69,3 +69,26 @@ test('failed recovery records the exact content passed by both send paths', () =
   assert.ok(contextSend >= 0 && contextRecovery > contextSend,
     'fresh/context recovery must record the augmented content passed to transport')
 })
+
+test('fresh-send transcript reconciliation starts only after acknowledgement', () => {
+  const source = readFileSync(new URL('../ChatView.jsx', import.meta.url), 'utf8')
+  const start = source.indexOf('// FRESH SEND PATH: no active turn, no queue.')
+  const end = source.indexOf('\n  }, [', start)
+  const freshSend = source.slice(start, end)
+  const transport = freshSend.indexOf('const result = await sendAfterSettingsSaved(')
+  const canonicalCommit = freshSend.indexOf(
+    'replaceOptimisticWithBatch(prev, cid, startedMessages)',
+    transport,
+  )
+  const reconcile = freshSend.indexOf('void fetchMessages({ force: true })', transport)
+
+  assert.ok(transport >= 0 && canonicalCommit > transport,
+    'the accepted server row must replace its optimistic twin after acknowledgement')
+  assert.ok(reconcile > canonicalCommit,
+    'a compact snapshot must not reconcile before the send is acknowledged and canonical')
+  assert.equal(
+    freshSend.slice(0, transport).includes('fetchMessages({ force: true })'),
+    false,
+    'an idle pre-ack snapshot must never erase the optimistic turn',
+  )
+})

--- a/frontend/src/components/ChatView/__tests__/composerSubmission.test.js
+++ b/frontend/src/components/ChatView/__tests__/composerSubmission.test.js
@@ -80,12 +80,17 @@ test('fresh-send transcript reconciliation starts only after acknowledgement', (
     'replaceOptimisticWithBatch(prev, cid, startedMessages)',
     transport,
   )
-  const reconcile = freshSend.indexOf('void fetchMessages({ force: true })', transport)
+  const reconcile = freshSend.indexOf('void fetchMessages({ force: true,', transport)
 
   assert.ok(transport >= 0 && canonicalCommit > transport,
     'the accepted server row must replace its optimistic twin after acknowledgement')
   assert.ok(reconcile > canonicalCommit,
     'a compact snapshot must not reconcile before the send is acknowledged and canonical')
+  assert.match(
+    freshSend.slice(reconcile, reconcile + 120),
+    /preserveAcceptedCid:\s*cid/,
+    'the handoff must retain the accepted row until the compact snapshot proves its cid',
+  )
   assert.equal(
     freshSend.slice(0, transport).includes('fetchMessages({ force: true })'),
     false,

--- a/frontend/src/components/ChatView/__tests__/questionCardState.test.js
+++ b/frontend/src/components/ChatView/__tests__/questionCardState.test.js
@@ -132,8 +132,8 @@ test('question submission freezes the visible anchor before the async handoff', 
 
   assert.ok(freeze >= 0 && send > freeze,
     'the reader anchor must freeze synchronously before answer delivery resumes output')
-  assert.match(component, /onPointerDown=\{\(event\) => \{[\s\S]*prepareSubmit\(\)/,
-    'pointer activation must freeze before keyboard-dismiss geometry can change')
+  assert.match(component, /onPointerDownCapture=\{\(event\) => \{[\s\S]*prepareSubmit\(\)/,
+    'capture-phase pointer activation must freeze before the scroll owner claims the pointer')
   assert.match(silentSubmit, /preparedQuestionSubmission \|\| freezeQuestionSubmission\(\)/,
     'click submission must consume the pointer-prepared anchor with a keyboard fallback')
 })

--- a/frontend/src/components/ChatView/__tests__/questionCardState.test.js
+++ b/frontend/src/components/ChatView/__tests__/questionCardState.test.js
@@ -132,6 +132,10 @@ test('question submission freezes the visible anchor before the async handoff', 
 
   assert.ok(freeze >= 0 && send > freeze,
     'the reader anchor must freeze synchronously before answer delivery resumes output')
+  assert.match(component, /onPointerDown=\{\(event\) => \{[\s\S]*prepareSubmit\(\)/,
+    'pointer activation must freeze before keyboard-dismiss geometry can change')
+  assert.match(silentSubmit, /preparedQuestionSubmission \|\| freezeQuestionSubmission\(\)/,
+    'click submission must consume the pointer-prepared anchor with a keyboard fallback')
 })
 
 test('a pending question exposes Stop instead of an impossible steer', () => {

--- a/frontend/src/components/ChatView/__tests__/scrollOwnership.test.js
+++ b/frontend/src/components/ChatView/__tests__/scrollOwnership.test.js
@@ -94,6 +94,8 @@ test('gesture scroll frames defer anchor, spacer, and persistence work until set
     'the intent reducer must latch the follow-stick band, not a pixel-exact tail')
   assert.match(hotPath, /readerScrollEscapeDirection\(/,
     'directionless native scrollbar movement must update the escape latch')
+  assert.match(hotPath, /movementDirection:\s*scrollEscapeDir/,
+    'upward reader movement must retire any earlier tail-arrival latch')
 
   const settleStart = ownerSource.indexOf('const settleReaderScroll = () => {')
   const settleEnd = ownerSource.indexOf(
@@ -107,7 +109,8 @@ test('gesture scroll frames defer anchor, spacer, and persistence work until set
   assert.match(settlePath, /modeAfterReaderGesture/)
   assert.match(settlePath, /escaped:\s*settledEscaped/)
   assert.match(settlePath, /reachedNearBottom:\s*settledReachedNearBottom/)
-  assert.match(settlePath, /wasFollowing/)
+  assert.doesNotMatch(settlePath, /wasFollowing/,
+    'prior follow state cannot authorize a far-up reader gesture to follow again')
   assert.doesNotMatch(settlePath, /spacerH|hasReservedTail/,
     'physical-bottom intent must not branch on invisible reservation')
   assert.match(settlePath, /persistMode\(\)/)

--- a/frontend/src/components/ChatView/__tests__/scrollRepairDirection.test.js
+++ b/frontend/src/components/ChatView/__tests__/scrollRepairDirection.test.js
@@ -90,7 +90,6 @@ test('reserved-bottom reader settlement enters follow without moving backward', 
   const settledMode = modeAfterReaderGesture({
     escaped: false,
     reachedNearBottom: true,
-    wasFollowing: false,
     holdMode,
   })
   assert.deepEqual(settledMode, { kind: 'FOLLOW_BOTTOM' })
@@ -105,13 +104,11 @@ test('physical reader bottom creates follow without a reservation branch', () =>
   assert.deepEqual(modeAfterReaderGesture({
     escaped: false,
     reachedNearBottom: true,
-    wasFollowing: false,
     holdMode: hold,
   }), { kind: 'FOLLOW_BOTTOM' })
   assert.equal(modeAfterReaderGesture({
     escaped: false,
     reachedNearBottom: false,
-    wasFollowing: false,
     holdMode: hold,
   }), hold)
 })
@@ -230,6 +227,26 @@ test('two gestures inside one quiet settlement advance two generations', () => {
     reachedBottom: reachedTail.reachedBottom,
     atBottom: false,
   }), reachedTail, 'lazy output cannot erase tail intent before settlement')
+
+  const leftTail = readerIntentAfterScroll({
+    gestureSequence: 11,
+    claimedSequence: reachedTail.claimedSequence,
+    version: reachedTail.version,
+    reachedBottom: reachedTail.reachedBottom,
+    atBottom: false,
+    movementDirection: 'up',
+  })
+  assert.deepEqual(leftTail, {
+    claimedSequence: 11, version: 5, reachedBottom: false,
+  }, 'an upward reader move retires the earlier tail arrival')
+  assert.deepEqual(readerIntentAfterScroll({
+    gestureSequence: 11,
+    claimedSequence: leftTail.claimedSequence,
+    version: leftTail.version,
+    reachedBottom: leftTail.reachedBottom,
+    atBottom: false,
+    movementDirection: 'down',
+  }), leftTail, 'a direction correction far up-thread cannot relatch follow')
 
   const secondGesture = readerIntentAfterScroll({
     gestureSequence: 12,

--- a/frontend/src/components/ChatView/__tests__/streamingRobustness.test.js
+++ b/frontend/src/components/ChatView/__tests__/streamingRobustness.test.js
@@ -49,7 +49,7 @@ test('streaming deltas are flags on the shared active markdown tree', () => {
   assert.match(msgContentSource, /<ProgressiveMarkdown[\s\S]*isStreaming=\{isStreaming/,
     'active DB and live text must keep ProgressiveMarkdown mounted')
   assert.match(blockRendererSource, /data-is-streaming=\{isStreaming \? 'true' : undefined\}/)
-  assert.match(blockRendererSource, /\{isStreaming && <span className="chat__cursor" \/>\}/,
+  assert.match(blockRendererSource, /\{isStreaming && \([\s\S]*<span className="chat__cursor" aria-hidden="true" \/>/,
     'cursor insertion must toggle behind isStreaming instead of selecting another renderer')
 })
 

--- a/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
+++ b/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
@@ -822,29 +822,24 @@ test('reader settlement follows the physical tail even while reservation remains
   assert.deepEqual(modeAfterReaderGesture({
     escaped: false,
     reachedNearBottom: true,
-    wasFollowing: false,
     holdMode: exactHold,
   }), { kind: 'FOLLOW_BOTTOM' })
   // Not following and never reached the band → hold exactly where the reader is.
   assert.equal(modeAfterReaderGesture({
     escaped: false,
     reachedNearBottom: false,
-    wasFollowing: false,
     holdMode: exactHold,
   }), exactHold)
-  // Already following and the reader did NOT scroll up → stay glued, even if
-  // streamed content pushed the tail out of the band during the gesture.
-  assert.deepEqual(modeAfterReaderGesture({
+  // Prior follow state cannot override the gesture's actual off-bottom result.
+  assert.equal(modeAfterReaderGesture({
     escaped: false,
     reachedNearBottom: false,
-    wasFollowing: true,
     holdMode: exactHold,
-  }), { kind: 'FOLLOW_BOTTOM' })
-  // An explicit scroll UP is the only thing that breaks an engaged follow.
+  }), exactHold)
+  // An upward escape wins even if the gesture had touched the tail earlier.
   assert.equal(modeAfterReaderGesture({
     escaped: true,
     reachedNearBottom: true,
-    wasFollowing: true,
     holdMode: exactHold,
   }), exactHold)
 
@@ -861,8 +856,8 @@ test('reader settlement follows the physical tail even while reservation remains
 
 // Direction helpers are part of the same bottom-follow contract exercised above.
 {
-  // Wheel up escapes the bottom lock; wheel down re-engages it; no vertical
-  // delta is neutral.
+  // Wheel up escapes; wheel down points toward the tail but still needs bottom
+  // geometry before it may follow. No vertical delta is neutral.
   assert.equal(readerInputEscapeDirection('wheel', { deltaY: -20 }), 'up')
   assert.equal(readerInputEscapeDirection('wheel', { deltaY: 20 }), 'down')
   assert.equal(readerInputEscapeDirection('wheel', { deltaY: 0 }), null)

--- a/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
+++ b/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
@@ -1799,6 +1799,17 @@ test('question submission reserves the exact room that keeps its anchor reachabl
     _computeSpacerH(scrollEl, listEl, latestUser, mode),
     340,
   )
+  assert.equal(
+    _computeSpacerH(
+      scrollEl,
+      listEl,
+      latestUser,
+      mode,
+      { pinViewportHeight: 1000 },
+    ),
+    740,
+    'submit activation pre-reserves the known keyboard-closed viewport',
+  )
   scrollEl.clientHeight = 700
   assert.equal(
     _computeSpacerH(scrollEl, listEl, latestUser, mode),

--- a/frontend/src/components/ChatView/activityGrouping.js
+++ b/frontend/src/components/ChatView/activityGrouping.js
@@ -15,6 +15,12 @@ export function groupActivityRuns(entries) {
 
   for (const entry of entries) {
     const type = entry?.item?.type
+    // Some providers persist empty separator text blocks between reasoning and
+    // tool events. They have no visible content, so treating them as prose
+    // splits one coherent activity into repeated disclosure rows. Meaningful
+    // prose remains a boundary; only a truly transparent separator disappears.
+    const content = entry?.item?.content
+    if (type === 'text' && typeof content === 'string' && !content.trim()) continue
     if (isDistinctiveActivityTool(entry?.item)) {
       flush()
       nodes.push({ group: [entry] })

--- a/frontend/src/components/ChatView/chatRuntimeState.js
+++ b/frontend/src/components/ChatView/chatRuntimeState.js
@@ -6,6 +6,7 @@
 import { groupActivityRuns } from './activityGrouping.js'
 import { hasPendingQuestionMessage } from '../../lib/chatDetailCache.js'
 import { shouldShowOpenAppCta } from './openAppCtaState.js'
+import { cidOf } from './messageIdentity.js'
 
 export { shouldShowOpenAppCta }
 
@@ -76,6 +77,17 @@ export function serverSnapshotBehindLocal(serverMsgs, localMsgs) {
     if (m?.ts == null || serverTs.has(m.ts)) return false
     return m.optimistic === true || m.queued === true || m.serverTs === false
   })
+}
+
+/** An accepted fresh send may be acknowledged before the compact transcript
+ * projection contains its durable row. Keep the mounted turn authoritative
+ * until the server snapshot proves that exact cid is present; timing or a
+ * transient `running` flag is not sufficient evidence for this handoff. */
+export function serverSnapshotMissingAcceptedCid(serverMsgs, acceptedCid) {
+  if (acceptedCid == null || !Array.isArray(serverMsgs)) return false
+  return !serverMsgs.some(message => (
+    message?.role === 'user' && cidOf(message) === acceptedCid
+  ))
 }
 
 /** The floating jump-to-latest control (contract R5a) shows only while the

--- a/frontend/src/components/ChatView/markdown/BlockRenderer.jsx
+++ b/frontend/src/components/ChatView/markdown/BlockRenderer.jsx
@@ -79,8 +79,10 @@ export function ProgressiveMarkdown({
             />
           )
         })}
+        {isStreaming && (
+          <span className="chat__cursor" aria-hidden="true" />
+        )}
       </div>
-      {isStreaming && <span className="chat__cursor" />}
     </>
   )
 }

--- a/frontend/src/components/ChatView/scroll/geometry.js
+++ b/frontend/src/components/ChatView/scroll/geometry.js
@@ -543,14 +543,15 @@ export function _anchorReapplyNeeded(scrollEl, mode, lastAnchorTop) {
  *  the pre-cushion behavior; a >0 value re-adds breathing room if the exact
  *  end-of-scroll rest ever feels cramped.)
  *
- *  PIN_USER_MSG may calculate that exact deficit against a larger, already
- *  observed same-width viewport so software-keyboard close cannot make the
- *  target unreachable for one paint. FOLLOW and ordinary anchors remain based
- *  on the active viewport.
+ *  PIN_USER_MSG and the transient question-submit hold may calculate that
+ *  exact deficit against a larger, already observed same-width viewport so
+ *  software-keyboard close cannot make the target unreachable for one paint.
+ *  FOLLOW and ordinary anchors remain based on the active viewport.
  *
- *  A question-submit anchor instead reserves only its exact reachability
- *  deficit. Viewport changes recompute that deficit and reapply the same
- *  anchor, so submission remains visually fixed until response activity.
+ *  A question-submit anchor still reserves only its exact reachability
+ *  deficit. The same-width ceiling merely precomputes the imminent viewport;
+ *  later changes recompute that deficit and reapply the same anchor, so
+ *  submission remains visually fixed until response activity.
  */
 export function _computeSpacerH(
   scrollEl,
@@ -567,7 +568,7 @@ export function _computeSpacerH(
   // largest same-width viewport already observed so that imminent growth is
   // reachable before it happens. FOLLOW_BOTTOM and ordinary anchors keep using
   // the active box and therefore retain their responsive keyboard behavior.
-  const viewH = mode?.kind === 'PIN_USER_MSG'
+  const viewH = mode?.kind === 'PIN_USER_MSG' || isQuestionSubmissionMode(mode)
     ? Math.max(activeViewH, Number(pinViewportHeight) || 0)
     : activeViewH
   if (isQuestionSubmissionMode(mode)) {

--- a/frontend/src/components/ChatView/scroll/policy.js
+++ b/frontend/src/components/ChatView/scroll/policy.js
@@ -99,35 +99,29 @@ export function modeAfterTerminalLayout(mode, spacerH, layoutStable) {
 }
 
 
-/** Resolve the quiet edge of a real reader gesture, using use-stick-to-bottom's
- * escape-latch semantics rather than a pixel-exact bottom test.
+/** Resolve the quiet edge of a real reader gesture.
  *
- * Stickiness is a latch broken only by an explicit scroll UP (`escaped`).
- *   - Already following: stay in FOLLOW_BOTTOM unless the reader escaped upward.
- *     Content growth or downward momentum that drifted the viewport out of the
- *     band never breaks follow (the layout owner re-glues the tail).
- *   - Not following: enter FOLLOW_BOTTOM only when the gesture reached the
- *     bottom band (`reachedNearBottom`) and did not end escaped — i.e. the
- *     reader scrolled down to the tail.
- * Anything else holds the exact reader position. */
+ * A gesture enters FOLLOW_BOTTOM only after it reaches the physical tail. The
+ * mode that happened to own the viewport before the gesture is deliberately
+ * irrelevant: once the reader moves off the tail, even a later direction
+ * correction far up-thread remains an exact hold. Stream growth may preserve a
+ * tail arrival already expressed by the reader, but it may never manufacture
+ * one from prior follow state. */
 export function modeAfterReaderGesture({
   escaped,
   reachedNearBottom,
-  wasFollowing,
   holdMode,
 }) {
-  const stick = !escaped && (wasFollowing || reachedNearBottom)
+  const stick = !escaped && reachedNearBottom
   if (stick) return { kind: 'FOLLOW_BOTTOM' }
   return holdMode || { kind: 'INITIAL' }
 }
 
 
-/** The escape/re-engage direction a raw reader input implies, mirroring
- * use-stick-to-bottom's wheel + keyboard handling: scrolling UP escapes the
- * bottom lock, scrolling DOWN re-engages it. Returns null for inputs with no
- * vertical scroll intent (they neither escape nor re-engage the latch). Read
- * from the input event itself so a single wheel tick or arrow press flips the
- * latch immediately, with zero layout cost. */
+/** The direction a raw reader input implies. Scrolling UP escapes follow;
+ * scrolling DOWN may express tail intent, but physical tail geometry remains
+ * the only authority that can actually re-enter follow. Returns null for input
+ * with no vertical scroll intent. */
 export function readerInputEscapeDirection(
   type,
   { deltaY = 0, key = '', shiftKey = false } = {},
@@ -163,7 +157,7 @@ export function readerInputClaimsPhysicalTail(
 }
 
 
-/** Infer the same escape/re-engage direction from an actual scroll position.
+/** Infer the same reader direction from an actual scroll position.
  * Wheel, keyboard, and touch inputs expose direction before scrolling, but a
  * mouse scrollbar drag does not. Comparing consecutive owned positions keeps
  * that native path inside the same latch instead of snapping an upward drag
@@ -267,8 +261,10 @@ export function scrollAuthorityAllowsCommit({
 
 /** Reduce one scroll frame into the current input sequence's intent.
  * A sequence advances the monotonic generation once and latches physical-tail
- * arrival until settlement. A newer sequence starts a fresh tail decision even
- * when several nearby gestures share one quiet-edge layout pass.
+ * arrival through layout drift. An explicit upward reader move clears that
+ * latch; a later downward correction cannot recreate it until geometry proves
+ * the reader reached the tail again. A newer sequence also starts a fresh tail
+ * decision even when several nearby gestures share one quiet-edge layout pass.
  */
 export function readerIntentAfterScroll({
   gestureSequence,
@@ -276,12 +272,14 @@ export function readerIntentAfterScroll({
   version,
   reachedBottom = false,
   atBottom = false,
+  movementDirection = null,
 }) {
   const sameSequence = gestureSequence === claimedSequence
+  const leftTail = movementDirection === 'up'
   return {
     claimedSequence: gestureSequence,
     version: sameSequence ? version : version + 1,
-    reachedBottom: atBottom || (sameSequence && reachedBottom),
+    reachedBottom: !leftTail && (atBottom || (sameSequence && reachedBottom)),
   }
 }
 

--- a/frontend/src/components/ChatView/useScrollMode.js
+++ b/frontend/src/components/ChatView/useScrollMode.js
@@ -315,6 +315,7 @@ export default function useScrollMode({
   // the gesture's dirty state lives inside the layout effect. This bridge reads
   // the exact hold only on that rare semantic boundary, never in the hot scroll
   // path.
+  const questionSubmissionLayoutRef = useRef(null)
   // Monotonic generation for actual reader scroll intent. Send/steer snapshots
   // and every deferred/automatic geometry commit use this same authority:
   // once a newer gesture lands, older work can never regain ownership merely
@@ -708,6 +709,13 @@ export default function useScrollMode({
       nextMode,
       'send:question-freeze',
     )
+    // Pointer activation can dismiss the mobile keyboard before React commits
+    // the card's pending state. Reserve the held anchor against that imminent
+    // viewport growth in this same task so the browser never gets one paint in
+    // which it can clamp the question away from its submitted position.
+    questionSubmissionLayoutRef.current?.(
+      readerIntentVersionRef.current,
+    )
     return {
       mode,
       readerIntentVersion: readerIntentVersionRef.current,
@@ -1093,6 +1101,8 @@ export default function useScrollMode({
         persistMode()
       }
     }
+
+    questionSubmissionLayoutRef.current = sizeSpacer
 
     function rememberAppliedMode() {
       const mode = modeRef.current
@@ -2077,6 +2087,9 @@ export default function useScrollMode({
       clearTimeout(deferredGestureLayoutTimer)
       if (resumeLayoutAfterGestureRef.current === resumeLayoutAfterGesture) {
         resumeLayoutAfterGestureRef.current = null
+      }
+      if (questionSubmissionLayoutRef.current === sizeSpacer) {
+        questionSubmissionLayoutRef.current = null
       }
       mountMutationObserver?.disconnect()
       scrollEl.removeEventListener('load', requestRevealOnQuiet, true)

--- a/frontend/src/components/ChatView/useScrollMode.js
+++ b/frontend/src/components/ChatView/useScrollMode.js
@@ -1589,11 +1589,9 @@ export default function useScrollMode({
         // the physical tail instead enters FOLLOW_BOTTOM, including while
         // latest-turn reservation remains.
         const holdMode = anchorModeFromScroll(scrollEl)
-        const wasFollowing = modeRef.current.kind === 'FOLLOW_BOTTOM'
         const settledMode = modeAfterReaderGesture({
           escaped: settledEscaped,
           reachedNearBottom: settledReachedNearBottom,
-          wasFollowing,
           holdMode,
         })
         transitionMode(
@@ -1720,11 +1718,11 @@ export default function useScrollMode({
         performance.now(),
         touchContactActive(),
       )
-      // Escape latch (use-stick-to-bottom): a fresh gesture starts un-escaped,
-      // then this input's own vertical direction sets it (scroll up) or clears
-      // it (scroll down). Read straight from the event so a single wheel tick or
-      // arrow press flips follow immediately, at zero layout cost. Disclosure
-      // taps carry no scroll direction and must not disturb the latch.
+      // A fresh gesture starts un-escaped, then this input's own vertical
+      // direction sets it (scroll up) or clears the directional marker (scroll
+      // down). Clearing that marker does NOT re-enter follow: the scroll event's
+      // physical-tail geometry is the sole follow authority. Disclosure taps
+      // carry no scroll direction and must not disturb the marker.
       if (!activatesDisclosure) {
         if (!readerAlreadyOwns) gesture.escaped = false
         // Every input is a fresh pre-scroll sample. This is redundant for
@@ -1851,10 +1849,10 @@ export default function useScrollMode({
       // semantic action (send, nudge) while this finger stayed on the glass.
       if (gestureWindowUntilRef.current !== Number.POSITIVE_INFINITY
           && !gesture.dirty) onUserInput(event)
-      // Touch escape latch: a finger moving UP drags content toward the tail —
-      // that is scrolling DOWN, which re-engages follow; a finger moving down is
-      // scrolling UP and escapes. Applied last so the stationary-touch re-arm
-      // above (a fresh onUserInput claim) cannot clobber the direction.
+      // A finger moving UP drags content toward the tail; a finger moving down
+      // scrolls toward older content and escapes. Direction alone never enters
+      // follow — the owned scroll event must still prove physical-tail arrival.
+      // Applied last so the stationary-touch re-arm above cannot clobber it.
       if (touchDirection === 'down') gesture.escaped = false
       else if (touchDirection === 'up') gesture.escaped = true
     }
@@ -2023,6 +2021,7 @@ export default function useScrollMode({
         claimedSequence: gesture.claimedSequence,
         version: readerIntentVersionRef.current,
         reachedBottom: gesture.reachedBottom,
+        movementDirection: scrollEscapeDir,
         // Follow-stick band, not the pixel-exact clamp: reaching within 70px of
         // the tail during the gesture counts as "reached the bottom" so a fast
         // stream can't shake the reader out of engaging follow.

--- a/frontend/src/components/GlobalSearch/GlobalSearch.jsx
+++ b/frontend/src/components/GlobalSearch/GlobalSearch.jsx
@@ -18,19 +18,21 @@ import {
 import { searchSnippetPresentation } from '../../lib/searchTermHighlight.js'
 import { formatRelativeTime } from '../../lib/relativeTime.js'
 import {
-  clearRecentSelections,
+  buildSearchResultGroups,
   chatSearchOpenTarget,
   chatSearchResultIsCurrent,
   moveSearchSelection,
   pointerPositionChanged,
-  readRecentSelections,
-  rememberRecentSelection,
-  resolveRecentSelections,
   resolvedSearchSelection,
   searchCommands,
   searchInstalledApps,
   visibleChatSearchState,
 } from './globalSearchModel.js'
+import {
+  clearRecentSelections,
+  readRecentSelections,
+  resolveRecentSelections,
+} from '../../lib/recentSelections.js'
 import './GlobalSearch.css'
 
 const SEARCH_DEBOUNCE_MS = 180
@@ -251,8 +253,13 @@ export default function GlobalSearch({ commands = [], onClose, onOpenTarget, onR
   const normalizedQuery = query.trim()
   const visibleChats = visibleChatSearchState(chatState, normalizedQuery)
   const appResults = useMemo(
-    () => searchInstalledApps(appsQuery.data, normalizedQuery),
-    [appsQuery.data, normalizedQuery],
+    () => searchInstalledApps(
+      appsQuery.data,
+      normalizedQuery,
+      8,
+      recentSelectionRefs,
+    ),
+    [appsQuery.data, normalizedQuery, recentSelectionRefs],
   )
   const commandResults = useMemo(
     () => searchCommands(commands, normalizedQuery).filter(command => command.id !== 'search.open'),
@@ -268,7 +275,6 @@ export default function GlobalSearch({ commands = [], onClose, onOpenTarget, onR
   )
   const openChat = useCallback((result) => {
     if (!chatSearchResultIsCurrent(result, latestQueryRef.current)) return
-    rememberRecentSelection({ kind: 'chat', id: result.id })
     if (result.anchor_key) {
       requestChatSearchReveal(result.id, {
         anchorKey: result.anchor_key,
@@ -281,14 +287,12 @@ export default function GlobalSearch({ commands = [], onClose, onOpenTarget, onR
 
   const openApp = useCallback((app) => {
     if (!app?.id) return
-    rememberRecentSelection({ kind: 'app', id: app.id })
     onClose()
     onOpenTarget?.({ view: 'canvas', app: String(app.id), intent: null })
   }, [onClose, onOpenTarget])
 
   const openRecentChat = useCallback((chat) => {
     if (!chat?.id) return
-    rememberRecentSelection({ kind: 'chat', id: chat.id })
     onClose()
     onOpenTarget?.(chatSearchOpenTarget(chat))
   }, [onClose, onOpenTarget])
@@ -300,56 +304,13 @@ export default function GlobalSearch({ commands = [], onClose, onOpenTarget, onR
   }, [onClose, onRunCommand])
 
   const resultGroups = useMemo(() => {
-    const groups = normalizedQuery
-      ? [
-          ...(commandResults.length ? [{
-            headingId: 'global-search-commands',
-            listId: 'global-search-command-results',
-            label: 'Commands',
-            rows: commandResults.map(command => ({
-              kind: 'command', value: command,
-            })),
-          }] : []),
-          ...(appResults.length ? [{
-            headingId: 'global-search-apps',
-            listId: 'global-search-app-results',
-            label: 'Apps',
-            rows: appResults.map(({ app, matchArea }) => ({
-              kind: 'app', value: app, matchArea,
-            })),
-          }] : []),
-          {
-            headingId: 'global-search-chats',
-            listId: 'global-search-chat-results',
-            label: 'Chats',
-            status: visibleChats.status,
-            rows: visibleChats.results.map(result => ({
-              kind: 'chat', value: result,
-            })),
-          },
-        ]
-      : [
-          ...(commandResults.length ? [{
-            headingId: 'global-search-commands',
-            listId: 'global-search-command-results',
-            label: 'Commands',
-            rows: commandResults.map(command => ({
-              kind: 'command', value: command,
-            })),
-          }] : []),
-          ...(recentSelectionRows.length ? [{
-            headingId: 'global-search-recent-selections',
-            listId: 'global-search-recent-selection-results',
-            label: 'Recent selections',
-            clearable: true,
-            rows: recentSelectionRows.map(({ kind, value }) => ({
-              kind,
-              value,
-              recent: true,
-              matchArea: 'Recent',
-            })),
-          }] : []),
-        ]
+    const groups = buildSearchResultGroups({
+      query: normalizedQuery,
+      commandResults,
+      appResults,
+      visibleChats,
+      recentSelections: recentSelectionRows,
+    })
 
     let nextIndex = 0
     return groups.map(group => ({
@@ -502,10 +463,10 @@ export default function GlobalSearch({ commands = [], onClose, onOpenTarget, onR
               <span className="global-search__empty-icon" aria-hidden="true">
                 <MagnifyingGlassSearch width={30} height={30} />
               </span>
-              <h3>{loadingRecentSelections ? 'Loading workspace actions…' : 'No commands are available'}</h3>
+              <h3>{loadingRecentSelections ? 'Loading recent destinations…' : 'No commands are available'}</h3>
               <p>
                 {loadingRecentSelections
-                  ? 'Commands and the chats and apps you opened through search will appear here.'
+                  ? 'Your recently opened chats and apps will appear here.'
                   : 'Search for a command, chat, or app.'}
               </p>
             </div>

--- a/frontend/src/components/GlobalSearch/__tests__/globalSearchModel.test.js
+++ b/frontend/src/components/GlobalSearch/__tests__/globalSearchModel.test.js
@@ -2,37 +2,16 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 import {
   appManifestSearchDocument,
+  buildSearchResultGroups,
   chatSearchOpenTarget,
   chatSearchResultIsCurrent,
-  clearRecentSelections,
   moveSearchSelection,
   pointerPositionChanged,
-  readRecentSelections,
-  rememberRecentSelection,
-  resolveRecentSelections,
   resolvedSearchSelection,
   searchCommands,
   searchInstalledApps,
   visibleChatSearchState,
 } from '../globalSearchModel.js'
-
-class MemoryStorage {
-  constructor(initial = {}) {
-    this.values = new Map(Object.entries(initial))
-  }
-
-  getItem(key) {
-    return this.values.get(key) ?? null
-  }
-
-  setItem(key, value) {
-    this.values.set(key, String(value))
-  }
-
-  removeItem(key) {
-    this.values.delete(key)
-  }
-}
 
 const apps = [
   {
@@ -106,6 +85,23 @@ test('all query terms must match and result limits are stable', () => {
   assert.equal(searchInstalledApps(apps, 'news', 1).length, 1)
 })
 
+test('recency breaks equally relevant app suggestions without beating match quality', () => {
+  const notes = [
+    { id: 3, name: 'Daily Notes', description: 'Plain text' },
+    { id: 4, name: 'Notes Archive', description: 'Plain text' },
+    { id: 5, name: 'Archive', description: 'Includes notes' },
+  ]
+  const recent = [
+    { kind: 'app', id: '4' },
+    { kind: 'app', id: '5' },
+  ]
+
+  assert.deepEqual(
+    searchInstalledApps(notes, 'notes', 8, recent).map(result => result.app.id),
+    [4, 3, 5],
+  )
+})
+
 test('command search covers action copy, keywords, and shortcut labels', () => {
   const commands = [
     {
@@ -123,51 +119,23 @@ test('command search covers action copy, keywords, and shortcut labels', () => {
   assert.deepEqual(searchCommands(commands, ''), commands)
 })
 
-test('recent selections persist as a deduplicated most-recent-first list', () => {
-  const storage = new MemoryStorage()
-  assert.deepEqual(readRecentSelections(storage), [])
+test('recent destinations precede commands until a typed query restores search grouping', () => {
+  const recent = [{ kind: 'app', value: apps[0] }]
+  const commands = [{ id: 'chat.new', title: 'New chat' }]
 
-  rememberRecentSelection({ kind: 'chat', id: 'chat-1' }, storage)
-  rememberRecentSelection({ kind: 'app', id: 42 }, storage)
-  rememberRecentSelection({ kind: 'chat', id: 'chat-1' }, storage)
+  assert.deepEqual(buildSearchResultGroups({
+    query: '',
+    recentSelections: recent,
+    commandResults: commands,
+  }).map(group => group.label), ['Recent selections', 'Commands'])
 
-  assert.deepEqual(readRecentSelections(storage), [
-    { kind: 'chat', id: 'chat-1' },
-    { kind: 'app', id: '42' },
-  ])
-
-  for (let index = 0; index < 14; index += 1) {
-    rememberRecentSelection({ kind: 'chat', id: `chat-${index}` }, storage)
-  }
-  const bounded = readRecentSelections(storage)
-  assert.equal(bounded.length, 12)
-  assert.deepEqual(bounded.slice(0, 2), [
-    { kind: 'chat', id: 'chat-13' },
-    { kind: 'chat', id: 'chat-12' },
-  ])
-
-  clearRecentSelections(storage)
-  assert.deepEqual(readRecentSelections(storage), [])
-})
-
-test('recent selections resolve current items in selection order and omit missing ones', () => {
-  const chats = [
-    { id: 'chat-1', title: 'First chat' },
-    { id: 'chat-2', title: 'Second chat' },
-  ]
-  const installedApps = [
-    { id: 7, name: 'Memory' },
-  ]
-  const rows = resolveRecentSelections([
-    { kind: 'app', id: '7' },
-    { kind: 'chat', id: 'missing' },
-    { kind: 'chat', id: 'chat-2' },
-  ], chats, installedApps)
-
-  assert.deepEqual(rows, [
-    { kind: 'app', value: installedApps[0] },
-    { kind: 'chat', value: chats[1] },
-  ])
+  assert.deepEqual(buildSearchResultGroups({
+    query: 'brief',
+    recentSelections: recent,
+    commandResults: commands,
+    appResults: [{ app: apps[0], matchArea: 'Name' }],
+    visibleChats: { status: 'ready', results: [{ id: 'chat-1' }] },
+  }).map(group => group.label), ['Commands', 'Apps', 'Chats'])
 })
 
 test('keyboard search selection starts at the first result and wraps with arrows', () => {

--- a/frontend/src/components/GlobalSearch/globalSearchModel.js
+++ b/frontend/src/components/GlobalSearch/globalSearchModel.js
@@ -67,9 +67,14 @@ export function searchCommands(commands, query, limit = 12) {
     .slice(0, Math.max(0, limit))
 }
 
-export function searchInstalledApps(apps, query, limit = 8) {
+export function searchInstalledApps(apps, query, limit = 8, recentSelections = []) {
   const tokens = queryTokens(query)
   if (!tokens.length) return []
+  const recentIndex = new Map(
+    recentSelections
+      .filter(selection => selection?.kind === 'app')
+      .map((selection, index) => [String(selection.id), index]),
+  )
 
   const ranked = []
   for (const app of Array.isArray(apps) ? apps : []) {
@@ -102,6 +107,10 @@ export function searchInstalledApps(apps, query, limit = 8) {
   return ranked
     .sort((left, right) => (
       right.score - left.score
+      // Recency breaks equally relevant suggestions; it never lets a weaker
+      // description/detail match outrank a stronger name match.
+      || (recentIndex.get(String(left.app?.id)) ?? Infinity)
+        - (recentIndex.get(String(right.app?.id)) ?? Infinity)
       || String(left.app?.name || '').localeCompare(String(right.app?.name || ''))
       || Number(left.app?.id || 0) - Number(right.app?.id || 0)
     ))
@@ -109,86 +118,59 @@ export function searchInstalledApps(apps, query, limit = 8) {
     .map(({ score: _score, ...result }) => result)
 }
 
-export const RECENT_SELECTION_LIMIT = 12
-const RECENT_SELECTIONS_STORAGE_KEY = 'mobius:global-search:recent-selections:v1'
-
-function browserStorage() {
-  try {
-    return globalThis.localStorage || null
-  } catch (_) {
-    return null
+export function buildSearchResultGroups({
+  query,
+  commandResults = [],
+  appResults = [],
+  visibleChats = { status: 'idle', results: [] },
+  recentSelections = [],
+}) {
+  if (!String(query || '').trim()) {
+    return [
+      ...(recentSelections.length ? [{
+        headingId: 'global-search-recent-selections',
+        listId: 'global-search-recent-selection-results',
+        label: 'Recent selections',
+        clearable: true,
+        rows: recentSelections.map(({ kind, value }) => ({
+          kind,
+          value,
+          recent: true,
+          matchArea: 'Recent',
+        })),
+      }] : []),
+      ...(commandResults.length ? [{
+        headingId: 'global-search-commands',
+        listId: 'global-search-command-results',
+        label: 'Commands',
+        rows: commandResults.map(command => ({ kind: 'command', value: command })),
+      }] : []),
+    ]
   }
-}
 
-function normalizedRecentSelections(selections) {
-  const seen = new Set()
-  const normalized = []
-  for (const selection of Array.isArray(selections) ? selections : []) {
-    if (!['app', 'chat'].includes(selection?.kind)) continue
-    const id = String(selection?.id ?? '').trim()
-    if (!id) continue
-    const key = `${selection.kind}:${id}`
-    if (seen.has(key)) continue
-    seen.add(key)
-    normalized.push({ kind: selection.kind, id })
-    if (normalized.length === RECENT_SELECTION_LIMIT) break
-  }
-  return normalized
-}
-
-// Selection history intentionally stores only stable item references. Titles,
-// snippets, and the owner's query text remain in their owning data sources and
-// are resolved afresh when the dialog opens.
-export function readRecentSelections(storage = browserStorage()) {
-  try {
-    return normalizedRecentSelections(JSON.parse(
-      storage?.getItem(RECENT_SELECTIONS_STORAGE_KEY) || '[]',
-    ))
-  } catch (_) {
-    return []
-  }
-}
-
-export function rememberRecentSelection(selection, storage = browserStorage()) {
-  const next = normalizedRecentSelections([
-    selection,
-    ...readRecentSelections(storage),
-  ])
-  try {
-    storage?.setItem(RECENT_SELECTIONS_STORAGE_KEY, JSON.stringify(next))
-  } catch (_) {
-    // Restricted and private browsing contexts may reject Web Storage. Search
-    // still works; it simply has no history on the next open.
-  }
-  return next
-}
-
-export function clearRecentSelections(storage = browserStorage()) {
-  try {
-    storage?.removeItem(RECENT_SELECTIONS_STORAGE_KEY)
-  } catch (_) {
-    // Clearing an unavailable store is already the desired end state.
-  }
-}
-
-export function resolveRecentSelections(selections, chats, apps) {
-  const chatsById = new Map(
-    (Array.isArray(chats) ? chats : [])
-      .filter(chat => chat?.id)
-      .map(chat => [String(chat.id), chat]),
-  )
-  const appsById = new Map(
-    (Array.isArray(apps) ? apps : [])
-      .filter(app => app?.id)
-      .map(app => [String(app.id), app]),
-  )
-
-  return normalizedRecentSelections(selections).flatMap(selection => {
-    const value = selection.kind === 'chat'
-      ? chatsById.get(selection.id)
-      : appsById.get(selection.id)
-    return value ? [{ kind: selection.kind, value }] : []
-  })
+  return [
+    ...(commandResults.length ? [{
+      headingId: 'global-search-commands',
+      listId: 'global-search-command-results',
+      label: 'Commands',
+      rows: commandResults.map(command => ({ kind: 'command', value: command })),
+    }] : []),
+    ...(appResults.length ? [{
+      headingId: 'global-search-apps',
+      listId: 'global-search-app-results',
+      label: 'Apps',
+      rows: appResults.map(({ app, matchArea }) => ({
+        kind: 'app', value: app, matchArea,
+      })),
+    }] : []),
+    {
+      headingId: 'global-search-chats',
+      listId: 'global-search-chat-results',
+      label: 'Chats',
+      status: visibleChats.status,
+      rows: visibleChats.results.map(result => ({ kind: 'chat', value: result })),
+    },
+  ]
 }
 
 export function resolvedSearchSelection(index, resultCount) {

--- a/frontend/src/components/Shell/Shell.css
+++ b/frontend/src/components/Shell/Shell.css
@@ -8,7 +8,7 @@
    to rgba(..., <1) will leak whatever sits behind through every
    surface that paints it. */
 .shell {
-  --desktop-sidebar-width: 320px;
+  --desktop-sidebar-width: 360px;
   /* Shared geometry contract for fixed shell-level overlays. The notice rail
      reads this instead of guessing at chrome height from the root font size.
      Shell publishes --shell-tabstrip-height from paneModel.STRIP_H. */
@@ -909,7 +909,9 @@
     padding: 8px 12px;
     flex-direction: row;
     align-items: center;
-    border-right: 0;
+    /* Continue the drawer's right edge through its desktop header so the
+       brand and quick actions belong to one visually bounded column. */
+    border-right: 1px solid var(--border-light);
     border-bottom: 0;
   }
 

--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -180,6 +180,7 @@ import ShellBrand from './ShellBrand.jsx'
 import ScreenControlButton from './ScreenControlButton.jsx'
 import { createMediaSessionOwner } from './mediaSessionOwner.js'
 import { HistoryDismissProvider } from '../../hooks/useHistoryDismiss.jsx'
+import { rememberRecentDestination } from '../../lib/recentSelections.js'
 
 const APP_SETTINGS_SECTIONS = new Set([
   'ai-providers',
@@ -260,6 +261,16 @@ export default function Shell({ onInitialVisualReady }) {
     dragActiveRef,
     beforeRestoreRouteRef,
   })
+
+  // Navigation owns the search MRU so drawer, history, deep-link, and search
+  // activations all contribute the same current destination.
+  useEffect(() => {
+    rememberRecentDestination({
+      view: activeView,
+      chatId: activeChatId,
+      appId: activeAppId,
+    })
+  }, [activeAppId, activeChatId, activeView])
 
   // A mobile drawer is a history-backed virtual route. A desktop sidebar is a
   // saved layout preference. Keep those state machines separate: while a mobile

--- a/frontend/src/components/Shell/__tests__/desktopSidebar.test.js
+++ b/frontend/src/components/Shell/__tests__/desktopSidebar.test.js
@@ -37,6 +37,7 @@ test('desktop sidebar storage is versioned, minimal, and failure-safe', () => {
 })
 
 test('desktop sidebar width is clamped, persisted, and failure-safe', () => {
+  assert.equal(DESKTOP_SIDEBAR_DEFAULT_WIDTH, 360)
   assert.equal(clampDesktopSidebarWidth('412.4'), 412)
   assert.equal(clampDesktopSidebarWidth(100), DESKTOP_SIDEBAR_MIN_WIDTH)
   assert.equal(clampDesktopSidebarWidth(1000), DESKTOP_SIDEBAR_MAX_WIDTH)

--- a/frontend/src/components/Shell/__tests__/drawerAlignment.test.js
+++ b/frontend/src/components/Shell/__tests__/drawerAlignment.test.js
@@ -39,6 +39,15 @@ test('collapsed and expanded drawer actions share one vertical rhythm', () => {
   )
 })
 
+test('the expanded desktop drawer edge continues through its header', () => {
+  const desktopDrawerHeader = ruleBody(shellCss, '.shell--drawer-docked .shell__bar')
+
+  assert.match(
+    desktopDrawerHeader,
+    /border-right:\s*1px solid var\(--border-light\);/,
+  )
+})
+
 test('phone drawer increases row type without changing the section-title scale', () => {
   const drawerItem = ruleBody(drawerCss, '.drawer__item')
   const drawerLabel = ruleBody(drawerCss, '.drawer__label')

--- a/frontend/src/components/Shell/useDesktopSidebar.js
+++ b/frontend/src/components/Shell/useDesktopSidebar.js
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useState } from 'react'
 export const DESKTOP_SIDEBAR_QUERY = '(min-width: 1024px)'
 export const DESKTOP_SIDEBAR_STORAGE_KEY = 'mobius:desktop-sidebar-open:v1'
 export const DESKTOP_SIDEBAR_WIDTH_STORAGE_KEY = 'mobius:desktop-sidebar-width:v1'
-export const DESKTOP_SIDEBAR_DEFAULT_WIDTH = 320
+export const DESKTOP_SIDEBAR_DEFAULT_WIDTH = 360
 export const DESKTOP_SIDEBAR_MIN_WIDTH = 240
 export const DESKTOP_SIDEBAR_MAX_WIDTH = 560
 export const DESKTOP_RAIL_WIDTH = 58

--- a/frontend/src/lib/__tests__/recentSelections.test.js
+++ b/frontend/src/lib/__tests__/recentSelections.test.js
@@ -1,0 +1,83 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  clearRecentSelections,
+  readRecentSelections,
+  rememberRecentDestination,
+  rememberRecentSelection,
+  resolveRecentSelections,
+} from '../recentSelections.js'
+
+class MemoryStorage {
+  constructor(initial = {}) {
+    this.values = new Map(Object.entries(initial))
+    this.writeCount = 0
+  }
+
+  getItem(key) { return this.values.get(key) ?? null }
+  setItem(key, value) {
+    this.writeCount += 1
+    this.values.set(key, String(value))
+  }
+  removeItem(key) { this.values.delete(key) }
+}
+
+test('selection history is deduplicated in most-recent-first order', () => {
+  const storage = new MemoryStorage()
+  assert.deepEqual(readRecentSelections(storage), [])
+
+  rememberRecentSelection({ kind: 'chat', id: 'chat-1' }, storage)
+  rememberRecentSelection({ kind: 'app', id: 42 }, storage)
+  rememberRecentSelection({ kind: 'chat', id: 'chat-1' }, storage)
+
+  assert.deepEqual(readRecentSelections(storage), [
+    { kind: 'chat', id: 'chat-1' },
+    { kind: 'app', id: '42' },
+  ])
+
+  for (let index = 0; index < 14; index += 1) {
+    rememberRecentSelection({ kind: 'chat', id: `chat-${index}` }, storage)
+  }
+  const bounded = readRecentSelections(storage)
+  assert.equal(bounded.length, 12)
+  assert.deepEqual(bounded.slice(0, 2), [
+    { kind: 'chat', id: 'chat-13' },
+    { kind: 'chat', id: 'chat-12' },
+  ])
+
+  clearRecentSelections(storage)
+  assert.deepEqual(readRecentSelections(storage), [])
+})
+
+test('shell destinations feed one shared history while non-destinations stay inert', () => {
+  const storage = new MemoryStorage()
+
+  rememberRecentDestination({ view: 'chat', chatId: 'chat-1' }, storage)
+  rememberRecentDestination({ view: 'apps', appId: 9 }, storage)
+  rememberRecentDestination({ view: 'canvas', appId: 9 }, storage)
+  rememberRecentDestination({ view: 'settings', chatId: 'chat-2' }, storage)
+  rememberRecentDestination({ view: 'chat', chatId: 'chat-1' }, storage)
+
+  assert.deepEqual(readRecentSelections(storage), [
+    { kind: 'chat', id: 'chat-1' },
+    { kind: 'app', id: '9' },
+  ])
+  assert.equal(storage.writeCount, 3)
+})
+
+test('selection history resolves current items in MRU order and omits missing ones', () => {
+  const chats = [
+    { id: 'chat-1', title: 'First chat' },
+    { id: 'chat-2', title: 'Second chat' },
+  ]
+  const apps = [{ id: 7, name: 'Memory' }]
+
+  assert.deepEqual(resolveRecentSelections([
+    { kind: 'app', id: '7' },
+    { kind: 'chat', id: 'missing' },
+    { kind: 'chat', id: 'chat-2' },
+  ], chats, apps), [
+    { kind: 'app', value: apps[0] },
+    { kind: 'chat', value: chats[1] },
+  ])
+})

--- a/frontend/src/lib/__tests__/useScrollModeLifecycle.test.js
+++ b/frontend/src/lib/__tests__/useScrollModeLifecycle.test.js
@@ -576,6 +576,49 @@ test('visible FOLLOW_BOTTOM survives repeated Markdown-sized content growth', ()
   }
 })
 
+test('off-bottom direction correction stays held while the live reply grows', () => {
+  const observers = []
+  const restoreBrowser = installBrowserEnvironment({ observers })
+  try {
+    const { hook, listeners, scroll, list, assistant } = mountTailController(
+      'off-bottom-stream-hold',
+    )
+    const target = { parentElement: scroll, closest: () => null }
+    hook.result.current.followLatest()
+    assert.equal(scroll.dataset.scrollMode, 'FOLLOW_BOTTOM')
+
+    // Move far into older content, then make the small toward-newer correction
+    // that used to clear the escape latch without ever reaching the tail.
+    listeners.get('wheel')({
+      type: 'wheel', deltaY: -280, shiftKey: false, target,
+    })
+    scroll.scrollTop = 120
+    listeners.get('scroll')()
+    listeners.get('wheel')({
+      type: 'wheel', deltaY: 20, shiftKey: false, target,
+    })
+    scroll.scrollTop = 140
+    listeners.get('scroll')()
+    listeners.get('scrollend')()
+
+    assert.equal(scroll.dataset.scrollMode, 'ANCHOR_AT',
+      'settlement must hold the actual off-bottom reading position')
+    const heldTop = scroll.scrollTop
+
+    assistant.offsetHeight += 300
+    list.offsetHeight += 300
+    scroll.scrollHeight += 300
+    observers[0].callback([{ target: list }])
+
+    assert.equal(scroll.dataset.scrollMode, 'ANCHOR_AT')
+    assert.equal(scroll.scrollTop, heldTop,
+      'continued streaming must not pull the held reader to the live tail')
+    hook.unmount()
+  } finally {
+    restoreBrowser()
+  }
+})
+
 test('a hidden chat performs no scroll work and returns to its saved hold', () => {
   const observers = []
   const restoreBrowser = installBrowserEnvironment({ observers })

--- a/frontend/src/lib/chatDetailCache.js
+++ b/frontend/src/lib/chatDetailCache.js
@@ -259,6 +259,13 @@ export function mergeRecentMessagesIntoLoadedWindow({
   if (!Array.isArray(loadedMessages) || loadedMessages.length === 0) {
     return { ...fallback, verified: true }
   }
+  if (preserveLocalSuffix && recent.length === 0) {
+    return {
+      messages: loadedMessages,
+      offset: loadedOffset,
+      verified: true,
+    }
+  }
   if (!Number.isInteger(loadedOffset) || !Number.isInteger(recentOffset)) return fallback
 
   const prefixLength = recentOffset - loadedOffset

--- a/frontend/src/lib/recentSelections.js
+++ b/frontend/src/lib/recentSelections.js
@@ -1,0 +1,95 @@
+/* Recent selections are one bounded MRU list shared by shell navigation and search. */
+
+export const RECENT_SELECTION_LIMIT = 12
+const RECENT_SELECTIONS_STORAGE_KEY = 'mobius:global-search:recent-selections:v1'
+
+function browserStorage() {
+  try {
+    return globalThis.localStorage || null
+  } catch (_) {
+    return null
+  }
+}
+
+function normalizedRecentSelections(selections) {
+  const seen = new Set()
+  const normalized = []
+  for (const selection of Array.isArray(selections) ? selections : []) {
+    if (!['app', 'chat'].includes(selection?.kind)) continue
+    const id = String(selection?.id ?? '').trim()
+    if (!id) continue
+    const key = `${selection.kind}:${id}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    normalized.push({ kind: selection.kind, id })
+    if (normalized.length === RECENT_SELECTION_LIMIT) break
+  }
+  return normalized
+}
+
+// History stores only stable item references. Titles and other presentation
+// data stay in their owning queries and are resolved afresh when search opens.
+export function readRecentSelections(storage = browserStorage()) {
+  try {
+    return normalizedRecentSelections(JSON.parse(
+      storage?.getItem(RECENT_SELECTIONS_STORAGE_KEY) || '[]',
+    ))
+  } catch (_) {
+    return []
+  }
+}
+
+export function rememberRecentSelection(selection, storage = browserStorage()) {
+  const next = normalizedRecentSelections([
+    selection,
+    ...readRecentSelections(storage),
+  ])
+  try {
+    storage?.setItem(RECENT_SELECTIONS_STORAGE_KEY, JSON.stringify(next))
+  } catch (_) {
+    // Restricted and private browsing contexts may reject Web Storage. Search
+    // still works; it simply has no history on the next open.
+  }
+  return next
+}
+
+export function rememberRecentDestination(
+  { view, chatId, appId },
+  storage = browserStorage(),
+) {
+  if (view === 'chat' && chatId != null) {
+    return rememberRecentSelection({ kind: 'chat', id: chatId }, storage)
+  }
+  if (view === 'canvas' && appId != null) {
+    return rememberRecentSelection({ kind: 'app', id: appId }, storage)
+  }
+  return null
+}
+
+export function clearRecentSelections(storage = browserStorage()) {
+  try {
+    storage?.removeItem(RECENT_SELECTIONS_STORAGE_KEY)
+  } catch (_) {
+    // Clearing an unavailable store is already the desired end state.
+  }
+}
+
+export function resolveRecentSelections(selections, chats, apps) {
+  const chatsById = new Map(
+    (Array.isArray(chats) ? chats : [])
+      .filter(chat => chat?.id)
+      .map(chat => [String(chat.id), chat]),
+  )
+  const appsById = new Map(
+    (Array.isArray(apps) ? apps : [])
+      .filter(app => app?.id)
+      .map(app => [String(app.id), app]),
+  )
+
+  return normalizedRecentSelections(selections).flatMap(selection => {
+    const value = selection.kind === 'chat'
+      ? chatsById.get(selection.id)
+      : appsById.get(selection.id)
+    return value ? [{ kind: selection.kind, value }] : []
+  })
+}

--- a/tests/question-follow.spec.mjs
+++ b/tests/question-follow.spec.mjs
@@ -13,7 +13,7 @@ const BASE = process.env.MOBIUS_URL || 'http://localhost:8001'
 attachCleanup()
 test.use({ serviceWorkers: 'block' })
 
-async function installQuestionStream(page, questionBlock) {
+async function installQuestionStream(page, questionBlock, { longTurn = false } = {}) {
   await page.addInitScript(({ question, prefix, suffix }) => {
     const realFetch = window.fetch.bind(window)
     window.fetch = (input, init) => {
@@ -61,21 +61,38 @@ async function installQuestionStream(page, questionBlock) {
     // Keep meaningful reserved tail beneath the card. The regression only
     // appears when an acceptance-time FOLLOW handoff can consume that blank
     // room before any continuation is visible.
-    prefix: `${'Question follow line.\n\n'.repeat(2)}READY_FOR_QUESTION`,
+    // A real agentic turn can be tens of viewport-heights inside one assistant
+    // row. The long variant also exercises the production display:contents
+    // copy wrapper that unit fixtures used to omit.
+    prefix: `${'Question follow line.\n\n'.repeat(longTurn ? 140 : 2)}READY_FOR_QUESTION`,
     suffix: `${'Continued answer line.\n\n'.repeat(24)}AFTER_QUESTION_END`,
   })
 }
 
 const questionFollowScenarios = [
   {
-    name: 'accepted same-turn answer waits for response activity before following',
+    name: 'followed question holds its reserved tail through acceptance',
     readerScrollBeforeSubmit: false,
     expectedMode: 'FOLLOW_BOTTOM',
     viewport: {
       width: 412,
       initialHeight: 520,
-      expandedHeight: 915,
-      postSubmitHeight: 1015,
+      expandedHeight: 861,
+      postSubmitHeight: 915,
+    },
+  },
+  {
+    name: 'long wrapped question stays fixed from activation until response activity',
+    readerScrollBeforeSubmit: false,
+    expectedMode: 'FOLLOW_BOTTOM',
+    longTurn: true,
+    viewport: {
+      width: 412,
+      // Model the actual keyboard cycle: the controller has seen the full
+      // viewport, the keyboard reduces it, then Submit dismisses the keyboard.
+      initialHeight: 1015,
+      expandedHeight: 520,
+      preClickHeight: 1015,
     },
   },
   {
@@ -100,7 +117,7 @@ for (const scenario of questionFollowScenarios) test(scenario.name, async ({ pag
       ],
     }],
   }
-  await installQuestionStream(page, questionBlock)
+  await installQuestionStream(page, questionBlock, scenario)
 
   let turnStarted = false
   let pendingQuestionId = null
@@ -130,9 +147,10 @@ for (const scenario of questionFollowScenarios) test(scenario.name, async ({ pag
     route.fulfill({ status: 200, body: '{}' })
   ))
 
-  // Begin at a keyboard-sized height so this short question can consume the
-  // initial reservation and enter FOLLOW. Expanding the viewport afterward
-  // recreates the real blank-tail condition without changing reader intent.
+  // Each scenario begins at the geometry needed to establish its original
+  // mode, then changes to the submit-time geometry without reader intent. The
+  // long case starts full-height and shrinks first so the controller knows the
+  // real keyboard-closed height before Submit restores it.
   await page.setViewportSize({
     width: scenario.viewport.width,
     height: scenario.viewport.initialHeight,
@@ -202,12 +220,12 @@ for (const scenario of questionFollowScenarios) test(scenario.name, async ({ pag
     width: scenario.viewport.width,
     height: scenario.viewport.expandedHeight,
   })
-  await page.waitForFunction(() => {
+  await page.waitForFunction(({ longTurn }) => {
     const scroll = document.querySelector('[data-chat-surface="painted"] .chat__scroll')
     const spacer = document.querySelector('[data-chat-surface="painted"] .spacer-dynamic')
     return scroll?.dataset.scrollMode === 'FOLLOW_BOTTOM'
-      && (spacer?.offsetHeight || 0) >= 80
-  }, undefined, { timeout: 5000 })
+      && (longTurn || (spacer?.offsetHeight || 0) >= 80)
+  }, scenario, { timeout: 5000 })
 
   await card.getByRole('radio', { name: 'Yes' }).click()
   const submit = card.getByRole('button', { name: 'Submit' })
@@ -247,12 +265,65 @@ for (const scenario of questionFollowScenarios) test(scenario.name, async ({ pag
     cardTopBeforeSubmit = await card.evaluate(
       element => element.getBoundingClientRect().top,
     )
-    await submit.click()
+    if (scenario.viewport.preClickHeight) {
+      // Capture the real pointerdown boundary first, then model native
+      // keyboard-close geometry before click dispatch. The click must commit
+      // the prepared card coordinate rather than capturing the browser's
+      // intermediate clamp.
+      await page.evaluate(() => {
+        const cardElement = document.querySelector(
+          '[data-chat-surface="painted"] .qcard',
+        )
+        window.__questionActivationTops = []
+        window.__sampleQuestionActivation = true
+        const sample = () => {
+          if (!window.__sampleQuestionActivation) return
+          window.__questionActivationTops.push(
+            cardElement.getBoundingClientRect().top,
+          )
+          requestAnimationFrame(sample)
+        }
+        sample()
+      })
+      await submit.hover()
+      await page.mouse.down()
+      const preparedReservation = await surface.locator('.spacer-dynamic')
+        .evaluate(element => element.offsetHeight)
+      expect(preparedReservation).toBeGreaterThanOrEqual(
+        scenario.viewport.preClickHeight - scenario.viewport.expandedHeight - 5,
+      )
+      await page.setViewportSize({
+        width: scenario.viewport.width,
+        height: scenario.viewport.preClickHeight,
+      })
+      await page.evaluate(() => new Promise(resolve => (
+        requestAnimationFrame(() => requestAnimationFrame(resolve))
+      )))
+      const cardTopDuringActivation = await card.evaluate(
+        element => element.getBoundingClientRect().top,
+      )
+      expect(cardTopDuringActivation).toBeCloseTo(cardTopBeforeSubmit, 0)
+      await page.mouse.up()
+    } else {
+      await submit.click()
+    }
   }
   await expect(card.locator('.qcard__submit')).toHaveText('Submitted')
   await expect.poll(() => surface.locator('.chat__scroll').getAttribute(
     'data-scroll-mode',
   )).toBe('ANCHOR_AT')
+  if (scenario.viewport.preClickHeight) {
+    const activationTops = await page.evaluate(() => new Promise(resolve => {
+      requestAnimationFrame(() => {
+        window.__sampleQuestionActivation = false
+        resolve(window.__questionActivationTops || [])
+      })
+    }))
+    expect(activationTops.length).toBeGreaterThan(1)
+    expect(Math.max(...activationTops.map(top => (
+      Math.abs(top - activationTops[0])
+    )))).toBeLessThanOrEqual(1)
+  }
   const cardTopAfterAcceptance = await card.evaluate(
     element => element.getBoundingClientRect().top,
   )

--- a/tests/settled-transcript-handoff.spec.mjs
+++ b/tests/settled-transcript-handoff.spec.mjs
@@ -1,0 +1,280 @@
+import { test, expect } from '@playwright/test'
+import { createTaggedChat, attachCleanup } from './_chatTracker.mjs'
+
+const BASE = process.env.MOBIUS_URL || 'http://localhost:8000'
+
+attachCleanup()
+test.use({
+  serviceWorkers: 'block',
+  viewport: { width: 1512, height: 861 },
+  deviceScaleFactor: 2,
+})
+
+function seedHistory() {
+  return Array.from({ length: 20 }, (_, index) => {
+    const role = index % 2 === 0 ? 'user' : 'assistant'
+    const content = role === 'user'
+      ? `Earlier question ${index / 2 + 1}`
+      : `### Earlier result\n\n${'Historical response text. '.repeat(14)}`
+    return {
+      role,
+      content,
+      blocks: [{ type: 'text', content }],
+      ts: 1_780_000_000_000 + index,
+      ...(role === 'user' ? { cid: `history-${index}` } : {}),
+    }
+  })
+}
+
+async function installStreamMock(page, firstItems) {
+  await page.addInitScript(({ initialItems }) => {
+    const realFetch = window.fetch.bind(window)
+    let streamIndex = 0
+    window.fetch = (input, init) => {
+      const url = String(input?.url || input)
+      if (!/\/api\/chats\/[^/]+\/stream$/.test(url)) {
+        return realFetch(input, init)
+      }
+      const current = streamIndex++
+      const items = current === 0
+        ? initialItems
+        : [{ type: 'thinking', content: 'Checking the follow-up.' }]
+      const delay = current === 0 ? 0 : 300
+      const doneAfter = current === 0 ? 420 : 1800
+      const encoder = new TextEncoder()
+      return Promise.resolve(new Response(new ReadableStream({
+        start(controller) {
+          setTimeout(() => controller.enqueue(encoder.encode(
+            `data: ${JSON.stringify({ type: 'stream_snapshot', items })}\n\n`,
+          )), delay + 5)
+          setTimeout(() => controller.enqueue(encoder.encode(
+            `data: ${JSON.stringify({ type: 'catch_up_done' })}\n\n`,
+          )), delay + 20)
+          setTimeout(() => {
+            controller.enqueue(encoder.encode(
+              `data: ${JSON.stringify({ type: 'done' })}\n\n`,
+            ))
+            controller.close()
+          }, delay + doneAfter)
+        },
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream' },
+      }))
+    }
+  }, { initialItems: firstItems })
+}
+
+async function mountScenario(page) {
+  await page.goto(BASE, { waitUntil: 'domcontentloaded' })
+  const chat = await createTaggedChat(page, 'settled-transcript-handoff')
+  expect(chat?.id).toBeTruthy()
+
+  const mediaPath = `/api/chats/${chat.id}/media/handoff.png`
+  const finalText = [
+    '### Verification result',
+    '',
+    'The complete response includes a tall visual proof.',
+    '',
+    `![Tall proof](${mediaPath})`,
+  ].join('\n')
+  const liveItems = [
+    { type: 'text', content: 'I’ll verify the handoff first.' },
+    {
+      type: 'tool',
+      tool: 'Bash',
+      input: 'run verification',
+      output: 'passed',
+      status: 'done',
+      tool_use_id: 'handoff-tool',
+    },
+    { type: 'text', content: finalText },
+  ]
+  const settledAssistant = {
+    role: 'assistant',
+    content: liveItems.filter(item => item.type === 'text')
+      .map(item => item.content).join('\n\n'),
+    blocks: liveItems,
+    ts: 1_787_000_000_100,
+    media_dimensions: {
+      [mediaPath]: { width: 320, height: 900 },
+    },
+  }
+
+  let messages = seedHistory()
+  let running = false
+  let sendCount = 0
+
+  await installStreamMock(page, liveItems)
+
+  await page.route(new RegExp(`${mediaPath}$`), route => route.fulfill({
+    status: 200,
+    contentType: 'image/svg+xml',
+    body: '<svg xmlns="http://www.w3.org/2000/svg" width="320" height="900" viewBox="0 0 320 900"><rect width="320" height="900" fill="#8b5cf6"/></svg>',
+  }))
+  await page.route(new RegExp(`/api/chats/${chat.id}/runtime(?:\\?.*)?$`), route => (
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        running,
+        active_goal_objective: null,
+        pending_messages: [],
+        pending_question_id: null,
+      }),
+    })
+  ))
+  await page.route(new RegExp(`/api/chats/${chat.id}(?:\\?.*)?$`), async route => {
+    if (route.request().method() !== 'GET') return route.continue()
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: chat.id,
+        title: 'Settled transcript handoff',
+        messages,
+        total: messages.length,
+        offset: 0,
+        running,
+        pending_messages: [],
+        pending_question_id: null,
+        provider: 'codex',
+      }),
+    })
+  })
+  await page.route(new RegExp(`/api/chats/${chat.id}/messages$`), async route => {
+    const request = route.request().postDataJSON()
+    sendCount += 1
+    running = true
+    const message = {
+      role: 'user',
+      content: request.content,
+      blocks: [{ type: 'text', content: request.content }],
+      ts: 1_787_000_000_000 + sendCount,
+      cid: request.cid,
+    }
+    messages = [...messages, message]
+    if (sendCount === 1) {
+      setTimeout(() => {
+        messages = [...messages, settledAssistant]
+        running = false
+      }, 320)
+    }
+    await new Promise(resolve => setTimeout(resolve, 100))
+    await route.fulfill({
+      status: 202,
+      contentType: 'application/json',
+      body: JSON.stringify({ status: 'started', message }),
+    })
+  })
+
+  await page.goto(`${BASE}/shell/?chat=${encodeURIComponent(chat.id)}`, {
+    waitUntil: 'domcontentloaded',
+  })
+  const surface = page.locator('[data-chat-surface="painted"]')
+  const scroll = surface.locator('.chat__scroll')
+  await expect(scroll).toBeVisible({ timeout: 30000 })
+  await expect(surface.locator('.chat__msg')).toHaveCount(20, { timeout: 30000 })
+
+  return {
+    chat,
+    surface,
+    scroll,
+    settledAssistant,
+  }
+}
+
+async function prepareSendFromBottom(page, surface, text) {
+  await page.evaluate(() => {
+    const scroll = document.querySelector(
+      '[data-chat-surface="painted"] .chat__scroll',
+    )
+    scroll.scrollTop = scroll.scrollHeight
+  })
+  const input = surface.getByRole('textbox', { name: 'Message Möbius…' })
+  await input.fill(text)
+  await page.waitForFunction(() => {
+    const scroll = document.querySelector(
+      '[data-chat-surface="painted"] .chat__scroll',
+    )
+    return scroll
+      && scroll.scrollHeight - scroll.scrollTop - scroll.clientHeight < 4
+  })
+}
+
+async function sendFromBottom(page, surface, text) {
+  await prepareSendFromBottom(page, surface, text)
+  await page.keyboard.press('Enter')
+}
+
+async function sampleNextSend(page, surface, text, settledAssistantTs) {
+  await prepareSendFromBottom(page, surface, text)
+  const priorCount = await surface.locator('.chat__msg--user').count()
+  await page.evaluate(() => {
+    window.__handoffFrames = []
+    window.__handoffSampling = true
+    const sample = () => {
+      const surface = document.querySelector('[data-chat-surface="painted"]')
+      const scroll = surface?.querySelector('.chat__scroll')
+      const users = surface?.querySelectorAll('.chat__msg--user') || []
+      const row = users[users.length - 1]
+      const sr = scroll?.getBoundingClientRect()
+      const rr = row?.getBoundingClientRect()
+      window.__handoffFrames.push({
+        users: users.length,
+        top: sr && rr ? rr.top - sr.top : null,
+      })
+      if (window.__handoffSampling) requestAnimationFrame(sample)
+    }
+    requestAnimationFrame(sample)
+  })
+
+  await page.keyboard.press('Enter')
+  await page.waitForFunction(ts => {
+    const rows = document.querySelectorAll(
+      '[data-chat-surface="painted"] .chat__msg--assistant',
+    )
+    return [...rows].some(row => row.dataset.key === `assistant-${ts}`)
+  }, settledAssistantTs, { timeout: 10000 })
+  await page.evaluate(() => new Promise(resolve => (
+    requestAnimationFrame(() => requestAnimationFrame(resolve))
+  )))
+  return page.evaluate(previousCount => {
+    window.__handoffSampling = false
+    return (window.__handoffFrames || [])
+      .filter(frame => frame.users > previousCount && frame.top != null)
+      .map(frame => frame.top)
+  }, priorCount)
+}
+
+test('an authoritative settled-answer handoff cannot move a pinned send', async ({ page }) => {
+  const scenario = await mountScenario(page)
+  await sendFromBottom(page, scenario.surface, 'First message')
+  await expect(scenario.surface.getByText('Verification result', { exact: false }))
+    .toBeVisible({ timeout: 10000 })
+  // Finish the first stream while its detailed live row is still mounted. The
+  // server already holds the compact settled projection, but the next send's
+  // authoritative read is what hands the rendered row over to that source.
+  await expect(scenario.surface.locator('.chat__stop')).toHaveCount(0, {
+    timeout: 10000,
+  })
+  await page.waitForFunction(ts => {
+    const rows = document.querySelectorAll(
+      '[data-chat-surface="painted"] .chat__msg--assistant',
+    )
+    const key = rows[rows.length - 1]?.dataset.key
+    return key && key !== `assistant-${ts}`
+  }, scenario.settledAssistant.ts)
+
+  // Sample every painted frame across that source handoff. The newly sent row
+  // must stay at its semantic pin rather than wait for a later resize repair.
+  const tops = await sampleNextSend(
+    page,
+    scenario.surface,
+    'Second message',
+    scenario.settledAssistant.ts,
+  )
+  expect(tops.length).toBeGreaterThan(0)
+  expect(Math.max(...tops)).toBeLessThanOrEqual(12)
+  expect(Math.min(...tops)).toBeGreaterThanOrEqual(-2)
+})

--- a/tests/settled-transcript-handoff.spec.mjs
+++ b/tests/settled-transcript-handoff.spec.mjs
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test'
 import { createTaggedChat, attachCleanup } from './_chatTracker.mjs'
+import { testChatAgentSettings } from './_chatTestPrerequisites.mjs'
 
 const BASE = process.env.MOBIUS_URL || 'http://localhost:8000'
 
@@ -139,6 +140,7 @@ async function mountScenario(page) {
         pending_messages: [],
         pending_question_id: null,
         provider: 'codex',
+        ...testChatAgentSettings(),
       }),
     })
   })


### PR DESCRIPTION
## Summary

Consolidated subsystem changes grouping 8 reviewed improvements:

- Keep shell recent destinations useful in search
- Keep transparent provider separators inside activity runs
- Refine the desktop drawer boundary and default width
- Anchor the streaming cursor to rendered Markdown
- Expand chat scroll handoff browser coverage
- Keep off-bottom readers anchored during live replies
- Freeze question-answer submissions before keyboard geometry can paint
- Reconcile a settled answer before pinning its fresh follow-up

## Testing

- full frontend suite: 2,956 library/structure tests and 95 hook tests
- production frontend build
- 39 deployment-control tests from the current upstream base

The two failing merge-group scenarios now have owning-layer fixes rather than timing retries.
