### PR TITLE
Seed local images from exact Git objects

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,12 @@
+# syntax=docker/dockerfile:1
 # Single-container Möbius image.
 #
 # Builds the frontend, installs the backend + CLI tools, and serves
 # everything from one FastAPI process.  Works on VPS, Railway, PikaPods.
+
+# An ordinary Dockerfile build has no local source input. Compose may override
+# this named stage with a dedicated context containing one reviewed Git bundle.
+FROM scratch AS mobius-local-platform-source
 
 # Keep the Node runtime source independent of the frontend build. Copying Node
 # from the completed frontend stage made every UI edit invalidate the backend's
@@ -277,11 +282,6 @@ RUN python /tmp/verify-legacy-jose.py && rm /tmp/verify-legacy-jose.py
 # the checkout being built. The disposable test compose is the sole explicit
 # exception because it mounts and verifies its checkout at runtime.
 ARG MOBIUS_PLATFORM_ORIGIN=https://github.com/mobius-os/mobius.git
-# A local deployment may fetch an unpushed reviewed commit from a temporary,
-# trusted Host-side Git service. Keep that transport separate from the durable
-# origin written into the baked checkout so a container never retains an
-# ephemeral or host-private URL.
-ARG MOBIUS_PLATFORM_FETCH_ORIGIN=
 ARG BUILD_SHA=unknown
 ARG BUILD_DATE=unknown
 ARG RAILWAY_GIT_COMMIT_SHA=unknown
@@ -289,11 +289,11 @@ ARG RAILWAY_DEPLOYMENT_ID=unknown
 ARG MOBIUS_ALLOW_UNKNOWN_BUILD_SHA=0
 ARG MOBIUS_USE_LOCAL_PLATFORM_SOURCE=0
 ARG MOBIUS_LOCAL_PLATFORM_SHA=unknown
+ARG MOBIUS_LOCAL_PLATFORM_BASE_SHA=unknown
 ARG MOBIUS_LOCAL_PLATFORM_DATE=unknown
 RUN set -eux; \
     _build_sha="${BUILD_SHA:-unknown}"; \
     _railway_sha="${RAILWAY_GIT_COMMIT_SHA:-unknown}"; \
-    _platform_fetch_origin="${MOBIUS_PLATFORM_FETCH_ORIGIN:-$MOBIUS_PLATFORM_ORIGIN}"; \
     case "${MOBIUS_USE_LOCAL_PLATFORM_SOURCE:-0}" in 0|1) ;; *) \
       echo "FATAL: MOBIUS_USE_LOCAL_PLATFORM_SOURCE must be 0 or 1" >&2; exit 1;; \
     esac; \
@@ -308,14 +308,14 @@ RUN set -eux; \
       echo "FATAL: an exact 40-character BUILD_SHA is required; set it to the checkout commit before building" >&2; \
       exit 1; \
     fi; \
-    git clone --depth 1 "$_platform_fetch_origin" /app/platform-baked; \
+    git clone --depth 1 "$MOBIUS_PLATFORM_ORIGIN" /app/platform-baked; \
     _build_date="${BUILD_DATE:-unknown}"; \
     if [ "$_build_date" = "unknown" ] || [ -z "$_build_date" ]; then \
       _build_date="$(date -u +%Y-%m-%d)"; \
     fi; \
     if [ "${MOBIUS_USE_LOCAL_PLATFORM_SOURCE:-0}" != "1" ] \
        && printf '%s' "$_build_sha" | grep -Eq '^[0-9a-fA-F]{40}$'; then \
-      if git -C /app/platform-baked fetch --depth 1 "$_platform_fetch_origin" "$_build_sha" \
+      if git -C /app/platform-baked fetch --depth 1 "$MOBIUS_PLATFORM_ORIGIN" "$_build_sha" \
          && git -C /app/platform-baked checkout "$_build_sha"; then \
         :; \
       else \
