### PR TITLE
Replace abandoned Codex message items

### DIFF
--- a/backend/app/codex_sdk_runner.py
+++ b/backend/app/codex_sdk_runner.py
@@ -1788,6 +1788,12 @@ async def _run_codex_sdk_turn(
   current_session_id = session_id
   completed_turn: Any | None = None
   completed_message_phases: list[str | None] = []
+  # Codex can abandon an in-progress AgentMessage and immediately start a
+  # replacement item without completing the first one. Keep that provider
+  # lifecycle identity until another item makes the first message deliberate,
+  # so the replacement can discard only the orphaned partial text.
+  open_agent_message_item_id: str | None = None
+  abandoned_agent_message_item_ids: set[str] = set()
   first_token_usage: Any | None = None
   final_token_usage: Any | None = None
   call_token_usages: list[Any] = []
@@ -2255,9 +2261,11 @@ async def _run_codex_sdk_turn(
         payload = notification.payload
 
         if isinstance(payload, sdk["AgentMessageDeltaNotification"]):
+          item_id = str(getattr(payload, "item_id", None) or "")
+          if item_id and item_id in abandoned_agent_message_item_ids:
+            continue
           if payload.delta:
             event = {"type": "text", "content": payload.delta}
-            item_id = getattr(payload, "item_id", None)
             if item_id:
               event["text_item_id"] = item_id
             bc.publish(event)
@@ -2298,8 +2306,24 @@ async def _run_codex_sdk_turn(
         if isinstance(payload, sdk["ItemStartedNotification"]):
           item = payload.item.root if hasattr(payload.item, "root") else payload.item
           if isinstance(item, sdk["AgentMessageThreadItem"]):
-            bc.publish({"type": "text_boundary"})
+            item_id = str(getattr(item, "id", None) or "")
+            event = {"type": "text_boundary"}
+            if (
+              open_agent_message_item_id
+              and item_id
+              and item_id != open_agent_message_item_id
+            ):
+              event["replace_text_item_id"] = open_agent_message_item_id
+              abandoned_agent_message_item_ids.add(
+                open_agent_message_item_id,
+              )
+            open_agent_message_item_id = item_id or None
+            bc.publish(event)
             continue
+          # A tool/reasoning item between two assistant messages makes the
+          # earlier text a deliberate separate block, even if the provider
+          # omitted its completion notification.
+          open_agent_message_item_id = None
           if isinstance(item, sdk["CollabAgentToolCallThreadItem"]):
             # One provider-neutral Task block hosts every helper activation in
             # this turn. Codex may announce ThreadStarted before or after its
@@ -2374,7 +2398,13 @@ async def _run_codex_sdk_turn(
             _publish_codex_context_compaction(bc, chat_id)
             continue
           if isinstance(item, sdk["AgentMessageThreadItem"]):
+            item_id = str(getattr(item, "id", None) or "")
+            if item_id and item_id in abandoned_agent_message_item_ids:
+              abandoned_agent_message_item_ids.discard(item_id)
+              continue
             completed_message_phases.append(_agent_message_phase(item, sdk))
+            if item_id and item_id == open_agent_message_item_id:
+              open_agent_message_item_id = None
           if not isinstance(item, sdk["CollabAgentToolCallThreadItem"]):
             for event in _tool_completed_events(item, sdk):
               _stamp_tool_use_id(event, item)

--- a/backend/app/events.py
+++ b/backend/app/events.py
@@ -1101,12 +1101,22 @@ def process_event(event: dict, assistant_blocks: list) -> bool:
     # paragraph instead of becoming `previous.next`. The marker is internal:
     # build_assistant_message ignores it and finalize_blocks removes any
     # trailing boundary that never received text.
+    changed = False
+    replace_text_item_id = event.get("replace_text_item_id")
+    if replace_text_item_id:
+      for idx in range(len(assistant_blocks) - 1, -1, -1):
+        block = assistant_blocks[idx]
+        if (block.get("type") == "text"
+            and block.get("text_item_id") == replace_text_item_id):
+          assistant_blocks.pop(idx)
+          changed = True
+          break
     if (assistant_blocks
         and assistant_blocks[-1].get("type") == "text"
         and assistant_blocks[-1].get("content")):
       assistant_blocks.append({"type": "text_boundary"})
       return True
-    return False
+    return changed
 
   if event_type == "context_compacted":
     # Provider-native compaction is a chronological product event, not tool

--- a/backend/tests/test_codex_sdk_runner.py
+++ b/backend/tests/test_codex_sdk_runner.py
@@ -2241,6 +2241,96 @@ def test_run_codex_sdk_turn_cleans_up_active_session_on_stream_exception(
   assert mark_finished_calls == [True]
 
 
+def test_codex_replacement_message_discards_unfinished_provider_item(monkeypatch):
+  class AgentMessage:
+    def __init__(self, item_id, text, phase):
+      self.id = item_id
+      self.text = text
+      self.phase = phase
+
+  class AgentMessageDelta:
+    def __init__(self, item_id, delta):
+      self.item_id = item_id
+      self.delta = delta
+
+  class ItemStarted:
+    def __init__(self, item):
+      self.item = item
+
+  class ItemCompleted:
+    def __init__(self, item):
+      self.item = item
+
+  abandoned = AgentMessage(
+    "msg-abandoned", "I will publish those two commits",
+    _FakeMessagePhase.commentary,
+  )
+  replacement = AgentMessage(
+    "msg-replacement", "I will publish the two approved commits",
+    _FakeMessagePhase.final_answer,
+  )
+  completed_turn = SimpleNamespace(
+    id="turn-1", usage=None, error=None, status=_FakeTurnStatus.completed,
+    items=[replacement],
+  )
+  notifications = [
+    SimpleNamespace(payload=ItemStarted(abandoned)),
+    SimpleNamespace(payload=AgentMessageDelta(
+      abandoned.id, "I will publish those two commits",
+    )),
+    SimpleNamespace(payload=ItemStarted(replacement)),
+    SimpleNamespace(payload=AgentMessageDelta(
+      replacement.id, "I will publish the two approved commits",
+    )),
+    # Late notifications for the abandoned item must never resurrect it.
+    SimpleNamespace(payload=AgentMessageDelta(abandoned.id, " (late)")),
+    SimpleNamespace(payload=ItemCompleted(abandoned)),
+    SimpleNamespace(payload=ItemCompleted(replacement)),
+    SimpleNamespace(payload=_FakeTurnCompletedNotification(completed_turn)),
+  ]
+  thread = _FakeThread("thread-1", _FakeTurnHandle(notifications))
+
+  class FakeAsyncCodex:
+    def __init__(self, config=None):
+      self.config = config
+
+    async def __aenter__(self):
+      return self
+
+    async def __aexit__(self, _exc_type, _exc, _tb):
+      return None
+
+    async def thread_start(self, *_args, **_kwargs):
+      return thread
+
+  sdk = _fake_sdk(FakeAsyncCodex)
+  sdk.update({
+    "AgentMessageThreadItem": AgentMessage,
+    "AgentMessageDeltaNotification": AgentMessageDelta,
+    "ItemStartedNotification": ItemStarted,
+    "ItemCompletedNotification": ItemCompleted,
+  })
+  monkeypatch.setattr(codex_sdk_runner, "_sdk_imports", lambda: sdk)
+
+  bus = _FakeBroadcast()
+  result = asyncio.run(codex_sdk_runner.run_codex_sdk_turn(
+    user_message="ship", session_id=None, base_env={}, cwd="/tmp",
+    chat_id="chat-replacement", bc=bus, pending_questions={}, db=None,
+  ))
+
+  assert result["error"] is None
+  assert {
+    "type": "text_boundary",
+    "replace_text_item_id": abandoned.id,
+  } in bus.events
+  assert not any(
+    event.get("text_item_id") == abandoned.id
+    and event.get("type") == "text_final"
+    for event in bus.events
+  )
+  assert not any(event.get("content") == " (late)" for event in bus.events)
+
+
 @pytest.mark.parametrize(
   "event_kind",
   ["context_compaction_item", "legacy_notification"],

--- a/backend/tests/test_events.py
+++ b/backend/tests/test_events.py
@@ -1184,6 +1184,31 @@ def test_text_boundary_reducer_splits_consecutive_text():
   assert all(b.get("type") != "text_boundary" for b in blocks)
 
 
+def test_replacement_boundary_discards_only_the_abandoned_text_item():
+  blocks = []
+  process_event({
+    "type": "text", "content": "settled", "text_item_id": "msg-1",
+  }, blocks)
+  process_event({"type": "text_boundary"}, blocks)
+  process_event({
+    "type": "text", "content": "abandoned partial",
+    "text_item_id": "msg-2",
+  }, blocks)
+
+  changed = process_event({
+    "type": "text_boundary", "replace_text_item_id": "msg-2",
+  }, blocks)
+  process_event({
+    "type": "text", "content": "replacement", "text_item_id": "msg-3",
+  }, blocks)
+
+  assert changed is True
+  assert [
+    (block["content"], block.get("text_item_id"))
+    for block in blocks if block.get("type") == "text"
+  ] == [("settled", "msg-1"), ("replacement", "msg-3")]
+
+
 def test_text_boundary_on_empty_is_noop():
   """A leading boundary (no prior non-empty text) does nothing — guards the
   first-block case so a turn never opens with a stray marker."""

--- a/frontend/src/components/ChatView/__tests__/streamReducers.test.js
+++ b/frontend/src/components/ChatView/__tests__/streamReducers.test.js
@@ -29,6 +29,7 @@ import {
   attachToolSources,
   reconcileStreamItems,
   appendTextItem,
+  discardTextItem,
   repairInterleavedQuestionText,
   replaceTextItem,
   startToolLifecycle,
@@ -163,6 +164,17 @@ test('boundary plus final-only item does not replace the preceding text', () => 
   assert.deepEqual(items, [
     { type: 'text', content: 'first item' },
     { type: 'text', content: 'second item', text_item_id: 'msg-2' },
+  ])
+})
+
+test('abandoned text removal uses provider identity, not content overlap', () => {
+  const items = discardTextItem([
+    { type: 'text', content: 'settled', text_item_id: 'msg-1' },
+    { type: 'text', content: 'abandoned partial', text_item_id: 'msg-2' },
+  ], 'msg-2')
+
+  assert.deepEqual(items, [
+    { type: 'text', content: 'settled', text_item_id: 'msg-1' },
   ])
 })
 

--- a/frontend/src/components/ChatView/streamReducers.js
+++ b/frontend/src/components/ChatView/streamReducers.js
@@ -195,6 +195,20 @@ export function appendTextItem(prev, content, {
   return updated
 }
 
+/** Remove one provider-owned text item that was abandoned before completion. */
+export function discardTextItem(prev, textItemId) {
+  if (!textItemId) return prev
+  for (let i = prev.length - 1; i >= 0; i -= 1) {
+    const item = prev[i]
+    if (item?.type === 'text' && item.text_item_id === textItemId) {
+      const updated = [...prev]
+      updated.splice(i, 1)
+      return updated
+    }
+  }
+  return prev
+}
+
 /** Replace the authoritative full text for one provider message item. */
 export function replaceTextItem(prev, content, {
   textItemId = null,

--- a/frontend/src/components/ChatView/useStreamConnection.js
+++ b/frontend/src/components/ChatView/useStreamConnection.js
@@ -21,6 +21,7 @@ import {
   reconcileStreamItems,
   applyTaskEvent,
   appendTextItem,
+  discardTextItem,
   replaceTextItem,
   startToolLifecycle,
   applySkillLoaded,
@@ -1117,6 +1118,11 @@ export default function useStreamConnection(chatId, {
             // Identity was adopted above; it has no renderable payload.
           } else if (event.type === 'text_boundary') {
             flushBuffer()
+            if (event.replace_text_item_id) {
+              applyStreamItems(
+                prev => discardTextItem(prev, event.replace_text_item_id),
+              )
+            }
             forceNewTextBlockRef.current = true
           } else if (event.type === 'text') {
             const content = event.content || ''


### PR DESCRIPTION
## Summary

- discard an unfinished Codex assistant message when the provider immediately starts a replacement item
- ignore late deltas and completion events for the abandoned item while preserving deliberate earlier message blocks
- cover the provider lifecycle and frontend stream reducer with focused regressions

## Verification

- 2 focused backend tests passed
- 76 focused frontend stream reducer tests passed