### PR TITLE
Bump bundled Codex CLI to 0.153.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ RUN useradd -m -s /bin/bash mobius
 # agent-browser looks by default).
 # Discard npm's download cache in each layer: installed packages are the
 # runtime artifact; registry tarballs only make the production image larger.
-ARG CODEX_VERSION=0.152.1
+ARG CODEX_VERSION=0.153.4
 ARG AGENT_BROWSER_VERSION=0.35.1
 RUN apt-get update && apt-get install -y --no-install-recommends \
     age ca-certificates cron curl git jq procps ripgrep sqlite3 sudo unzip util-linux \
@@ -150,24 +150,10 @@ RUN pip install --no-cache-dir --require-hashes -r requirements.lock \
 # replace its private payload in the SAME image layer with a link to Möbius's
 # lockstep npm CLI. This preserves the external SDK contract without storing a
 # second ~350 MB runtime or running a second protocol version.
-# Pinned to commit SHA (not tag) for full reproducibility — tags are
-# mutable on GitHub. SHA corresponds to refs/tags/rust-v0.152.1
-# as of 2026-09-01, and is kept in lockstep with the npm @openai/codex
-# binary above (the SDK spawns it via codex_bin=shutil.which("codex")).
-# We moved from rust-v0.144.5 to this tag because the 0.144.x generated
-# ReasoningEffort enum was strict (none/minimal/low/medium/high/xhigh)
-# and rejected efforts the running CLI advertises for newer models, so
-# codex.models() and ThreadResumeResponse validation failed and broke a
-# real chat resume. alpha.13 turned ReasoningEffort into a forgiving
-# `str, Enum` with a `_missing_` hook that accepts any effort string;
-# 0.152.1 is the latest stable tag published to BOTH the git repo and npm, so
-# binary and schema stay matched. The SDK exposes the request bridge as a
-# public `approval_handler` constructor argument on
-# `openai_codex.client.CodexClient`; `AsyncCodex` still does not forward
-# it, so codex_sdk_runner.py installs the handler on the wrapped sync
-# client's `_approval_handler`.
+# Pin the SDK to the immutable commit for the npm CLI's release. Production
+# SDK contract tests verify the protocol and approval bridge before image merge.
 RUN pip install --no-cache-dir --no-deps \
-      'openai-codex @ git+https://github.com/openai/codex.git@5adb68a49933ae446bf11935662c83dba55a0804#subdirectory=sdk/python' \
+      'openai-codex @ git+https://github.com/openai/codex.git@3d2ee51ca2d5db578f328aa75e20aa22c0197c9a#subdirectory=sdk/python' \
     && pip install --no-cache-dir 'openai-codex-cli-bin==0.147.0' \
     && _codex_cli_bin="$(python -c \
       'from pathlib import Path; import codex_cli_bin; print(Path(codex_cli_bin.__file__).parent)')" \


### PR DESCRIPTION
## Summary

- Update the bundled Codex CLI from 0.152.1 to 0.153.4.
- Pin the Python SDK to the immutable commit for that same release.
- Replace stale release-specific rationale with the enduring lockstep contract.

## Verification

- `codex --version` reports 0.153.4 in the live instance.
- 31 focused image-runtime contract tests passed.
- The release tag resolves to the pinned immutable SDK commit, whose declared CLI package remains 0.147.0.
- Reviewed the complete one-file diff; it contains no owner data or credentials.
