### PR TITLE
Add owner-managed outbound Connect sharing

### DIFF
--- a/backend/app/connect_outbound.py
+++ b/backend/app/connect_outbound.py
@@ -1,0 +1,469 @@
+"""Owner-managed outbound Connect runners for this Möbius instance.
+
+The Connect UI accepts the exact one-line pairing command produced by another
+Möbius instance.  This module parses that command as data (never through a
+shell), downloads that instance's runner, and starts it in an isolated HOME.
+Each saved profile is independently revocable and contains its bearer only in
+the runner's own mode-0600 config file.
+
+Runner processes deliberately outlive a backend restart.  Their durable
+profile record is the lifecycle owner: every ``_RECONCILE_SECONDS`` the
+supervisor relaunches any ``active`` profile whose runner it neither owns nor
+finds alive, while a runner that exits on its own is recorded as ``ended``
+(exit 0) or ``error`` and is never restarted.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import re
+import secrets
+import select
+import shutil
+import signal
+import ssl
+import subprocess
+import sys
+import threading
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+from app import connect_runner
+from app.config import get_settings
+from app.storage_io import atomic_write
+
+
+log = logging.getLogger(__name__)
+
+_MAX_RUNNER_BYTES = 2 * 1024 * 1024
+_PAIR_TIMEOUT_SECONDS = 35
+_RECONCILE_SECONDS = 5
+_ID_RE = re.compile(r"^o_[a-f0-9]{16}$")
+_COMMAND_RE = re.compile(
+  r"^\s*curl\s+-fsSL\s+"
+  r"(?P<base>[^\s'\"]+)/api/connect/i/"
+  r"(?P<code>[ABCDEFGHJKLMNPQRSTUVWXYZ23456789]{4}-"
+  r"[ABCDEFGHJKLMNPQRSTUVWXYZ23456789]{4})"
+  r"\s*\|\s*sh\s*$",
+)
+_lock = threading.RLock()
+_owned_processes: dict[str, subprocess.Popen] = {}
+
+
+class OutboundConnectError(RuntimeError):
+  """A safe, owner-facing outbound Connect failure."""
+
+
+def _now() -> float:
+  return time.time()
+
+
+def _profiles_dir() -> Path:
+  root = Path(get_settings().data_dir) / "shared" / "connect" / "outbound"
+  root.mkdir(parents=True, exist_ok=True)
+  try:
+    root.chmod(0o700)
+  except OSError:
+    pass
+  return root
+
+
+def _profile_dir(profile_id: str) -> Path:
+  if not _ID_RE.fullmatch(profile_id or ""):
+    raise LookupError(profile_id)
+  return _profiles_dir() / profile_id
+
+
+def _meta_path(profile_id: str) -> Path:
+  return _profile_dir(profile_id) / "profile.json"
+
+
+def _pid_path(profile_id: str) -> Path:
+  return _profile_dir(profile_id) / "runner.pid"
+
+
+def _runner_path(profile_id: str) -> Path:
+  return _profile_dir(profile_id) / "home" / ".mobius-connect" / "runner.py"
+
+
+def _runner_config_path(profile_id: str) -> Path:
+  return _profile_dir(profile_id) / "home" / ".mobius-connect" / "config.json"
+
+
+def _atomic_json(path: Path, value: dict) -> None:
+  atomic_write(path, json.dumps(value, indent=2), mode=0o600)
+
+
+def _read_json(path: Path) -> dict | None:
+  try:
+    value = json.loads(path.read_text(encoding="utf-8"))
+  except (OSError, ValueError):
+    return None
+  return value if isinstance(value, dict) else None
+
+
+def parse_pairing_command(command: str) -> tuple[str, str]:
+  """Extract a trusted origin and code from Connect's exact copyable line."""
+  match = _COMMAND_RE.fullmatch(str(command or ""))
+  if match is None:
+    raise OutboundConnectError(
+      "Paste the complete command from the other person’s Connect app.",
+    )
+  try:
+    base_url = connect_runner._validated_base_url(match.group("base"))
+  except ValueError as exc:
+    raise OutboundConnectError(str(exc)) from exc
+  return base_url, match.group("code")
+
+
+def _download_runner(base_url: str) -> bytes:
+  request = urllib.request.Request(
+    base_url + "/api/connect/runner",
+    headers={"Accept": "text/x-python", "User-Agent": "Mobius-Connect/1"},
+  )
+  try:
+    with connect_runner._open_url(
+      request, timeout=30, context=ssl.create_default_context(),
+    ) as response:
+      source = response.read(_MAX_RUNNER_BYTES + 1)
+  except (OSError, ValueError, urllib.error.URLError) as exc:
+    raise OutboundConnectError(
+      "Couldn’t reach the other person’s Möbius.",
+    ) from exc
+  if len(source) > _MAX_RUNNER_BYTES:
+    raise OutboundConnectError("That Connect runner is unexpectedly large.")
+  if not source.startswith(b"#!/usr/bin/env python3") or b"Mobius Connect runner" not in source[:4096]:
+    raise OutboundConnectError("That address did not return a Connect runner.")
+  return source
+
+
+def _runner_env(profile_id: str) -> dict[str, str]:
+  home = _profile_dir(profile_id) / "home"
+  home.mkdir(parents=True, exist_ok=True)
+  try:
+    home.chmod(0o700)
+  except OSError:
+    pass
+  env = os.environ.copy()
+  env["HOME"] = str(home)
+  env["XDG_CONFIG_HOME"] = str(home / ".config")
+  return env
+
+
+def _write_pid(profile_id: str, pid: int) -> None:
+  atomic_write(_pid_path(profile_id), str(pid), mode=0o600)
+
+
+def _read_pid(profile_id: str) -> int | None:
+  try:
+    return int(_pid_path(profile_id).read_text(encoding="ascii").strip())
+  except (OSError, ValueError):
+    return None
+
+
+def _process_alive(profile_id: str) -> bool:
+  pid = _read_pid(profile_id)
+  if not pid or pid == os.getpid():
+    return False
+  try:
+    os.kill(pid, 0)
+    cmdline = Path(f"/proc/{pid}/cmdline").read_bytes()
+  except (OSError, ProcessLookupError):
+    return False
+  return str(_runner_path(profile_id)).encode() in cmdline.split(b"\0")
+
+
+def _launch(profile_id: str, *args: str) -> subprocess.Popen:
+  runner = _runner_path(profile_id)
+  if not runner.is_file():
+    raise OutboundConnectError("The saved Connect runner is missing.")
+  log_path = _profile_dir(profile_id) / "runner.log"
+  with log_path.open("ab") as log_file:
+    process = subprocess.Popen(
+      [sys.executable, str(runner), *args],
+      cwd=str(_profile_dir(profile_id)),
+      env=_runner_env(profile_id),
+      stdin=subprocess.DEVNULL,
+      stdout=log_file,
+      stderr=log_file,
+      start_new_session=True,
+    )
+  _owned_processes[profile_id] = process
+  _write_pid(profile_id, process.pid)
+  return process
+
+
+def _public_profile(meta: dict) -> dict:
+  profile_id = str(meta.get("id") or "")
+  online = _ID_RE.fullmatch(profile_id) is not None and _process_alive(profile_id)
+  status = "active" if online else str(meta.get("status") or "ended")
+  parsed = urllib.parse.urlsplit(str(meta.get("base_url") or ""))
+  return {
+    "id": profile_id,
+    "label": meta.get("label") or "Shared access",
+    "target": parsed.hostname or "Another Möbius",
+    "status": status,
+    "online": online,
+    "created_at": meta.get("created_at"),
+  }
+
+
+def list_profiles() -> list[dict]:
+  profiles = []
+  with _lock:
+    for path in sorted(_profiles_dir().glob("o_*/profile.json")):
+      meta = _read_json(path)
+      if meta and _ID_RE.fullmatch(str(meta.get("id") or "")):
+        profiles.append(_public_profile(meta))
+  return sorted(profiles, key=lambda item: float(item.get("created_at") or 0), reverse=True)
+
+
+def _await_pairing(process: subprocess.Popen, profile_id: str) -> dict | None:
+  """Return the runner's saved config once paired, or None if it gave up."""
+  deadline = time.monotonic() + _PAIR_TIMEOUT_SECONDS
+  while time.monotonic() < deadline:
+    config = _read_json(_runner_config_path(profile_id))
+    if config and config.get("token") and config.get("host_id"):
+      return config
+    if process.poll() is not None:
+      return None
+    time.sleep(0.1)
+  return None
+
+
+def _discard(profile_id: str) -> None:
+  _stop_process_tree(profile_id)
+  _owned_processes.pop(profile_id, None)
+  shutil.rmtree(_profile_dir(profile_id))
+
+
+def _create_profile(label: str, command: str) -> dict:
+  base_url, code = parse_pairing_command(command)
+  source = _download_runner(base_url)
+  profile_id = "o_" + secrets.token_hex(8)
+  meta = {
+    "id": profile_id,
+    "label": label,
+    "base_url": base_url,
+    "created_at": _now(),
+    "status": "connecting",
+  }
+  with _lock:
+    _profile_dir(profile_id).mkdir(parents=True, mode=0o700)
+  try:
+    with _lock:
+      runner = _runner_path(profile_id)
+      runner.parent.mkdir(parents=True, mode=0o700)
+      runner.write_bytes(source)
+      runner.chmod(0o700)
+      _atomic_json(_meta_path(profile_id), meta)
+      process = _launch(profile_id, "--pair", code, "--url", base_url)
+
+    config = _await_pairing(process, profile_id)
+    if config is None:
+      raise OutboundConnectError(
+        "The other Möbius did not accept that command. It may have expired or already been used.",
+      )
+    try:
+      saved_base = connect_runner._validated_base_url(str(config.get("url") or ""))
+    except ValueError:
+      saved_base = ""
+    if saved_base != base_url:
+      raise OutboundConnectError("The Connect runner saved an unexpected address.")
+    meta["status"] = "active"
+    with _lock:
+      _atomic_json(_meta_path(profile_id), meta)
+    return _public_profile(meta)
+  except Exception:
+    with _lock:
+      _discard(profile_id)
+    raise
+
+
+async def create_profile(label: str, command: str) -> dict:
+  return await asyncio.to_thread(_create_profile, label, command)
+
+
+def _process_identity(pid: int) -> tuple[int, int] | None:
+  """Return parent pid and kernel start time, which distinguishes PID reuse."""
+  try:
+    text = Path(f"/proc/{pid}/stat").read_text(encoding="utf-8")
+    fields = text[text.rfind(")") + 2:].split()
+    return int(fields[1]), int(fields[19])
+  except (OSError, ValueError, IndexError):
+    return None
+
+
+def _descendant_processes(root_pid: int) -> dict[int, tuple[int, int]]:
+  processes = {}
+  for stat in Path("/proc").glob("[0-9]*/stat"):
+    pid = int(stat.parent.name)
+    identity = _process_identity(pid)
+    if identity is not None:
+      processes[pid] = identity
+  descendants = {}
+  frontier = [root_pid]
+  while frontier:
+    parent = frontier.pop()
+    children = {pid: identity for pid, identity in processes.items() if identity[0] == parent}
+    descendants.update(children)
+    frontier.extend(children)
+  return descendants
+
+
+def _stop_process_tree(profile_id: str) -> None:
+  # Remote commands start independent sessions. Pin every discovered process
+  # with a pidfd so PID reuse, including after SIGTERM, cannot target a stranger.
+  owned = _owned_processes.get(profile_id)
+  pid = owned.pid if owned is not None else _read_pid(profile_id)
+  if not pid or (owned is not None and owned.poll() is not None):
+    return
+  identity = _process_identity(pid)
+  if identity is None or (owned is None and not _process_alive(profile_id)):
+    return
+  processes = _descendant_processes(pid)
+  processes[pid] = identity
+  handles = []
+  root_handle = None
+  try:
+    for target, expected in processes.items():
+      try:
+        handle = os.pidfd_open(target)
+      except ProcessLookupError:
+        continue
+      if _process_identity(target) != expected:
+        os.close(handle)
+        continue
+      handles.append(handle)
+      if target == pid:
+        root_handle = handle
+    if root_handle is None or _process_identity(pid) != identity:
+      return
+    for handle in handles:
+      try:
+        signal.pidfd_send_signal(handle, signal.SIGTERM)
+      except ProcessLookupError:
+        pass
+    pending = set(handles)
+    poller = select.poll()
+    for handle in pending:
+      poller.register(handle, select.POLLIN)
+    deadline = time.monotonic() + 3
+    while pending:
+      remaining = deadline - time.monotonic()
+      if remaining <= 0:
+        break
+      for handle, _event in poller.poll(max(1, int(remaining * 1000))):
+        pending.discard(handle)
+        poller.unregister(handle)
+    for handle in pending:
+      try:
+        signal.pidfd_send_signal(handle, signal.SIGKILL)
+      except ProcessLookupError:
+        pass
+    owned = _owned_processes.get(profile_id)
+    if owned is not None:
+      owned.wait(timeout=3)
+  finally:
+    for handle in handles:
+      os.close(handle)
+
+
+def _disconnect_remote(config: dict) -> None:
+  try:
+    base_url = connect_runner._validated_base_url(str(config.get("url") or ""))
+  except ValueError as exc:
+    raise OutboundConnectError(
+      "The saved Connect address is invalid, so access was kept.",
+    ) from exc
+  token = str(config.get("token") or "")
+  if not token:
+    raise OutboundConnectError(
+      "The saved Connect credential is missing, so access was kept.",
+    )
+  request = urllib.request.Request(
+    base_url + "/api/connect/disconnect",
+    data=b"{}",
+    method="POST",
+    headers={
+      "Authorization": "Bearer " + token,
+      "Content-Type": "application/json",
+      "User-Agent": "Mobius-Connect/1",
+    },
+  )
+  try:
+    with connect_runner._open_url(
+      request, timeout=30, context=ssl.create_default_context(),
+    ) as response:
+      response.read(64 * 1024)
+  except urllib.error.HTTPError as exc:
+    if exc.code not in (401, 403, 404):
+      raise OutboundConnectError(
+        "Couldn’t confirm revocation with the other Möbius, so access was kept.",
+      ) from exc
+  except (OSError, ValueError, urllib.error.URLError) as exc:
+    raise OutboundConnectError(
+      "Couldn’t confirm revocation with the other Möbius, so access was kept.",
+    ) from exc
+
+
+def _revoke_profile(profile_id: str) -> None:
+  meta = _read_json(_meta_path(profile_id))
+  if meta is None:
+    raise LookupError(profile_id)
+  config = _read_json(_runner_config_path(profile_id))
+  if config is None:
+    raise OutboundConnectError(
+      "The saved Connect details are unreadable, so access was kept.",
+    )
+  _disconnect_remote(config)
+  with _lock:
+    _discard(profile_id)
+
+
+async def revoke_profile(profile_id: str) -> None:
+  await asyncio.to_thread(_revoke_profile, profile_id)
+
+
+def _reconcile_once() -> None:
+  with _lock:
+    for path in sorted(_profiles_dir().glob("o_*/profile.json")):
+      meta = _read_json(path)
+      if not meta:
+        continue
+      profile_id = str(meta.get("id") or "")
+      if not _ID_RE.fullmatch(profile_id):
+        continue
+      owned = _owned_processes.get(profile_id)
+      if owned is not None:
+        result = owned.poll()
+        if result is None:
+          continue
+        _owned_processes.pop(profile_id, None)
+        meta["status"] = "ended" if result == 0 else "error"
+        _atomic_json(_meta_path(profile_id), meta)
+        continue
+      if _process_alive(profile_id):
+        continue
+      if meta.get("status") != "active":
+        continue
+      try:
+        _launch(profile_id)
+      except (OSError, OutboundConnectError):
+        meta["status"] = "error"
+        _atomic_json(_meta_path(profile_id), meta)
+
+
+async def supervise_outbound_connects() -> None:
+  while True:
+    try:
+      await asyncio.to_thread(_reconcile_once)
+    except Exception as exc:
+      log.error("outbound Connect reconciliation failed: %s", exc, exc_info=True)
+    await asyncio.sleep(_RECONCILE_SECONDS)

