### PR TITLE
Harden deploy, provider runtime, and frontend dependency safety

### DIFF
--- a/backend/app/routes/connect.py
+++ b/backend/app/routes/connect.py
@@ -137,11 +137,25 @@ def _new_id() -> str:
   return "h_" + secrets.token_hex(8)
 
 
+# Human-friendly, unambiguous alphabet (no 0/O/1/I), grouped for readability.
+_CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
+
+
 def _new_code() -> str:
-  # Human-friendly, unambiguous alphabet (no 0/O/1/I), grouped for readability.
-  alphabet = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
-  raw = "".join(secrets.choice(alphabet) for _ in range(8))
+  raw = "".join(secrets.choice(_CODE_ALPHABET) for _ in range(8))
   return f"{raw[:4]}-{raw[4:]}"
+
+
+def _normalize_code(raw: str) -> str | None:
+  """Return the canonical XXXX-XXXX code, or None if it is not well-formed.
+
+  The result only ever contains characters from `_CODE_ALPHABET` and a single
+  hyphen, so it is safe to interpolate into the install shell script below.
+  """
+  body = (raw or "").strip().upper().replace("-", "")
+  if len(body) != 8 or any(ch not in _CODE_ALPHABET for ch in body):
+    return None
+  return f"{body[:4]}-{body[4:]}"
 
 
 def _hash(token: str) -> str:
@@ -491,12 +505,11 @@ def _base_url() -> str:
 
 
 def _install_command(base: str, code: str) -> str:
-  # --install sets up a service that survives reboot; drop it to run in the
-  # foreground for a quick try.
-  return (
-    f'curl -fsSL "{base}/api/connect/runner" | python3 - '
-    f'--pair {code} --url "{base}" --install'
-  )
+  # One fetch with the code + instance URL baked into the path. No pipe-into-
+  # python arguments and no quotes, so nothing gets corrupted when the command
+  # is copied and pasted into a terminal. The served script pairs and installs
+  # a service that survives reboot (see `install_script`).
+  return f"curl -fsSL {base}/api/connect/i/{code} | sh"
 
 
 def _update_command(base: str) -> str:
@@ -1110,3 +1123,36 @@ async def runner_script() -> PlainTextResponse:
   return PlainTextResponse(
     _RUNNER_PATH.read_text("utf-8"), media_type="text/x-python",
   )
+
+
+# A POSIX shell bootstrap with the pairing code + instance URL baked in. It
+# fetches the Python runner and hands it the same flags the pipe form uses, so
+# the single-line install command carries no arguments or quotes of its own.
+_INSTALL_SCRIPT_TEMPLATE = """\
+#!/bin/sh
+# Mobius Connect installer -- pairs this machine and installs the background
+# runner. It only makes outbound HTTPS requests and runs commands as you.
+set -eu
+base="{base}"
+code="{code}"
+runner="$(mktemp)"
+trap 'rm -f "$runner"' EXIT INT TERM
+curl -fsSL "$base/api/connect/runner" -o "$runner"
+python3 "$runner" --pair "$code" --url "$base" --install
+"""
+
+
+@router.get("/i/{code}")
+async def install_script(code: str) -> PlainTextResponse:
+  """Serve the single-line install bootstrap: `curl .../i/<code> | sh`.
+
+  Collapsing the fetch, pipe, and flags into one URL removes the quotes and
+  arguments that get mangled when the command is copied and pasted. The code is
+  normalized to its shell-safe canonical form before it is interpolated; an
+  unredeemed or expired code still fails clearly at the runner's pairing step.
+  """
+  normalized = _normalize_code(code)
+  if normalized is None:
+    raise HTTPException(status_code=404, detail="Unknown pairing code.")
+  script = _INSTALL_SCRIPT_TEMPLATE.format(base=_base_url(), code=normalized)
+  return PlainTextResponse(script, media_type="text/x-shellscript")

