### PR TITLE
Restore one authoritative Claude runtime and local image provenance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ FROM python:3.12-slim-trixie
 
 # Copy Node.js binary from the frontend stage instead of installing via
 # apt.  The debian nodejs/npm packages pull in ~200MB of system node
-# packages we don't need — only the claude CLI and npm globals need Node.
+# packages we don't need — only npm globals need Node.
 COPY --from=node-runtime /usr/local/bin/node /usr/local/bin/node
 COPY --from=node-runtime /usr/local/lib/node_modules/npm /usr/local/lib/node_modules/npm
 RUN ln -s ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
@@ -42,7 +42,6 @@ RUN useradd -m -s /bin/bash mobius
 # agent-browser looks by default).
 # Discard npm's download cache in each layer: installed packages are the
 # runtime artifact; registry tarballs only make the production image larger.
-ARG CLAUDE_CODE_VERSION=2.1.258
 ARG CODEX_VERSION=0.152.1
 ARG AGENT_BROWSER_VERSION=0.35.1
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -52,8 +51,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libxfixes3 libxrandr2 libgbm1 libpango-1.0-0 libcairo2 libasound2t64 \
     fonts-liberation fonts-noto-color-emoji \
     && npm install -g --engine-strict --strict-allow-scripts \
-      --allow-scripts="@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION},@openai/codex@${CODEX_VERSION},agent-browser@${AGENT_BROWSER_VERSION}" \
-      "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
+      --allow-scripts="@openai/codex@${CODEX_VERSION},agent-browser@${AGENT_BROWSER_VERSION}" \
       "@openai/codex@${CODEX_VERSION}" \
       "agent-browser@${AGENT_BROWSER_VERSION}" \
     && agent-browser install \
@@ -135,7 +133,11 @@ WORKDIR /app
 COPY backend/requirements.txt backend/requirements.lock ./
 RUN pip install --no-cache-dir --require-hashes -r requirements.lock \
     && python -c \
-      'from pathlib import Path; import claude_agent_sdk; p = Path(claude_agent_sdk.__file__).parent / "_bundled" / "claude"; p.unlink(missing_ok=True); assert not p.exists()'
+      'from pathlib import Path; import claude_agent_sdk; p = Path(claude_agent_sdk.__file__).parent / "_bundled" / "claude"; assert p.is_file() and p.stat().st_mode & 0o111' \
+    && ln -s "$(python -c 'from pathlib import Path; import claude_agent_sdk; print(Path(claude_agent_sdk.__file__).parent / "_bundled" / "claude")')" /usr/local/bin/claude \
+    && python -c \
+      'from pathlib import Path; import shutil, claude_agent_sdk; assert Path(shutil.which("claude")).samefile(Path(claude_agent_sdk.__file__).parent / "_bundled" / "claude")' \
+    && claude --version | grep -Fx '2.1.259 (Claude Code)'
 
 # openai-codex Python SDK: its upstream pyproject pins a second, older
 # openai-codex-cli-bin payload. Keep that declared package so `pip check` and
@@ -173,18 +175,19 @@ RUN pip install --no-cache-dir --no-deps \
       'from pathlib import Path; import openai_codex; from codex_cli_bin import bundled_codex_path; assert bundled_codex_path().samefile(Path("/usr/local/bin/codex"))' \
     && pip check
 
-# Capture each installed agent CLI's npm publish date into a small JSON the
+# Capture each installed agent CLI's publish date into a small JSON the
 # Settings row reads (routes/settings._cli_release_dates), keyed by the
-# version actually installed above. Done at build time so a CLI pin bump
+# version reported by its actual executable. Done at build time so a CLI bump
 # refreshes the date automatically — no hand-maintained map, no test to
 # satisfy. Best effort: if the npm registry is unreachable the file is left
 # empty and the Settings row simply shows the bare version, never an error.
 RUN if ! node -e "const cp=require('child_process'),fs=require('fs');\
-const want=['@anthropic-ai/claude-code','@openai/codex'];\
 let installed={};\
 try{installed=(JSON.parse(cp.execSync('npm ls -g --depth=0 --json',{stdio:['ignore','pipe','ignore']}).toString()).dependencies)||{};}catch(e){}\
+const claude=(cp.execSync('claude --version').toString().match(/^(\\S+)/)||[])[1];\
+const want={'@anthropic-ai/claude-code':claude,'@openai/codex':installed['@openai/codex']&&installed['@openai/codex'].version};\
 const out={};\
-for(const name of want){const v=installed[name]&&installed[name].version;if(!v)continue;\
+for(const [name,v] of Object.entries(want)){if(!v)continue;\
 try{const t=JSON.parse(cp.execSync('npm view '+name+'@'+v+' time --json',{stdio:['ignore','pipe','ignore']}).toString());if(t&&t[v])out[v]=String(t[v]).slice(0,10);}catch(e){}}\
 fs.writeFileSync('/app/cli-release-dates.json',JSON.stringify(out));\
 console.log('cli-release-dates.json:',JSON.stringify(out));"; then \
@@ -274,14 +277,26 @@ RUN python /tmp/verify-legacy-jose.py && rm /tmp/verify-legacy-jose.py
 # the checkout being built. The disposable test compose is the sole explicit
 # exception because it mounts and verifies its checkout at runtime.
 ARG MOBIUS_PLATFORM_ORIGIN=https://github.com/mobius-os/mobius.git