--- a/backend/app/connect_outbound.py
+++ b/backend/app/connect_outbound.py
@@ -195,13 +195,43 @@ def _launch(profile_id: str, *args: str) -> subprocess.Popen:
       start_new_session=True,
     )
   _owned_processes[profile_id] = process
-  _write_pid(profile_id, process.pid)
+  try:
+    _write_pid(profile_id, process.pid)
+  except BaseException as persistence_error:
+    # Popen and its durable identity form one launch transaction.  Callers
+    # must never receive a failed launch while its runner still grants access.
+    try:
+      _stop_process_tree(profile_id)
+    except BaseException:
+      log.exception("outbound Connect launch cleanup failed for %s", profile_id)
+    # A newly created, unreaped Popen still pins its PID, so this fallback
+    # cannot signal a reused PID even if the broader tree cleanup failed.
+    if process.poll() is None:
+      try:
+        process.kill()
+        process.wait(timeout=3)
+      except (OSError, subprocess.TimeoutExpired):
+        pass
+    if process.poll() is None:
+      raise OutboundConnectError(
+        "The Connect runner started, but its process record could not be saved "
+        "and the runner could not be stopped.",
+      ) from persistence_error
+    _owned_processes.pop(profile_id, None)
+    try:
+      _pid_path(profile_id).unlink(missing_ok=True)
+    except OSError:
+      pass
+    raise
   return process
 
 
 def _public_profile(meta: dict) -> dict:
   profile_id = str(meta.get("id") or "")
