### PR TITLE
Improve runtime robustness and observability

### DIFF
--- a/backend/app/routes/debug.py
+++ b/backend/app/routes/debug.py
@@ -28,6 +28,7 @@ from app.chat_writer import writer_memory_diagnostics
 from app.config import get_settings
 from app.database import database_pool_snapshot, get_db
 from app.deps import get_current_owner
+from app.text_util import elide
 from app.memory_observability import (
   allocation_report,
   gc_diagnostics,
@@ -286,7 +287,9 @@ def debug_logs(
   if chat_id:
     all_lines = [l for l in all_lines if chat_id in l]
 
-  result = all_lines[-lines:]
+  # Bound each entry independently so one serialized payload cannot dominate
+  # an otherwise line-bounded diagnostic response.
+  result = [elide(line, 4000)[0] for line in all_lines[-lines:]]
   return {"lines": result, "total_size": total_size}
 
 

--- a/backend/app/text_util.py
+++ b/backend/app/text_util.py
@@ -1,0 +1,36 @@
+"""Small dependency-free text helpers for agent-facing surfaces."""
+
+from __future__ import annotations
+
+
+def elide(text: str, max_chars: int, *, note: str | None = None) -> tuple[str, bool]:
+  """Bound text to ``max_chars`` while retaining useful head and tail context.
+
+  A non-positive limit disables trimming. The returned boolean reports whether
+  any source characters were omitted.
+  """
+  if max_chars <= 0 or len(text) <= max_chars:
+    return text, False
+
+  if note is not None:
+    marker = f"\n…{note}…\n"
+  else:
+    # The marker length affects the number of source characters that fit.
+    # Recalculate until the dropped-count width is stable.
+    dropped = len(text) - max_chars
+    while True:
+      marker = f"\n…[{dropped} characters truncated]…\n"
+      preserved = max(0, max_chars - len(marker))
+      actual = len(text) - preserved
+      if actual == dropped:
+        break
+      dropped = actual
+
+  if len(marker) >= max_chars:
+    return marker[:max_chars], True
+
+  preserved = max_chars - len(marker)
+  head = (preserved + 1) // 2
+  tail = preserved // 2
+  suffix = text[-tail:] if tail else ""
+  return f"{text[:head]}{marker}{suffix}", True

--- a/backend/tests/test_debug_status.py
+++ b/backend/tests/test_debug_status.py
@@ -129,3 +129,24 @@ def test_debug_status_does_not_silently_enable_guessed_payload_option(
     "omitted": True,
     "detail_url": "/api/debug/memory",
   }
+
+
+def test_debug_logs_bounds_each_returned_line(client, auth, tmp_path, monkeypatch):
+  from app.routes import debug
+
+  log_dir = tmp_path / "logs"
+  log_dir.mkdir()
+  (log_dir / "chat.log").write_text("start-" + ("x" * 5000) + "-finish\n")
+  monkeypatch.setattr(
+    debug,
+    "get_settings",
+    lambda: type("Settings", (), {"data_dir": str(tmp_path)})(),
+  )
+
+  response = client.get("/api/debug/logs?lines=10", headers=auth)
+
+  assert response.status_code == 200
+  line = response.json()["lines"][0]
+  assert len(line) == 4000
+  assert "characters truncated" in line
+  assert line.endswith("-finish")

--- a/backend/tests/test_restart_util.py
+++ b/backend/tests/test_restart_util.py
@@ -80,6 +80,47 @@ def test_restart_drains_then_requests_supervisor_and_arms_force_kill(monkeypatch
   assert calls[-1] == (os.getpid(), signal.SIGKILL)
 
 
+def test_restart_announces_server_restarting_on_the_system_bus(monkeypatch):
+  """The drain-gated restart publishes `server_restarting` to the system bus
+  before it drains — the ONLY cue that covers a graceful drain (health still
+  answers, so client reachability alone shows nothing). The shell mirrors it
+  into restartStore and lights its offline dot; see frontend restartStore.js."""
+  from app.broadcast import get_system_broadcast
+
+  _FakeTimer.instances = []
+  monkeypatch.setattr(ru.os, "kill", lambda pid, sig: None)
+  monkeypatch.setattr(ru.threading, "Timer", _FakeTimer)
+  monkeypatch.setattr(restart_ledger, "current_boot_id", lambda: "boot-12345678")
+  monkeypatch.setattr(restart_ledger, "new_nonce", lambda: "nonce-12345678")
+  monkeypatch.setattr(restart_ledger, "request_restart", lambda **kwargs: None)
+
+  async def _prepare(nonce):
+    del nonce
+    return []
+
+  observed_before_drain = []
+
+  async def _fake_drain(timeout=0, *, restart_nonce="", prepared_runs=None):
+    del timeout, restart_nonce, prepared_runs
+    observed_before_drain.append(q.get_nowait())
+    return []
+
+  monkeypatch.setattr(chat_mod, "prepare_restart_intents", _prepare)
+  monkeypatch.setattr(chat_mod, "drain_all_for_restart", _fake_drain)
+  chat_mod.draining = False
+
+  bus = get_system_broadcast()
+  q = bus.subscribe()
+  try:
+    assert q.empty()
+    asyncio.run(ru.restart_this_worker())
+  finally:
+    bus.unsubscribe(q)
+
+  assert observed_before_drain == [{"type": "server_restarting"}]
+  assert q.empty()
+
+
 def test_restart_request_survives_drain_failure(monkeypatch):
   _FakeTimer.instances = []
   calls = []

--- a/backend/tests/test_text_util.py
+++ b/backend/tests/test_text_util.py
@@ -1,0 +1,24 @@
+from app.text_util import elide
+
+
+def test_elide_bounds_total_output_and_keeps_both_ends():
+  source = "start-" + ("x" * 5000) + "-finish"
+
+  result, truncated = elide(source, 100)
+
+  assert truncated is True
+  assert len(result) == 100
+  assert result.startswith("start-")
+  assert result.endswith("-finish")
+  assert "characters truncated" in result
+
+
+def test_elide_non_positive_limit_disables_trimming():
+  assert elide("unchanged", 0) == ("unchanged", False)
+
+
+def test_elide_tiny_limit_still_honors_the_bound():
+  result, truncated = elide("oversized", 4)
+
+  assert truncated is True
+  assert len(result) == 4

--- a/frontend/public/mobius-runtime.js
+++ b/frontend/public/mobius-runtime.js
@@ -4007,6 +4007,7 @@ function makeProjects() {
 //#region src/runtime/index.js
 let _online = typeof navigator !== "undefined" ? navigator.onLine : true;
 const _onlineListeners = /* @__PURE__ */ new Set();
+let _probedVerdictReceived = false;
 function _setOnline(next) {
 	if (next === _online) return;
 	_online = next;
@@ -4014,15 +4015,22 @@ function _setOnline(next) {
 		cb(next);
 	} catch (e) {}
 }
+function _seedOnline(next) {
+	if (_probedVerdictReceived) return;
+	_setOnline(next);
+}
 if (typeof window !== "undefined") {
 	window.addEventListener("message", (e) => {
 		if (e.origin !== window.location.origin) return;
 		const msg = e.data;
 		if (!msg || typeof msg !== "object") return;
-		if (msg.type === "moebius:online-status" && typeof msg.online === "boolean") _setOnline(msg.online);
+		if (msg.type === "moebius:online-status" && typeof msg.online === "boolean") {
+			_probedVerdictReceived = true;
+			_setOnline(msg.online);
+		}
 	});
-	window.addEventListener("online", () => _setOnline(true));
-	window.addEventListener("offline", () => _setOnline(false));
+	window.addEventListener("online", () => _seedOnline(true));
+	window.addEventListener("offline", () => _seedOnline(false));
 }
 let _runtimeContext = null;
 const runtimeFeatures = Object.freeze({

--- a/frontend/src/components/ChatView/ChatSettingsPanel.jsx
+++ b/frontend/src/components/ChatView/ChatSettingsPanel.jsx
@@ -552,7 +552,7 @@ export default function ChatSettingsPanel({
     typeof providerUsage?.contextTokensUsed === 'number'
     && typeof providerUsage?.contextTokensMaximum === 'number'
   )
-    ? `${formatRoundedTokenCount(providerUsage.contextTokensUsed)} / ${formatRoundedTokenCount(providerUsage.contextTokensMaximum)} tokens`
+    ? `${formatRoundedTokenCount(providerUsage.contextTokensUsed)}/${formatRoundedTokenCount(providerUsage.contextTokensMaximum)} context`
     : 'Context'
   return (
     <div className="csp">

--- a/frontend/src/components/ChatView/__tests__/brainUsage.test.js
+++ b/frontend/src/components/ChatView/__tests__/brainUsage.test.js
@@ -21,13 +21,21 @@ test('context gauge measures the latest model call against its context window', 
   assert.equal(contextUsedPercent({ input_tokens: 100, context_window: 0 }), null)
 })
 
-test('context legend rounds current and maximum token counts to 1k', () => {
+test('context legend keeps token counts to three digits and a unit symbol', () => {
   assert.deepEqual(contextTokenCounts({
     input_tokens: 44_063,
     context_window: 258_400,
   }), { used: 44_063, maximum: 258_400 })
   assert.equal(formatRoundedTokenCount(66_648), '67k')
   assert.equal(formatRoundedTokenCount(258_400), '258k')
+  // Step up a unit instead of spilling into four-plus digits with a comma.
+  assert.equal(formatRoundedTokenCount(1_000_000), '1M')
+  assert.equal(formatRoundedTokenCount(1_400_000), '1.4M')
+  assert.equal(formatRoundedTokenCount(1_030_000_000), '1G')
+  // A value just under a threshold rounds up into the next unit rather than
+  // spilling to four digits (999_999 → "1M", not "1000k").
+  assert.equal(formatRoundedTokenCount(999_999), '1M')
+  assert.equal(formatRoundedTokenCount(999_999_999), '1G')
   assert.equal(formatRoundedTokenCount(0), '0')
   assert.equal(contextTokenCounts({ input_tokens: null, context_window: 258_400 }), null)
 })

--- a/frontend/src/components/ChatView/brainUsage.js
+++ b/frontend/src/components/ChatView/brainUsage.js
@@ -57,11 +57,39 @@ export function resolvedContextTokenCounts(snapshot, registry, provider, model) 
     : null
 }
 
+// Descending unit steps so a count keeps at most three digits before its
+// symbol: thousands (k), millions (M), billions (G).
+const TOKEN_UNITS = [
+  { limit: 1_000_000_000, symbol: 'G' },
+  { limit: 1_000_000, symbol: 'M' },
+  { limit: 1_000, symbol: 'k' },
+]
+
+// One decimal below ten (1.4M) keeps three significant digits, whole numbers
+// above; drop a bare ".0" so a round magnitude reads as "1M" not "1.0M".
+function _scaledText(value, limit) {
+  const scaled = value / limit
+  return scaled.toFixed(Math.abs(scaled) < 10 ? 1 : 0)
+}
+
 export function formatRoundedTokenCount(value) {
   if (typeof value !== 'number' || !Number.isFinite(value)) return ''
   if (Math.abs(value) < 500) return '0'
-  const thousands = Math.round(value / 1_000)
-  return `${new Intl.NumberFormat(undefined, { maximumFractionDigits: 0 }).format(thousands)}k`
+  for (let i = 0; i < TOKEN_UNITS.length; i++) {
+    if (Math.abs(value) < TOKEN_UNITS[i].limit) continue
+    let { symbol } = TOKEN_UNITS[i]
+    let text = _scaledText(value, TOKEN_UNITS[i].limit)
+    // Rounding a value just under the next threshold (999_999) can carry the
+    // scaled count to four digits ("1000k"); that magnitude reads as one unit
+    // up ("1M"). The carry is at most a single step, so promote once.
+    if (i > 0 && Math.abs(Number(text)) >= 1_000) {
+      symbol = TOKEN_UNITS[i - 1].symbol
+      text = _scaledText(value, TOKEN_UNITS[i - 1].limit)
+    }
+    return `${text.replace(/\.0$/, '')}${symbol}`
+  }
+  // 500–999 rounds up into the smallest unit instead of showing bare digits.
+  return `${Math.round(value / 1_000)}k`
 }
 
 export function contextUsedPercent(snapshot) {

--- a/frontend/src/runtime/index.js
+++ b/frontend/src/runtime/index.js
@@ -110,6 +110,13 @@ export * from './projects.js'
 // ─────────────────────────────────────────────────────────────────────────────
 let _online = typeof navigator !== 'undefined' ? navigator.onLine : true
 const _onlineListeners = new Set()
+// After AppCanvas posts its first probed verdict (on iframe load, then on every
+// change) the /api/health probe is the SOLE authority for connectivity. The raw
+// navigator online/offline events are only a pre-probe seed: navigator.onLine
+// reads 'true' on captive portals and dead LANs, so letting it keep driving
+// _online after a probe verdict has landed would let a false 'online' override a
+// correct offline verdict (and the reverse) — the two drivers silently contradict.
+let _probedVerdictReceived = false
 
 function _setOnline(next) {
   if (next === _online) return
@@ -119,6 +126,12 @@ function _setOnline(next) {
   }
 }
 
+// Seed connectivity from raw browser events ONLY until the first probed verdict.
+function _seedOnline(next) {
+  if (_probedVerdictReceived) return
+  _setOnline(next)
+}
+
 // Listen for the probed verdict from AppCanvas.
 if (typeof window !== 'undefined') {
   window.addEventListener('message', (e) => {
@@ -126,12 +139,13 @@ if (typeof window !== 'undefined') {
     const msg = e.data
     if (!msg || typeof msg !== 'object') return
     if (msg.type === 'moebius:online-status' && typeof msg.online === 'boolean') {
+      _probedVerdictReceived = true
       _setOnline(msg.online)
     }
   })
-  // Keep the seed roughly current before AppCanvas's first probed verdict.
-  window.addEventListener('online', () => _setOnline(true))
-  window.addEventListener('offline', () => _setOnline(false))
+  // Pre-probe seed only (see _seedOnline): inert once a probed verdict lands.
+  window.addEventListener('online', () => _seedOnline(true))
+  window.addEventListener('offline', () => _seedOnline(false))
 }
 // ─────────────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Consolidated subsystem changes grouping 4 reviewed improvements:

- Bound oversized debug log lines
- Test restart announcement before chat drain
- Keep probed app reachability authoritative
- Brain token counts: compact k/M/G units and a one-line context legend

## Testing

Each change was individually reviewed; the combined branch matches the reviewed local source and applies cleanly on current `main`.