+# A local deployment may fetch an unpushed reviewed commit from a temporary,
+# trusted Host-side Git service. Keep that transport separate from the durable
+# origin written into the baked checkout so a container never retains an
+# ephemeral or host-private URL.
+ARG MOBIUS_PLATFORM_FETCH_ORIGIN=
 ARG BUILD_SHA=unknown
 ARG BUILD_DATE=unknown
 ARG RAILWAY_GIT_COMMIT_SHA=unknown
 ARG RAILWAY_DEPLOYMENT_ID=unknown
 ARG MOBIUS_ALLOW_UNKNOWN_BUILD_SHA=0
+ARG MOBIUS_USE_LOCAL_PLATFORM_SOURCE=0
+ARG MOBIUS_LOCAL_PLATFORM_SHA=unknown
+ARG MOBIUS_LOCAL_PLATFORM_DATE=unknown
 RUN set -eux; \
     _build_sha="${BUILD_SHA:-unknown}"; \
     _railway_sha="${RAILWAY_GIT_COMMIT_SHA:-unknown}"; \
+    _platform_fetch_origin="${MOBIUS_PLATFORM_FETCH_ORIGIN:-$MOBIUS_PLATFORM_ORIGIN}"; \
+    case "${MOBIUS_USE_LOCAL_PLATFORM_SOURCE:-0}" in 0|1) ;; *) \
+      echo "FATAL: MOBIUS_USE_LOCAL_PLATFORM_SOURCE must be 0 or 1" >&2; exit 1;; \
+    esac; \
     if [ "$_build_sha" = "unknown" ] && [ "$_railway_sha" != "unknown" ] && [ -n "$_railway_sha" ]; then \
       _build_sha="$_railway_sha"; \
     fi; \
@@ -293,13 +308,14 @@ RUN set -eux; \
       echo "FATAL: an exact 40-character BUILD_SHA is required; set it to the checkout commit before building" >&2; \
       exit 1; \
     fi; \
-    git clone --depth 1 "$MOBIUS_PLATFORM_ORIGIN" /app/platform-baked; \
+    git clone --depth 1 "$_platform_fetch_origin" /app/platform-baked; \
     _build_date="${BUILD_DATE:-unknown}"; \
     if [ "$_build_date" = "unknown" ] || [ -z "$_build_date" ]; then \
       _build_date="$(date -u +%Y-%m-%d)"; \
     fi; \
-    if printf '%s' "$_build_sha" | grep -Eq '^[0-9a-fA-F]{40}$'; then \
-      if git -C /app/platform-baked fetch --depth 1 origin "$_build_sha" \
+    if [ "${MOBIUS_USE_LOCAL_PLATFORM_SOURCE:-0}" != "1" ] \
+       && printf '%s' "$_build_sha" | grep -Eq '^[0-9a-fA-F]{40}$'; then \
+      if git -C /app/platform-baked fetch --depth 1 "$_platform_fetch_origin" "$_build_sha" \
          && git -C /app/platform-baked checkout "$_build_sha"; then \
         :; \
       else \
@@ -329,6 +345,61 @@ RUN set -eux; \
       > /app/build-info.json; \
     chown -R root:root /app/platform-baked; \
     chmod -R a+rX,go-w /app/platform-baked
+
+# `railway up` uploads a working tree rather than a Git source deployment, so
+# Railway cannot provide RAILWAY_GIT_COMMIT_SHA. Review deployments may still
+# need the exact unpushed checkout to seed /data/platform. Keep that exception
+# explicit and provenance-bound: normal builds never copy this overlay, while
+# the opt-in path requires the caller to name the exact local commit and records
+# a synthetic Git commit whose tree is the uploaded source.
+COPY . /tmp/mobius-local-platform-source/
+RUN set -eux; \
+    case "${MOBIUS_USE_LOCAL_PLATFORM_SOURCE:-0}" in 0|1) ;; *) \
+      echo "FATAL: MOBIUS_USE_LOCAL_PLATFORM_SOURCE must be 0 or 1" >&2; exit 1;; \
+    esac; \
+    if [ "${MOBIUS_USE_LOCAL_PLATFORM_SOURCE:-0}" = "1" ]; then \
+      printf '%s' "${MOBIUS_LOCAL_PLATFORM_SHA:-unknown}" \
+        | grep -Eq '^[0-9a-fA-F]{40}$' \
+        || { echo "FATAL: local platform source requires its exact Git SHA" >&2; exit 1; }; \
+      cp -a /tmp/mobius-local-platform-source/. /app/platform-baked/; \
+      git -C /app/platform-baked add -A; \
+      git -C /app/platform-baked commit --allow-empty \
+        -m "Seed local review source ${MOBIUS_LOCAL_PLATFORM_SHA}"; \
+      git -C /app/platform-baked checkout -B main HEAD; \
+      git -C /app/platform-baked branch -f upstream HEAD; \
+      git -C /app/platform-baked update-ref refs/remotes/origin/main HEAD; \
+      if [ -d /app/platform-baked/frontend ]; then \
+        cd /app/platform-baked/frontend; \
+        [ -e node_modules ] || [ -L node_modules ] \
+          || ln -s /app/shell-src/node_modules node_modules; \
+        mkdir -p dist; \
+        cp -a /app/static/. dist/; \
+      fi; \
+      git -C /app/platform-baked rev-parse HEAD > /app/platform-baked/.baked-sha; \
+      printf '{"sha":"%s","build_date":"%s","railway_deployment_id":"%s","source":"local-overlay"}\n' \
+        "${MOBIUS_LOCAL_PLATFORM_SHA}" \
+        "${MOBIUS_LOCAL_PLATFORM_DATE:-unknown}" \
+        "${RAILWAY_DEPLOYMENT_ID:-unknown}" > /app/build-info.json; \
+      chown -R root:root /app/platform-baked; \
+      chmod -R a+rX,go-w /app/platform-baked; \
+    fi; \
+    rm -rf /tmp/mobius-local-platform-source
+
+# What this image actually contains, so a running container can compare itself
+# with the source it serves instead of remembering which update touched what:
+# the hash of every image input at the baked checkout (build-info.json
+# `image_inputs`), and the package inventories the layers above installed. A
+# later `pip`/`apt` install made live in a container shows up as a difference
+# from these lists, which is exactly what a replacement would drop.
+RUN set -eux; \
+    python3 -c 'import json, subprocess, pathlib; \
+info = pathlib.Path("/app/build-info.json"); data = json.loads(info.read_text()); \
+data["image_inputs"] = json.loads(subprocess.run(["python3", "/app/platform-baked/backend/app/platform_activation.py", "--hashes", "/app/platform-baked"], check=True, capture_output=True, text=True).stdout); \
+info.write_text(json.dumps(data, sort_keys=True) + "\n")'; \
+    mkdir -p /app/image-inventory; \
+    pip freeze --disable-pip-version-check 2>/dev/null | sort > /app/image-inventory/pip.txt; \
+    dpkg-query -W -f '${Package}=${Version}\n' | sort > /app/image-inventory/apt.txt; \
+    chmod -R a+rX /app/image-inventory /app/build-info.json
 
 # Initialize the runtime volume paths for the non-root agent user.
 RUN mkdir -p /data/db /data/apps /data/compiled /data/shared \