-  online = _ID_RE.fullmatch(profile_id) is not None and _process_alive(profile_id)
+  owned = _owned_processes.get(profile_id)
+  online = _ID_RE.fullmatch(profile_id) is not None and (
+    (owned is not None and owned.poll() is None) or _process_alive(profile_id)
+  )
   status = "active" if online else str(meta.get("status") or "ended")
   parsed = urllib.parse.urlsplit(str(meta.get("base_url") or ""))
   return {
@@ -417,12 +447,16 @@ def _revoke_profile(profile_id: str) -> None:
   meta = _read_json(_meta_path(profile_id))
   if meta is None:
     raise LookupError(profile_id)
-  config = _read_json(_runner_config_path(profile_id))
+  config_path = _runner_config_path(profile_id)
+  config = _read_json(config_path)
   if config is None:
-    raise OutboundConnectError(
-      "The saved Connect details are unreadable, so access was kept.",
-    )
-  _disconnect_remote(config)
+    if meta.get("status") != "revoked" or config_path.exists():
+      raise OutboundConnectError(
+        "The saved Connect details are unreadable, so remote revocation "
+        "cannot be confirmed. Access was kept.",
+      )
+  else:
+    _disconnect_remote(config)
   with _lock:
     _discard(profile_id)
 
@@ -446,7 +480,21 @@ def _reconcile_once() -> None:
         if result is None:
           continue
         _owned_processes.pop(profile_id, None)
-        meta["status"] = "ended" if result == 0 else "error"
+        # A remotely requested disconnect cleanly exits only after removing
+        # all local runner artifacts.  Record that observed transition so a
+        # later local removal does not need credentials that no longer exist.
+        runner_uninstalled = result == 0 and all(
+          not artifact.exists()
+          for artifact in (
+            _runner_config_path(profile_id),
+            _runner_path(profile_id),
+            _runner_path(profile_id).with_name("runner.pid"),
+          )
+        )
+        if runner_uninstalled:
+          meta["status"] = "revoked"
+        else:
+          meta["status"] = "ended" if result == 0 else "error"
         _atomic_json(_meta_path(profile_id), meta)
         continue
       if _process_alive(profile_id):

--- a/backend/app/routes/connect.py
+++ b/backend/app/routes/connect.py
@@ -19,6 +19,9 @@ remains visible to the owner with an in-place update command.
 
 Owner/app surface:
 
+  GET    /api/connect/outbound            list people this Möbius joined
+  POST   /api/connect/outbound            paste another Connect command
+  DELETE /api/connect/outbound/{id}       revoke that outbound access
   POST   /api/connect/hosts               create a host + pairing code
   GET    /api/connect/hosts               list hosts + live status
   PATCH  /api/connect/hosts/{id}          rename a host
@@ -56,13 +59,14 @@ from pydantic import BaseModel, Field, field_validator, model_validator
 from slowapi import Limiter
 from slowapi.util import get_remote_address
 
-from app import models
+from app import connect_outbound, models
 from app.config import get_settings
 from app.deps import (
   get_owner_or_app_with_connect_manage,
   reject_cross_site,
   require_nondelegated_owner_or_app_control,
 )
+from app.storage_io import atomic_write
 
 router = APIRouter(
   prefix="/api/connect",
@@ -122,9 +126,7 @@ def _load_host(host_id: str) -> dict | None:
 
 def _save_host(host: dict) -> None:
   p = _host_path(host["id"])
-  tmp = p.with_suffix(".json.tmp")
-  tmp.write_text(json.dumps(host, indent=2), "utf-8")
-  tmp.replace(p)
+  atomic_write(p, json.dumps(host, indent=2), mode=0o600)
 
 
 def _list_hosts() -> list[dict]:
@@ -501,9 +503,60 @@ class RenameHostBody(BaseModel):
   name: str = Field(min_length=1, max_length=80)
 
 
+class CreateOutboundBody(BaseModel):
+  label: str = Field(min_length=1, max_length=80)
+  command: str = Field(min_length=1, max_length=4096)
+
+  @field_validator("label")
+  @classmethod
+  def normalize_label(cls, value: str) -> str:
+    label = value.strip()
+    if not label:
+      raise ValueError("Name who will have access.")
+    return label
+
+
 # --------------------------------------------------------------------------- #
 # Owner/app surface
 # --------------------------------------------------------------------------- #
+@router.get("/outbound")
+async def list_outbound_access(
+  _owner: models.Owner = Depends(get_owner_or_app_with_connect_manage),
+) -> dict:
+  return {"connections": connect_outbound.list_profiles()}
+
+
+@router.post(
+  "/outbound",
+  dependencies=[Depends(require_nondelegated_owner_or_app_control)],
+)
+async def create_outbound_access(
+  body: CreateOutboundBody,
+  _owner: models.Owner = Depends(get_owner_or_app_with_connect_manage),
+) -> dict:
+  try:
+    return await connect_outbound.create_profile(body.label, body.command)
+  except connect_outbound.OutboundConnectError as exc:
+    raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.delete(
+  "/outbound/{profile_id}",
+  dependencies=[Depends(require_nondelegated_owner_or_app_control)],
+)
+async def revoke_outbound_access(
+  profile_id: str,
+  _owner: models.Owner = Depends(get_owner_or_app_with_connect_manage),
+) -> dict:
+  try:
+    await connect_outbound.revoke_profile(profile_id)
+  except LookupError as exc:
+    raise HTTPException(status_code=404, detail="No such shared access.") from exc
+  except connect_outbound.OutboundConnectError as exc:
+    raise HTTPException(status_code=409, detail=str(exc)) from exc
+  return {"ok": True}
+
+
 def _base_url() -> str:
   return get_settings().frontend_origin.rstrip("/")
 

--- a/backend/app/runtime_supervisors.py
+++ b/backend/app/runtime_supervisors.py
@@ -57,6 +57,8 @@ class RuntimeSupervisors:
   async def start_process_services(self) -> None:
     """Start services that are safe without a serviceable database."""
     await self._start_frontend_watcher()
+    from app.connect_outbound import supervise_outbound_connects
+    self._spawn("connect-outbound", supervise_outbound_connects())
 
   async def start_database_services(self) -> None:
     """Start long-lived database work; individual wiring failures fail open."""

--- a/backend/app/storage_io.py
+++ b/backend/app/storage_io.py
@@ -92,7 +92,9 @@ def etag_matches(token: str, if_match: str) -> bool:
   return False
 
 
-def atomic_write(file_path: Path, content: str | bytes) -> None:
+def atomic_write(
+  file_path: Path, content: str | bytes, *, mode: int = 0o644,
+) -> None:
   """Writes content to file_path atomically — no torn or interleaved reads.
 
   A reader (or the listing-based completion poll a mini-app runs after a job)
@@ -107,8 +109,9 @@ def atomic_write(file_path: Path, content: str | bytes) -> None:
   file_path.parent.mkdir(parents=True, exist_ok=True)
   data = content.encode("utf-8") if isinstance(content, str) else content
   # Unique temp name (mkstemp) so concurrent writers to the same path don't
-  # collide on the temp file itself. mkstemp creates 0600; chmod to 0644 so the
-  # file is readable the same way a normal umask-022 write would leave it.
+  # collide on the temp file itself. mkstemp creates 0600, so private callers
+  # never expose a secret before replacement; callers that need world-readable
+  # output keep the 0644 default.
   fd, tmp = tempfile.mkstemp(
     dir=file_path.parent, prefix=f".{file_path.name}.", suffix=".tmp"
   )
@@ -117,7 +120,7 @@ def atomic_write(file_path: Path, content: str | bytes) -> None:
       f.write(data)
       f.flush()
       os.fsync(f.fileno())
-    os.chmod(tmp, 0o644)
+    os.chmod(tmp, mode)
     os.replace(tmp, file_path)
   except BaseException:
     try:

--- a/backend/tests/test_connect.py
+++ b/backend/tests/test_connect.py
@@ -2,7 +2,9 @@
 
 import asyncio
 import json
+import stat
 import shlex
+import signal
 import sys
 import threading
 import time
@@ -14,7 +16,7 @@ import pytest
 from sqlalchemy import create_engine, inspect, text
 from starlette.requests import Request
 
-from app import connect_runner, models
+from app import connect_outbound, connect_runner, models
 from app.connect_runner import _run_command
 from app.database import SessionLocal
 from app.manifest_contract import ManifestContractError, validate_manifest_contract
@@ -97,6 +99,354 @@ def test_install_command_is_single_fetch_and_serves_shell_bootstrap(client, auth
   loose = client.get(f"/api/connect/i/{code.replace('-', '').lower()}")
   assert loose.status_code == 200, loose.text
   assert f'code="{code}"' in loose.text
+
+
+def test_outbound_command_is_parsed_as_data_not_shell():
+  base, code = connect_outbound.parse_pairing_command(
+    "curl -fsSL https://friend.example/api/connect/i/ABCD-EFGH | sh",
+  )
+  assert base == "https://friend.example"
+  assert code == "ABCD-EFGH"
+
+  for unsafe in (
+    "curl -fsSL https://friend.example/api/connect/i/ABCD-EFGH | sh; id",
+    "curl -fsSL https://friend.example/anything | sh",
+    "echo hello",
+  ):
+    with pytest.raises(connect_outbound.OutboundConnectError):
+      connect_outbound.parse_pairing_command(unsafe)
+
+  with pytest.raises(connect_outbound.OutboundConnectError, match="HTTPS"):
+    connect_outbound.parse_pairing_command(
+      "curl -fsSL http://friend.example/api/connect/i/ABCD-EFGH | sh",
+    )
+
+
+def test_outbound_json_replaces_an_existing_public_mode_with_private_storage(
+  tmp_path,
+):
+  path = tmp_path / "config.json"
+  path.write_text("stale", encoding="utf-8")
+  path.chmod(0o644)
+
+  connect_outbound._atomic_json(path, {"token": "remote-secret"})
+
+  assert json.loads(path.read_text(encoding="utf-8")) == {
+    "token": "remote-secret",
+  }
+  assert stat.S_IMODE(path.stat().st_mode) == 0o600
+
+
+def test_inbound_host_registry_is_private(tmp_path, monkeypatch):
+  monkeypatch.setattr(connect_routes, "_hosts_dir", lambda: tmp_path)
+
+  connect_routes._save_host({"id": "h_example", "pairing_code": "ABCD-EFGH"})
+
+  path = tmp_path / "h_example.json"
+  assert json.loads(path.read_text(encoding="utf-8"))["pairing_code"] == "ABCD-EFGH"
+  assert stat.S_IMODE(path.stat().st_mode) == 0o600
+
+
+@pytest.mark.asyncio
+async def test_outbound_profile_keeps_pairing_code_out_of_saved_record(
+  tmp_path, monkeypatch,
+):
+  profiles = tmp_path / "outbound"
+  monkeypatch.setattr(connect_outbound, "_profiles_dir", lambda: profiles)
+  monkeypatch.setattr(
+    connect_outbound,
+    "_download_runner",
+    lambda _base: b"#!/usr/bin/env python3\n# Mobius Connect runner\n",
+  )
+
+  class Running:
+    pid = 424242
+
+    def poll(self):
+      return None
+
+  launched = []
+
+  def launch(profile_id, *args):
+    launched.append(args)
+    connect_outbound._atomic_json(
+      connect_outbound._runner_config_path(profile_id),
+      {
+        "url": "https://friend.example",
+        "host_id": "h_remote",
+        "token": "remote-secret",
+      },
+    )
+    return Running()
+
+  monkeypatch.setattr(connect_outbound, "_launch", launch)
+  monkeypatch.setattr(connect_outbound, "_process_alive", lambda _id: True)
+  created = await connect_outbound.create_profile(
+    "Alex",
+    "curl -fsSL https://friend.example/api/connect/i/ABCD-EFGH | sh",
+  )
+
+  # The one-time code reaches the runner only as argv, never the saved record.
+  assert launched == [("--pair", "ABCD-EFGH", "--url", "https://friend.example")]
+  meta = json.loads(
+    connect_outbound._meta_path(created["id"]).read_text(encoding="utf-8"),
+  )
+  assert meta["base_url"] == "https://friend.example"
+  assert "ABCD-EFGH" not in json.dumps(meta)
+  assert "remote-secret" not in json.dumps(meta)
+  assert created["status"] == "active"
+  assert "remote-secret" not in json.dumps(created)
+
+
+def test_outbound_reconcile_records_exits_and_relaunches_orphans(
+  tmp_path, monkeypatch,
+):
+  profiles = tmp_path / "outbound"
+  monkeypatch.setattr(connect_outbound, "_profiles_dir", lambda: profiles)
+  ended, failed, running, adopted, orphan, finished = (
+    f"o_{digit * 16}" for digit in "123456"
+  )
+  for profile_id in (ended, failed, running, adopted, orphan):
+    connect_outbound._atomic_json(connect_outbound._meta_path(profile_id), {
+      "id": profile_id, "base_url": "https://friend.example", "status": "active",
+    })
+  connect_outbound._atomic_json(connect_outbound._meta_path(finished), {
+    "id": finished, "base_url": "https://friend.example", "status": "ended",
+  })
+
+  class Owned:
+    def __init__(self, result):
+      self.result = result
+
+    def poll(self):
+      return self.result
+
+  owned = {ended: Owned(0), failed: Owned(1), running: Owned(None)}
+  monkeypatch.setattr(connect_outbound, "_owned_processes", owned)
+  monkeypatch.setattr(
+    connect_outbound, "_process_alive", lambda profile_id: profile_id == adopted,
+  )
+  launched = []
+  monkeypatch.setattr(
+    connect_outbound, "_launch",
+    lambda profile_id, *args: launched.append((profile_id, args)),
+  )
+
+  connect_outbound._reconcile_once()
+
+  def status(profile_id):
+    return json.loads(
+      connect_outbound._meta_path(profile_id).read_text(encoding="utf-8"),
+    )["status"]
+
+  assert status(ended) == "ended"
+  assert status(failed) == "error"
+  assert status(running) == "active"
+  # An orphaned active profile is relaunched without a pairing code; a runner
+  # found alive by pid, or one that already exited on its own, is left alone.
+  assert launched == [(orphan, ())]
+  assert set(owned) == {running}
+
+
+@pytest.mark.asyncio
+async def test_outbound_revoke_fails_closed_until_remote_confirms(
+  tmp_path, monkeypatch,
+):
+  profiles = tmp_path / "outbound"
+  monkeypatch.setattr(connect_outbound, "_profiles_dir", lambda: profiles)
+  profile_id = "o_0123456789abcdef"
+  connect_outbound._atomic_json(connect_outbound._meta_path(profile_id), {
+    "id": profile_id,
+    "label": "Alex",
+    "base_url": "https://friend.example",
+    "created_at": 1,
+    "status": "active",
+  })
+  connect_outbound._atomic_json(
+    connect_outbound._runner_config_path(profile_id),
+    {"url": "https://friend.example", "host_id": "h_remote", "token": "secret"},
+  )
+  def keep_access(_config):
+    raise connect_outbound.OutboundConnectError("access was kept")
+
+  monkeypatch.setattr(connect_outbound, "_disconnect_remote", keep_access)
+  stopped = []
+  monkeypatch.setattr(connect_outbound, "_stop_process_tree", stopped.append)
+
+  with pytest.raises(connect_outbound.OutboundConnectError, match="kept"):
+    await connect_outbound.revoke_profile(profile_id)
+  assert connect_outbound._profile_dir(profile_id).is_dir()
+  assert stopped == []
+
+
+def test_outbound_revoke_does_not_signal_a_reused_runner_pid(monkeypatch):
+  profile_id = "o_0123456789abcdef"
+  monkeypatch.setattr(connect_outbound, "_read_pid", lambda _id: 424242)
+  monkeypatch.setattr(connect_outbound, "_process_alive", lambda _id: False)
+  monkeypatch.setattr(connect_outbound, "_process_identity", lambda _pid: (1, 100))
+  opened = []
+  monkeypatch.setattr(connect_outbound, "os", SimpleNamespace(pidfd_open=opened.append))
+
+  connect_outbound._stop_process_tree(profile_id)
+
+  assert opened == []
+
+
+def test_outbound_teardown_pins_processes_before_term_and_kill(monkeypatch):
+  profile_id = "o_0123456789abcdef"
+  monkeypatch.setattr(connect_outbound, "_read_pid", lambda _id: 424242)
+  monkeypatch.setattr(connect_outbound, "_process_alive", lambda _id: True)
+  monkeypatch.setattr(connect_outbound, "_process_identity", lambda _pid: (1, 100))
+  monkeypatch.setattr(connect_outbound, "_descendant_processes", lambda _pid: {424243: (424242, 101)})
+  opened, closed, signals = [], [], []
+
+  def open_pid(pid):
+    opened.append(pid)
+    return pid + 10
+
+  monkeypatch.setattr(connect_outbound, "os", SimpleNamespace(pidfd_open=open_pid, close=closed.append))
+  monkeypatch.setattr(connect_outbound.signal, "pidfd_send_signal", lambda *args: signals.append(args))
+  # No process has exited before the deadline. SIGKILL must reuse the pinned
+  # handle, never look up a numeric PID again after SIGTERM.
+  clock = iter((0, 4))
+  monkeypatch.setattr(connect_outbound, "time", SimpleNamespace(monotonic=lambda: next(clock)))
+
+  connect_outbound._stop_process_tree(profile_id)
+
+  assert opened == [424243, 424242]
+  assert signals == [(424252, signal.SIGTERM), (424252, signal.SIGKILL)]
+  assert closed == [424253, 424252]  # Reused descendant was rejected before signaling.
+
+
+def test_outbound_reused_root_does_not_signal_replacement_descendants(monkeypatch):
+  profile_id = "o_0123456789abcdef"
+  root = 424242
+  monkeypatch.setattr(connect_outbound, "_read_pid", lambda _id: root)
+  monkeypatch.setattr(connect_outbound, "_process_alive", lambda _id: True)
+  root_versions = iter(((1, 100), (1, 200)))
+  monkeypatch.setattr(
+    connect_outbound, "_process_identity",
+    lambda pid: next(root_versions) if pid == root else (root, 300),
+  )
+  monkeypatch.setattr(connect_outbound, "_descendant_processes", lambda _pid: {root + 1: (root, 300)})
+  closed, signals = [], []
+  monkeypatch.setattr(connect_outbound, "os", SimpleNamespace(pidfd_open=lambda pid: pid + 10, close=closed.append))
+  monkeypatch.setattr(connect_outbound.signal, "pidfd_send_signal", lambda *args: signals.append(args))
+
+  connect_outbound._stop_process_tree(profile_id)
+
+  assert signals == []
+  assert set(closed) == {root + 10, root + 11}
+
+
+@pytest.mark.parametrize("failure_stage", ["launch", "pairing"])
+def test_outbound_creation_failure_cleans_profile_and_runner(
+  tmp_path, monkeypatch, failure_stage,
+):
+  profiles = tmp_path / "outbound"
+  monkeypatch.setattr(connect_outbound, "_profiles_dir", lambda: profiles)
+  monkeypatch.setattr(connect_outbound, "_download_runner", lambda _url: b"runner")
+  stopped = []
+  monkeypatch.setattr(connect_outbound, "_stop_process_tree", stopped.append)
+
+  def fail(*_args):
+    raise OSError("setup failed")
+
+  monkeypatch.setattr(connect_outbound, "_launch", fail if failure_stage == "launch" else lambda *_args: object())
+  monkeypatch.setattr(connect_outbound, "_await_pairing", fail)
+
+  with pytest.raises(OSError, match="setup failed"):
+    connect_outbound._create_profile(
+      "Shared access",
+      "curl -fsSL https://friend.example/api/connect/i/ABCD-EFGH | sh",
+    )
+
+  assert len(stopped) == 1
+  assert list(profiles.iterdir()) == []
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="Linux pidfd process ownership")
+def test_outbound_pid_write_failure_stops_and_reaps_started_runner(
+  tmp_path, monkeypatch,
+):
+  profiles = tmp_path / "outbound"
+  monkeypatch.setattr(connect_outbound, "_profiles_dir", lambda: profiles)
+  monkeypatch.setattr(connect_outbound, "_download_runner", lambda _url: b"import time\ntime.sleep(60)\n")
+  owned = {}
+  monkeypatch.setattr(connect_outbound, "_owned_processes", owned)
+  started = []
+
+  def fail_pid_write(profile_id, _pid):
+    started.append(owned[profile_id])
+    raise OSError("pid write failed")
+
+  monkeypatch.setattr(connect_outbound, "_write_pid", fail_pid_write)
+  try:
+    with pytest.raises(OSError, match="pid write failed"):
+      connect_outbound._create_profile(
+        "Shared access",
+        "curl -fsSL https://friend.example/api/connect/i/ABCD-EFGH | sh",
+      )
+    assert len(started) == 1
+    assert started[0].poll() is not None
+    assert owned == {}
+    assert list(profiles.iterdir()) == []
+  finally:
+    for process in started:
+      if process.poll() is None:
+        process.kill()
+      process.wait(timeout=5)
+
+
+def test_outbound_routes_use_connect_manage_capability(
+  client, auth, monkeypatch,
+):
+  public = {
+    "id": "o_0123456789abcdef",
+    "label": "Alex",
+    "target": "friend.example",
+    "status": "active",
+    "online": True,
+    "created_at": 1,
+  }
+  monkeypatch.setattr(connect_outbound, "list_profiles", lambda: [public])
+
+  denied = _app_auth(client, auth, granted=False)
+  assert client.get("/api/connect/outbound", headers=denied).status_code == 403
+  granted = _app_auth(client, auth, granted=True)
+  assert client.get("/api/connect/outbound", headers=granted).json() == {
+    "connections": [public],
+  }
+
+
+def test_outbound_mutations_require_permission_and_report_domain_failures(
+  client, auth, monkeypatch,
+):
+  denied = _app_auth(client, auth, granted=False)
+  body = {
+    "label": "Shared access",
+    "command": "curl -fsSL https://friend.example/api/connect/i/ABCD-EFGH | sh",
+  }
+  path = "/api/connect/outbound"
+  assert client.post(path, headers=denied, json=body).status_code == 403
+  assert client.delete(path + "/o_0123456789abcdef", headers=denied).status_code == 403
+  granted = _app_auth(client, auth, granted=True)
+  assert client.post(path, headers=granted, json={**body, "label": "  "}).status_code == 422
+
+  async def rejected_pairing(_label, _command):
+    raise connect_outbound.OutboundConnectError("Pairing was rejected.")
+
+  async def rejected_revocation(_profile_id):
+    raise connect_outbound.OutboundConnectError("Access was kept.")
+
+  monkeypatch.setattr(connect_outbound, "create_profile", rejected_pairing)
+  monkeypatch.setattr(connect_outbound, "revoke_profile", rejected_revocation)
+  response = client.post(path, headers=granted, json=body)
+  assert response.status_code == 400
+  assert response.json()["detail"] == "Pairing was rejected."
+  response = client.delete(path + "/o_0123456789abcdef", headers=granted)
+  assert response.status_code == 409
+  assert response.json()["detail"] == "Access was kept."
 
 
 def test_pairing_code_exchange_is_rate_limited(client):

--- a/backend/tests/test_connect.py
+++ b/backend/tests/test_connect.py
@@ -213,6 +213,8 @@ def test_outbound_reconcile_records_exits_and_relaunches_orphans(
   connect_outbound._atomic_json(connect_outbound._meta_path(finished), {
     "id": finished, "base_url": "https://friend.example", "status": "ended",
   })
+  connect_outbound._runner_path(ended).parent.mkdir(parents=True, exist_ok=True)
+  connect_outbound._runner_path(ended).write_text("runner", encoding="utf-8")
 
   class Owned:
     def __init__(self, result):
@@ -275,6 +277,94 @@ async def test_outbound_revoke_fails_closed_until_remote_confirms(
 
   with pytest.raises(connect_outbound.OutboundConnectError, match="kept"):
     await connect_outbound.revoke_profile(profile_id)
+  assert connect_outbound._profile_dir(profile_id).is_dir()
+  assert stopped == []
+
+
+def test_outbound_observed_remote_revocation_allows_local_profile_cleanup(
+  tmp_path, monkeypatch,
+):
+  profiles = tmp_path / "outbound"
+  monkeypatch.setattr(connect_outbound, "_profiles_dir", lambda: profiles)
+  profile_id = "o_0123456789abcdef"
+  connect_outbound._atomic_json(connect_outbound._meta_path(profile_id), {
+    "id": profile_id,
+    "base_url": "https://friend.example",
+    "status": "active",
+  })
+  connect_outbound._atomic_json(
+    connect_outbound._runner_config_path(profile_id),
+    {"url": "https://friend.example", "host_id": "h_remote", "token": "secret"},
+  )
+  connect_outbound._runner_path(profile_id).write_text("runner", encoding="utf-8")
+  connect_outbound._write_pid(profile_id, 424242)
+
+  runner_pid = connect_outbound._runner_path(profile_id).with_name("runner.pid")
+  runner_pid.write_text("424242", encoding="ascii")
+
+  class RemotelyRevoked:
+    def poll(self):
+      return 0
+
+  owned = {profile_id: RemotelyRevoked()}
+  monkeypatch.setattr(connect_outbound, "_owned_processes", owned)
+  for artifact in (
+    connect_outbound._runner_config_path(profile_id),
+    connect_outbound._runner_path(profile_id),
+    runner_pid,
+  ):
+    artifact.unlink()
+
+  assert connect_outbound._pid_path(profile_id).exists()
+  connect_outbound._reconcile_once()
+
+  meta = json.loads(
+    connect_outbound._meta_path(profile_id).read_text(encoding="utf-8"),
+  )
+  assert meta["status"] == "revoked"
+  assert owned == {}
+  monkeypatch.setattr(
+    connect_outbound,
+    "_disconnect_remote",
+    lambda _config: pytest.fail("revoked credentials must not be required"),
+  )
+  connect_outbound._revoke_profile(profile_id)
+  assert not connect_outbound._profile_dir(profile_id).exists()
+
+
+@pytest.mark.parametrize(
+  "config_text",
+  [
+    None,
+    "{not-json",
+    json.dumps({"url": "https://friend.example", "host_id": "h_remote"}),
+  ],
+  ids=["missing-config", "corrupt-config", "missing-credential"],
+)
+def test_outbound_revoke_keeps_ambiguous_unreadable_credentials(
+  tmp_path, monkeypatch, config_text,
+):
+  profiles = tmp_path / "outbound"
+  monkeypatch.setattr(connect_outbound, "_profiles_dir", lambda: profiles)
+  profile_id = "o_0123456789abcdef"
+  connect_outbound._atomic_json(connect_outbound._meta_path(profile_id), {
+    "id": profile_id,
+    "base_url": "https://friend.example",
+    "status": "ended",
+  })
+  if config_text is not None:
+    connect_outbound._runner_config_path(profile_id).parent.mkdir(
+      parents=True, exist_ok=True,
+    )
+    connect_outbound._runner_config_path(profile_id).write_text(
+      config_text, encoding="utf-8",
+    )
+  stopped = []
+  monkeypatch.setattr(connect_outbound, "_stop_process_tree", stopped.append)
+
+  with pytest.raises(connect_outbound.OutboundConnectError, match="kept"):
+    connect_outbound._revoke_profile(profile_id)
+
   assert connect_outbound._profile_dir(profile_id).is_dir()
   assert stopped == []
 
@@ -391,6 +481,48 @@ def test_outbound_pid_write_failure_stops_and_reaps_started_runner(
     assert started[0].poll() is not None
     assert owned == {}
     assert list(profiles.iterdir()) == []
+  finally:
+    for process in started:
+      if process.poll() is None:
+        process.kill()
+      process.wait(timeout=5)
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="Linux pidfd process ownership")
+def test_outbound_reconcile_pid_write_failure_stops_started_runner_and_marks_error(
+  tmp_path, monkeypatch,
+):
+  profiles = tmp_path / "outbound"
+  monkeypatch.setattr(connect_outbound, "_profiles_dir", lambda: profiles)
+  profile_id = "o_0123456789abcdef"
+  connect_outbound._atomic_json(connect_outbound._meta_path(profile_id), {
+    "id": profile_id,
+    "base_url": "https://friend.example",
+    "status": "active",
+  })
+  runner = connect_outbound._runner_path(profile_id)
+  runner.parent.mkdir(parents=True, exist_ok=True)
+  runner.write_text("import time\ntime.sleep(60)\n", encoding="utf-8")
+  owned = {}
+  monkeypatch.setattr(connect_outbound, "_owned_processes", owned)
+  started = []
+
+  def fail_pid_write(profile_id, _pid):
+    started.append(owned[profile_id])
+    raise OSError("pid write failed")
+
+  monkeypatch.setattr(connect_outbound, "_write_pid", fail_pid_write)
+  try:
+    connect_outbound._reconcile_once()
+
+    assert len(started) == 1
+    assert started[0].poll() is not None
+    assert owned == {}
+    assert not connect_outbound._pid_path(profile_id).exists()
+    meta = json.loads(
+      connect_outbound._meta_path(profile_id).read_text(encoding="utf-8"),
+    )
+    assert meta["status"] == "error"
   finally:
     for process in started:
       if process.poll() is None:

--- a/backend/tests/test_external_owner_controls.py
+++ b/backend/tests/test_external_owner_controls.py
@@ -437,3 +437,36 @@ def test_owner_top_level_agent_and_scoped_app_keep_scoped_connection_controls(
     "Workstation top_level",
     "Workstation app",
   ]
+
+
+def test_outbound_sharing_keeps_external_owner_control_boundary(
+  client, owner_token, db, monkeypatch,
+):
+  from app import connect_outbound
+
+  auths, _app_id = _external_control_auth(client, owner_token, db)
+  calls = []
+
+  async def create(label, command):
+    calls.append(("create", label))
+    return {"id": "o_0123456789abcdef"}
+
+  async def revoke(profile_id):
+    calls.append(("revoke", profile_id))
+
+  monkeypatch.setattr(connect_outbound, "create_profile", create)
+  monkeypatch.setattr(connect_outbound, "revoke_profile", revoke)
+  body = {"label": "Shared access", "command": "pairing-command-data"}
+  path = "/api/connect/outbound"
+  created = client.post(path, headers=auths["delegated"], json=body)
+  deleted = client.delete(path + "/o_0123456789abcdef", headers=auths["delegated"])
+  assert created.status_code == 403, created.text
+  assert deleted.status_code == 403, deleted.text
+  assert calls == []
+
+  for actor in ("owner", "top_level", "app"):
+    created = client.post(path, headers=auths[actor], json=body)
+    deleted = client.delete(path + "/o_0123456789abcdef", headers=auths[actor])
+    assert created.status_code == 200, (actor, created.text)
+    assert deleted.status_code == 200, (actor, deleted.text)
+  assert len(calls) == 6

--- a/backend/tests/test_runtime_supervisors.py
+++ b/backend/tests/test_runtime_supervisors.py
@@ -66,9 +66,13 @@ async def test_start_fails_open_when_chat_supervisor_wiring_breaks(monkeypatch):
   monkeypatch.setattr(supervisors, "_start_chat_supervisors", broken_chat_wiring)
 
   await supervisors.start_process_services()
+  before = set(supervisors._tasks)
   await supervisors.start_database_services()
 
   assert frontend_started is True
+  assert "connect-outbound" in supervisors._tasks
+  assert set(supervisors._tasks) == before
+  await supervisors.stop()
   assert supervisors._tasks == {}
 
 


### PR DESCRIPTION
## Summary
- Add the missing shared-access platform routes expected by Connect 0.4.3: list, pair, and revoke outbound connections.
- Supervise saved runners across backend restarts, keep credentials private, and parse pairing commands as data rather than executing a shell command.
- Clean up failed setup/pairing and pin process identities during teardown so reused PIDs cannot target unrelated processes.
- Preserve the existing external-control boundary: the owner, top-level agent, and permission-granted Connect app may manage sharing; delegated agents may not.

## Context
This supplies the platform companion missing from [app-connect#9](https://github.com/mobius-os/app-connect/pull/9). Basic machine control is already upstream; outbound shared access was not. The app also has a separate compatibility-message fix so older installations no longer mistake a missing route for a pending restart.

## Verification
- `scripts/wt-pytest.sh backend/tests/test_connect.py backend/tests/test_runtime_supervisors.py backend/tests/test_external_owner_controls.py -q`: 91 passed; after the final test-only assertion refinement, all 7 runtime-supervisor tests passed again.
- Regression coverage for private file modes, pairing cleanup, process identity, restart reconciliation, and mutation authorization.
- Python compile and diff checks passed.
- The runtime helper reports a dependency-lock mismatch in the local image; hosted CI remains authoritative for the exact dependencies.

## Activation
A platform update and backend restart load the new routes and supervisor. No database migration or container replacement is required by this change. Process lifecycle handling uses Linux /proc and pidfds, matching the Linux Möbius deployment runtime.