@@ -349,11 +349,11 @@ RUN set -eux; \
 # `railway up` uploads a working tree rather than a Git source deployment, so
 # Railway cannot provide RAILWAY_GIT_COMMIT_SHA. Review deployments may still
 # need the exact unpushed checkout to seed /data/platform. Keep that exception
-# explicit and provenance-bound: normal builds never copy this overlay, while
-# the opt-in path requires the caller to name the exact local commit and records
-# a synthetic Git commit whose tree is the uploaded source.
-COPY . /tmp/mobius-local-platform-source/
-RUN set -eux; \
+# explicit and provenance-bound: normal builds mount an empty context, while
+# the opt-in path mounts only a temporary bundle of committed Git objects.
+# Nothing from this read-only mount is retained in an image layer.
+RUN --mount=type=bind,from=mobius-local-platform-source,source=/,target=/tmp/mobius-local-platform-source,ro \
+    set -eux; \
     case "${MOBIUS_USE_LOCAL_PLATFORM_SOURCE:-0}" in 0|1) ;; *) \
       echo "FATAL: MOBIUS_USE_LOCAL_PLATFORM_SOURCE must be 0 or 1" >&2; exit 1;; \
     esac; \
@@ -361,10 +361,20 @@ RUN set -eux; \
       printf '%s' "${MOBIUS_LOCAL_PLATFORM_SHA:-unknown}" \
         | grep -Eq '^[0-9a-fA-F]{40}$' \
         || { echo "FATAL: local platform source requires its exact Git SHA" >&2; exit 1; }; \
-      cp -a /tmp/mobius-local-platform-source/. /app/platform-baked/; \
-      git -C /app/platform-baked add -A; \
-      git -C /app/platform-baked commit --allow-empty \
-        -m "Seed local review source ${MOBIUS_LOCAL_PLATFORM_SHA}"; \
+      printf '%s' "${MOBIUS_LOCAL_PLATFORM_BASE_SHA:-unknown}" \
+        | grep -Eq '^[0-9a-fA-F]{40}$' \
+        || { echo "FATAL: local platform source requires its public base SHA" >&2; exit 1; }; \
+      _bundle=/tmp/mobius-local-platform-source/platform.bundle; \
+      [ -f "$_bundle" ] \
+        || { echo "FATAL: local platform source bundle is missing" >&2; exit 1; }; \
+      git -C /app/platform-baked fetch --depth 1 "$MOBIUS_PLATFORM_ORIGIN" \
+        "${MOBIUS_LOCAL_PLATFORM_BASE_SHA}"; \
+      git -C /app/platform-baked fetch --no-tags "$_bundle" HEAD; \
+      [ "$(git -C /app/platform-baked rev-parse FETCH_HEAD)" = \
+        "${MOBIUS_LOCAL_PLATFORM_SHA}" ] \
+        || { echo "FATAL: local platform source bundle does not match its declared SHA" >&2; exit 1; }; \
+      git -C /app/platform-baked checkout --detach \
+        "${MOBIUS_LOCAL_PLATFORM_SHA}"; \
       git -C /app/platform-baked checkout -B main HEAD; \
       git -C /app/platform-baked branch -f upstream HEAD; \
       git -C /app/platform-baked update-ref refs/remotes/origin/main HEAD; \
@@ -382,8 +392,7 @@ RUN set -eux; \
         "${RAILWAY_DEPLOYMENT_ID:-unknown}" > /app/build-info.json; \
       chown -R root:root /app/platform-baked; \
       chmod -R a+rX,go-w /app/platform-baked; \
-    fi; \
-    rm -rf /tmp/mobius-local-platform-source
+    fi
 
 # What this image actually contains, so a running container can compare itself
 # with the source it serves instead of remembering which update touched what:

