### PR TITLE
Wait only at measured resource limits

### DIFF
--- a/backend/app/agent_admission.py
+++ b/backend/app/agent_admission.py
@@ -1,0 +1,135 @@
+"""Last-resort admission guard for provider turns under real resource pressure."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Awaitable, Callable
+
+from app.resource_pressure import MIB, resource_status
+
+
+class AgentTurnDeferred(RuntimeError):
+  """Starting another provider turn would endanger durable chat data.
+
+  ``resource`` names what the turn is waiting for (``memory`` or ``storage``)
+  so the caller can park it for automatic continuation once that resource is
+  back rather than failing it.
+  """
+
+  def __init__(self, message: str, *, resource: str) -> None:
+    super().__init__(message)
+    self.resource = resource
+
+
+def _section(status: dict[str, Any], *path: str) -> dict[str, Any]:
+  node: Any = status
+  for key in path:
+    node = node.get(key) if isinstance(node, dict) else None
+  return node if isinstance(node, dict) else {}
+
+
+def _memory_deferral(status: dict[str, Any]) -> str | None:
+  """Why a new turn must wait for memory, or ``None`` when it may start.
+
+  PSI is a retrospective contention signal: an avg60 threshold can remain
+  tripped after the stall has cleared, and by itself does not imply OOM risk.
+  Keep PSI visible in resource diagnostics, but admission defers only when the
+  point-in-time unreclaimable working set is at its critical ratio.
+  """
+  memory = _section(status, "pressure", "memory")
+  ratio = memory.get("working_set_ratio")
+  critical_at = memory.get("critical_at_ratio")
+  if not isinstance(ratio, (int, float)):
+    return None
+  if not isinstance(critical_at, (int, float)):
+    critical_at = 0.90
+  if ratio < critical_at:
+    return None
+  return (
+    "memory headroom because unreclaimable footprint is "
+    f"{ratio:.0%} of the limit (threshold {critical_at:.0%})"
+  )
+
+
+def _storage_deferral(status: dict[str, Any]) -> str | None:
+  """Why measured disk pressure requires a pause, or ``None`` otherwise.
+
+  The shared pressure snapshot already owns the installation-aware critical
+  floor. Admission deliberately does not multiply a guessed per-turn growth
+  allowance by the number of active chats: that turned healthy free space
+  into a hidden concurrency cap and reported contradictory owner-facing
+  numbers. Cleanup and the next fresh snapshot decide whether the real floor
+  is still crossed.
+  """
+  disk = _section(status, "pressure", "disk")
+  if disk.get("state") != "critical":
+    return None
+  free = _section(status, "facts", "disk").get("free_bytes")
+  threshold = disk.get("critical_below_bytes")
+  if not isinstance(free, int):
+    return "critically low shared storage"
+  if isinstance(threshold, int):
+    return (
+      f"critically low shared storage ({free // MIB} MiB free; "
+      f"safety floor {threshold // MIB} MiB)"
+    )
+  return f"critically low shared storage ({free // MIB} MiB free)"
+
+
+class _Blocked(Exception):
+  """One admission attempt found a resource short; carries the deferral."""
+
+  def __init__(self, deferral: AgentTurnDeferred) -> None:
+    self.deferral = deferral
+
+
+def _admit(status: dict[str, Any]) -> None:
+  """One attempt: defer only for measured critical memory or storage.
+
+  Unknown telemetry fails open. Raises ``_Blocked`` with the owner-facing
+  deferral when the shared pressure snapshot says a resource is critical.
+  """
+  memory_reason = _memory_deferral(status)
+  if memory_reason is not None:
+    raise _Blocked(AgentTurnDeferred(
+      f"This turn is waiting for {memory_reason}. It will continue "
+      "automatically when enough memory is available.",
+      resource="memory",
+    ))
+  storage_reason = _storage_deferral(status)
+  if storage_reason is not None:
+    raise _Blocked(AgentTurnDeferred(
+      f"This turn is waiting because Möbius has {storage_reason}. It will "
+      "continue automatically after cleanup frees space.",
+      resource="storage",
+    ))
+
+
+async def require_agent_turn_admission(
+  data_dir: str | Path,
+  *,
+  status_reader: Callable[[str | Path], dict[str, Any]] = resource_status,
+  scratch_sweeper: Callable[[], Awaitable[dict[str, Any]]] | None = None,
+) -> None:
+  """Admit a turn, reclaiming idle scratch once before a real deferral.
+
+  Owner lifecycle cleanup should normally keep the system above the measured
+  critical boundary. Unknown telemetry fails open for developer hosts and
+  unusual self-hosted runtimes.
+  """
+  try:
+    return _admit(status_reader(data_dir))
+  except _Blocked:
+    pass
+  if scratch_sweeper is None:
+    from app.agent_scratch import sweep_idle_scratch
+    scratch_sweeper = sweep_idle_scratch
+  try:
+    await scratch_sweeper()
+  except OSError:
+    # Cleanup is best-effort; the fresh snapshot below still owns admission.
+    pass
+  try:
+    return _admit(status_reader(data_dir))
+  except _Blocked as blocked:
+    raise blocked.deferral from None

--- a/backend/app/chat.py
+++ b/backend/app/chat.py
@@ -42,6 +42,7 @@ from app.broadcast import (
   has_running_chat_broadcast,
   set_active_broadcast,
 )
+from app.agent_admission import AgentTurnDeferred, require_agent_turn_admission
 from app.chat_event_sink import (
   ChatEventSink as _ChatEventSink,
   _pause_note,
@@ -555,15 +556,31 @@ async def _finish_run_strict(
   await _await_ack(ack)
 
 
-async def _recover_wedged_run_strict(chat_id: str, run_token: str) -> None:
-  """Atomically leave a durable interruption marker and close a wedged run."""
+async def _recover_wedged_run_strict(
+  chat_id: str,
+  run_token: str,
+  *,
+  message: str = "This response could not be saved. You can resume the turn.",
+  kind: str | None = None,
+  resumable: bool = True,
+  parked_until: datetime | None = None,
+  park_reason: str | None = None,
+) -> None:
+  """Atomically leave a durable interruption marker and close a wedged run.
+
+  Callers pass ``message`` (and optionally ``kind``/``resumable``) so the same
+  atomic "append a durable pause block + close or park the run + preserve
+  pending_messages" command serves both mid-turn recovery and setup/admission
+  outcomes. ``RecoverWedgedRun`` self-fences on the run token/status, so a run
+  a successor already superseded is a safe no-op.
+  """
   ack = get_writer().submit(
     RecoverWedgedRun(
       chat_id=chat_id,
       run_token=run_token,
-      interruption_block=_pause_note(
-        "This response could not be saved. You can resume the turn.",
-      ),
+      interruption_block=_pause_note(message, kind=kind, resumable=resumable),
+      parked_until=parked_until,
+      park_reason=park_reason,
     )
   )
   await _await_ack(ack)
@@ -1736,12 +1753,7 @@ async def _auto_resume_chat(
                 and accepted_nonce == park.restart_nonce
               )
             policy_enabled = bool(
-              chat is not None
-              and (
-                chat.auto_resume_on_restart
-                if park is not None and park.park_reason == "restart"
-                else chat.auto_resume_on_limit
-              )
+              chat is not None and _park_continues_automatically(chat, park)
             )
             if (
               chat is None
@@ -1757,6 +1769,7 @@ async def _auto_resume_chat(
               or (
                 park.initiated_by_app_id is not None
                 and not restart_park
+                and park.park_reason not in RESOURCE_PARK_REASONS
               )
               or latest_id != park.id
               or any(
@@ -1768,14 +1781,20 @@ async def _auto_resume_chat(
               return False
             current_provider = chat.provider or "claude"
             resume_reason = (
-              "restart" if restart_park else "usage_limit"
+              "restart" if restart_park
+              else park.park_reason
+              if park.park_reason in RESOURCE_PARK_REASONS
+              else "usage_limit"
             )
             resume_app_id = (
               # A real owner follow-up already waiting behind an app-owned
               # turn takes ownership of the resumed turn. This matches normal
               # pending promotion, where the first queued row owns attribution.
               park.initiated_by_app_id
-              if restart_park and not pending else None
+              if (
+                (restart_park or park.park_reason in RESOURCE_PARK_REASONS)
+                and not pending
+              ) else None
             )
           if not mark_starting(chat_id):
             return False
@@ -1986,6 +2005,8 @@ async def sweep_reset_parks(
   notification_requests: list[tuple[str, bool]] = []
 
   def queue_due_notification(chat_id: str, run: models.ChatRun) -> None:
+    if run.park_reason in RESOURCE_PARK_REASONS:
+      return
     notification_requests.append((chat_id, run.park_reason == "restart"))
 
   def auto_resume_rejection(chat, run) -> str | None:
@@ -1999,14 +2020,15 @@ async def sweep_reset_parks(
     restart_park = run.park_reason == "restart"
     if app_work_queued:
       return "app-attributed work"
-    if run.initiated_by_app_id is not None and not restart_park:
+    if (
+      run.initiated_by_app_id is not None
+      and not restart_park
+      and run.park_reason not in RESOURCE_PARK_REASONS
+    ):
       return "app-attributed work"
     if _has_unanswered_question(chat):
       return "waiting for an answer"
-    policy_enabled = bool(
-      chat.auto_resume_on_restart
-      if restart_park else chat.auto_resume_on_limit
-    )
+    policy_enabled = _park_continues_automatically(chat, run)
     if not policy_enabled:
       return "policy disabled"
     if restart_park and not (
@@ -3093,6 +3115,25 @@ def _parse_reset_text(text: str, now: datetime) -> datetime | None:
   return None
 
 
+RESOURCE_PARK_REASONS = frozenset({"memory", "storage"})
+RESOURCE_PARK_RECHECK = timedelta(seconds=60)
+
+
+def _park_continues_automatically(chat, park) -> bool:
+  reason = park.park_reason if park is not None else None
+  if reason == "restart":
+    return bool(chat.auto_resume_on_restart)
+  if reason in RESOURCE_PARK_REASONS:
+    return True
+  return bool(chat.auto_resume_on_limit)
+
+
+def _resource_park_fields(reason: str, now: datetime | None = None):
+  if now is None:
+    now = datetime.now(UTC).replace(tzinfo=None)
+  return now + RESOURCE_PARK_RECHECK, reason
+
+
 def _limit_park_fields(
   runner_result: dict,
   error_text: str | None,
@@ -3639,6 +3680,7 @@ async def run_chat(
   disposition = chat_queue.TerminalDisposition.FAILED_LEAVE_MARKER
   runtime_settled = False
   try:
+    await require_agent_turn_admission(get_settings().data_dir)
     disposition = await _run_chat_impl(
       messages, chat_id=chat_id, session_id=session_id,
       provider_id=provider_id, run_gen=run_gen,
@@ -3657,32 +3699,93 @@ async def run_chat(
     # other failure paths and durably fail the run. The queue marker keeps
     # its FAILED_LEAVE_MARKER default above, so reconciliation still sees
     # the evidence it needs.
-    _get_logger().exception(
-      "chat turn failed before the agent started chat_id=%s", chat_id,
-    )
-    bc = get_broadcast(chat_id) if chat_id else None
-    if bc is not None:
-      bc.publish({
-        "type": "error",
-        "message": (
+    if isinstance(exc, AgentTurnDeferred):
+      # Admission deferral is an expected protective outcome. Keep one concise
+      # breadcrumb, but do not allocate a traceback while disk is constrained.
+      _get_logger().warning(
+        "chat turn deferred before the agent started chat_id=%s: %s",
+        chat_id,
+        exc,
+      )
+    else:
+      _get_logger().exception(
+        "chat turn failed before the agent started chat_id=%s", chat_id,
+      )
+    if isinstance(exc, AgentTurnDeferred):
+      # Persist an actionable pause in the transcript rather than leaving a
+      # saved user message with an empty assistant reply. RecoverWedgedRun
+      # self-fences on run ownership, parks this run, and preserves the queue;
+      # the continuation sweep rechecks admission after pressure may ease.
+      recovered = False
+      if chat_id:
+        try:
+          parked_until, park_reason = _resource_park_fields(exc.resource)
+          await _recover_wedged_run_strict(
+            chat_id, run_token or "",
+            message=f"{exc} Your message is saved.",
+            kind=park_reason,
+            resumable=False,
+            parked_until=parked_until,
+            park_reason=park_reason,
+          )
+          recovered = True
+        except Exception:
+          _get_logger().warning(
+            "admission-deferral recovery did not persist chat_id=%s "
+            "(reconciliation will repair)", chat_id, exc_info=True,
+          )
+      # A Stop during admission may already have handed the chat to a fresh
+      # turn. Only this generation may close the shared live broadcast.
+      still_ours = run_gen is None or current_run_generation(chat_id) == run_gen
+      bc = get_broadcast(chat_id) if chat_id else None
+      if bc is not None and still_ours:
+        parked_until, park_reason = _resource_park_fields(exc.resource)
+        resource_event = _limit_error_event(
+          f"{exc} Your message is saved.", parked_until, park_reason,
+        )
+        resource_event.pop("resumable", None)
+        bc.publish(resource_event)
+        bc.publish({"type": "done"})
+        bc.mark_completed()
+      if chat_id and still_ours:
+        _publish_chat_run_finished(chat_id)
+      if chat_id and not recovered:
+        # The durable resumable pause could not persist; fall back to durably
+        # failing the run so it is never stranded 'running'.
+        try:
+          await _finish_run_strict(
+            chat_id, run_token or "", terminal_status="failed",
+          )
+        except Exception:
+          _get_logger().warning(
+            "admission-deferral FinishRun fallback did not persist chat_id=%s "
+            "(reconciliation will repair)", chat_id, exc_info=True,
+          )
+    else:
+      bc = get_broadcast(chat_id) if chat_id else None
+      if bc is not None:
+        message = (
           "This turn failed before the agent could start "
           f"({type(exc).__name__}). Your message is saved; the full error "
           "is in the server log."
-        ),
-      })
-      bc.publish({"type": "done"})
-      bc.mark_completed()
-    if chat_id:
-      _publish_chat_run_finished(chat_id)
-      try:
-        await _finish_run_strict(
-          chat_id, run_token or "", terminal_status="failed",
         )
-      except Exception:
-        _get_logger().warning(
-          "setup-failure FinishRun did not persist chat_id=%s "
-          "(reconciliation will repair)", chat_id, exc_info=True,
-        )
+        bc.publish({
+          "type": "error",
+          "message": message,
+        })
+        bc.publish({"type": "done"})
+        bc.mark_completed()
+      if chat_id:
+        _publish_chat_run_finished(chat_id)
+        try:
+          await _finish_run_strict(
+            chat_id, run_token or "", terminal_status="failed",
+          )
+        except Exception:
+          _get_logger().warning(
+            "setup-failure FinishRun did not persist chat_id=%s "
+            "(reconciliation will repair)", chat_id, exc_info=True,
+          )
   finally:
     stopped_gen = _clear_after_terminal_generation.get(chat_id)
     clear_stopped_run = run_gen is not None and stopped_gen == run_gen

--- a/backend/app/chat_writer.py
+++ b/backend/app/chat_writer.py
@@ -713,6 +713,8 @@ class RecoverWedgedRun(_Command):
   chat_id: str = ""
   run_token: str = ""
   interruption_block: dict = field(default_factory=dict)
+  parked_until: datetime | None = None
+  park_reason: str | None = None
 
 
 @dataclass
@@ -3435,8 +3437,14 @@ class ChatWriterActor:
       and owner_is_ours
       and self._run_is_latest(db, run)
     )
+    parks = cmd.parked_until is not None and run_is_current
     if run is not None and run.status == "running":
-      run.status = "interrupted"
+      if parks:
+        run.status = "parked"
+        run.parked_until = cmd.parked_until
+        run.park_reason = cmd.park_reason
+      else:
+        run.status = "interrupted"
       run.ended_at = datetime.now(UTC)
       run.restart_nonce = None
       changed = True

--- a/backend/app/chat_writer.py
+++ b/backend/app/chat_writer.py
@@ -48,6 +48,7 @@ import time
 import uuid
 from concurrent.futures import Future, InvalidStateError
 from dataclasses import dataclass, field
+from datetime import datetime
 
 from sqlalchemy import select, text, update
 from sqlalchemy.exc import SQLAlchemyError

--- a/backend/tests/test_agent_admission.py
+++ b/backend/tests/test_agent_admission.py
@@ -1,0 +1,231 @@
+"""Provider turns pause only for measured critical resource pressure."""
+
+import pytest
+
+from app.agent_admission import AgentTurnDeferred, require_agent_turn_admission
+
+
+def _status(state: str, free: int = 512 * 1024 * 1024) -> dict:
+  return {
+    "facts": {"disk": {"free_bytes": free}},
+    "pressure": {"disk": {
+      "state": state,
+      "critical_below_bytes": 1024 * 1024 * 1024,
+    }},
+  }
+
+
+@pytest.mark.asyncio
+async def test_unpressured_storage_starts_without_sweeping():
+  swept = False
+
+  async def sweep():
+    nonlocal swept
+    swept = True
+    return {}
+
+  result = await require_agent_turn_admission(
+    "/data",
+    status_reader=lambda _path: _status("normal", 2 * 1024 * 1024 * 1024),
+    scratch_sweeper=sweep,
+  )
+
+  assert swept is False
+  assert result is None
+
+
+@pytest.mark.asyncio
+async def test_unavailable_storage_telemetry_fails_open_without_sweeping():
+  swept = False
+
+  async def sweep():
+    nonlocal swept
+    swept = True
+    return {}
+
+  result = await require_agent_turn_admission(
+    "/data",
+    status_reader=lambda _path: {
+      "facts": {"disk": {"free_bytes": None}},
+      "pressure": {"disk": {"state": "unknown"}},
+    },
+    scratch_sweeper=sweep,
+  )
+
+  assert result is None
+  assert swept is False
+
+
+@pytest.mark.asyncio
+async def test_constrained_storage_starts_without_sweeping():
+  swept = False
+
+  async def sweep():
+    nonlocal swept
+    swept = True
+    return {}
+
+  result = await require_agent_turn_admission(
+    "/data",
+    status_reader=lambda _path: _status("constrained", 1995 * 1024 * 1024),
+    scratch_sweeper=sweep,
+  )
+
+  assert swept is False
+  assert result is None
+
+
+@pytest.mark.asyncio
+async def test_idle_scratch_reclaim_can_restore_critical_admission():
+  statuses = iter([
+    _status("critical"),
+    _status("constrained", 2 * 1024 * 1024 * 1024),
+  ])
+  sweeps = 0
+
+  async def sweep():
+    nonlocal sweeps
+    sweeps += 1
+    return {"removed": 1, "bytes": 1024}
+
+  result = await require_agent_turn_admission(
+    "/data",
+    status_reader=lambda _path: next(statuses),
+    scratch_sweeper=sweep,
+  )
+
+  assert sweeps == 1
+  assert result is None
+
+
+@pytest.mark.asyncio
+async def test_persistent_critical_pressure_defers_with_truthful_reason():
+  async def sweep():
+    return {"removed": 0, "bytes": 0}
+
+  with pytest.raises(
+    AgentTurnDeferred,
+    match="512 MiB free; safety floor 1024 MiB",
+  ):
+    await require_agent_turn_admission(
+      "/data",
+      status_reader=lambda _path: _status("critical"),
+      scratch_sweeper=sweep,
+    )
+
+
+@pytest.mark.asyncio
+async def test_normal_pressure_does_not_invent_per_turn_storage_claims():
+  async def sweep():
+    return {"removed": 0, "bytes": 0}
+
+  result = await require_agent_turn_admission(
+    "/data",
+    status_reader=lambda _path: _status("normal", 10_000 * 1024 * 1024),
+    scratch_sweeper=sweep,
+  )
+
+  assert result is None
+
+
+@pytest.mark.asyncio
+async def test_concurrent_turns_do_not_turn_healthy_disk_into_a_hidden_cap():
+  free = 10_000 * 1024 * 1024
+
+  async def sweep():
+    return {"removed": 0, "bytes": 0}
+
+  first = await require_agent_turn_admission(
+    "/data",
+    status_reader=lambda _path: _status("normal", free),
+    scratch_sweeper=sweep,
+  )
+  second = await require_agent_turn_admission(
+    "/data",
+    status_reader=lambda _path: _status("normal", free),
+    scratch_sweeper=sweep,
+  )
+
+  assert first is None
+  assert second is None
+
+
+def _memory_status(
+  state: str,
+  *signals: str,
+  working_set_ratio: float = 0.5,
+) -> dict:
+  return {
+    "facts": {"disk": {"free_bytes": 8 * 1024 * 1024 * 1024}},
+    "pressure": {
+      "disk": {"state": "normal"},
+      "memory": {
+        "state": state,
+        "working_set_ratio": working_set_ratio,
+        "critical_at_ratio": 0.9,
+        "reason": {"signals": list(signals)} if signals else None,
+      },
+    },
+  }
+
+
+@pytest.mark.asyncio
+async def test_constrained_memory_still_admits_new_turns():
+  result = await require_agent_turn_admission(
+    "/data",
+    status_reader=lambda _path: _memory_status(
+      "constrained", "PSI some avg60 1.8 >= 1.0",
+    ),
+    scratch_sweeper=None,
+  )
+  assert result is None
+
+
+@pytest.mark.asyncio
+async def test_critical_memory_defers_new_turns_and_names_the_signal():
+  """Starting another agent under critical memory invites the OOM killer."""
+  async def sweep():
+    return {"removed": 0, "bytes": 0}
+
+  with pytest.raises(
+    AgentTurnDeferred,
+    match=r"memory headroom because unreclaimable footprint is 94% of the limit",
+  ):
+    await require_agent_turn_admission(
+      "/data",
+      status_reader=lambda _path: _memory_status(
+        "critical",
+        "unreclaimable footprint is 94% of the limit (threshold 90%)",
+        working_set_ratio=0.94,
+      ),
+      scratch_sweeper=sweep,
+    )
+
+
+@pytest.mark.asyncio
+async def test_psi_only_critical_memory_is_diagnostic_not_an_admission_veto():
+  result = await require_agent_turn_admission(
+    "/data",
+    status_reader=lambda _path: _memory_status(
+      "critical",
+      "PSI full avg60 2.0 >= 2.0",
+      working_set_ratio=0.5,
+    ),
+  )
+
+  assert result is None
+
+
+@pytest.mark.asyncio
+async def test_cleanup_error_does_not_replace_resource_wait():
+  async def sweep():
+    raise OSError("scratch vanished during cleanup")
+
+  with pytest.raises(AgentTurnDeferred, match="512 MiB free") as exc:
+    await require_agent_turn_admission(
+      "/data",
+      status_reader=lambda _path: _status("critical"),
+      scratch_sweeper=sweep,
+    )
+
+  assert exc.value.resource == "storage"

--- a/backend/tests/test_limit_park.py
+++ b/backend/tests/test_limit_park.py
@@ -2126,3 +2126,87 @@ def test_limit_park_releases_starting_claim_before_returning():
     assert chat_mod.mark_starting(cid)
   finally:
     chat_mod.discard_starting(cid)
+
+# -- (h) platform-resource parks ----------------------------------------------
+
+def test_sweep_continues_resource_park_without_limit_opt_in(
+  owner_token, monkeypatch,
+):
+  del owner_token
+  notified = []
+  monkeypatch.setattr(
+    "app.push.notify_owner_async",
+    _async_notify(lambda db, owner_id, **kw: notified.append(kw) or "n"),
+  )
+  scheduled = []
+  monkeypatch.setattr(
+    chat_mod, "_schedule_continuation", lambda **kw: scheduled.append(kw),
+  )
+  monkeypatch.setattr(chat_mod, "_limit_auto_resume_now", lambda: 10**9)
+  _due_park(
+    "sweep-storage", "rt-sweep-storage",
+    auto_resume=False, park_reason="storage",
+  )
+  try:
+    assert _run_sweep() == ["sweep-storage"]
+    assert len(scheduled) == 1
+    assert scheduled[0]["chat_id"] == "sweep-storage"
+    assert notified == []
+  finally:
+    chat_mod.discard_starting("sweep-storage")
+
+
+def test_admission_recovery_command_parks_exact_run():
+  from app.chat_writer import RecoverWedgedRun
+
+  cid = "defer-storage-park"
+  _seed_chat(cid)
+  _seed_run(cid, "rt-defer-storage-park")
+  due = datetime.now(UTC).replace(tzinfo=None) + timedelta(seconds=60)
+  event = chat_mod._limit_error_event("waiting", due, "storage")
+  event.pop("resumable", None)
+  ack = get_writer().submit(RecoverWedgedRun(
+    chat_id=cid,
+    run_token="rt-defer-storage-park",
+    interruption_block=event,
+    parked_until=due,
+    park_reason="storage",
+  ))
+  assert ack.result(timeout=5) is True
+
+  row = _run_row("rt-defer-storage-park")
+  assert row["status"] == "parked"
+  assert row["park_reason"] == "storage"
+  assert row["parked_until"] == due
+  tail = _chat_row(cid)["messages"][-1]
+  assert tail["blocks"][-1]["pause"]["kind"] == "storage"
+
+
+def test_app_initiated_resource_park_preserves_attribution(
+  owner_token, monkeypatch,
+):
+  del owner_token
+  monkeypatch.setattr(
+    "app.push.notify_owner_async", _async_notify(lambda *args, **kwargs: "n"),
+  )
+  scheduled = []
+  monkeypatch.setattr(
+    chat_mod, "_schedule_continuation", lambda **kw: scheduled.append(kw),
+  )
+  monkeypatch.setattr(chat_mod, "_limit_auto_resume_now", lambda: 10**9)
+  cid = "sweep-app-storage"
+  app_id = 42
+  _due_park(
+    cid, f"rt-{cid}", auto_resume=False, park_reason="storage",
+    initiated_by_app_id=app_id,
+  )
+  try:
+    assert _run_sweep() == [cid]
+    assert len(scheduled) == 1
+    resumed = _run_row(scheduled[0]["run_token"])
+    assert resumed["initiated_by_app_id"] == app_id
+    assert scheduled[0]["next_user"]["_messages"][-1][
+      "continuation_reason"
+    ] == "storage"
+  finally:
+    chat_mod.discard_starting(cid)

--- a/backend/tests/test_run_chat_setup_failure.py
+++ b/backend/tests/test_run_chat_setup_failure.py
@@ -11,6 +11,7 @@ import asyncio
 import pytest
 
 from app import chat as chat_mod
+from app.agent_admission import AgentTurnDeferred
 from app.broadcast import create_broadcast, remove_broadcast
 
 
@@ -68,3 +69,155 @@ async def test_setup_cancellation_still_propagates(chat, monkeypatch):
       )
   finally:
     remove_broadcast(chat.id)
+
+
+@pytest.mark.asyncio
+async def test_disk_admission_deferral_parks_for_automatic_retry(
+  chat, monkeypatch, caplog,
+):
+  """Disk pressure becomes a truthful automatic wait, not a dead Resume."""
+  async def defer(_data_dir):
+    raise AgentTurnDeferred(
+      "This turn is waiting for storage headroom because only 512 MiB remains.",
+      resource="storage",
+    )
+
+  async def must_not_start(*_args, **_kwargs):
+    raise AssertionError("provider turn started despite failed admission")
+
+  monkeypatch.setattr(chat_mod, "require_agent_turn_admission", defer)
+  monkeypatch.setattr(chat_mod, "_run_chat_impl", must_not_start)
+
+  recovered = []
+
+  async def record_recover(
+    chat_id, run_token, *, message="", kind=None, resumable=True,
+    parked_until=None, park_reason=None,
+  ):
+    recovered.append({
+      "chat_id": chat_id, "run_token": run_token,
+      "message": message, "kind": kind, "resumable": resumable,
+      "parked_until": parked_until, "park_reason": park_reason,
+    })
+
+  monkeypatch.setattr(chat_mod, "_recover_wedged_run_strict", record_recover)
+
+  finished = []
+
+  async def record_finish(chat_id, run_token="", terminal_status="completed"):
+    finished.append((chat_id, run_token, terminal_status))
+
+  monkeypatch.setattr(chat_mod, "_finish_run_strict", record_finish)
+  bc = create_broadcast(chat.id)
+  events = []
+  real_publish = bc.publish
+
+  def recording_publish(event):
+    events.append(event)
+    return real_publish(event)
+
+  monkeypatch.setattr(bc, "publish", recording_publish)
+  try:
+    await chat_mod.run_chat(
+      [], chat_id=chat.id, session_id=None, provider_id="codex",
+      run_gen=chat_mod.current_run_generation(chat.id), run_token="tok-disk",
+    )
+  finally:
+    remove_broadcast(chat.id)
+
+  # Recovery persists the pause instead of finishing with an empty reply.
+  assert len(recovered) == 1
+  assert recovered[0]["run_token"] == "tok-disk"
+  assert "only 512 MiB remains" in recovered[0]["message"]
+  assert recovered[0]["message"].endswith("Your message is saved.")
+  assert recovered[0]["resumable"] is False
+  assert recovered[0]["kind"] == "storage"
+  assert recovered[0]["park_reason"] == "storage"
+  assert recovered[0]["parked_until"] is not None
+  # Recovery persisted, so the failed-finish fallback is not taken.
+  assert finished == []
+  # The live viewer gets the same automatic resource wait and terminal event.
+  err = next(event for event in events if event.get("type") == "error")
+  assert err["pause"]["kind"] == "storage"
+  assert "resumable" not in err
+  assert err["message"].endswith("Your message is saved.")
+  assert [event.get("type") for event in events][-1] == "done"
+  # One concise breadcrumb, no traceback allocated while disk is constrained.
+  deferral_logs = [
+    record for record in caplog.records
+    if "chat turn deferred before the agent started" in record.message
+  ]
+  assert len(deferral_logs) == 1
+  assert deferral_logs[0].exc_info is None
+
+
+@pytest.mark.asyncio
+async def test_disk_admission_recovery_failure_falls_back_to_failed_run(
+  chat, monkeypatch,
+):
+  async def defer(_data_dir):
+    raise AgentTurnDeferred("Storage headroom is still constrained.", resource="storage")
+
+  async def fail_recovery(*_args, **_kwargs):
+    raise RuntimeError("writer unavailable")
+
+  finished = []
+
+  async def record_finish(chat_id, run_token="", terminal_status="completed"):
+    finished.append((chat_id, run_token, terminal_status))
+
+  monkeypatch.setattr(chat_mod, "require_agent_turn_admission", defer)
+  monkeypatch.setattr(chat_mod, "_recover_wedged_run_strict", fail_recovery)
+  monkeypatch.setattr(chat_mod, "_finish_run_strict", record_finish)
+  bc = create_broadcast(chat.id)
+  try:
+    await chat_mod.run_chat(
+      [], chat_id=chat.id, session_id=None, provider_id="codex",
+      run_gen=chat_mod.current_run_generation(chat.id), run_token="tok-fallback",
+    )
+  finally:
+    remove_broadcast(chat.id)
+
+  assert finished == [(chat.id, "tok-fallback", "failed")]
+
+
+@pytest.mark.asyncio
+async def test_stale_disk_deferral_does_not_close_successor_broadcast(
+  chat, monkeypatch,
+):
+  start_gen = chat_mod.current_run_generation(chat.id)
+
+  async def defer_after_successor_started(_data_dir):
+    chat_mod.bump_run_generation(chat.id)
+    raise AgentTurnDeferred(
+      "Storage headroom is still constrained.", resource="storage",
+    )
+
+  async def recover_stale_run(*_args, **_kwargs):
+    return None
+
+  finished = []
+  monkeypatch.setattr(
+    chat_mod, "require_agent_turn_admission", defer_after_successor_started,
+  )
+  monkeypatch.setattr(
+    chat_mod, "_recover_wedged_run_strict", recover_stale_run,
+  )
+  monkeypatch.setattr(
+    chat_mod, "_publish_chat_run_finished", finished.append,
+  )
+  bc = create_broadcast(chat.id)
+  events = []
+  monkeypatch.setattr(bc, "publish", events.append)
+  try:
+    await chat_mod.run_chat(
+      [], chat_id=chat.id, session_id=None, provider_id="codex",
+      run_gen=start_gen, run_token="tok-stale",
+    )
+  finally:
+    remove_broadcast(chat.id)
+
+  assert events == []
+  assert finished == []
+  assert bc.running is True
+  assert bc.completed_at is None

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -97,6 +97,7 @@ import MessageMetaRow from './MessageMetaRow.jsx'
 import ActivityLineHeader from './ActivityLineHeader.jsx'
 import { messageCopyText } from './messageCopy.js'
 import { formatResetTime } from './resetTime.js'
+import { isResourcePause } from './resourcePause.js'
 import {
   resetDeadlineDelay,
   resetDeadlineState,
@@ -327,6 +328,17 @@ function tailResumableBlock(messages) {
     if (message.role !== 'assistant' || !message.blocks?.length) return null
     const tail = message.blocks[message.blocks.length - 1]
     return tail.type === 'error' && tail.resumable ? tail : null
+  }
+  return null
+}
+
+function tailResourcePauseBlock(messages) {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i].hidden) continue
+    const message = messages[i]
+    if (message.role !== 'assistant' || !message.blocks?.length) return null
+    const tail = message.blocks[message.blocks.length - 1]
+    return tail.type === 'error' && isResourcePause(tail) ? tail : null
   }
   return null
 }
@@ -4961,10 +4973,15 @@ export default function ChatView({
   // nudge + SR status can name the recovery. A pause is terminal (the turn has
   // ended), so it only ever lives in `messages`, never in a live stream item.
   const pendingResumeBlock = tailResumableBlock(messages)
-  // An open question is the single blocker: answering it IS the continuation,
-  // so don't surface a competing Resume (which the backend would now refuse).
-  const hasPendingResume = !!pendingResumeBlock && !hasPendingQuestion
-  const pendingLimitResetAt = pendingResumeBlock?.pause?.resets_at || null
+  const resourcePause = tailResourcePauseBlock(messages)
+  // Resource parks retry themselves and use the standard Waiting indicator;
+  // presenting Resume would offer an action admission must reject.
+  const hasPendingResume = !!pendingResumeBlock
+    && !resourcePause
+    && !hasPendingQuestion
+  const pendingLimitResetAt = resourcePause
+    ? null
+    : pendingResumeBlock?.pause?.resets_at || null
   useEffect(() => {
     if (!embedded || !autoResumeEnabled || !pendingLimitResetAt) {
       if (!pendingLimitResetAt) armedEmbeddedResetRef.current = null
@@ -5135,6 +5152,11 @@ export default function ChatView({
   // ready, it's waiting on the owner), and a screen-reader user has no visual
   // Resume card to fall back on.
   const resumeStatus = (() => {
+    if (resourcePause) {
+      return resourcePause.pause?.kind === 'memory'
+        ? 'Waiting for memory headroom. Möbius will continue automatically.'
+        : 'Waiting for storage headroom. Möbius will continue automatically.'
+    }
     if (!pendingResumeBlock) return null
     if (pendingResumeBlock.pause?.resets_at) {
       const label = formatResetTime(pendingResumeBlock.pause.resets_at)
@@ -5679,8 +5701,12 @@ export default function ChatView({
           onActionItem={handleGoalRailAction}
         />
         {draftGoal !== null && <GoalDraftChip objective={draftGoal} />}
-        {!turnActive && armedWaits.length > 0 && (
-          <WaitingChip waits={armedWaits} onCancel={handleCancelWait} />
+        {!turnActive && (armedWaits.length > 0 || resourcePause) && (
+          <WaitingChip
+            waits={armedWaits}
+            resourcePause={resourcePause}
+            onCancel={handleCancelWait}
+          />
         )}
         <ConnectionStatus
           error={connectionError}

--- a/frontend/src/components/ChatView/ErrorCard.jsx
+++ b/frontend/src/components/ChatView/ErrorCard.jsx
@@ -1,5 +1,6 @@
 import { StandardMarkdown } from './markdown/BlockRenderer.jsx'
 import { formatResetTime } from './resetTime.js'
+import { isResourcePause } from './resourcePause.js'
 import { ChevronRight } from '@openai/apps-sdk-ui/components/Icon'
 
 // The single renderer for the error/pause/park card family. MsgContent consumes
@@ -16,13 +17,14 @@ import { ChevronRight } from '@openai/apps-sdk-ui/components/Icon'
 // danger-red "Error" card is reserved for genuine failures (no `pause`). Old
 // persisted blocks predate `pause` and fall back to the error rendering.
 export function errorCardViewModel(block) {
-  const parked = !!block.pause?.resets_at
+  const resourceWait = isResourcePause(block)
+  const parked = !!block.pause?.resets_at && !resourceWait
   const benign = !!block.pause
   return {
     parked,
     benign,
     className: `chat__text--error${benign ? ' chat__text--parked' : ''}`,
-    label: parked ? 'Rate limit' : (block.pause ? 'Paused' : 'Error'),
+    label: resourceWait ? 'Waiting' : parked ? 'Rate limit' : (block.pause ? 'Paused' : 'Error'),
     resetLabel: parked ? formatResetTime(block.pause.resets_at) : null,
   }
 }

--- a/frontend/src/components/ChatView/MsgContent.jsx
+++ b/frontend/src/components/ChatView/MsgContent.jsx
@@ -16,6 +16,7 @@ import {
 } from './streamReducers.js'
 import { stripAugmentation } from './msgText.js'
 import ErrorCard from './ErrorCard.jsx'
+import { isResourcePause } from './resourcePause.js'
 import { ownsRecoveryAction } from './recoveryCard.js'
 import ContextCompactionMarker from './ContextCompactionMarker.jsx'
 import { assistantBlockKey } from './streamPromotion.js'
@@ -348,9 +349,10 @@ function MsgContentInner({
           canResume: !!onResume,
           questionOwnsTurn,
         })
-        const parked = !!block.pause?.resets_at
+        const resourceWait = isResourcePause(block)
+        const parked = !!block.pause?.resets_at && !resourceWait
         const automaticContinuation = recoveryOwner && parked && !!autoResumeEnabled
-        const manualResumeAvailable = recoveryOwner && (
+        const manualResumeAvailable = recoveryOwner && !resourceWait && (
           !parked || (!!limitResetElapsed && !autoResumeEnabled)
         )
         return (

--- a/frontend/src/components/ChatView/WaitingChip.jsx
+++ b/frontend/src/components/ChatView/WaitingChip.jsx
@@ -17,10 +17,30 @@ function intervalLabel(wait) {
   return minutes <= 1 ? 'checking every minute' : `checking every ${minutes} min`
 }
 
-export default function WaitingChip({ waits, onCancel }) {
-  if (!waits?.length) return null
+export default function WaitingChip({ waits, resourcePause, onCancel }) {
+  if (!waits?.length && !resourcePause) return null
+  const resourceLabel = resourcePause?.pause?.kind === 'memory'
+    ? 'Waiting for memory headroom'
+    : 'Waiting for storage headroom'
+  const resourceMeta = resourcePause?.pause?.resets_at
+    ? `checks again ${new Date(resourcePause.pause.resets_at).toLocaleTimeString([], {
+        hour: '2-digit', minute: '2-digit',
+      })}`
+    : 'checks again automatically'
   return (
     <div className="chat__waits" role="status" aria-live="polite">
+      {resourcePause && (
+        <div className="chat__wait-chip">
+          <span className="chat__wait-tag" aria-hidden="true">
+            <span className="chat__wait-pulse" />
+            Waiting
+          </span>
+          <span className="chat__wait-text" title={`${resourceLabel} — ${resourceMeta}`}>
+            {resourceLabel}
+          </span>
+          <span className="chat__wait-meta">{resourceMeta}</span>
+        </div>
+      )}
       {waits.map(wait => (
         <div key={wait.id} className="chat__wait-chip">
           <span className="chat__wait-tag" aria-hidden="true">

--- a/frontend/src/components/ChatView/__tests__/parkedCard.test.js
+++ b/frontend/src/components/ChatView/__tests__/parkedCard.test.js
@@ -3,6 +3,7 @@ import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import { ownsRecoveryAction } from '../recoveryCard.js'
 import { upsertTerminalErrorItem } from '../streamReducers.js'
+import { isResourcePause, resourcePauseLabel } from '../resourcePause.js'
 
 // Provider-limit parking (design §2.4): a limit-killed turn persists an error
 // block carrying a single `pause` descriptor ({kind, resets_at?}), which
@@ -13,6 +14,7 @@ import { upsertTerminalErrorItem } from '../streamReducers.js'
 const msgContent = readFileSync(new URL('../MsgContent.jsx', import.meta.url), 'utf8')
 const streamingMessage = readFileSync(new URL('../StreamingMessage.jsx', import.meta.url), 'utf8')
 const errorCard = readFileSync(new URL('../ErrorCard.jsx', import.meta.url), 'utf8')
+const waitingChip = readFileSync(new URL('../WaitingChip.jsx', import.meta.url), 'utf8')
 const resetTime = readFileSync(new URL('../resetTime.js', import.meta.url), 'utf8')
 const promotion = readFileSync(new URL('../streamPromotion.js', import.meta.url), 'utf8')
 const css = readFileSync(new URL('../ChatView.css', import.meta.url), 'utf8')
@@ -112,7 +114,7 @@ test('the rate-limit card presents one recovery action at a time', () => {
     'a future reset names the persistent chat policy')
   assert.match(msgContent, /Turn off auto-continue/,
     'an enabled policy stays reversible without a competing retry')
-  assert.match(msgContent, /manualResumeAvailable = recoveryOwner && \([\s\S]*!parked \|\| \(!!limitResetElapsed && !autoResumeEnabled\)/,
+  assert.match(msgContent, /manualResumeAvailable = recoveryOwner && !resourceWait && \([\s\S]*!parked \|\| \(!!limitResetElapsed && !autoResumeEnabled\)/,
     'manual continuation appears only after reset and only when auto continuation is off')
   assert.doesNotMatch(msgContent, /<Switch/,
     'the card must not present a switch beside a competing action')
@@ -247,4 +249,22 @@ test('the park card keeps provider mechanics behind progressive disclosure', () 
     'technical detail has an explicit visible disclosure indicator')
   assert.match(css, /\[open\] \.chat__recovery-details-chevron[\s\S]*rotate\(90deg\)/,
     'the disclosure indicator reflects its open state')
+})
+
+
+test('platform resource pauses use Waiting and never expose manual Resume', () => {
+  const storage = { pause: { kind: 'storage', resets_at: '2026-09-04T20:00:00Z' } }
+  const memory = { pause: { kind: 'memory' } }
+  assert.equal(isResourcePause(storage), true)
+  assert.equal(isResourcePause(memory), true)
+  assert.equal(isResourcePause({ pause: { kind: 'rate_limit' } }), false)
+  assert.equal(resourcePauseLabel(storage), 'Waiting for storage headroom')
+  assert.equal(resourcePauseLabel(memory), 'Waiting for memory headroom')
+  assert.match(msgContent, /manualResumeAvailable = recoveryOwner && !resourceWait/)
+  assert.match(chatView, /const pendingLimitResetAt = resourcePause[\s\S]*\? null/)
+  assert.match(chatView, /armedWaits.length > 0 \|\| resourcePause/)
+  assert.match(chatView, /const resumeStatus = \(\(\) => \{[\s\S]*if \(resourcePause\)[\s\S]*if \(!pendingResumeBlock\) return null/)
+  assert.match(waitingChip, /resourcePause && \(/)
+  assert.match(waitingChip, /Waiting for storage headroom/)
+  assert.doesNotMatch(waitingChip, /onCancel\?\.\(resourcePause/)
 })

--- a/frontend/src/components/ChatView/resourcePause.js
+++ b/frontend/src/components/ChatView/resourcePause.js
@@ -1,0 +1,11 @@
+const RESOURCE_PAUSE_KINDS = new Set(['memory', 'storage'])
+
+export function isResourcePause(block) {
+  return RESOURCE_PAUSE_KINDS.has(block?.pause?.kind)
+}
+
+export function resourcePauseLabel(block) {
+  if (block?.pause?.kind === 'memory') return 'Waiting for memory headroom'
+  if (block?.pause?.kind === 'storage') return 'Waiting for storage headroom'
+  return null
+}


### PR DESCRIPTION
## Summary
- remove speculative per-turn storage reservations and admit work until shared storage or memory is actually critical
- reclaim idle scratch once at the real boundary, then recheck fresh measurements before pausing
- park resource-stopped turns for automatic retry rather than presenting a manual Resume action that can only fail again
- show memory and storage pauses through the standard Waiting indicator, with truthful headroom and recheck copy
- preserve app attribution and queued messages across automatic resource recovery

This keeps the safety boundary without recreating the fixed concurrency ceiling removed by #780. Provider usage-limit retries retain their existing opt-in; platform resource waits resume automatically because Möbius, not the provider, interrupted them.

## Validation
- 90 focused backend tests on the exact rebased head
- full frontend unit suite on the exact rebased head
- frontend lint: 0 errors (39 existing warnings, below the repository threshold)
- 97-test hermetic backend contract suite on the pre-rebase candidate; the exact rebase was then covered by the focused backend suite
- Python compilation, clean diff, commit trailer, ancestry, and sensitive-data review

## Review
Reviewed for correctness, maintainability, simplicity, tests, security/privacy, and technical debt. Two issues found during review were fixed before publication: cleanup races now retain the resource-wait outcome, and non-resumable resource pauses are discovered independently of the manual-resume path so the Waiting status and screen-reader announcement remain visible.