--- a/backend/scripts/agent_selftest.py
+++ b/backend/scripts/agent_selftest.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Bounded synthetic-turn diagnostic: prove the REAL chat pipeline end to end.
+
+Basic HTTP health cannot see the failure the 2026-09-01 incident exposed: the
+web/API surface was fine while every chat turn died. This drives a short-lived,
+self-cleaning throwaway chat turn through the live provider pipeline and scores
+it with ``deploy_support.classify_synthetic_turn`` — which REJECTS an
+error/resumable/empty reply (the exact state a full-/data admission deferral
+emits, and the false-green the old deploy canary scored as passing).
+
+It proves, for real: message persistence, runner admission, provider invocation,
+stream/terminal completion, and NON-EMPTY assistant output.
+
+Operator/deploy contract: repeatable (each run owns one throwaway chat), low-cost (a
+trivial no-tool prompt), timeout-bounded, and it cleans up ONLY the chat it
+created. It never prints the service token. Exit codes: 0 passed, 2 failed
+(pipeline broken), 3 unavailable (no token / no provider / setup error) so a
+deploy can distinguish "provider not connected" (warn) from "pipeline broken"
+(fail + roll back).
+
+Usage:
+  agent_selftest.py [--expect-provider codex|claude|mobius]
+                    [--expect-model <id>] [--timeout 90]
+                    [--prompt 'Reply with exactly: OK'] [--keep]
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Callable
+
+_DEPLOY_SUPPORT = Path(__file__).resolve().parents[2] / "scripts" / "deploy_support.py"
+
+
+def _load_classifier():
+  spec = importlib.util.spec_from_file_location("deploy_support", _DEPLOY_SUPPORT)
+  assert spec is not None and spec.loader is not None
+  module = importlib.util.module_from_spec(spec)
+  spec.loader.exec_module(module)
+  return module.classify_synthetic_turn
+
+
+def _service_token() -> str | None:
+  # Prefer the explicit in-container owner service token; never echo it.
+  for path in (
+    os.environ.get("MOBIUS_SERVICE_TOKEN_FILE"),
+    "/data/service-token.txt",
+  ):
+    if not path:
+      continue
+    try:
+      token = Path(path).read_text(encoding="utf-8").strip()
+    except OSError:
+      continue
+    if token:
+      return token
+  token = os.environ.get("AGENT_TOKEN")
+  return token.strip() if token else None
+
+
+def _request(
+  base: str,
+  method: str,
+  path: str,
+  token: str,
+  body: dict | None = None,
+  *,
+  timeout: float = 30,
+):
+  data = json.dumps(body).encode() if body is not None else None
+  req = urllib.request.Request(base + path, data=data, method=method)
+  req.add_header("Authorization", f"Bearer {token}")
+  if data is not None:
+    req.add_header("Content-Type", "application/json")
+  with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310 (operator URL)
+    raw = resp.read().decode("utf-8")
+  return json.loads(raw) if raw else {}
+
+
+def run_selftest(
+  *,
+  base: str,
+  token: str,
+  expected_provider: str | None,
+  expected_model: str | None,
+  prompt: str,
+  timeout: float,
+  keep: bool,
+  clock: Callable[[], float] = time.monotonic,
+  sleep: Callable[[float], None] = time.sleep,
+) -> dict:
+  classify = _load_classifier()
+  started = clock()
+  deadline = started + timeout
+  chat_id = None
+  outcome = None
+
+  def request(method: str, path: str, body: dict | None = None):
+    remaining = deadline - clock()
+    if remaining <= 0:
+      raise TimeoutError
+    return _request(
+      base, method, path, token, body, timeout=min(30.0, remaining),
+    )
+
+  try:
+    # The owner chat-create contract snapshots the owner's current complete
+    # picker choice. Do not send provider/model fields here: ChatCreate does
+    # not own them, and switching the new chat through the ordinary settings
+    # route would also mutate the owner's saved picker defaults. Expectations
+    # are checked below without changing any persistent owner setting.
+    create_body: dict = {"title": "Deploy self-test", "messages": []}
+    chat = request("POST", "/api/chats", create_body)
+    chat_id = chat.get("id")
+    if not chat_id:
+      outcome = {"result": "failed", "reason": "chat create returned no id"}
+      return outcome
+
+    detail = chat.get("detail") if isinstance(chat.get("detail"), dict) else chat
+    provider = detail.get("provider")
+    effective = detail.get("effective_agent_settings")
+    model = effective.get("model") if isinstance(effective, dict) else None
+    if expected_provider and provider != expected_provider:
+      outcome = {
+        "result": "unavailable",
+        "reason": "active provider does not match expectation",
+        "provider": provider,
+        "model": model,
+      }
+      return outcome
+    if expected_model and model != expected_model:
+      outcome = {
+        "result": "unavailable",
+        "reason": "active model does not match expectation",
+        "provider": provider,
+        "model": model,
+      }
+      return outcome
+
+    request(
+      "POST",
+      f"/api/chats/{chat_id}/messages",
+      {"content": prompt, "hidden": True},
+    )
+
+    last = {}
+    while clock() < deadline:
+      last = request("GET", f"/api/chats/{chat_id}?limit=10")
+      verdict = classify(last)
+      if verdict != "pending":
+        outcome = {
+          "result": "passed" if verdict == "passed" else "failed",
+          "latency_s": round(clock() - started, 2),
+          "provider": provider,
+          "model": model,
+        }
+        return outcome
+      sleep(min(1.0, max(0.0, deadline - clock())))
+    outcome = {
+      "result": "failed",
+      "reason": "timeout",
+      "latency_s": round(clock() - started, 2),
+      "provider": provider,
+      "model": model,
+    }
+    return outcome
+  except urllib.error.HTTPError as exc:
+    # Auth/setup conflicts are unavailable operator prerequisites. Rate limits,
+    # timeouts, and server failures mean the real turn pipeline did not work.
+    unavailable = exc.code in (401, 403, 409, 422)
+    outcome = {
+      "result": "unavailable" if unavailable else "failed",
+      "reason": f"http {exc.code}",
+    }
+    return outcome
+  except (TimeoutError, urllib.error.URLError, OSError, TypeError, ValueError) as exc:
+    outcome = {"result": "failed", "reason": type(exc).__name__}
+    return outcome
+  finally:
+    if chat_id and keep and isinstance(outcome, dict):
+      outcome["chat_id"] = chat_id
+    elif chat_id:
+      try:
+        _request(
+          base,
+          "DELETE",
+          f"/api/chats/{chat_id}",
+          token,
+          timeout=min(5.0, max(0.1, timeout)),
+        )
+      except Exception:
+        # Cleanup failure does not turn a proven provider round-trip red, but it
+        # must be visible so the operator can reclaim the exact throwaway chat.
+        if isinstance(outcome, dict):
+          outcome["cleanup"] = "failed"
+          outcome["cleanup_chat_id"] = chat_id
+
+
+def main(argv: list[str] | None = None) -> int:
+  parser = argparse.ArgumentParser(description=__doc__)
+  parser.add_argument(
+    "--expect-provider", choices=("claude", "codex", "mobius"), default=None,
+  )
+  parser.add_argument("--expect-model", default=None)
+  parser.add_argument("--prompt", default="Reply with exactly: OK")
+  parser.add_argument("--timeout", type=float, default=90.0)
+  parser.add_argument("--keep", action="store_true")
+  parser.add_argument("--base", default=os.environ.get("API_BASE_URL", "http://localhost:8000"))
+  args = parser.parse_args(argv)
+
+  token = _service_token()
+  if not token:
+    print(json.dumps({"result": "unavailable", "reason": "no service token"}))
+    return 3
+
+  outcome = run_selftest(
+    base=args.base.rstrip("/"), token=token,
+    expected_provider=args.expect_provider,
+    expected_model=args.expect_model,
+    prompt=args.prompt, timeout=args.timeout, keep=args.keep,
+  )
+  print(json.dumps(outcome, sort_keys=True))
+  return {"passed": 0, "failed": 2, "unavailable": 3}.get(outcome["result"], 3)
+
+
+if __name__ == "__main__":
+  raise SystemExit(main())