--- a/backend/tests/test_verify_test_runtime.py
+++ b/backend/tests/test_verify_test_runtime.py
@@ -143,7 +143,7 @@ def test_test_wrapper_isolates_compose_and_rejects_stale_images():
   backend_source = "COPY backend/app ./app/"
   backend_scripts = "COPY backend/scripts ./scripts/"
   platform_seed = (
-    'git clone --depth 1 "$_platform_fetch_origin" /app/platform-baked'
+    'git clone --depth 1 "$MOBIUS_PLATFORM_ORIGIN" /app/platform-baked'
   )
   frontend_source = "COPY frontend/ ./shell-src/"
   assert dockerfile.count(backend_source) == 1
@@ -153,15 +153,21 @@ def test_test_wrapper_isolates_compose_and_rejects_stale_images():
     assert dockerfile.index(asset_stage) < dockerfile.index(frontend_source)
   assert dockerfile.index(frontend_source) < dockerfile.index(platform_seed)
   assert dockerfile.index(platform_seed) < dockerfile.index(backend_source)
-  assert "ARG MOBIUS_PLATFORM_FETCH_ORIGIN=" in dockerfile
   assert (
     '[ "${MOBIUS_USE_LOCAL_PLATFORM_SOURCE:-0}" != "1" ]'
     in dockerfile
   )
+  assert 'ARG MOBIUS_LOCAL_PLATFORM_BASE_SHA=unknown' in dockerfile
+  assert "FROM scratch AS mobius-local-platform-source" in dockerfile
+  assert dockerfile.startswith("# syntax=docker/dockerfile:1\n")
   assert (
-    'git -C /app/platform-baked fetch --depth 1 "$_platform_fetch_origin"'
+    "RUN --mount=type=bind,from=mobius-local-platform-source"
     in dockerfile
   )
+  assert "/tmp/mobius-local-platform-source/platform.bundle" in dockerfile
+  assert 'git -C /app/platform-baked fetch --no-tags "$_bundle" HEAD' in dockerfile
+  assert 'git -C /app/platform-baked checkout --detach' in dockerfile
+  assert "COPY . /tmp/mobius-local-platform-source" not in dockerfile
   assert (
     'git -C /app/platform-baked remote set-url origin "$MOBIUS_PLATFORM_ORIGIN"'
     in dockerfile
@@ -171,12 +177,73 @@ def test_test_wrapper_isolates_compose_and_rejects_stale_images():
     in dockerfile
   )
   compose = (ROOT / "docker-compose.yml").read_text(encoding="utf-8")
+  assert "additional_contexts:" in compose
+  assert "mobius-local-platform-source:" in compose
+  assert "MOBIUS_LOCAL_PLATFORM_CONTEXT:-./.docker/empty-context" in compose
   assert "MOBIUS_USE_LOCAL_PLATFORM_SOURCE:" in compose
   assert "MOBIUS_LOCAL_PLATFORM_SHA:" in compose
+  assert "MOBIUS_LOCAL_PLATFORM_BASE_SHA:" in compose
   assert "MOBIUS_LOCAL_PLATFORM_DATE:" in compose
   deploy = (ROOT / "scripts" / "deploy-prod.sh").read_text(encoding="utf-8")
   assert "MOBIUS_USE_LOCAL_PLATFORM_SOURCE=1 requires a clean" in deploy
   assert 'export MOBIUS_LOCAL_PLATFORM_SHA="$_sha"' in deploy