--- a/backend/app/platform_activation.py
+++ b/backend/app/platform_activation.py
@@ -367,11 +367,57 @@ def dependency_fingerprint_paths(root: Path) -> list[str]:
   return sorted(paths)
 
 
+def image_input_paths(root: Path) -> list[str]:
+  """Every source path the container image bakes in, as it exists in ``root``.
+
+  The dependency inputs plus the baked runtime/bootstrap tree: exactly the
+  paths whose change the classifier says needs a new image (or, for Python
+  requirements, an in-place install). Hashing them at build time and again at
+  runtime answers "does the running image still match this source?" directly,
+  instead of remembering which update touched what.
+  """
+  paths: set[str] = set(dependency_fingerprint_paths(root))
+  for rule in _RULES:
+    if rule.level is not ActivationLevel.IMAGE_REBUILD or rule.dependency_fingerprint:
+      continue
+    for exact in rule.exact:
+      if (root / exact).is_file():
+        paths.add(exact)
+    for prefix in rule.prefixes:
+      base = root / prefix
+      if base.is_dir():
+        paths.update(
+          str(path.relative_to(root))
+          for path in base.rglob("*")
+          if path.is_file()
+        )
+  return sorted(path for path in paths if (root / path).is_file())
+
+
+def image_input_hashes(root: Path) -> dict[str, str]:
+  import hashlib
+
+  return {
+    path: hashlib.sha256((root / path).read_bytes()).hexdigest()
+    for path in image_input_paths(root)
+  }
+
+
 def _main() -> int:
   parser = argparse.ArgumentParser()
   parser.add_argument("root", type=Path)
+  parser.add_argument(
+    "--hashes", action="store_true",
+    help="print the image input hashes as JSON instead of the fingerprint paths",
+  )
   args = parser.parse_args()
-  for path in dependency_fingerprint_paths(args.root.resolve()):
+  root = args.root.resolve()
+  if args.hashes:
+    import json
+
+    print(json.dumps(image_input_hashes(root), sort_keys=True))
+    return 0
+  for path in dependency_fingerprint_paths(root):
     print(path)
   return 0
 

--- a/backend/app/platform_update.py
+++ b/backend/app/platform_update.py
@@ -274,6 +274,10 @@ class PlatformReviewedRebuild(TypedDict):
   local_base_sha: str
   activation: PlatformActivationImpact
   blockers: list[str]
+  # Packages installed live in this container that the running image does not
+  # carry (``pip``/``apt`` entries as ``name==version`` / ``name=version``).
+  # A replacement drops them; the owner decides whether that matters.
+  live_installs: dict[str, list[str]]
 
 
 class _ActivationMarker(TypedDict):
@@ -1130,6 +1134,7 @@ def reviewed_container_rebuild_plan(
       local_base_sha=base,
       activation=activation,
       blockers=blockers,
+      live_installs=live_install_drift(),
     )
 
 
@@ -1284,7 +1289,95 @@ def _pending_activation_paths(repo: Path = PLATFORM_REPO) -> list[str]:
     except Exception:
       head = None
     paths.extend(_activation_paths_between(repo, served, head))
+  paths.extend(image_input_drift(repo) or [])
   return sorted({str(path) for path in paths if str(path)})
