### PR TITLE
Improve offline shell, embeds, and account-link framing

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -429,6 +429,20 @@ def _loopback_delivery_origin(scope) -> str | None:
   return origin
 
 
+def _static_embed_csp_for_scope(scope) -> str:
+  """Allow packaged games to run on the loopback origin that served them.
+
+  Production documents remain pinned to ``frontend_origin``. Local operator
+  tools and the authenticated screenshot harness deliberately reach uvicorn
+  over loopback; an opaque sandbox cannot use CSP ``'self'`` for its own
+  modules, so name that loopback delivery origin for this response only.
+  """
+  delivery_origin = _loopback_delivery_origin(scope)
+  if delivery_origin is None:
+    return _STATIC_EMBED_CSP
+  return static_embed_csp(settings.frontend_origin, delivery_origin)
+
+
 def _app_frame_csp_for_scope(scope) -> str:
   """Let the loopback test harness exercise the real opaque app frame."""
   delivery_origin = _loopback_delivery_origin(scope)
@@ -516,7 +530,7 @@ class _SecurityHeadersMiddleware:
       ]
     if not service_surface:
       if opaque_static_embed:
-        csp = _STATIC_EMBED_CSP
+        csp = _static_embed_csp_for_scope(scope)
       elif published_site:
         csp = _PUBLISHED_SITE_CSP
       elif chat_embed:

--- a/backend/app/response_policy.py
+++ b/backend/app/response_policy.py
@@ -128,19 +128,26 @@ CHAT_EMBED_CSP = (
 )
 
 
-def static_embed_csp(frontend_origin: str) -> str:
-  origin = _validated_frontend_origin(frontend_origin)
+def static_embed_csp(
+  frontend_origin: str, *additional_origins: str,
+) -> str:
+  origins = [_validated_frontend_origin(frontend_origin)]
+  for candidate in additional_origins:
+    origin = _validated_frontend_origin(candidate)
+    if origin not in origins:
+      origins.append(origin)
+  source = " ".join(origins)
   return (
     "sandbox allow-scripts allow-forms allow-pointer-lock allow-popups "
     "allow-popups-to-escape-sandbox; "
-    f"default-src {origin}; "
-    f"script-src {origin} 'unsafe-inline'; "
-    f"style-src {origin} 'unsafe-inline'; "
-    f"font-src {origin} data:; "
-    f"connect-src {origin}; "
-    f"img-src {origin} data: blob:; "
-    f"media-src {origin} blob:; "
-    f"worker-src {origin} blob:"
+    f"default-src {source}; "
+    f"script-src {source} 'unsafe-inline'; "
+    f"style-src {source} 'unsafe-inline'; "
+    f"font-src {source} data:; "
+    f"connect-src {source}; "
+    f"img-src {source} data: blob:; "
+    f"media-src {source} blob:; "
+    f"worker-src {source} blob:"
   )
 
 

--- a/backend/tests/test_security_headers.py
+++ b/backend/tests/test_security_headers.py
@@ -203,6 +203,22 @@ def test_static_embed_policy_authoritatively_replaces_route_headers(monkeypatch)
   assert "x-frame-options" not in response.headers
 
 
+def test_static_embed_names_loopback_delivery_origin_for_local_tools():
+  # Starlette's in-process TestClient identifies its peer as ``testclient``;
+  # production grants this exception only when BOTH the peer and Host are
+  # loopback. Exercise that owning predicate directly rather than weakening it
+  # to trust a spoofable Host header for the sake of the adapter fixture.
+  policy = main._static_embed_csp_for_scope({
+    "scheme": "http",
+    "headers": [(b"host", b"127.0.0.1:8123")],
+    "client": ("127.0.0.1", 49152),
+  })
+
+  assert "http://127.0.0.1:8123" in policy
+  assert main.settings.frontend_origin.rstrip("/") in policy
+  assert "allow-same-origin" not in policy
+
+
 def test_static_embed_policy_survives_unhandled_route_exception(monkeypatch):
   def _raise(*_args, **_kwargs):
     raise RuntimeError("static asset failure")

--- a/frontend/src/lib/__tests__/queryPersistAllowlist.test.js
+++ b/frontend/src/lib/__tests__/queryPersistAllowlist.test.js
@@ -15,16 +15,45 @@
  */
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
-import { QueryClient } from '@tanstack/react-query'
+import { dehydrate, QueryClient } from '@tanstack/react-query'
+import { persistQueryClientRestore } from '@tanstack/react-query-persist-client'
 import { indexedDB } from 'fake-indexeddb'
 import { get } from 'idb-keyval'
 import {
   awaitCacheFlushBeforeReload,
   compactPersistedChatDetails,
   flushPersistedQueryCache,
+  persistOptions,
   restorePersistedClient,
   shouldPersistQueryKey,
 } from '../../queryClient.js'
+
+test('last-known shell state remains restorable after a long offline stretch', async () => {
+  const source = new QueryClient()
+  source.setQueryData(['chats'], [{ id: 'chat-1', title: 'Kept offline' }])
+  const persisted = {
+    buster: 'v1',
+    timestamp: Date.now() - 30 * 24 * 60 * 60 * 1000,
+    clientState: dehydrate(source),
+  }
+  let removed = false
+  const restored = new QueryClient()
+
+  await persistQueryClientRestore({
+    ...persistOptions,
+    queryClient: restored,
+    persister: {
+      restoreClient: async () => persisted,
+      removeClient: async () => { removed = true },
+    },
+  })
+
+  assert.equal(removed, false)
+  assert.deepEqual(
+    restored.getQueryData(['chats']),
+    [{ id: 'chat-1', title: 'Kept offline' }],
+  )
+})
 
 test('background persistence bounds inactive chat history to the cold page', () => {
   const messages = Array.from({ length: 30 }, (_, index) => ({ content: `line-${index}` }))

--- a/frontend/src/queryClient.js
+++ b/frontend/src/queryClient.js
@@ -14,8 +14,10 @@
  *
  * `defaultOptions` are tuned to "cached but not stale": staleTime 30s
  * means data is considered fresh for 30s (no refetch on remount in
- * that window), gcTime 24h means it's kept on disk for a day after
- * last use. Tweak per-query via the queryKey/queryFn config.
+ * that window), while gcTime 24h bounds inactive queries during a live
+ * session. The last persisted snapshot itself does not expire by age: it is
+ * the shell's durable offline fallback and is explicitly erased on logout.
+ * Tweak per-query via the queryKey/queryFn config.
  */
 import { QueryClient, dehydrate } from '@tanstack/react-query'
 import { createAsyncStoragePersister } from '@tanstack/query-async-storage-persister'
@@ -89,7 +91,10 @@ export const queryPersister = createAsyncStoragePersister({
 
 export const persistOptions = {
   persister: queryPersister,
-  maxAge: 24 * 60 * 60 * 1000,
+  // Last-known owner state is more useful than a blank shell after a long
+  // offline stretch. Every restored query revalidates normally when the server
+  // returns, and logout explicitly deletes this owner-scoped database.
+  maxAge: Infinity,
   buster: QUERY_CACHE_BUSTER,
   dehydrateOptions: {
     shouldDehydrateQuery: (query) => shouldPersistQueryKey(query.queryKey),


### PR DESCRIPTION
## Summary

Consolidated subsystem changes grouping 2 reviewed improvements:

- Retain the last offline shell snapshot
- Allow static embeds to load over loopback

## Testing

Each change was individually reviewed; the combined branch matches the reviewed local source and applies cleanly on current `main`.
