### PR TITLE
Group helper results and clarify restart recovery

### DIFF
--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -5310,10 +5310,10 @@ export default function ChatView({
             && !goalWaitState.monitoring
         ? {
             actionKind: 'resume',
-            actionLabel: resumeState.pending ? 'Resuming…' : 'Resume',
-            actionDisabled: resumeState.pending || providerSwitching,
+            actionLabel: resumeState.pending ? 'Resuming…' : resumeState.unavailable ? 'Reconnecting…' : 'Resume',
+            actionDisabled: resumeState.pending || resumeState.unavailable || providerSwitching,
             actionError: resumeState.error,
-            actionAriaLabel: `${resumeState.pending ? 'Resuming' : 'Resume'} goal: ${visibleGoalObjective}`,
+            actionAriaLabel: `${resumeState.pending ? 'Resuming' : resumeState.unavailable ? 'Reconnecting' : 'Resume'} goal: ${visibleGoalObjective}`,
             actionIcon: <Play width={13} height={13} aria-hidden="true" />,
           }
         : {}),

--- a/frontend/src/components/ChatView/HelperResultCard.jsx
+++ b/frontend/src/components/ChatView/HelperResultCard.jsx
@@ -49,3 +49,37 @@ export default function HelperResultCard({ event, chatId, onInternalNav }) {
     </div>
   </div>
 }
+
+export function HelperResultGroupCard({ events, chatId, onInternalNav }) {
+  const [open, setOpen] = useDisclosureState(
+    chatId,
+    `helper-results:${events.map(event => event.activityId || event.id).join(',')}`,
+  )
+  const headerRef = useRef(null)
+  const detailRef = useRef(null)
+  const headerId = useId()
+  const detailId = useId()
+  const finished = events.filter(event => event.status === 'completed').length
+  const failed = events.length - finished
+  const label = failed
+    ? `${events.length} helper results · ${finished} finished, ${failed} need attention`
+    : `${events.length} helpers finished`
+  const date = peerTime(events.at(-1)?.created_at)
+  const last = Number.isFinite(date) ? new Date(date) : null
+  return <div className="chat__tool chat__tool--done chat__tool--compact chat__peer-tool chat__helper-result-group">
+    <button ref={headerRef} id={headerId} type="button" className="chat__tool-header"
+      aria-expanded={open} aria-controls={detailId} aria-label={label}
+      onClick={() => {
+        preserveTogglePosition(headerRef.current, detailRef.current)
+        setOpen(value => !value)
+      }}>
+      <span className="chat__tool-icon" data-tool-kind="agents" aria-hidden="true"><ArrowDown width={14} height={14} /></span>
+      <span className="chat__tool-name" title={label}>{label}</span>
+      {last && <time className="chat__peer-time" dateTime={last.toISOString()} title={last.toLocaleString()}>{last.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}</time>}
+    </button>
+    <div ref={detailRef} id={detailId} className="chat__tool-detail chat__peer-detail chat__helper-result-group-detail" role="region"
+      aria-labelledby={headerId} tabIndex={open ? 0 : undefined} hidden={!open}>
+      {open && events.map(event => <HelperResultCard key={event.activityId || event.id} event={event} chatId={chatId} onInternalNav={onInternalNav} />)}
+    </div>
+  </div>
+}

--- a/frontend/src/components/ChatView/MsgContent.jsx
+++ b/frontend/src/components/ChatView/MsgContent.jsx
@@ -440,13 +440,15 @@ function MsgContentInner({
                 type="button"
                 className="chat__resume chat__recovery-action"
                 onClick={onResume}
-                disabled={submissionBlocked || resumeState?.pending}
+                disabled={submissionBlocked || resumeState?.pending || resumeState?.unavailable}
                 aria-busy={resumeState?.pending || undefined}
                 title={submissionBlocked
                   ? 'Wait for the provider switch to finish.'
+                  : resumeState?.unavailable
+                    ? 'Möbius is reconnecting this paused turn.'
                   : undefined}
               >
-                {resumeState?.pending ? 'Resuming…' : parked
+                {resumeState?.pending ? 'Resuming…' : resumeState?.unavailable ? 'Reconnecting…' : parked
                   ? limitResetElapsed ? 'Continue now' : 'Try now'
                   : 'Resume'}
               </button>

--- a/frontend/src/components/ChatView/PeerTimeline.jsx
+++ b/frontend/src/components/ChatView/PeerTimeline.jsx
@@ -2,10 +2,11 @@
 import { useEffect, useMemo } from 'react'
 import { useInfiniteQuery } from '@tanstack/react-query'
 import { api, jsonOrThrow } from '../../api/client.js'
-import HelperResultCard from './HelperResultCard.jsx'
+import HelperResultCard, { HelperResultGroupCard } from './HelperResultCard.jsx'
 import PeerMessageCard from './PeerMessageCard.jsx'
 import { projectChatActivity } from './chatActivity.js'
 import { chatActivityQueryKey } from './chatActivityQueries.js'
+import { groupHelperResultRows } from './helperResultGrouping.js'
 import { peerRecordTool, peerTime, foldPeerActivity } from './peerTimeline.js'
 
 export function usePeerTimeline(chatId, messages, enabled, activeTools, activeMirrorIndex = -1) {
@@ -30,11 +31,20 @@ export function usePeerTimeline(chatId, messages, enabled, activeTools, activeMi
 }
 
 export function PeerTimelineRows({ notes, chatId, onInternalNav }) {
-  return notes?.map(note => <li key={note.activityId || `peer-${note.id}`} className="chat__msg chat__msg--assistant chat__msg--peer" data-peer-id={note.type === 'peer_message' ? note.id : undefined} data-activity-id={note.activityId} data-key={note.activityId || `peer-${note.id}`} tabIndex={-1}>
+  return groupHelperResultRows(notes).map(group => {
+    const groupedHelpers = group.length > 1 && group.every(note => note.type === 'helper_result')
+    const key = groupedHelpers
+      ? `helper-results:${group.map(note => note.activityId || note.id).join(',')}`
+      : group[0].activityId || `peer-${group[0].id}`
+    const note = group[0]
+    return <li key={key} className="chat__msg chat__msg--assistant chat__msg--peer" data-peer-id={note.type === 'peer_message' ? note.id : undefined} data-activity-id={groupedHelpers ? undefined : note.activityId} data-key={key} tabIndex={-1}>
     <div className="chat__tools">
-      {note.type === 'helper_result'
+      {groupedHelpers
+        ? <HelperResultGroupCard events={group} chatId={chatId} onInternalNav={onInternalNav} />
+        : note.type === 'helper_result'
         ? <HelperResultCard event={note} chatId={chatId} onInternalNav={onInternalNav} />
         : <PeerMessageCard onInternalNav={onInternalNav} t={peerRecordTool(note, chatId)} chatId={chatId} disclosureKey={`peer-${note.id}`} records={[note]} />}
     </div>
-  </li>)
+  </li>
+  })
 }

--- a/frontend/src/components/ChatView/__tests__/goalProgress.test.js
+++ b/frontend/src/components/ChatView/__tests__/goalProgress.test.js
@@ -571,8 +571,11 @@ test('the goal rail confirms and clears directly, sourced domain-neutrally', () 
     'the armed clear control must turn into a confirm check')
   assert.match(progressRail, /item\.clearConfirmLabel \|\| 'Confirm clear'/,
     'the confirmation label must be item-supplied with a neutral fallback')
-  assert.match(chatView, /actionLabel: resumeState\.pending \? 'Resuming…' : 'Resume'/,
-    'a paused Goal should expose the one-tap resume action')
+  assert.match(
+    chatView,
+    /actionLabel: resumeState\.pending \? 'Resuming…' : resumeState\.unavailable \? 'Reconnecting…' : 'Resume'/,
+    'a paused Goal should expose Resume only after its run identity is durable',
+  )
   assert.match(chatView, /actionIcon: <Play width=\{13\} height=\{13\}/,
     'the paused Goal action should spend only icon-sized visual space')
   assert.match(chatView, /ownerActionRequired: goalPresentation\?\.wait_kind === 'owner_question'/,

--- a/frontend/src/components/ChatView/__tests__/helperResultGrouping.test.js
+++ b/frontend/src/components/ChatView/__tests__/helperResultGrouping.test.js
@@ -1,0 +1,18 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { groupHelperResultRows } from '../helperResultGrouping.js'
+
+const helper = id => ({ id, type: 'helper_result' })
+const peer = id => ({ id, type: 'peer_message' })
+
+test('adjacent helper completions share one result group', () => {
+  const helpers = [helper('one'), helper('two'), helper('three')]
+  assert.deepEqual(groupHelperResultRows(helpers), [helpers])
+})
+
+test('ordinary chat activity remains a helper-result grouping boundary', () => {
+  const first = helper('one'), note = peer('note'), second = helper('two')
+  assert.deepEqual(groupHelperResultRows([first, note, second]), [
+    [first], [note], [second],
+  ])
+})

--- a/frontend/src/components/ChatView/__tests__/resumeAffordance.test.js
+++ b/frontend/src/components/ChatView/__tests__/resumeAffordance.test.js
@@ -120,6 +120,20 @@ test('MsgContent gates the Resume button on a resumable tail note', () => {
   )
 })
 
+test('restart recovery waits for a durable run identity instead of showing a false Resume', () => {
+  const resumeHook = readFileSync(new URL('../hooks/useResume.js', import.meta.url), 'utf8')
+  assert.match(resumeHook, /unavailable: !runId/,
+    'the resume state records when a restart has not published its replacement run')
+  assert.match(resumeHook, /onRefresh\(\)\s*\n\s*return false/,
+    'an unavailable recovery identity refreshes without an owner-facing failure')
+  assert.match(msgContent, /resumeState\?\.unavailable \? 'Reconnecting…'/,
+    'the interrupted-turn card explains the short restart handoff')
+  assert.match(msgContent, /resumeState\?\.pending \|\| resumeState\?\.unavailable/,
+    'the recovery action cannot be invoked before its identity is durable')
+  assert.match(chatView, /resumeState\.unavailable \? 'Reconnecting…' : 'Resume'/,
+    'the Goal rail follows the same unavailable-recovery contract')
+})
+
 test('MsgContent memo compares onResume so a stable ref skips re-render', () => {
   assert.match(msgContent, /prev\.onResume === next\.onResume/,
     'the memo comparator must include onResume')

--- a/frontend/src/components/ChatView/helperResultGrouping.js
+++ b/frontend/src/components/ChatView/helperResultGrouping.js
@@ -1,0 +1,19 @@
+// Terminal helper notices share one quiet summary until a reader asks for the
+// individual results. Other activity remains an ordering boundary.
+export function groupHelperResultRows(notes = []) {
+  const groups = []
+  let helperRun = []
+  const flush = () => {
+    if (helperRun.length) groups.push(helperRun)
+    helperRun = []
+  }
+  for (const note of notes) {
+    if (note?.type === 'helper_result') helperRun.push(note)
+    else {
+      flush()
+      groups.push([note])
+    }
+  }
+  flush()
+  return groups
+}

--- a/frontend/src/components/ChatView/hooks/__tests__/useResume.test.js
+++ b/frontend/src/components/ChatView/hooks/__tests__/useResume.test.js
@@ -106,7 +106,9 @@ test('provider switch or already running turn prevents Resume without changing s
   const h = fixture(() => { sent = true }, { blocked: () => true })
   assert.equal(await h.result.current.resume(), false)
   assert.equal(sent, false)
-  assert.deepEqual(h.result.current.state, { pending: false, error: '' })
+  assert.deepEqual(h.result.current.state, {
+    pending: false, error: '', unavailable: false,
+  })
 })
 
 

--- a/frontend/src/components/ChatView/hooks/useResume.js
+++ b/frontend/src/components/ChatView/hooks/useResume.js
@@ -2,7 +2,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 export default function useResume({ chatId, runId, send, onAccepted, onRefresh, blocked }) {
-  const [state, setState] = useState({ pending: false, error: '' })
+  const [state, setState] = useState({ pending: false, error: '', unavailable: !runId })
   const attemptRef = useRef(null)
   const scopeRef = useRef(null)
 
@@ -10,14 +10,17 @@ export default function useResume({ chatId, runId, send, onAccepted, onRefresh, 
     const scope = { chatId }
     scopeRef.current = scope
     attemptRef.current = null
-    setState({ pending: false, error: '' })
+    setState({ pending: false, error: '', unavailable: !runId })
     return () => { if (scopeRef.current === scope) scopeRef.current = null }
   }, [chatId, runId])
 
   const resume = useCallback(async () => {
     if (blocked?.() || attemptRef.current?.pending) return false
     if (!runId && !attemptRef.current) {
-      setState({ pending: false, error: 'Recovery details are not available yet. Try again once Möbius reconnects.' })
+      // A restart can briefly show a durable pause before its replacement run
+      // is readable. Refresh, but do not turn that expected handoff into an
+      // owner-facing error.
+      setState({ pending: false, error: '', unavailable: true })
       onRefresh()
       return false
     }
@@ -25,7 +28,7 @@ export default function useResume({ chatId, runId, send, onAccepted, onRefresh, 
     const attempt = attemptRef.current || { cid: crypto.randomUUID(), runId }
     attempt.pending = true
     attemptRef.current = attempt
-    setState({ pending: true, error: '' })
+    setState({ pending: true, error: '', unavailable: false })
     try {
       const result = await send('continue', undefined, {
         cid: attempt.cid,
@@ -37,7 +40,7 @@ export default function useResume({ chatId, runId, send, onAccepted, onRefresh, 
       // No optimistic continuation: only the server's accepted durable row
       // can supersede the recovery card or mark the turn as resumed.
       onAccepted(result)
-      setState({ pending: false, error: '' })
+      setState({ pending: false, error: '', unavailable: false })
       return true
     } catch (error) {
       if (scopeRef.current !== scope) return false
@@ -48,6 +51,7 @@ export default function useResume({ chatId, runId, send, onAccepted, onRefresh, 
           && !error?.outboxRetained) attemptRef.current = null
       setState({
         pending: false,
+        unavailable: false,
         error: error?.code === 'recovery_changed'
           ? 'Recovery state changed. Refreshing the chat…'
           : error?.code === 'pending_question_open'


### PR DESCRIPTION
## Summary
- group related helper-result notices into one readable card
- keep restart recovery honest when the run has already resumed
- add focused regression coverage for both behaviors

## Verification
- full frontend unit suite passed
- 29 focused ChatView tests passed

Playwright remains available but is not a merge-blocking check.