+
+
+def _build_info() -> dict:
+  path = Path(os.environ.get("MOBIUS_BUILD_INFO_PATH", "/app/build-info.json"))
+  try:
+    data = json.loads(path.read_text(encoding="utf-8"))
+  except Exception:
+    return {}
+  return data if isinstance(data, dict) else {}
+
+
+def image_input_drift(repo: Path = PLATFORM_REPO) -> list[str] | None:
+  """Image inputs whose served source no longer matches the running image.
+
+  The image records the hash of every input it was built from
+  (``build-info.json`` ``image_inputs``). Comparing those with the same paths
+  in the served checkout says, from state alone, whether this container still
+  matches its source — no marker to remember, no ancestry to prove. The
+  classifier then turns each differing path into its activation level
+  (Python requirements install in place; anything else needs a new image).
+  Returns None when the running image predates the record.
+  """
+  baked = _build_info().get("image_inputs")
+  if not isinstance(baked, dict) or not baked:
+    return None
+  try:
+    current = platform_activation.image_input_hashes(repo)
+  except OSError:
+    return None
+  return sorted(
+    path for path in set(baked) | set(current)
+    if baked.get(path) != current.get(path)
+  )
+
+
+def _inventory_drift(
+  baked_path: Path, current: list[str],
+) -> list[str] | None:
+  try:
+    baked = set(
+      line.strip() for line in baked_path.read_text(encoding="utf-8").splitlines()
+    )
+  except OSError:
+    return None
+  return sorted(
+    line.strip() for line in current
+    if line.strip() and line.strip() not in baked
+  )
+
+
+def live_install_drift(
+  inventory_dir: Path | None = None,
+  *,
+  run: Callable[..., subprocess.CompletedProcess] = subprocess.run,
+) -> dict[str, list[str]]:
+  """Packages present in this container that its image did not install.
+
+  Agents may ``pip``/``apt`` install into the running container; that is the
+  cheap, restart-free path and it survives a process restart, but a container
+  replacement rebuilds from the image and silently drops it. The image bakes
+  its own ``pip freeze`` and ``dpkg-query`` inventories; anything the current
+  container has beyond them is what a replacement would lose. An image
+  without inventories reports nothing rather than guessing.
+  """
+  root = inventory_dir or Path(
+    os.environ.get("MOBIUS_IMAGE_INVENTORY_DIR", "/app/image-inventory"),
+  )
+  commands = {
+    "pip": [sys.executable or "python3", "-m", "pip", "freeze",
+            "--disable-pip-version-check"],
+    "apt": ["dpkg-query", "-W", "-f", "${Package}=${Version}\n"],
+  }
+  drift: dict[str, list[str]] = {}
+  for kind, command in commands.items():
+    baked_path = root / f"{kind}.txt"
+    if not baked_path.is_file():
+      continue
+    try:
+      proc = run(command, capture_output=True, text=True, timeout=60, check=False)
+    except (OSError, subprocess.SubprocessError):
+      continue
+    if proc.returncode != 0:
+      continue
+    extras = _inventory_drift(baked_path, proc.stdout.splitlines())
+    if extras:
+      drift[kind] = extras
+  return drift
 
 
 def _platform_activation_impact(

--- a/backend/requirements.lock
+++ b/backend/requirements.lock
@@ -147,7 +147,6 @@ anyio==4.14.2 \
     # via
     #   claude-agent-sdk
     #   httpx
-    #   httpx2
     #   mcp
     #   sse-starlette
     #   starlette
@@ -428,13 +427,13 @@ charset-normalizer==3.4.9 \
     --hash=sha256:fa36ec09ef71d158186bc79e359ff5fdd6e7996fe8ab638f00d6b93139ba4fcf \
     --hash=sha256:fe2c7201c642b7c308f1675355ad7ff7b66acfe3541625efe5a3ad38f29d6115
     # via requests
-claude-agent-sdk==0.2.148 \
-    --hash=sha256:026e2b54bb3f3909712ff462b8469e2b1fc5471cfde796abc23f32d30b2c8ba1 \
-    --hash=sha256:221efbc0f583c80258189ab93e4f0d6b6a61ad61335de1fdf3e2331ad423dbeb \
-    --hash=sha256:3fbbea7cc30099d14f894e12fef68b0ee42fa9982567df94e59499b6aff55959 \
-    --hash=sha256:45c9972fa72dc6006745239c6838cc3cea7a9b42d6927c89f7bdb6996a1983b0 \
-    --hash=sha256:c8cca1f4e4eb4e0c9f44ccfca6f651cf35e8f3914e483632ae8867c5619818a0 \
-    --hash=sha256:f155252940fd77f1bcc707836924ca3a9691d19bbc464914ae2b7ccf17f0410f
+claude-agent-sdk==0.2.152 \
+    --hash=sha256:0822bbdf700ccdd1acecf8365345a56bde07833afe7f8bd1bee68cba0e2fcf9a \
+    --hash=sha256:1e5b619e6fa3c98f06ddc107652f7820c4573fb73a9a24263568d9974078bbc2 \
+    --hash=sha256:6cc1e949743c7634274ae526bfd1c0a216ff9d71c6b36d94cab80f32b0d32b4c \
+    --hash=sha256:9c79c4ef91b15e5fae6aba62a82afb983dc360bc159902c541046227e2852c86 \
+    --hash=sha256:f422c256358997ffa3a740f9fdc8127aa8404a9d57493502dc7d2ac05ecb5486 \
+    --hash=sha256:f885bd935054082a599dcf92bbdaf3c0b853117a79375cb3aae74674a8124326
     # via -r requirements.txt
 click==8.4.2 \
     --hash=sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6 \
@@ -729,7 +728,6 @@ h11==0.16.0 \
     --hash=sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86
     # via
     #   httpcore
-    #   httpcore2
     #   uvicorn
 http-ece==1.2.1 \
     --hash=sha256:8c6ab23116bbf6affda894acfd5f2ca0fb8facbcbb72121c11c75c33e7ce8cff
@@ -738,10 +736,6 @@ httpcore==1.0.9 \
     --hash=sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55 \
     --hash=sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8
     # via httpx
-httpcore2==2.12.0 \
-    --hash=sha256:7e04258ce01013d7d615e5b910a3b27fac937d7a95038227e79652b4ba3b4ceb \
-    --hash=sha256:9293522bba0aa7c4c8e9e3f040c16575bd8868e155a77fa30c7a9085a5eae648
-    # via httpx2
 httptools==0.8.0 \
     --hash=sha256:0770728beb05094c809b98e814edff5fef69d26ad7d21185f2f6d5884a0ba683 \
     --hash=sha256:0ea897f0c729581ebf72131a438a7932d9b14efef72d75ada966700cac3caaeb \
@@ -804,10 +798,6 @@ httpx-sse==0.4.3 \
     --hash=sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc \
     --hash=sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d
     # via mcp
-httpx2==2.12.0 \
-    --hash=sha256:7631fe9887a8a2275f4a2540e053aa670fcc50742864a9ae7c66e609fdcf12cf \
-    --hash=sha256:cc8b6eecb8661c146b8f89a60e97456ee086e91a784ed31ac450c3a9e613dd36
-    # via -r requirements.txt
 idna==3.18 \
     --hash=sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2 \
     --hash=sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848
@@ -815,7 +805,6 @@ idna==3.18 \
     #   anyio
     #   email-validator
     #   httpx
-    #   httpx2
     #   requests
     #   yarl
 iniconfig==2.3.0 \
@@ -1673,12 +1662,6 @@ starlette==1.3.1 \
     #   fastapi
     #   mcp
     #   sse-starlette
-truststore==0.10.4 \
-    --hash=sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301 \
-    --hash=sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981
-    # via
-    #   httpcore2
-    #   httpx2
 typing-extensions==4.16.0 \
     --hash=sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8 \
     --hash=sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5
@@ -1687,7 +1670,6 @@ typing-extensions==4.16.0 \
     #   aiosignal
     #   anyio
     #   fastapi
-    #   httpx2
     #   limits
     #   mcp
     #   pydantic

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,16 +8,13 @@ python-multipart>=0.0.18
 pydantic[email]>=2.13.5
 pydantic-settings>=2.15.0
 slowapi>=0.1.10
-# Runtime integrations use httpx; the self-testing runtime's Starlette
-# TestClient imports httpx2 instead of its deprecated httpx fallback.
 httpx>=0.28.0
-httpx2>=2.12.0
 Pillow>=11.0.0
 pywebpush>=2.0.0
 pytest>=8.0
 pytest-asyncio>=0.23
 watchdog>=4.0.0
-claude-agent-sdk==0.2.148
+claude-agent-sdk==0.2.152
 # openai-codex is installed --no-deps from a pinned Git SHA in Dockerfile.
 # Its declared cli-bin package is retained for SDK compatibility, but its
 # duplicate payload is replaced in-layer with a link to the pinned npm CLI.

--- a/backend/tests/test_platform_activation.py
+++ b/backend/tests/test_platform_activation.py
@@ -1,6 +1,9 @@
 """Activation classification is one ordered contract across deployments."""
 
+import json
 import re
+import subprocess
+import sys
 from pathlib import Path
 
 from app import platform_activation as activation
@@ -171,3 +174,45 @@ def test_bootstrap_allowlist_covers_entrypoint_app_script_references():
     assert activation.classify_activation([
       f"backend/scripts/{name}",
     ])["level"] == "image_rebuild", name
+
+
+def test_image_inputs_cover_dependency_and_baked_runtime_paths(tmp_path):
+  (tmp_path / "backend" / "runtime").mkdir(parents=True)
+  (tmp_path / "backend" / "app").mkdir(parents=True)
+  (tmp_path / "Dockerfile").write_text("FROM scratch\n")
+  (tmp_path / "backend" / "requirements.lock").write_text("a==1\n")
+  (tmp_path / "backend" / "runtime" / "broker.py").write_text("x = 1\n")
+  (tmp_path / "backend" / "app" / "main.py").write_text("y = 2\n")
+
+  paths = activation.image_input_paths(tmp_path)
+
+  # Only existing files; the served backend app is not an image input.
+  assert paths == [
+    "Dockerfile", "backend/requirements.lock", "backend/runtime/broker.py",
+  ]
+  hashes = activation.image_input_hashes(tmp_path)
+  assert set(hashes) == set(paths)
+  assert all(len(value) == 64 for value in hashes.values())
+  # Every input is a path the classifier already treats as image-owned.
+  for path in paths:
+    level = activation.classify_activation([path])["level"]
+    assert level in {
+      activation.ActivationLevel.IMAGE_REBUILD.value,
+      activation.ActivationLevel.DEPENDENCY_SYNC.value,
+    }
+
+
+def test_image_input_hashes_cli_matches_the_library_contract(tmp_path):
+  (tmp_path / "backend" / "runtime").mkdir(parents=True)
+  (tmp_path / "Dockerfile").write_text("FROM scratch\n")
+  (tmp_path / "backend" / "runtime" / "broker.py").write_text("x = 1\n")
+
+  module = Path(activation.__file__)
+  completed = subprocess.run(
+    [sys.executable, str(module), "--hashes", str(tmp_path)],
+    check=True,
+    capture_output=True,
+    text=True,
+  )
+
+  assert json.loads(completed.stdout) == activation.image_input_hashes(tmp_path)

--- a/backend/tests/test_platform_update.py
+++ b/backend/tests/test_platform_update.py
@@ -2473,3 +2473,63 @@ def test_boot_policy_ignores_durable_update_progress_from_outer_data_repo():
 
   assert "init_data_repo.py write-ignore /data" in entrypoint
   assert ".platform-update-progress.json" in data_repo_helper
+
+
+# --- the running image compared with the served source -----------------------
+
+def test_image_input_drift_feeds_the_activation_state(clone_env, monkeypatch, tmp_path):
+  _origin, platform = clone_env
+  (platform / "Dockerfile").write_text("FROM python:3.12\n")
+  (platform / "backend" / "requirements.lock").write_text("a==1\n")
+  _git(platform, "add", "-A")
+  _git(platform, "commit", "-q", "-m", "image inputs")
+  info = tmp_path / "build-info.json"
+  monkeypatch.setenv("MOBIUS_BUILD_INFO_PATH", str(info))
+
+  # An image that predates the record says nothing.
+  info.write_text(json.dumps({"sha": "x"}))
+  assert pu.image_input_drift(platform) is None
+
+  # An image built from exactly these inputs matches.
+  info.write_text(json.dumps({
+    "sha": "x",
+    "image_inputs": platform_activation.image_input_hashes(platform),
+  }))
+  assert pu.image_input_drift(platform) == []
+  assert pu.platform_status(platform)["activation"]["level"] == "live"
+
+  # A dependency bump is an in-place install; a Dockerfile change needs a new
+  # image. Both come from state, not from remembering which update did it.
+  (platform / "backend" / "requirements.lock").write_text("a==2\n")
+  assert pu.image_input_drift(platform) == ["backend/requirements.lock"]
+  assert pu.platform_status(platform)["activation"]["level"] == "dependency_sync"
+  (platform / "Dockerfile").write_text("FROM python:3.13\n")
+  assert pu.image_input_drift(platform) == [
+    "Dockerfile", "backend/requirements.lock",
+  ]
+  assert pu.platform_status(platform)["activation"]["level"] == "image_rebuild"
+
+
+def test_live_install_drift_reports_only_what_the_image_lacks(tmp_path):
+  inventory = tmp_path / "inventory"
+  inventory.mkdir()
+  (inventory / "pip.txt").write_text("fastapi==0.1\nhttpx==2\n")
+  (inventory / "apt.txt").write_text("curl=8\ngit=2\n")
+  outputs = {
+    "pip": "fastapi==0.1\nhttpx==3\nrich==13\n",
+    "dpkg-query": "curl=8\ngit=2\nffmpeg=6\n",
+  }
+
+  def fake_run(command, **_kwargs):
+    key = "pip" if "pip" in command else "dpkg-query"
+    return SimpleNamespace(returncode=0, stdout=outputs[key])
+
+  assert pu.live_install_drift(inventory, run=fake_run) == {
+    "pip": ["httpx==3", "rich==13"],
+    "apt": ["ffmpeg=6"],
+  }
+  # No inventories (an older image): nothing is claimed.
+  assert pu.live_install_drift(tmp_path / "missing", run=fake_run) == {}
+  # A failing query is not reported as drift.
+  failing = lambda command, **_k: SimpleNamespace(returncode=1, stdout="")
+  assert pu.live_install_drift(inventory, run=failing) == {}

--- a/backend/tests/test_verify_test_runtime.py
+++ b/backend/tests/test_verify_test_runtime.py
@@ -150,6 +150,10 @@ def test_test_wrapper_isolates_compose_and_rejects_stale_images():
     'git -C /app/platform-baked remote set-url origin "$MOBIUS_PLATFORM_ORIGIN"'
     in dockerfile
   )