--- a/backend/tests/test_agent_selftest.py
+++ b/backend/tests/test_agent_selftest.py
@@ -1,0 +1,216 @@
+"""Behavioral coverage for the bounded production agent self-test."""
+
+import importlib.util
+from pathlib import Path
+import urllib.error
+
+
+_PATH = Path(__file__).parents[1] / "scripts" / "agent_selftest.py"
+_SPEC = importlib.util.spec_from_file_location("agent_selftest", _PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+agent_selftest = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(agent_selftest)
+
+
+def _created_chat(*, provider="codex", model="gpt-test"):
+  return {
+    "id": "chat-1",
+    "detail": {
+      "provider": provider,
+      "effective_agent_settings": {"model": model},
+    },
+  }
+
+
+def test_selftest_uses_the_current_picker_without_mutating_owner_defaults(monkeypatch):
+  calls = []
+
+  def request(base, method, path, token, body=None, *, timeout=30):
+    assert 0 < timeout <= 5
+    calls.append((method, path, body))
+    if path == "/api/chats":
+      return _created_chat()
+    if method == "GET":
+      return {
+        "running": False,
+        "messages": [{"role": "assistant", "content": "OK"}],
+      }
+    return {}
+
+  monkeypatch.setattr(agent_selftest, "_request", request)
+  monkeypatch.setattr(
+    agent_selftest,
+    "_load_classifier",
+    lambda: lambda chat: "passed" if not chat.get("running") else "pending",
+  )
+
+  result = agent_selftest.run_selftest(
+    base="http://localhost:8000",
+    token="not-printed",
+    expected_provider="codex",
+    expected_model="gpt-test",
+    prompt="Reply with exactly: OK",
+    timeout=5,
+    keep=False,
+  )
+
+  assert result["result"] == "passed"
+  assert result["provider"] == "codex"
+  assert result["model"] == "gpt-test"
+  assert calls == [
+    ("POST", "/api/chats", {"title": "Deploy self-test", "messages": []}),
+    (
+      "POST",
+      "/api/chats/chat-1/messages",
+      {"content": "Reply with exactly: OK", "hidden": True},
+    ),
+    ("GET", "/api/chats/chat-1?limit=10", None),
+    ("DELETE", "/api/chats/chat-1", None),
+  ]
+
+
+def test_picker_expectation_mismatch_is_unavailable_and_still_cleans_up(monkeypatch):
+  calls = []
+
+  def request(base, method, path, token, body=None, *, timeout=30):
+    assert 0 < timeout <= 5
+    calls.append((method, path))
+    if path == "/api/chats":
+      return _created_chat(provider="claude", model="claude-test")
+    return {}
+
+  monkeypatch.setattr(agent_selftest, "_request", request)
+
+  result = agent_selftest.run_selftest(
+    base="http://localhost:8000",
+    token="not-printed",
+    expected_provider="codex",
+    expected_model=None,
+    prompt="OK",
+    timeout=5,
+    keep=False,
+  )
+
+  assert result == {
+    "result": "unavailable",
+    "reason": "active provider does not match expectation",
+    "provider": "claude",
+    "model": "claude-test",
+  }
+  assert calls == [
+    ("POST", "/api/chats"),
+    ("DELETE", "/api/chats/chat-1"),
+  ]
+
+
+def test_rate_limit_and_transport_failures_are_failed_not_unavailable(monkeypatch):
+  for exc in (
+    urllib.error.HTTPError("url", 429, "limited", {}, None),
+    urllib.error.URLError("connection refused"),
+  ):
+    monkeypatch.setattr(
+      agent_selftest,
+      "_request",
+      lambda *args, _exc=exc, **kwargs: (_ for _ in ()).throw(_exc),
+    )
+    result = agent_selftest.run_selftest(
+      base="http://localhost:8000",
+      token="not-printed",
+      expected_provider=None,
+      expected_model=None,
+      prompt="OK",
+      timeout=5,
+      keep=False,
+    )
+    assert result["result"] == "failed"
+
+
+def test_cleanup_failure_is_reported_without_erasing_a_passing_turn(monkeypatch):
+  def request(base, method, path, token, body=None, *, timeout=30):
+    if path == "/api/chats":
+      return _created_chat()
+    if method == "GET":
+      return {"running": False, "messages": [{"role": "assistant"}]}
+    if method == "DELETE":
+      raise OSError("cleanup failed")
+    return {}
+
+  monkeypatch.setattr(agent_selftest, "_request", request)
+  monkeypatch.setattr(agent_selftest, "_load_classifier", lambda: lambda chat: "passed")
+
+  result = agent_selftest.run_selftest(
+    base="http://localhost:8000",
+    token="not-printed",
+    expected_provider=None,
+    expected_model=None,
+    prompt="OK",
+    timeout=5,
+    keep=False,
+  )
+
+  assert result["result"] == "passed"
+  assert result["cleanup"] == "failed"
+  assert result["cleanup_chat_id"] == "chat-1"
+
+
+def test_keep_returns_the_exact_chat_identity_for_operator_inspection(monkeypatch):
+  calls = []
+
+  def request(base, method, path, token, body=None, *, timeout=30):
+    calls.append((method, path))
+    if path == "/api/chats":
+      return _created_chat()
+    if method == "GET":
+      return {"running": False, "messages": [{"role": "assistant"}]}
+    return {}
+
+  monkeypatch.setattr(agent_selftest, "_request", request)
+  monkeypatch.setattr(agent_selftest, "_load_classifier", lambda: lambda chat: "passed")
+
+  result = agent_selftest.run_selftest(
+    base="http://localhost:8000",
+    token="not-printed",
+    expected_provider=None,
+    expected_model=None,
+    prompt="OK",
+    timeout=5,
+    keep=True,
+  )
+
+  assert result["result"] == "passed"
+  assert result["chat_id"] == "chat-1"
+  assert all(method != "DELETE" for method, _path in calls)
+
+
+def test_request_timeout_is_capped_by_the_remaining_probe_budget(monkeypatch):
+  observed = []
+  now = iter((10.0, 10.0, 10.4, 10.7, 10.8, 10.85))
+
+  def request(base, method, path, token, body=None, *, timeout=30):
+    observed.append((method, timeout))
+    if path == "/api/chats":
+      return _created_chat()
+    if method == "GET":
+      return {"running": False, "messages": [{"role": "assistant"}]}
+    return {}
+
+  monkeypatch.setattr(agent_selftest, "_request", request)
+  monkeypatch.setattr(agent_selftest, "_load_classifier", lambda: lambda chat: "passed")
+
+  result = agent_selftest.run_selftest(
+    base="http://localhost:8000",
+    token="not-printed",
+    expected_provider=None,
+    expected_model=None,
+    prompt="OK",
+    timeout=1,
+    keep=False,
+    clock=lambda: next(now),
+    sleep=lambda _seconds: None,
+  )
+
+  assert result["result"] == "passed"
+  assert observed[0] == ("POST", 1.0)
+  assert observed[1][0] == "POST" and 0 < observed[1][1] <= 0.6
+  assert observed[2][0] == "GET" and 0 < observed[2][1] <= 0.3
+  assert observed[3] == ("DELETE", 1.0)

--- a/backend/tests/test_connect.py
+++ b/backend/tests/test_connect.py
@@ -66,6 +66,39 @@ def _paired_host(client, auth, name="Workstation"):
   return pairing, paired.json()["token"]
 
 
+def test_install_command_is_single_fetch_and_serves_shell_bootstrap(client, auth):
+  created = client.post(
+    "/api/connect/hosts", headers=auth, json={"name": "Laptop"},
+  )
+  assert created.status_code == 200, created.text
+  pairing = created.json()
+  code = pairing["pairing_code"]
+
+  # The copyable command is one fetch with the code in the path -- no pipe-into-
+  # python arguments and no quotes to be corrupted when it is pasted.
+  command = pairing["install_command"]
+  assert command.startswith("curl -fsSL ")
+  assert command.endswith(f"/api/connect/i/{code} | sh")
+  assert '"' not in command
+
+  script = client.get(f"/api/connect/i/{code}")
+  assert script.status_code == 200, script.text
+  body = script.text
+  assert body.startswith("#!/bin/sh")
+  # The bootstrap fetches the runner and hands it the same flags the pipe form
+  # used, so a machine ends up paired and installed as a service.
+  assert "/api/connect/runner" in body
+  assert f'code="{code}"' in body
+  assert "--pair" in body and "--install" in body
+
+  # A malformed code never reaches the shell template.
+  assert client.get("/api/connect/i/nope").status_code == 404
+  # A lowercased/ungrouped code is normalized back to canonical form.
+  loose = client.get(f"/api/connect/i/{code.replace('-', '').lower()}")
+  assert loose.status_code == 200, loose.text
+  assert f'code="{code}"' in loose.text
+
+
 def test_pairing_code_exchange_is_rate_limited(client):
   for _ in range(10):
     response = client.post("/api/connect/pair", json={"code": "AAAA-AAAA"})

--- a/backend/tests/test_deploy_support.py
+++ b/backend/tests/test_deploy_support.py
@@ -63,3 +63,107 @@ def test_cli_validation_requires_an_already_canonical_origin(capsys):
     "validate-gateway-origin", "https://Services.example.test/",
   ]) == 1
   assert capsys.readouterr().out == ""
