### PR TITLE
Skip app-source workspaces in project recency writes

### DIFF
--- a/frontend/src/components/Shell/Shell.jsx
+++ b/frontend/src/components/Shell/Shell.jsx
@@ -64,6 +64,7 @@ import {
   appSourceProject,
   appSourceProjectId,
   linkedProjectAppId,
+  parseAppSourceProjectId,
 } from '../../lib/appSourceProject.js'
 import { projectSourceAction } from '../../lib/projectSourceAction.js'
 import { immersiveReducer, isImmersiveActive } from '../../lib/immersive.js'
@@ -592,6 +593,7 @@ export default function Shell({ onInitialVisualReady }) {
     const projectId = String(activeProjectId)
     if (!projectId || recencyMarkedProjectRef.current === projectId) return
     recencyMarkedProjectRef.current = projectId
+    if (parseAppSourceProjectId(projectId)) return
 
     // Projects join the exact same Recents contract as apps: focused opening
     // promotes locally first, then a tiny navigation-state write makes it


### PR DESCRIPTION
## Summary

- distinguish temporary app-source workspaces from saved Projects when updating Recents
- avoid issuing a saved-Project recency write for synthetic `app-source:*` workspace IDs
- preserve the existing optimistic Recents behavior for real Projects

## Verification

- app-source project helper tests: 3 passed
- focused Shell lint: 0 errors (12 existing hook warnings within the repository threshold)