+  assert (
+    'platform_activation.py", "--hashes", "/app/platform-baked"'
+    in dockerfile
+  )
   compose = (ROOT / "docker-compose.yml").read_text(encoding="utf-8")
   assert "MOBIUS_USE_LOCAL_PLATFORM_SOURCE:" in compose
   assert "MOBIUS_LOCAL_PLATFORM_SHA:" in compose

--- a/backend/tests/test_verify_test_runtime.py
+++ b/backend/tests/test_verify_test_runtime.py
@@ -108,6 +108,22 @@ def test_test_compose_pins_runtime_to_mounted_checkout():
   assert "\n    init: true\n" in pytest_service
 
 
+def test_e2e_startup_has_one_bounded_readiness_owner():
+  compose = (ROOT / "docker-compose.test.yml").read_text(encoding="utf-8")
+  caddy_service = compose.split("\n  caddy:\n", 1)[1].split("\n  app:\n", 1)[0]
+  assert "condition: service_started" in caddy_service
+  assert "condition: service_healthy" not in caddy_service
+
+  workflow = (ROOT / ".github" / "workflows" / "test.yml").read_text(
+    encoding="utf-8"
+  )
+  startup = workflow.split("- name: Start test container", 1)[1].split(
+    "- name: Set up Node with npm cache", 1
+  )[0]
+  assert "timeout 120" in startup
+  assert ".State.Health.Status" in startup
+
+
 def test_test_wrapper_isolates_compose_and_rejects_stale_images():
   wrapper = (ROOT / "scripts" / "test.sh").read_text(encoding="utf-8")
   assert 'TEST_PROJECT="${MOBIUS_TEST_PROJECT:-mobius-test-' in wrapper