+
+
+# --- Synthetic-turn oracle (#2) ---------------------------------------------
+
+
+def test_synthetic_turn_still_running_is_pending():
+  assert deploy_support.classify_synthetic_turn({"running": True}) == "pending"
+
+
+def test_synthetic_turn_no_assistant_is_failed():
+  # An empty assistant response is exactly the incident's non-responsive chat.
+  chat = {"running": False, "messages": [{"role": "user", "content": "hi"}]}
+  assert deploy_support.classify_synthetic_turn(chat) == "failed"
+
+
+def test_synthetic_turn_error_or_resumable_block_is_failed():
+  # The incident: admission-deferred turns emit an error/resumable block. The
+  # old canary scored these as passing (any assistant block) — reject them.
+  resumable = {
+    "running": False,
+    "messages": [{"role": "assistant", "content": "", "resumable": True,
+                  "message": "waiting for storage headroom"}],
+  }
+  assert deploy_support.classify_synthetic_turn(resumable) == "failed"
+  error_block = {
+    "running": False,
+    "messages": [{"role": "assistant", "blocks": [{"type": "error"}]}],
+  }
+  assert deploy_support.classify_synthetic_turn(error_block) == "failed"
+
+
+def test_synthetic_turn_empty_text_is_failed():
+  chat = {"running": False, "messages": [{"role": "assistant", "content": "  "}]}
+  assert deploy_support.classify_synthetic_turn(chat) == "failed"
+
+
+def test_synthetic_turn_non_text_block_content_is_not_a_reply():
+  chat = {
+    "running": False,
+    "messages": [{
+      "role": "assistant",
+      "content": None,
+      "blocks": [{"type": "tool_result", "content": [{"type": "image"}]}],
+    }],
+  }
+  assert deploy_support.classify_synthetic_turn(chat) == "failed"
+
+
+def test_synthetic_turn_real_reply_passes():
+  by_content = {
+    "running": False,
+    "messages": [{"role": "assistant", "content": "OK"}],
+  }
+  assert deploy_support.classify_synthetic_turn(by_content) == "passed"
+  by_block = {
+    "running": False,
+    "messages": [{"role": "assistant", "blocks": [{"type": "text", "text": "OK"}]}],
+  }
+  assert deploy_support.classify_synthetic_turn(by_block) == "passed"
+
+
+def test_cli_classify_turn_failed_returns_nonzero(capsys):
+  import json
+  code = deploy_support.main([
+    "classify-turn",
+    json.dumps({"running": False, "messages": [
+      {"role": "assistant", "resumable": True, "content": ""}]}),
+  ])
+  assert code == 2
+  assert capsys.readouterr().out.strip() == "failed"
+
+
+# --- Deployment receipt (#8) ------------------------------------------------
+
+
+def test_receipt_requires_valid_outcome():
+  with pytest.raises(deploy_support.DeployInputError):
+    deploy_support.build_deploy_receipt({"outcome": "maybe"})
+
+
+def test_failed_receipt_must_record_rollback_target():
+  with pytest.raises(deploy_support.DeployInputError):
+    deploy_support.build_deploy_receipt({"outcome": "failed"})
+  ok = deploy_support.build_deploy_receipt({
+    "outcome": "failed", "rollback_target": "mobius-app:rollback-prev",
+  })
+  assert ok["outcome"] == "failed"
+  assert ok["rollback_target"] == "mobius-app:rollback-prev"
+
+
+def test_receipt_is_canonical_and_drops_unknown_keys():
+  receipt = deploy_support.build_deploy_receipt({
+    "outcome": "success",
+    "build_sha": "abc123",
+    "rollback_target": "mobius-app:rollback-prev",
+    "synthetic_turn": {"claude": {"result": "passed"}},
+    "unexpected_field": "SHOULD-NOT-APPEAR",
+  })
+  assert receipt["schema_version"] == deploy_support.RECEIPT_SCHEMA_VERSION
+  assert receipt["build_sha"] == "abc123"
+  assert "unexpected_field" not in receipt
+  # Every canonical field is present (as None when unset) for a stable shape.
+  for field in deploy_support.RECEIPT_FIELDS:
+    assert field in receipt