+  assert 'bundle create "$LOCAL_SOURCE_CONTEXT/platform.bundle"' in deploy
+  assert 'export MOBIUS_LOCAL_PLATFORM_CONTEXT="$LOCAL_SOURCE_CONTEXT"' in deploy
+
+
+def test_local_platform_bundle_preserves_source_deletions(tmp_path):
+  def git(repo, *args):
+    return subprocess.run(
+      ["git", "-C", str(repo), *args],
+      check=True,
+      capture_output=True,
+      text=True,
+    ).stdout.strip()
+
+  public = tmp_path / "public"
+  public.mkdir()
+  git(public, "init", "-b", "main")
+  git(public, "config", "user.name", "Test")
+  git(public, "config", "user.email", "test@example.com")
+  (public / "kept.txt").write_text("base\n", encoding="utf-8")
+  (public / "deleted.txt").write_text("remove me\n", encoding="utf-8")
+  git(public, "add", ".")
+  git(public, "commit", "-m", "base")
+  base_sha = git(public, "rev-parse", "HEAD")
+
+  local = tmp_path / "local"
+  subprocess.run(
+    ["git", "clone", str(public), str(local)],
+    check=True,
+    capture_output=True,
+    text=True,
+  )
+  git(local, "config", "user.name", "Test")
+  git(local, "config", "user.email", "test@example.com")
+  (local / "deleted.txt").unlink()
+  (local / "kept.txt").write_text("local\n", encoding="utf-8")
+  git(local, "add", "-A")
+  git(local, "commit", "-m", "local change")
+  local_sha = git(local, "rev-parse", "HEAD")
+  local_tree = git(local, "rev-parse", "HEAD^{tree}")
+  bundle = tmp_path / "local.bundle"
+  git(local, "bundle", "create", str(bundle), "HEAD", f"^{base_sha}")
+
+  baked = tmp_path / "baked"
+  subprocess.run(
+    ["git", "clone", "--depth", "1", f"file://{public}", str(baked)],
+    check=True,
+    capture_output=True,
+    text=True,
+  )
+  git(baked, "fetch", "--depth", "1", str(public), base_sha)
+  git(baked, "fetch", "--no-tags", str(bundle), "HEAD")
+  assert git(baked, "rev-parse", "FETCH_HEAD") == local_sha
+  git(baked, "checkout", "--detach", local_sha)
+
+  assert not (baked / "deleted.txt").exists()
+  assert (baked / "kept.txt").read_text(encoding="utf-8") == "local\n"
+  assert git(baked, "rev-parse", "HEAD^{tree}") == local_tree
 
 
 def test_node_runtime_satisfies_the_pinned_agent_browser_engine():

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,13 +26,15 @@ services:
   app:
     build:
       context: .