--- a/backend/tests/test_verify_test_runtime.py
+++ b/backend/tests/test_verify_test_runtime.py
@@ -14,13 +14,6 @@ SHA = "a" * 40
 ROOT = Path(__file__).resolve().parents[2]
 
 
-def test_starlette_test_client_uses_supported_httpx2_transport():
-  import httpx2
-  from starlette.testclient import TestClient
-
-  assert issubclass(TestClient, httpx2.Client)
-
-
 def _version(**overrides):
   value = {
     "test_runtime": True,
@@ -133,7 +126,9 @@ def test_test_wrapper_isolates_compose_and_rejects_stale_images():
   )
   backend_source = "COPY backend/app ./app/"
   backend_scripts = "COPY backend/scripts ./scripts/"
-  platform_seed = 'git clone --depth 1 "$MOBIUS_PLATFORM_ORIGIN" /app/platform-baked'
+  platform_seed = (
+    'git clone --depth 1 "$_platform_fetch_origin" /app/platform-baked'
+  )
   frontend_source = "COPY frontend/ ./shell-src/"
   assert dockerfile.count(backend_source) == 1
   assert dockerfile.count(backend_scripts) == 1
@@ -142,6 +137,26 @@ def test_test_wrapper_isolates_compose_and_rejects_stale_images():
     assert dockerfile.index(asset_stage) < dockerfile.index(frontend_source)
   assert dockerfile.index(frontend_source) < dockerfile.index(platform_seed)
   assert dockerfile.index(platform_seed) < dockerfile.index(backend_source)