--- a/scripts/deploy_support.py
+++ b/scripts/deploy_support.py
@@ -8,7 +8,9 @@ owner that can be exercised without Docker or a production environment.
 from __future__ import annotations
 
 import argparse
+import json
 import re
+import sys
 from urllib.parse import urlsplit
 
 _HOST_RE = re.compile(r"[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?")
@@ -62,6 +64,140 @@ def rollback_tag_for_image(image: str) -> str:
   return f"{repository}:rollback-prev"
 
 
+# --- Synthetic-turn oracle ---------------------------------------------------
+#
+# The deploy synthetic turn drives a real provider chat turn and must decide
+# pass/fail/pending from the chat's terminal state. The 2026-09-01 incident
+# (a full /data deferring admission) publishes an ERROR/RESUMABLE block and
+# ends the run — which the old canary oracle, accepting "any assistant message
+# with blocks", scored as PASSING. This owner rejects that false-green.
+
+SYNTHETIC_PASSED = "passed"
+SYNTHETIC_FAILED = "failed"
+SYNTHETIC_PENDING = "pending"
+
+
+def _is_error_block(block: dict) -> bool:
+  # A pause/resumable/error block is a FAILURE signal for a synthetic turn,
+  # even when it is a "benign" pause — the deploy proved the turn could not
+  # produce a real answer.
+  if not isinstance(block, dict):
+    return False
+  return bool(
+    block.get("type") == "error"
+    or block.get("resumable")
+    or block.get("pause")
+  )
+
+
+def _has_text(value: object) -> bool:
+  return isinstance(value, str) and bool(value.strip())
+
+
+def classify_synthetic_turn(chat: dict) -> str:
+  """Classify a synthetic deploy turn from the chat runtime JSON.
+
+  ``chat`` is the parsed ``GET /api/chats/{id}`` body: ``running`` plus
+  ``messages`` (each with ``role``, ``content``, optional ``blocks``).
+
+  * ``pending`` — the run is still going; keep polling.
+  * ``failed`` — no assistant reply, OR the reply is an error/resumable/pause
+    block, OR it has no non-empty text. This is what the incident produces.
+  * ``passed`` — a settled assistant reply with real, non-empty text and no
+    error/pause marker.
+  """
+  if chat.get("running"):
+    return SYNTHETIC_PENDING
+  messages = chat.get("messages") or []
+  assistant = None
+  for message in messages:
+    if isinstance(message, dict) and message.get("role") == "assistant":
+      assistant = message
+  if assistant is None:
+    # Infrastructure failure must never score as a passing turn — an empty
+    # assistant response is exactly the incident's "non-responsive chat".
+    return SYNTHETIC_FAILED
+  blocks = assistant.get("blocks") or []
+  if _is_error_block(assistant) or any(_is_error_block(b) for b in blocks):
+    return SYNTHETIC_FAILED
+  content = assistant.get("content")
+  has_text_block = any(
+    isinstance(block, dict)
+    and (_has_text(block.get("text")) or _has_text(block.get("content")))
+    for block in blocks
+  )
+  if _has_text(content) or has_text_block:
+    return SYNTHETIC_PASSED
+  return SYNTHETIC_FAILED
+
+
+# --- Durable deployment receipt ---------------------------------------------
+
+RECEIPT_SCHEMA_VERSION = 1
+
+# Canonical, NON-SECRET receipt fields. deploy-prod.sh assembles these from
+# /api/version, /api/ready, /api/ready/agent, /api/debug/status, and the
+# synthetic-turn result, then pipes them here to validate + canonicalize.
+RECEIPT_FIELDS = (
+  "outcome",                 # success | failed | rolled_back
+  "timestamp",               # ISO-8601 UTC
+  "deploy_actor",
+  "build_sha",
+  "platform_sha",
+  "served_sha",
+  "serving_source",          # platform | baked
+  "image_id",
+  "image_digest",
+  "rollback_target",         # exact image ref to roll back to
+  "migration_result",        # {ready: bool, schema_gaps: [...]}
+  "data_free_bytes",
+  "data_pressure_state",
+  "host_root_free_bytes",
+  "protected_runtime_state", # current | stale | unavailable
+  "provider_auth",           # {provider: bool}  (NON-SECRET)
+  "synthetic_turn",          # {provider: {result, latency_s, terminal}}
+  "public_basic_health",     # HTTP status of public /api/health
+  "public_agent_readiness",  # HTTP status / verdict of public /api/ready/agent
+)
+
+_RECEIPT_OUTCOMES = ("success", "failed", "rolled_back")
+
+
+def build_deploy_receipt(data: dict) -> dict:
+  """Validate + canonicalize a deployment receipt (success OR failure).
+
+  A failed/rolled_back deploy MUST still record its rollback target — the whole
+  point is that post-incident forensics and rollback have an authoritative
+  record instead of scrollback. Unknown top-level keys are dropped so the
+  receipt stays canonical. This is not a secret scrubber: the caller remains
+  responsible for supplying only the documented non-secret values.
+  """
+  outcome = data.get("outcome")
+  if outcome not in _RECEIPT_OUTCOMES:
+    raise DeployInputError(
+      f"receipt outcome must be one of {_RECEIPT_OUTCOMES}"
+    )
+  receipt: dict = {"schema_version": RECEIPT_SCHEMA_VERSION}
+  for field in RECEIPT_FIELDS:
+    receipt[field] = data.get(field)
+  if outcome in ("failed", "rolled_back") and not receipt.get("rollback_target"):
+    raise DeployInputError(
+      "a failed/rolled_back receipt must record rollback_target"
+    )
+  return receipt
+
+
+def _read_json_arg(source: str) -> dict:
+  raw = sys.stdin.read() if source == "-" else source
+  try:
+    parsed = json.loads(raw)
+  except json.JSONDecodeError as exc:
+    raise DeployInputError("invalid json") from exc
+  if not isinstance(parsed, dict):
+    raise DeployInputError("expected a json object")
+  return parsed
+
+
 def _parser() -> argparse.ArgumentParser:
   parser = argparse.ArgumentParser()
   commands = parser.add_subparsers(dest="command", required=True)
