### PR TITLE
Unify reviewed container updates

### DIFF
--- a/backend/app/deployment_control.py
+++ b/backend/app/deployment_control.py
@@ -624,18 +624,35 @@ async def request_rebuild() -> RebuildStatus:
 
 async def request_reviewed_rebuild(
   *,
+  db: Any,
   plan_id: str,
   current_sha: str,
   target_sha: str,
-  image_digest: str,
-) -> RebuildStatus:
-  """Cut over Railway to the exact GHCR image bound into an owner review."""
+  image_digest: str | None,
+) -> RebuildStatus | dict[str, Any]:
+  """Drive the container rebuild bound to an owner-reviewed update target.
+
+  Railway cuts over to the exact digest-pinned GHCR image. Self-hosted applies
+  the reviewed source in place first — activating every live/restart part and
+  advancing the upstream marker to the target — then queues the host helper to
+  rebuild the pinned ``sha-<target>`` image. Both deployments finish an
+  image-level update from the single reviewed-update confirmation instead of a
+  separate Apply followed by a manual Rebuild.
+  """
   if platform_activation.deployment_kind() != "railway":
+    return await _request_self_hosted_reviewed_rebuild(
+      db,
+      plan_id=plan_id,
+      current_sha=current_sha,
+      target_sha=target_sha,
+      image_digest=image_digest,
+    )
+  if not image_digest:
     raise DeploymentControlError(
-      "unsupported_deployment",
-      "Reviewed image updates are available on Railway deployments.",
+      "update_plan_invalid",
+      "This update review is no longer valid. Refresh it and try again.",
       status_code=409,
-  )
+    )
   def validate_reviewed_release() -> None:
     try:
       reviewed = platform_update.reviewed_container_rebuild_plan(
@@ -685,6 +702,61 @@ async def request_reviewed_rebuild(
     image_digest,
     final_check=validate_reviewed_release,
   )
+
+
+async def _request_self_hosted_reviewed_rebuild(
+  db: Any,
+  *,
+  plan_id: str,
+  current_sha: str,
+  target_sha: str,
+  image_digest: str | None,
+) -> RebuildStatus | dict[str, Any]:
+  """Apply a reviewed self-hosted image update, then queue the host rebuild.
+
+  The host image ``sha-<target>`` carries the target's baked runtime, while the
+  served source lives in the persistent ``/data/platform`` checkout. Applying
+  the reviewed plan first lands every live-activatable part and advances the
+  upstream marker to the target, so the subsequent host rebuild pins the exact
+  matching image and boots onto source already at the target. ``request_rebuild``
+  re-derives the expected SHA from the advanced marker and keeps its own
+  local-image-input blocker guard, so a local-only image change still fails
+  closed there rather than being silently dropped by the official image.
+  """
+  # Fail before mutating any source if the host helper cannot rebuild.
+  status = await read_rebuild_status()
+  if not status.get("supported"):
+    raise DeploymentControlError(
+      status.get("code") or "not_configured",
+      status.get("message")
+      or "Container rebuilds are not available on this host yet.",
+      status_code=409,
+    )
+  if status.get("state") in _ACTIVE_STATES:
+    raise DeploymentControlError(
+      "already_running",
+      "A container rebuild is already running.",
+      status_code=409,
+    )
+
+  apply_result = await platform_update.apply_platform_update(
+    db,
+    plan_id=plan_id,
+    current_sha=current_sha,
+    target_sha=target_sha,
+    image_digest=image_digest,
+  )
+  state = apply_result.get("state")
+  if state in (
+    platform_update.PlatformUpdateState.CONFLICT.value,
+    platform_update.PlatformUpdateState.ROLLED_BACK.value,
+  ):
+    # Nothing was activated; surface the apply outcome so the review sheet can
+    # render its conflict / rolled-back result instead of a rebuild.
+    return apply_result
+
+  # Source is now at the reviewed target. Queue the host rebuild bound to it.
+  return await request_rebuild()
 
 
 def _raise_local_runtime_blockers(blockers: list[str]) -> None:

--- a/backend/app/platform_activation.py
+++ b/backend/app/platform_activation.py
@@ -129,8 +129,9 @@ _RULES = (
   ),
   _Rule(
     "frontend_dependencies",
-    ActivationLevel.IMAGE_REBUILD,
-    "Frontend or app-compiler dependencies changed and need a new image.",
+    ActivationLevel.LIVE,
+    "Frontend dependencies changed; Apply installs them in place and rebuilds "
+    "the shell — no image rebuild.",
     exact=("frontend/package.json", "frontend/package-lock.json"),
     dependency_fingerprint=True,
   ),

--- a/backend/app/platform_update.py
+++ b/backend/app/platform_update.py
@@ -1416,6 +1416,44 @@ def _sync_python_dependencies(repo: Path) -> tuple[bool, str]:
   return True, ""
 
 
+def _frontend_deps_changed(
+  repo: Path, before: str | None, after: str | None
+) -> bool:
+  """Whether the locked frontend dependency inputs changed between two commits."""
+  return any(
+    path in ("frontend/package.json", "frontend/package-lock.json")
+    for path in (_changed_paths(repo, before, after) or [])
+  )
+
+
+def _sync_frontend_dependencies(repo: Path) -> tuple[bool, str]:
+  """Install the locked frontend deps in place — the SAME command the image build
+  runs (``npm ci --ignore-scripts``) — so an owner Apply lands a frontend
+  dependency bump and rebuilds the shell without a container rebuild. This is the
+  frontend twin of :func:`_sync_python_dependencies`; the caller runs it just
+  before the frontend rebuild so the build sees the new ``node_modules``.
+
+  Returns ``(ok, error_tail)`` and never raises for an operational failure.
+  """
+  frontend = repo / "frontend"
+  if not (frontend / "package-lock.json").is_file():
+    return True, ""
+  try:
+    proc = subprocess.run(
+      ["npm", "ci", "--ignore-scripts"],
+      cwd=str(frontend),
+      capture_output=True,
+      text=True,
+      timeout=_DEP_SYNC_TIMEOUT,
+    )
+  except (subprocess.TimeoutExpired, OSError) as exc:
+    return False, repr(exc)[-500:]
+  if proc.returncode != 0:
+    detail = (proc.stderr or proc.stdout or "npm ci failed").strip()
+    return False, detail[-500:]
+  return True, ""
+
+
 def _hook_git(repo: Path, *args: str) -> subprocess.CompletedProcess:
   """Run one bounded, non-interactive Git plumbing command for hook refresh."""
   return subprocess.run(
@@ -1948,6 +1986,14 @@ def _reconcile_under_lock(
       if progress:
         progress(PlatformUpdatePhase.BUILDING)
       try:
+        # Install the newly locked frontend deps in place before the build, the
+        # same way an owner Apply syncs Python deps — so a frontend dependency
+        # bump lands live and no longer forces a container rebuild. The build
+        # below would otherwise compile against stale node_modules.
+        if _frontend_deps_changed(repo, result.pre_sha, result.new_sha):
+          deps_ok, deps_err = _sync_frontend_dependencies(repo)
+          if not deps_ok:
+            raise RuntimeError(f"frontend dependency install failed: {deps_err}")
         _rebuild_frontend_after_update_if_needed(repo, result)
       except Exception as exc:
         log.warning(

--- a/backend/app/routes/platform.py
+++ b/backend/app/routes/platform.py
@@ -220,14 +220,19 @@ async def apply_platform_update(
 )
 async def rebuild_reviewed_platform_update(
   request: PlatformApplyIn,
+  db: Session = Depends(get_db),
   _: models.Owner = Depends(get_current_owner),
 ):
-  """Deploy the exact digest-pinned GHCR image represented by the review."""
-  if not request.image_digest:
-    exc = PlatformUpdateError("update_plan_invalid")
-    raise HTTPException(status_code=409, detail=_plan_error_detail(exc))
+  """Rebuild the container for the reviewed update target.
+
+  Railway pins the exact GHCR image (digest required); self-hosted applies the
+  reviewed source in place, then rebuilds the matching ``sha-<target>`` image.
+  Per-deployment preconditions (including Railway's digest) are enforced in
+  ``deployment_control.request_reviewed_rebuild``.
+  """
   try:
     return await deployment_control.request_reviewed_rebuild(
+      db=db,
       plan_id=request.plan_id,
       current_sha=request.current_sha,
       target_sha=request.target_sha,

--- a/backend/tests/test_deployment_control.py
+++ b/backend/tests/test_deployment_control.py
@@ -223,6 +223,7 @@ async def test_reviewed_rebuild_uses_exact_plan_target_and_digest(monkeypatch):
   monkeypatch.setattr(dc, "_request_managed_rebuild", start)
 
   status = await dc.request_reviewed_rebuild(
+    db=None,
     plan_id="a" * 64,
     current_sha="1" * 40,
     target_sha=target,
@@ -272,6 +273,7 @@ async def test_reviewed_immutable_plan_does_not_reconsult_moving_ghcr_main(
   monkeypatch.setattr(dc, "_request_managed_rebuild", start)
 
   result = await dc.request_reviewed_rebuild(
+    db=None,
     plan_id="a" * 64,
     current_sha="1" * 40,
     target_sha=target,
@@ -280,6 +282,128 @@ async def test_reviewed_immutable_plan_does_not_reconsult_moving_ghcr_main(
 
   assert result["expected_sha"] == target
   assert result["image_digest"] == digest
+
+
+@pytest.mark.asyncio
+async def test_self_hosted_reviewed_rebuild_applies_then_queues_host_rebuild(
+  monkeypatch,
+):
+  # Self-hosted has no GHCR digest: the reviewed image update applies the source
+  # in place (advancing the upstream marker to the target), then queues the host
+  # rebuild for the matching sha-<target> image — one confirmation.
+  target = "b" * 40
+  calls = []
+
+  monkeypatch.setattr(
+    dc.platform_activation, "deployment_kind", lambda *a, **k: "self_hosted",
+  )
+
+  async def ready_status():
+    return {"supported": True, "state": "idle"}
+
+  monkeypatch.setattr(dc, "read_rebuild_status", ready_status)
+
+  async def fake_apply(db, **plan):
+    calls.append(("apply", plan))
+    return {
+      "state": dc.platform_update.PlatformUpdateState.ACTIVATION_NEEDED.value,
+      "activation": {"level": "image_rebuild", "deployment": "self_hosted"},
+    }
+
+  monkeypatch.setattr(dc.platform_update, "apply_platform_update", fake_apply)
+
+  async def fake_request_rebuild():
+    calls.append(("rebuild", None))
+    return {"state": "queued", "expected_sha": target, "supported": True}
+
+  monkeypatch.setattr(dc, "request_rebuild", fake_request_rebuild)
+
+  result = await dc.request_reviewed_rebuild(
+    db=SimpleNamespace(),
+    plan_id="a" * 64,
+    current_sha="1" * 40,
+    target_sha=target,
+    image_digest=None,
+  )
+
+  assert result["state"] == "queued"
+  assert result["expected_sha"] == target
+  # Apply ran with the reviewed plan, then the host rebuild was queued — in order.
+  assert [name for name, _ in calls] == ["apply", "rebuild"]
+  assert calls[0][1]["target_sha"] == target
+
+
+@pytest.mark.asyncio
+async def test_self_hosted_reviewed_rebuild_surfaces_apply_conflict(monkeypatch):
+  # If applying the source hits a conflict, nothing is rebuilt; the apply result
+  # is returned so the review sheet renders its conflict surface.
+  monkeypatch.setattr(
+    dc.platform_activation, "deployment_kind", lambda *a, **k: "self_hosted",
+  )
+
+  async def ready_status():
+    return {"supported": True, "state": "idle"}
+
+  monkeypatch.setattr(dc, "read_rebuild_status", ready_status)
+
+  async def fake_apply(db, **plan):
+    return {
+      "state": dc.platform_update.PlatformUpdateState.CONFLICT.value,
+      "chat_id": "chat-1",
+    }
+
+  monkeypatch.setattr(dc.platform_update, "apply_platform_update", fake_apply)
+
+  async def must_not_rebuild():
+    raise AssertionError("a conflicted apply must not queue a rebuild")
+
+  monkeypatch.setattr(dc, "request_rebuild", must_not_rebuild)
+
+  result = await dc.request_reviewed_rebuild(
+    db=SimpleNamespace(),
+    plan_id="a" * 64,
+    current_sha="1" * 40,
+    target_sha="b" * 40,
+    image_digest=None,
+  )
+
+  assert result["state"] == "conflict"
+
+
+@pytest.mark.asyncio
+async def test_self_hosted_reviewed_rebuild_fails_closed_when_host_not_ready(
+  monkeypatch,
+):
+  # The host readiness check runs BEFORE any source is applied, so an unconfigured
+  # host never leaves a half-applied update behind.
+  monkeypatch.setattr(
+    dc.platform_activation, "deployment_kind", lambda *a, **k: "self_hosted",
+  )
+
+  async def unconfigured_status():
+    return {
+      "supported": False,
+      "code": "not_configured",
+      "message": "Finish the one-time host setup.",
+    }
+
+  monkeypatch.setattr(dc, "read_rebuild_status", unconfigured_status)
+
+  async def must_not_apply(db, **plan):
+    raise AssertionError("source was applied before verifying host readiness")
+
+  monkeypatch.setattr(dc.platform_update, "apply_platform_update", must_not_apply)
+
+  with pytest.raises(dc.DeploymentControlError) as excinfo:
+    await dc.request_reviewed_rebuild(
+      db=SimpleNamespace(),
+      plan_id="a" * 64,
+      current_sha="1" * 40,
+      target_sha="b" * 40,
+      image_digest=None,
+    )
+
+  assert excinfo.value.code == "not_configured"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_platform_activation.py
+++ b/backend/tests/test_platform_activation.py
@@ -45,12 +45,11 @@ def test_railway_config_guidance_does_not_promise_an_image_rebuild():
 
 def test_dependency_and_baked_runtime_never_degrade_to_restart_only():
   # Python deps now apply in place (a rebuild is no longer forced), but they are
-  # still MORE than a bare restart. Frontend deps and baked-runtime inputs still
-  # require a new image.
+  # still MORE than a bare restart. Baked-runtime inputs still require a new
+  # image. (Frontend deps now apply in place too — see the dedicated test.)
   expected = {
     "backend/requirements.txt": "dependency_sync",
     "backend/requirements.lock": "dependency_sync",
-    "frontend/package-lock.json": "image_rebuild",
     "backend/scripts/entrypoint.sh": "image_rebuild",
     "backend/scripts/init_skills.py": "image_rebuild",
     "backend/scripts/seed-skills/platform-maintenance.md": "image_rebuild",
@@ -62,6 +61,34 @@ def test_dependency_and_baked_runtime_never_degrade_to_restart_only():
     impact = activation.classify_activation([path], deployment="self_hosted")
     assert impact["level"] == level, path
     assert impact["level"] not in {"live", "server_restart"}, path
+
+
+def test_frontend_dependencies_apply_in_place_not_via_rebuild():
+  # A frontend dependency bump is installed in place during Apply (npm ci) and
+  # the shell is rebuilt live — it no longer forces a container/image rebuild,
+  # mirroring the Python dependency precedent.
+  for path in ("frontend/package.json", "frontend/package-lock.json"):
+    for deployment in ("self_hosted", "railway"):
+      impact = activation.classify_activation([path], deployment=deployment)
+      assert impact["level"] == "live", (path, deployment)
+
+  # It still contributes to the image dependency fingerprint (node_modules are
+  # baked at image-build time), so a rebuild's image content stays reproducible.
+  root = Path(__file__).resolve().parents[2]
+  fingerprint = activation.dependency_fingerprint_paths(root)
+  assert "frontend/package.json" in fingerprint
+  assert "frontend/package-lock.json" in fingerprint
+
+  # A frontend dep bump does not trigger the backend import probe.
+  assert not activation.backend_import_probe_required(
+    ["frontend/package-lock.json"],
+  )
+
+  # But a Dockerfile change in the same update still forces a rebuild.
+  with_dockerfile = activation.classify_activation(
+    ["frontend/package-lock.json", "Dockerfile"], deployment="self_hosted",
+  )
+  assert with_dockerfile["level"] == "image_rebuild"
 
 
 def test_dependency_fingerprint_comes_from_the_image_rules():

--- a/backend/tests/test_platform_routes.py
+++ b/backend/tests/test_platform_routes.py
@@ -118,7 +118,9 @@ def test_reviewed_rebuild_forwards_exact_sha_and_digest(
   captured = {}
 
   async def fake_rebuild(**plan):
-    captured.update(plan)
+    # The route also threads a DB session for the self-hosted apply step; the
+    # forwarded update-plan identity is what this test asserts.
+    captured.update({k: v for k, v in plan.items() if k != "db"})
     return {
       "supported": True,
       "bootstrap_available": False,
@@ -152,7 +154,14 @@ def test_reviewed_rebuild_forwards_exact_sha_and_digest(
   assert response.json()["release_source"] == "latest_ghcr"
 
 
-def test_reviewed_rebuild_requires_digest(client, auth):
+def test_reviewed_rebuild_railway_requires_digest(client, auth, monkeypatch):
+  # On Railway the image is pinned by GHCR digest, so a review with no digest is
+  # invalid. (Self-hosted has no GHCR digest and anchors on the sha-<target>
+  # tag, so it does not require one — see the deployment_control tests.)
+  monkeypatch.setattr(
+    "app.platform_activation.deployment_kind",
+    lambda *a, **k: "railway",
+  )
   response = client.post("/api/platform/rebuild", headers=auth, json={
     "plan_id": "a" * 64,
     "current_sha": "1" * 40,

--- a/backend/tests/test_platform_update.py
+++ b/backend/tests/test_platform_update.py
@@ -1846,7 +1846,7 @@ def test_boot_clears_restart_but_preserves_unverified_image_work(clone_env):
   target = _served_sha(platform)
   pu.mark_activation_needed(
     target,
-    ["backend/app/main.py", "frontend/package-lock.json"],
+    ["backend/app/main.py", "Dockerfile"],
   )
 
   res = pu.reconcile_clone(platform, at_boot=True)
@@ -1856,7 +1856,7 @@ def test_boot_clears_restart_but_preserves_unverified_image_work(clone_env):
     "version": 2,
     "target_sha": target,
     "upstream_sha": None,
-    "paths": ["frontend/package-lock.json"],
+    "paths": ["Dockerfile"],
     "image_paths": [],
   }
 
@@ -1868,11 +1868,11 @@ def test_boot_rebuild_retires_only_upstream_covered_image_paths(
   upstream = _served_sha(platform)
   local = _local_commit(
     platform,
-    edits={"frontend/package-lock.json": "local-only image input\n"},
+    edits={"protected-files.txt": "local-only image input\n"},
   )
   pu._write_activation_marker(
     local,
-    ["Dockerfile", "frontend/package-lock.json"],
+    ["Dockerfile", "protected-files.txt"],
     upstream_sha=upstream,
     image_paths=["Dockerfile"],
   )
@@ -1884,7 +1884,7 @@ def test_boot_rebuild_retires_only_upstream_covered_image_paths(
     "version": 2,
     "target_sha": local,
     "upstream_sha": upstream,
-    "paths": ["frontend/package-lock.json"],
+    "paths": ["protected-files.txt"],
     "image_paths": [],
   }
 
@@ -1973,6 +1973,88 @@ def test_apply_rolls_back_when_dependency_install_fails(clone_env, monkeypatch):
   assert res.status == "rolled_back"
   assert "boom" in (res.error or "")
   assert pu._rev(platform, pu._local_branch(platform)) == pre
+
+
+@pytest.mark.asyncio
+async def test_apply_installs_frontend_dependencies_in_place(
+  clone_env, monkeypatch,
+):
+  # A frontend dependency bump lands via an in-place `npm ci` during Apply and
+  # a live shell rebuild — no container/image rebuild, mirroring Python deps.
+  origin, platform = clone_env
+  target = _advance_origin(
+    origin,
+    edits={"frontend/package-lock.json": "new-locked-frontend-deps\n"},
+    msg="bump frontend deps",
+  )
+  pu._fetch(platform)
+  preview = pu.platform_update_preview(platform)
+
+  # A frontend dep change is classified as an in-place live activation, not a
+  # rebuild.
+  assert preview["activation"]["level"] == "live"
+
+  synced = {}
+
+  def fake_sync(repo):
+    synced["ran"] = True
+    return True, ""
+
+  monkeypatch.setattr(pu, "_sync_frontend_dependencies", fake_sync)
+  monkeypatch.setattr(
+    pu, "_rebuild_frontend_after_update_if_needed", lambda repo, result: None,
+  )
+
+  result = await pu.apply_platform_update(
+    SimpleNamespace(),
+    plan_id=preview["plan_id"],
+    current_sha=preview["current_sha"],
+    target_sha=preview["target_sha"],
+    repo=platform,
+  )
+
+  assert result["state"] != pu.PlatformUpdateState.ROLLED_BACK.value
+  assert result["state"] != pu.PlatformUpdateState.CONFLICT.value
+  assert synced.get("ran") is True  # npm ci ran during Apply, before the build
+  assert _served_sha(platform) == target
+
+
+@pytest.mark.asyncio
+async def test_apply_rolls_back_when_frontend_dependency_install_fails(
+  clone_env, monkeypatch,
+):
+  origin, platform = clone_env
+  before = _served_sha(platform)
+  target = _advance_origin(
+    origin,
+    edits={"frontend/package-lock.json": "new-locked-frontend-deps\n"},
+    msg="bump frontend deps",
+  )
+  pu._fetch(platform)
+  preview = pu.platform_update_preview(platform)
+
+  monkeypatch.setattr(
+    pu, "_sync_frontend_dependencies", lambda repo: (False, "npm boom"),
+  )
+  # If the source is not reset, a subsequent real build could run; keep it a
+  # no-op so the test isolates the dependency-install failure path.
+  monkeypatch.setattr(
+    pu, "_rebuild_frontend_after_update_if_needed", lambda repo, result: None,
+  )
+
+  result = await pu.apply_platform_update(
+    SimpleNamespace(),
+    plan_id=preview["plan_id"],
+    current_sha=preview["current_sha"],
+    target_sha=preview["target_sha"],
+    repo=platform,
+  )
+
+  # A failed in-place frontend install is fail-closed like a failed build: the
+  # source resets to the pre-Apply commit and the old tree keeps serving.
+  assert result["state"] == pu.PlatformUpdateState.ROLLED_BACK.value
+  assert "npm boom" in (result["error"] or "")
+  assert _served_sha(platform) == before
 
 
 # --- restart flag lifecycle -------------------------------------------------

--- a/frontend/src/components/SettingsView/SettingsView.jsx
+++ b/frontend/src/components/SettingsView/SettingsView.jsx
@@ -12,7 +12,6 @@ import {
 import { formatUpstreamCommitDate } from '../../lib/platformProvenance.js'
 import {
   rebuildIsActive,
-  rebuildNeedsBootstrap,
   rebuildPollShouldContinue,
   rebuildProgressMessage,
   rebuildRequestOutcome,
@@ -449,7 +448,6 @@ export default function SettingsView({
   // A manual restart interrupts any live chat, so it's a deliberate two-step:
   // the first tap arms the confirm, the second actually restarts.
   const [restartConfirm, setRestartConfirm] = useState(false)
-  const [rebuildConfirm, setRebuildConfirm] = useState(false)
   const [rebuildStatus, setRebuildStatus] = useState(null)
   const [rebuildError, setRebuildError] = useState('')
   const [rebuildRequesting, setRebuildRequesting] = useState(false)
@@ -1137,7 +1135,16 @@ export default function SettingsView({
   useEffect(() => {
     const state = rebuildStatus?.state
     if (!['failed', 'rolled_back', 'needs_recovery'].includes(state)) return
-    setRebuildConfirm(false)
+    // The controller keeps its last terminal result for diagnosis. That is not
+    // a current Settings error: after the standalone rebuild action was
+    // removed, only a rebuild started by this mounted update flow owns visible
+    // progress or failure UI. Otherwise an old failed attempt survives every
+    // reload indefinitely and looks like an action the owner still needs to
+    // take even when no image update is pending.
+    if (
+      !rebuildInitiatedHereRef.current
+      && !rebuildReviewedUpdateRef.current
+    ) return
     const message = rebuildStatus?.error
       || rebuildStatus?.message
       || (state === 'needs_recovery'
@@ -1180,7 +1187,6 @@ export default function SettingsView({
       rebuildInitiatedHereRef.current = outcome.cutoverAccepted
       setRebuildStartedHere(outcome.cutoverAccepted)
       setRebuildStatus(body)
-      setRebuildConfirm(false)
       if (outcome.cutoverAccepted) returnToSettingsAfterReload()
       if (outcome.alreadyCurrent) {
         rebuildReviewedUpdateRef.current = false
@@ -1207,16 +1213,13 @@ export default function SettingsView({
     }
   }
 
-  async function rebuildContainer() {
-    return startContainerRebuild(() => api.admin.rebuild())
-  }
-
   async function rebuildPlatformUpdate(plan) {
+    // Railway pins an immutable GHCR digest; self-hosted anchors on the
+    // sha-<target> tag and has no digest, so the digest is not required here.
     if (
       !plan?.plan_id
       || !plan?.current_sha
       || !plan?.target_sha
-      || !plan?.image_digest
     ) {
       setPlatformError('The update plan is incomplete. Refresh the preview and try again.')
       return { ok: false }
@@ -1226,8 +1229,6 @@ export default function SettingsView({
       { reviewedUpdate: true },
     )
   }
-
-  const rebuildBootstrap = rebuildNeedsBootstrap(rebuildStatus)
 
   async function signOut() {
     if (signingOut) return
@@ -2242,79 +2243,13 @@ export default function SettingsView({
               description={restartError}
             />
           )}
-          <div className="settings__row">
-            <SettingsInfoLabel
-              label={rebuildBootstrap ? 'Container updates' : 'Rebuild container'}
-              infoId="settings-rebuild-info"
-              expanded={serverInfo === 'rebuild'}
-              onToggle={() => setServerInfo((value) => (
-                value === 'rebuild' ? null : 'rebuild'
-              ))}
-              onDismiss={() => setServerInfo(null)}
-            >
-              {rebuildBootstrap
-                ? 'Enables safe container rebuilds on this Railway deployment with one managed upgrade.'
-                : 'On Railway, creates a fresh container from the newest published official image. Self-hosted setups rebuild the applied version. Your chats, apps, settings, and other saved data stay in place.'}
-            </SettingsInfoLabel>
-            {rebuildConfirm ? (
-              <div className="settings__confirm">
-                <button
-                  className="settings__btn settings__btn--outline settings__btn--sm"
-                  type="button"
-                  onClick={() => setRebuildConfirm(false)}
-                  disabled={rebuildRequesting || rebuildIsActive(rebuildStatus)}
-                >
-                  Cancel
-                </button>
-                <button
-                  className="settings__btn settings__btn--sm settings__btn--nowrap"
-                  type="button"
-                  onClick={rebuildContainer}
-                  disabled={rebuildRequesting || rebuildIsActive(rebuildStatus)}
-                >
-                  {rebuildRequesting || rebuildIsActive(rebuildStatus)
-                    ? (rebuildBootstrap ? 'Enabling…' : 'Rebuilding…')
-                    : (rebuildBootstrap ? 'Enable now' : 'Rebuild now')}
-                </button>
-              </div>
-            ) : (
-              <button
-                className="settings__btn settings__btn--outline settings__btn--sm"
-                type="button"
-                onClick={() => { setRebuildError(''); setRebuildConfirm(true) }}
-                disabled={
-                  restartPhase === 'restarting'
-                  || rebuildRequesting
-                  || rebuildIsActive(rebuildStatus)
-                  || (rebuildStatus?.supported === false && !rebuildBootstrap)
-                }
-              >
-                {rebuildBootstrap
-                  ? 'Enable'
-                  : (rebuildStatus?.supported === false ? 'Not set up' : 'Rebuild')}
-              </button>
-            )}
-          </div>
-          {rebuildConfirm && !rebuildIsActive(rebuildStatus) && (
-            <p className="settings__subtext settings__subtext--tight">
-              {rebuildBootstrap ? (
-                <>Performs one managed Railway redeploy, then verifies the safe
-                update controller. Finish active responses first; Railway restores
-                the previous container if the upgrade is unhealthy.</>
-              ) : (
-                <>Rebuilds the container from a pinned official image. Railway
-                first checks the newest image published to GHCR; self-hosted
-                setups use the applied version. Local-only runtime changes
-                recorded by Möbius block the rebuild; undeclared
-                container changes are lost. Active chats continue afterward.</>
-              )}
-            </p>
-          )}
-          {rebuildStatus?.supported === false && (
-            <p className="settings__subtext settings__subtext--tight">
-              {rebuildStatus.message || 'Container rebuilds are not set up on this installation.'}
-            </p>
-          )}
+          {/* The container rebuild is no longer a separate manual action: an
+              image-level update drives it on confirmation from the "Möbius"
+              update review above (Railway pins the GHCR image; self-hosted
+              applies the reviewed source in place, then rebuilds the matching
+              image). Only the in-progress status and any failure remain here so
+              a rebuild started from the update flow stays visible after the
+              review sheet closes and the shell reloads. */}
           {(rebuildIsActive(rebuildStatus) || (rebuildStartedHere && [
             'succeeded', 'no_change', 'rolled_back', 'needs_recovery',
           ].includes(rebuildStatus?.state))) && (

--- a/frontend/src/components/SettingsView/UpdateReviewModal.jsx
+++ b/frontend/src/components/SettingsView/UpdateReviewModal.jsx
@@ -33,6 +33,7 @@ import {
   deploymentKindLabel,
   platformActivationLabel,
   reviewedUpdateUsesContainerRebuild,
+  reviewedRebuildNeedsDigest,
 } from '../../lib/platformUpdateState.js'
 import UnifiedDiff from '../DiffView/UnifiedDiff.jsx'
 import './UpdateReviewModal.css'
@@ -174,7 +175,7 @@ export default function UpdateReviewModal({
     preview?.plan_id
     && preview?.current_sha
     && preview?.target_sha
-    && (!rebuildUpdate || preview?.image_digest)
+    && (!reviewedRebuildNeedsDigest(preview) || preview?.image_digest)
   )
   const progressLabel = rebuildUpdate && rebuilding
     ? 'Starting the exact reviewed official image…'

--- a/frontend/src/lib/__tests__/platformUpdateState.test.js
+++ b/frontend/src/lib/__tests__/platformUpdateState.test.js
@@ -8,6 +8,7 @@ import {
   platformStatusUnavailable,
   platformUpdateStatusLabel,
   reviewedUpdateUsesContainerRebuild,
+  reviewedRebuildNeedsDigest,
 } from '../platformUpdateState.js'
 
 test('an unavailable release check cannot inherit a cached current claim', () => {
@@ -41,17 +42,33 @@ test('the deployment badge names an unresolved deployment self-hosted', () => {
   assert.equal(deploymentKindLabel(null), 'Self-hosted')
 })
 
-test('only reviewed Railway image updates rebuild directly', () => {
+test('reviewed image updates rebuild directly on both deployments', () => {
   assert.equal(reviewedUpdateUsesContainerRebuild({
     activation: { deployment: 'railway', level: 'image_rebuild' },
   }), true)
+  // Self-hosted image updates now also drive the rebuild from the update flow.
   assert.equal(reviewedUpdateUsesContainerRebuild({
     activation: { deployment: 'self_hosted', level: 'image_rebuild' },
-  }), false)
+  }), true)
   assert.equal(reviewedUpdateUsesContainerRebuild({
     activation: { deployment: 'railway', level: 'server_restart' },
   }), false)
   assert.equal(reviewedUpdateUsesContainerRebuild(null), false)
+})
+
+test('only Railway image rebuilds require a pinned GHCR digest', () => {
+  assert.equal(reviewedRebuildNeedsDigest({
+    activation: { deployment: 'railway', level: 'image_rebuild' },
+  }), true)
+  // Self-hosted anchors on the sha-<target> tag, so no digest is required.
+  assert.equal(reviewedRebuildNeedsDigest({
+    activation: { deployment: 'self_hosted', level: 'image_rebuild' },
+  }), false)
+  // A non-rebuild update never needs a digest.
+  assert.equal(reviewedRebuildNeedsDigest({
+    activation: { deployment: 'railway', level: 'live' },
+  }), false)
+  assert.equal(reviewedRebuildNeedsDigest(null), false)
 })
 
 test('a clean apply consumes the reviewed target but preserves restart readiness', () => {

--- a/frontend/src/lib/__tests__/settingsViewAppearance.test.js
+++ b/frontend/src/lib/__tests__/settingsViewAppearance.test.js
@@ -37,17 +37,29 @@ test('model and concise synced version use the same normal-weight standard highl
   assert.match(css, /\.settings__standard-highlight\s*\{[^}]*color:\s*var\(--green\);[^}]*font-weight:\s*inherit;/s)
 })
 
-test('restart and rebuild explain their distinct container effects on demand', () => {
+test('restart explains its container effect on demand', () => {
   assert.match(view, /SettingsInfoLabel[\s\S]*aria-expanded=\{expanded\}/)
   assert.match(view, /settings__info-bubble[\s\S]*role="tooltip"/)
   assert.match(view, /dismissOnOutsidePress[\s\S]*dismissOnEscape/)
   assert.match(view, /label="Restart"[\s\S]*settings-restart-info/)
-  assert.match(view, /label=\{rebuildBootstrap \? 'Container updates' : 'Rebuild container'\}/)
   assert.match(view, /does not[\s\S]*install a newer container image/)
-  assert.match(view, /On Railway, creates a fresh container from the newest published official image/)
+  // The standalone manual container-rebuild control was removed: an image-level
+  // update now drives the rebuild on confirmation from the update review flow.
+  assert.doesNotMatch(view, /label=\{rebuildBootstrap \? 'Container updates' : 'Rebuild container'\}/)
+  assert.doesNotMatch(view, /Rebuild now|Rebuild container|settings-rebuild-info/)
   assert.doesNotMatch(view, /Replace container|Replace now|Replacing…/)
   assert.match(css, /\.settings__info-button\s*\{[^}]*width:\s*32px;[^}]*height:\s*32px;/s)
   assert.match(css, /\.settings__info-bubble\s*\{[^}]*position:\s*absolute;[^}]*bottom:\s*calc\(100% \+ 10px\);/s)
+})
+
+test('historical rebuild failures do not become permanent Settings errors', () => {
+  // The host controller deliberately retains its last terminal status. Only a
+  // rebuild initiated by this mounted, reviewed update flow may surface that
+  // result; otherwise a stale failure would outlive the removed manual action.
+  assert.match(
+    view,
+    /\['failed', 'rolled_back', 'needs_recovery'\][\s\S]*!rebuildInitiatedHereRef\.current[\s\S]*!rebuildReviewedUpdateRef\.current[\s\S]*return/,
+  )
 })
 
 test('platform status failures replace cached current claims with unknown state', () => {

--- a/frontend/src/lib/__tests__/updateReviewModal.test.js
+++ b/frontend/src/lib/__tests__/updateReviewModal.test.js
@@ -37,11 +37,13 @@ test('apply outcomes close only for explicit clean states and preserve actionabl
   assert.match(modal, /applyProgress\?\.plan_id === preview\?\.plan_id/)
 })
 
-test('Railway image reviews rebuild the exact immutable image instead of applying in place', () => {
+test('image reviews rebuild the container instead of applying in place, on both deployments', () => {
   assert.match(modal, /reviewedUpdateUsesContainerRebuild\(preview\)/)
   assert.match(modal, /rebuildUpdate \? onRebuild\(plan\) : onApply\(plan\)/)
   assert.match(modal, /image_digest: preview\?\.image_digest/)
-  assert.match(modal, /!rebuildUpdate \|\| preview\?\.image_digest/)
+  // Only Railway pins a GHCR digest; self-hosted has none, so the plan is
+  // complete without one.
+  assert.match(modal, /!reviewedRebuildNeedsDigest\(preview\) \|\| preview\?\.image_digest/)
   assert.match(modal, /Rebuild to update/)
   assert.match(modal, /Starting the exact reviewed official image…/)
   assert.match(settingsView, /api\.platform\.rebuild\(plan\)/)

--- a/frontend/src/lib/platformUpdateState.js
+++ b/frontend/src/lib/platformUpdateState.js
@@ -98,13 +98,25 @@ export function deploymentKindLabel(activation) {
 }
 
 /**
- * Railway image updates are activated by replacing the container, not by
- * mutating the checkout that is still serving the current container.
+ * An image-level update is finished by rebuilding the container, on both
+ * deployments. Railway cuts over to the pinned GHCR image; self-hosted applies
+ * the reviewed source in place and then rebuilds the matching sha-<target>
+ * image via the host helper. Either way the single reviewed-update confirmation
+ * drives the rebuild — there is no separate manual rebuild step.
  */
 export function reviewedUpdateUsesContainerRebuild(preview) {
+  return preview?.activation?.level === 'image_rebuild'
+}
+
+/**
+ * Only Railway pins the rebuild to an immutable GHCR image digest. Self-hosted
+ * anchors on the sha-<target> tag, so its reviewed rebuild has no digest and
+ * must not be blocked on one.
+ */
+export function reviewedRebuildNeedsDigest(preview) {
   return (
-    deploymentKind(preview?.activation) === 'railway'
-    && preview?.activation?.level === 'image_rebuild'
+    reviewedUpdateUsesContainerRebuild(preview)
+    && deploymentKind(preview?.activation) === 'railway'
   )
 }
 


### PR DESCRIPTION
## Summary
- finish image-required updates from the single reviewed update action on Railway and self-hosted installations
- install locked frontend dependencies in place and reserve container rebuilds for genuine image inputs
- remove the standalone rebuild control and keep historical controller failures from appearing as current Settings errors

## Prior work
Builds on the replacement-safety guarantees from #1052; this change unifies the owner workflow and narrows when replacement is required.

## Testing
- 163 focused backend tests passed
- 33 focused frontend tests passed
- 97 fast host-contract tests passed
- targeted ESLint passed with 0 errors