+      additional_contexts:
+        mobius-local-platform-source: ${MOBIUS_LOCAL_PLATFORM_CONTEXT:-./.docker/empty-context}
       args:
         BUILD_SHA: ${BUILD_SHA:-unknown}
         BUILD_DATE: ${BUILD_DATE:-unknown}
         MOBIUS_PLATFORM_ORIGIN: ${MOBIUS_PLATFORM_ORIGIN:-https://github.com/mobius-os/mobius.git}
-        MOBIUS_PLATFORM_FETCH_ORIGIN: ${MOBIUS_PLATFORM_FETCH_ORIGIN:-}
         MOBIUS_USE_LOCAL_PLATFORM_SOURCE: ${MOBIUS_USE_LOCAL_PLATFORM_SOURCE:-0}
         MOBIUS_LOCAL_PLATFORM_SHA: ${MOBIUS_LOCAL_PLATFORM_SHA:-unknown}
+        MOBIUS_LOCAL_PLATFORM_BASE_SHA: ${MOBIUS_LOCAL_PLATFORM_BASE_SHA:-unknown}
         MOBIUS_LOCAL_PLATFORM_DATE: ${MOBIUS_LOCAL_PLATFORM_DATE:-unknown}
     image: ${MOBIUS_IMAGE:-mobius}
     container_name: mobius

--- a/scripts/deploy-prod.sh
+++ b/scripts/deploy-prod.sh
@@ -33,10 +33,6 @@
 #                           target maximum retained build cache after success (8)
 #   MOBIUS_IMAGE            stable Compose app image tag used for build,
 #                           preflight, cutover, and rollback (default: mobius)
-#   MOBIUS_PLATFORM_FETCH_ORIGIN
-#                           optional trusted build-only Git origin for a local
-#                           commit; the baked checkout keeps the public
-#                           MOBIUS_PLATFORM_ORIGIN as its durable remote
 #   MOBIUS_USE_LOCAL_PLATFORM_SOURCE
 #                           set to 1 to bake the clean local checkout rather
 #                           than fetching BUILD_SHA from the public origin;
@@ -172,6 +168,13 @@ else
 fi
 
 CURRENT_STEP=""
+LOCAL_SOURCE_CONTEXT=""
+cleanup_local_source_context() {
+  if [ -n "$LOCAL_SOURCE_CONTEXT" ]; then
+    rm -rf "$LOCAL_SOURCE_CONTEXT"
+    LOCAL_SOURCE_CONTEXT=""
+  fi
+}
 on_err() {
   local rc=$?
   if [ -n "$CURRENT_STEP" ]; then
@@ -182,6 +185,7 @@ on_err() {
   exit "$rc"
 }
 trap on_err ERR
+trap cleanup_local_source_context EXIT
 
 step()  { CURRENT_STEP="$1"; printf '\n%s[%s] %s%s\n' "$C_BOLD$C_BLUE" "$(date +%H:%M:%S)" "$1" "$C_RESET"; }
 info()  { printf '  %s\n' "$1"; }
@@ -1382,6 +1386,16 @@ else
         ;;
     esac
     export MOBIUS_LOCAL_PLATFORM_SHA="$_sha"
+    _local_base="$(git -C "$REPO_ROOT" merge-base HEAD "$PLATFORM_RELEASE_TRACKING_REF" 2>/dev/null || true)"
+    if ! printf '%s' "$_local_base" | grep -Eq '^[0-9a-fA-F]{40}$'; then
+      fail "could not identify the public base for the local platform commit"
+      exit 1
+    fi
+    if [ "$_local_base" = "$_sha" ]; then
+      fail "local platform source has no commits beyond ${PLATFORM_RELEASE_LABEL}; disable MOBIUS_USE_LOCAL_PLATFORM_SOURCE"
+      exit 1
+    fi
+    export MOBIUS_LOCAL_PLATFORM_BASE_SHA="$_local_base"
     export MOBIUS_LOCAL_PLATFORM_DATE="$BUILD_DATE"
   fi
   BUILT_THIS_RUN=1
@@ -1408,7 +1422,16 @@ else
       exit 1
     fi
   fi
+  if [ "${MOBIUS_USE_LOCAL_PLATFORM_SOURCE:-0}" = "1" ]; then
+    LOCAL_SOURCE_CONTEXT="$(mktemp -d "${TMPDIR:-/tmp}/mobius-platform-source.XXXXXX")"
+    git -C "$REPO_ROOT" bundle create "$LOCAL_SOURCE_CONTEXT/platform.bundle" \
+      HEAD "^${MOBIUS_LOCAL_PLATFORM_BASE_SHA}"
+    git -C "$REPO_ROOT" bundle verify \
+      "$LOCAL_SOURCE_CONTEXT/platform.bundle" >/dev/null
+    export MOBIUS_LOCAL_PLATFORM_CONTEXT="$LOCAL_SOURCE_CONTEXT"
+  fi
   docker compose "${COMPOSE_ARGS[@]}" build
+  cleanup_local_source_context
   ok "image rebuilt"
 fi
 


### PR DESCRIPTION
## Summary
- seed local images from a Git bundle of the exact committed overlay
- mount only that bundle during the build, so ignored or untracked host files cannot enter an image layer
- fetch the declared public base before importing the bundle, preserving deletions, modes, and exact commit identity
- remove the redundant build-only origin override and clean temporary bundle data after every build

## Testing
- `scripts/test.sh --fast` (98 passed)
- `bash -n scripts/deploy-prod.sh`

Follow-up to #1068. This completes the exact-tree contract described in #990: a local image now checks out the declared Git commit instead of copying a working directory over a public clone.