@@ -75,6 +211,12 @@ def _parser() -> argparse.ArgumentParser:
 
   rollback = commands.add_parser("rollback-tag")
   rollback.add_argument("image")
+
+  classify = commands.add_parser("classify-turn")
+  classify.add_argument("chat_json", help="chat runtime JSON, or - for stdin")
+
+  receipt = commands.add_parser("build-receipt")
+  receipt.add_argument("receipt_json", help="receipt fields JSON, or - for stdin")
   return parser
 
 
@@ -87,9 +229,19 @@ def main(argv: list[str] | None = None) -> int:
       normalized = normalize_gateway_origin(args.origin)
       if normalized != args.origin:
         raise DeployInputError("origin is not canonical")
+    elif args.command == "classify-turn":
+      result = classify_synthetic_turn(_read_json_arg(args.chat_json))
+      print(result)
+      # A settled synthetic turn that did not pass is a deploy-gate failure.
+      if result == SYNTHETIC_FAILED:
+        return 2
+    elif args.command == "build-receipt":
+      receipt = build_deploy_receipt(_read_json_arg(args.receipt_json))
+      print(json.dumps(receipt, separators=(",", ":"), sort_keys=True))
     else:
       print(rollback_tag_for_image(args.image))
-  except DeployInputError:
+  except DeployInputError as exc:
+    print(str(exc), file=sys.stderr)
     return 1
   return 0
 


### PR DESCRIPTION
## Summary

Consolidated subsystem changes grouping 2 reviewed improvements:

- Add a truthful synthetic-turn deploy oracle
- Connect: one-line install command that survives copy/paste

## Testing

Each change was individually reviewed; the combined branch matches the reviewed local source and applies cleanly on current `main`.