+  assert "ARG MOBIUS_PLATFORM_FETCH_ORIGIN=" in dockerfile
+  assert (
+    '[ "${MOBIUS_USE_LOCAL_PLATFORM_SOURCE:-0}" != "1" ]'
+    in dockerfile
+  )
+  assert (
+    'git -C /app/platform-baked fetch --depth 1 "$_platform_fetch_origin"'
+    in dockerfile
+  )
+  assert (
+    'git -C /app/platform-baked remote set-url origin "$MOBIUS_PLATFORM_ORIGIN"'
+    in dockerfile
+  )
+  compose = (ROOT / "docker-compose.yml").read_text(encoding="utf-8")
+  assert "MOBIUS_USE_LOCAL_PLATFORM_SOURCE:" in compose
+  assert "MOBIUS_LOCAL_PLATFORM_SHA:" in compose
+  assert "MOBIUS_LOCAL_PLATFORM_DATE:" in compose
+  deploy = (ROOT / "scripts" / "deploy-prod.sh").read_text(encoding="utf-8")
+  assert "MOBIUS_USE_LOCAL_PLATFORM_SOURCE=1 requires a clean" in deploy
+  assert 'export MOBIUS_LOCAL_PLATFORM_SHA="$_sha"' in deploy
 
 
 def test_node_runtime_satisfies_the_pinned_agent_browser_engine():
@@ -149,7 +164,6 @@ def test_node_runtime_satisfies_the_pinned_agent_browser_engine():
   preship = (ROOT / "scripts" / "preship-gate.sh").read_text(encoding="utf-8")
   assert "FROM node:24-trixie-slim AS node-runtime" in dockerfile
   pinned_script_packages = {
-    "@anthropic-ai/claude-code": "CLAUDE_CODE_VERSION",
     "@openai/codex": "CODEX_VERSION",
     "agent-browser": "AGENT_BROWSER_VERSION",
   }
@@ -209,18 +223,31 @@ def test_image_deduplicates_agent_cli_payloads_without_breaking_sdk_contracts():
     "pip install --no-cache-dir --require-hashes -r requirements.lock"
     in requirements_layer
   )
-  assert "claude-agent-sdk==0.2.148" in requirements
-  assert "claude-agent-sdk==0.2.148" in requirements_lock
+  assert "claude-agent-sdk==0.2.152" in requirements
+  assert "claude-agent-sdk==0.2.152" in requirements_lock
   assert (
     'Path(claude_agent_sdk.__file__).parent / "_bundled" / "claude"'
     in requirements_layer
-    and "unlink(missing_ok=True)" in requirements_layer
-    and "assert not p.exists()" in requirements_layer
+    and 'ln -s "$(python -c' in requirements_layer
+    and 'Path(shutil.which("claude")).samefile' in requirements_layer
+    and "claude --version | grep -Fx '2.1.259 (Claude Code)'" in requirements_layer
   )
