### PR TITLE
Let unlinked instances browse public community apps

### DIFF
--- a/backend/app/community_broker.py
+++ b/backend/app/community_broker.py
@@ -21,8 +21,19 @@ import httpx
 
 DEFAULT_SOCKET = "/run/mobius-identity-broker.sock"
 COMMUNITY_PREFIX = "/v1/community"
+COMMUNITY_BASE_URL = os.environ.get(
+  "MOBIUS_COMMUNITY_REGISTRY_URL", "https://www.mobius.you",
+).rstrip("/")
 MAX_RESPONSE_BYTES = 10_000_000
 _IDEMPOTENCY_KEY = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{15,127}$")
+_PUBLIC_APP_READS = (
+  re.compile(r"/v1/community/apps"),
+  re.compile(r"/v1/community/apps/[A-Za-z0-9_:-]{8,200}"),
+  re.compile(
+    r"/v1/community/apps/[A-Za-z0-9_:-]{8,200}/revisions/"
+    r"[A-Za-z0-9_:-]{8,200}"
+  ),
+)
 
 
 @dataclass(frozen=True)
@@ -48,6 +59,32 @@ def bound_request_id(
   material += method.upper().encode("ascii") + b"\0" + path.encode("utf-8")
   material += b"\0" + (idempotency_key or "").encode("utf-8") + b"\0" + body
   return "community:" + hashlib.sha256(material).hexdigest()
+
+
+def _public_read_target(method: str, path: str, target: str) -> str | None:
+  if method != "GET":
+    return None
+  if path == "/v1/community/editorial/spotlight" or any(
+    pattern.fullmatch(path) for pattern in _PUBLIC_APP_READS
+  ):
+    return "/api/store/v1" + target.removeprefix(COMMUNITY_PREFIX)
+  return None
+
+
+def _decode_response(response: httpx.Response) -> tuple[Any, dict[str, str]]:
+  if len(response.content) > MAX_RESPONSE_BYTES:
+    raise CommunityBrokerError(502, "The community service response was too large.")
+  try:
+    payload = response.json() if response.content else {}
+  except ValueError as exc:
+    raise CommunityBrokerError(
+      502, "The community service returned an invalid response.",
+    ) from exc
+  response_headers = {
+    key.lower(): value for key, value in response.headers.items()
+    if key.lower() in {"retry-after", "etag", "last-modified"}
+  }
+  return payload, response_headers
 
 
 class CommunityBrokerClient:
@@ -98,10 +135,12 @@ class CommunityBrokerClient:
       headers["Content-Type"] = "application/json"
     if idempotency_key:
       headers["Idempotency-Key"] = idempotency_key
-    transport = self.transport or httpx.AsyncHTTPTransport(uds=self.socket_path)
+    broker_transport = self.transport or httpx.AsyncHTTPTransport(
+      uds=self.socket_path,
+    )
     try:
       async with httpx.AsyncClient(
-        transport=transport,
+        transport=broker_transport,
         base_url="http://mobius-identity-broker",
         timeout=45.0,
         follow_redirects=False,
@@ -109,22 +148,26 @@ class CommunityBrokerClient:
         response = await client.request(
           method, target, content=encoded if encoded else None, headers=headers,
         )
+      payload, response_headers = _decode_response(response)
+      public_target = _public_read_target(method, path, target)
+      if (
+        response.status_code == 401
+        and isinstance(payload, dict)
+        and payload.get("error") == "a mobius.you account must be linked"
+        and public_target is not None
+      ):
+        async with httpx.AsyncClient(
+          transport=self.transport,
+          base_url=COMMUNITY_BASE_URL,
+          timeout=45.0,
+          follow_redirects=False,
+        ) as client:
+          response = await client.request("GET", public_target, headers=headers)
+        payload, response_headers = _decode_response(response)
     except httpx.HTTPError as exc:
       raise CommunityBrokerError(
         503, "The Möbius community service could not be reached.",
       ) from exc
-    if len(response.content) > MAX_RESPONSE_BYTES:
-      raise CommunityBrokerError(502, "The community service response was too large.")
-    try:
-      payload = response.json() if response.content else {}
-    except ValueError as exc:
-      raise CommunityBrokerError(
-        502, "The community service returned an invalid response.",
-      ) from exc
-    response_headers = {
-      key.lower(): value for key, value in response.headers.items()
-      if key.lower() in {"retry-after", "etag", "last-modified"}
-    }
     if response.is_error:
       error = payload.get("error") if isinstance(payload, dict) else None
       if isinstance(error, dict):

--- a/backend/tests/test_community_broker.py
+++ b/backend/tests/test_community_broker.py
@@ -82,6 +82,81 @@ async def test_read_preserves_bounded_query_for_broker_binding():
 
 
 @pytest.mark.asyncio
+async def test_unlinked_public_app_reads_fall_back_without_authorization():
+  seen = []
+
+  async def handler(request: httpx.Request) -> httpx.Response:
+    seen.append((request.method, str(request.url), dict(request.headers)))
+    if request.url.host == "mobius-identity-broker":
+      return httpx.Response(
+        401, json={"error": "a mobius.you account must be linked"},
+      )
+    return httpx.Response(
+      200,
+      headers={"ETag": '"catalog-1"'},
+      json={"apps": [{"id": "app_12345678"}]},
+    )
+
+  client = CommunityBrokerClient(transport=httpx.MockTransport(handler))
+  payload, status, headers = await client.request(
+    "GET", "/v1/community/apps",
+    params={"limit": 25, "offset": 0, "q": "social"},
+  )
+
+  assert status == 200
+  assert payload == {"apps": [{"id": "app_12345678"}]}
+  assert headers == {"etag": '"catalog-1"'}
+  assert [item[1] for item in seen] == [
+    "http://mobius-identity-broker/v1/community/apps?limit=25&offset=0&q=social",
+    "https://www.mobius.you/api/store/v1/apps?limit=25&offset=0&q=social",
+  ]
+  assert "authorization" not in seen[-1][2]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("path", [
+  "/v1/community/apps/app_12345678",
+  "/v1/community/apps/app_12345678/revisions/rev_12345678",
+  "/v1/community/editorial/spotlight",
+])
+async def test_unlinked_public_detail_reads_use_the_matching_public_path(path):
+  seen = []
+
+  async def handler(request: httpx.Request) -> httpx.Response:
+    seen.append(str(request.url))
+    if request.url.host == "mobius-identity-broker":
+      return httpx.Response(
+        401, json={"error": "a mobius.you account must be linked"},
+      )
+    return httpx.Response(200, json={"ok": True})
+
+  client = CommunityBrokerClient(transport=httpx.MockTransport(handler))
+  await client.request("GET", path)
+
+  assert seen[-1] == "https://www.mobius.you/api/store/v1" + path.removeprefix(
+    "/v1/community"
+  )
+
+
+@pytest.mark.asyncio
+async def test_unlinked_private_reads_stay_account_gated():
+  seen = []
+
+  async def handler(request: httpx.Request) -> httpx.Response:
+    seen.append(str(request.url))
+    return httpx.Response(
+      401, json={"error": "a mobius.you account must be linked"},
+    )
+
+  client = CommunityBrokerClient(transport=httpx.MockTransport(handler))
+  with pytest.raises(CommunityBrokerError) as raised:
+    await client.request("GET", "/v1/community/publications")
+
+  assert raised.value.status_code == 401
+  assert len(seen) == 1
+
+
+@pytest.mark.asyncio
 async def test_mutation_requires_idempotency_before_socket_call():
   called = False
 


### PR DESCRIPTION
## Summary

- let unlinked instances browse the public community catalog and editorial spotlight
- keep linked instances on capability-backed routes for personalized viewer data
- preserve account requirements for publishing and feedback mutations

## Why

The Host already exposes public read-only Store routes, but the local identity broker required a linked account before forwarding every community request. This made public catalog search appear empty on unlinked instances.

This implements the public catalog and identity-overlay separation described in #989 for the existing Store routes.

## Tests

- `scripts/wt-pytest.sh backend/tests/test_identity_broker.py backend/tests/test_community_broker.py backend/tests/test_community_routes.py -q`