+  assert "CLAUDE_CODE_VERSION" not in dockerfile
+  install_layer = dockerfile[
+    dockerfile.index("RUN apt-get update"):
+    dockerfile.index("# Capture each installed agent CLI's publish date")
+  ]
+  assert "@anthropic-ai/claude-code" not in install_layer
+  release_dates_layer = dockerfile[
+    dockerfile.index("# Capture each installed agent CLI's publish date"):
+    dockerfile.index("# Install the shell and mini-app compiler dependency tree")
+  ]
+  assert "cp.execSync('claude --version')" in release_dates_layer
+  assert "'@anthropic-ai/claude-code':claude" in release_dates_layer
 
   codex_layer = dockerfile[
     dockerfile.index("# openai-codex Python SDK:"):
-    dockerfile.index("# Capture each installed agent CLI")
+    dockerfile.index("# Capture each installed agent CLI's publish date")
   ]
   assert "pip install --no-cache-dir --no-deps" in codex_layer
   assert "pip install --no-cache-dir 'openai-codex-cli-bin==0.147.0'" in codex_layer

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -15,7 +15,11 @@ services:
     ports: !override ["${TEST_PORT:-8001}:${TEST_PORT:-8001}"]
     depends_on:
       app:
-        condition: service_healthy
+        # CI owns one bounded 120-second readiness gate after Compose returns.
+        # Waiting for this healthcheck here as well made Compose enforce its
+        # shorter retry budget first, so a cold first boot could fail before
+        # the deliberate gate had a chance to observe it.
+        condition: service_started
 
   app:
     # container_name and image are GLOBAL (not Compose-project-scoped), so two

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,11 @@ services:
       args:
         BUILD_SHA: ${BUILD_SHA:-unknown}
         BUILD_DATE: ${BUILD_DATE:-unknown}
+        MOBIUS_PLATFORM_ORIGIN: ${MOBIUS_PLATFORM_ORIGIN:-https://github.com/mobius-os/mobius.git}
+        MOBIUS_PLATFORM_FETCH_ORIGIN: ${MOBIUS_PLATFORM_FETCH_ORIGIN:-}
+        MOBIUS_USE_LOCAL_PLATFORM_SOURCE: ${MOBIUS_USE_LOCAL_PLATFORM_SOURCE:-0}
+        MOBIUS_LOCAL_PLATFORM_SHA: ${MOBIUS_LOCAL_PLATFORM_SHA:-unknown}
+        MOBIUS_LOCAL_PLATFORM_DATE: ${MOBIUS_LOCAL_PLATFORM_DATE:-unknown}
     image: ${MOBIUS_IMAGE:-mobius}
     container_name: mobius
     init: true

--- a/scripts/deploy-prod.sh
+++ b/scripts/deploy-prod.sh
@@ -33,6 +33,14 @@
 #                           target maximum retained build cache after success (8)
 #   MOBIUS_IMAGE            stable Compose app image tag used for build,
 #                           preflight, cutover, and rollback (default: mobius)
+#   MOBIUS_PLATFORM_FETCH_ORIGIN
+#                           optional trusted build-only Git origin for a local
+#                           commit; the baked checkout keeps the public
+#                           MOBIUS_PLATFORM_ORIGIN as its durable remote
+#   MOBIUS_USE_LOCAL_PLATFORM_SOURCE
+#                           set to 1 to bake the clean local checkout rather
+#                           than fetching BUILD_SHA from the public origin;
+#                           intended for committed local instance overlays
 #
 # Safety: only the `docker compose build` step prompts (it's slow and
 # has OOM'd this 7.6GB host before). Everything else auto-proceeds.
@@ -1366,6 +1374,16 @@ else
     *-dirty) export BUILD_DATE="$(date -u +%Y-%m-%d)" ;;
     *) export BUILD_DATE="$(git -C "$REPO_ROOT" show -s --format=%cs HEAD 2>/dev/null || echo unknown)" ;;
   esac
+  if [ "${MOBIUS_USE_LOCAL_PLATFORM_SOURCE:-0}" = "1" ]; then
+    case "$_sha" in
+      *-dirty)
+        fail "MOBIUS_USE_LOCAL_PLATFORM_SOURCE=1 requires a clean committed checkout"
+        exit 1
+        ;;
+    esac
+    export MOBIUS_LOCAL_PLATFORM_SHA="$_sha"
+    export MOBIUS_LOCAL_PLATFORM_DATE="$BUILD_DATE"
+  fi
   BUILT_THIS_RUN=1
   info "baking BUILD_SHA=${BUILD_SHA:0:18}… (${BUILD_DATE}) into the image"
   intent "docker compose ${COMPOSE_ARGS[*]} build"


### PR DESCRIPTION
## Summary

- Use the Claude Agent SDK’s bundled executable as the single Claude CLI, removing the duplicate npm payload and its stale parallel pin.
- Update the SDK and remove the temporary `httpx2` compatibility dependency now that the current Starlette transport no longer needs it.
- Restore the explicit, trusted local-source path used to bake an exact reviewed self-hosted commit without persisting a private fetch origin.
- Preserve image input and package inventories so a running instance can compare its replacement image with the source it serves.

## Prior work

This restores the single-runtime design from #328 and the replacement-image contract refined by #1050 after later alignment replay drifted from both. It keeps those responsibilities together because the Dockerfile, dependency lock, Compose arguments, deployment caller, and contract test form one release boundary.

## Testing

- `scripts/test.sh --fast` — 96 passed
- `bash -n scripts/deploy-prod.sh`

A full container build is intentionally left to hosted checks because this runtime has no Docker client.
