### PR TITLE
Run privileged code only from the reviewed image

### DIFF
--- a/backend/app/deployment_control.py
+++ b/backend/app/deployment_control.py
@@ -74,11 +74,10 @@ _KNOWN_STATES = {
 }
 _ACTIVE_STATES = {"queued", "preparing", "replacing", "verifying"}
 _HANDOFF_VERSION = "external-cutover-v1"
-_RUNTIME_OVERLAY_VERSION = "active-runtime-v1"
 _MANAGED_USER_AGENT = "mobius-managed-deployment/1"
 _managed_recovery_tasks: set[asyncio.Task[None]] = set()
 _UPGRADE_MESSAGE = (
-  "The Host replacement helper predates safe active-runtime carry-forward. Re-run "
+  "The Host replacement helper predates safe external chat handoff. Re-run "
   "scripts/install-rebuild-helper.sh from the current trusted checkout."
 )
 
@@ -426,16 +425,12 @@ def _read_host_status() -> dict[str, Any]:
         "expected_sha": expected,
         "message": "Container rebuild queued.",
         "handoff": value.get("handoff"),
-        "runtime_overlay": value.get("runtime_overlay"),
       }
   return value
 
 
 def _current_handoff(raw: dict[str, Any]) -> bool:
-  return (
-    raw.get("handoff") == _HANDOFF_VERSION
-    and raw.get("runtime_overlay") == _RUNTIME_OVERLAY_VERSION
-  )
+  return raw.get("handoff") == _HANDOFF_VERSION
 
 
 def _write_request(expected_sha: str) -> None:

--- a/backend/app/platform_update.py
+++ b/backend/app/platform_update.py
@@ -1084,11 +1084,10 @@ def container_replacement_blockers(
   remove that runtime addition, so the owner action must fail closed before
   cutover.
 
-  Protected runtime (``backend/runtime``) is never a blocker here: the
-  replacement controller's active-runtime overlay contract owns that case at
-  the root boundary, carrying forward only bytes already executing from
-  ``/app/runtime`` and never promoting newer editable source. Other image
-  inputs have no equivalent active-generation receipt.
+  Protected runtime (``backend/runtime``) follows the same rule as every other
+  image input. Privileged code comes only from the reviewed image; a local
+  protected-runtime change must therefore be upstream in that exact target or
+  block replacement before chat drain.
   """
   marker = _read_activation_marker()
   covered = set(marker["image_paths"]) if marker else set()
@@ -1121,8 +1120,6 @@ def container_replacement_blockers(
 
   image_pending: list[str] = []
   for path in sorted(set(pending)):
-    if path == "backend/runtime" or path.startswith("backend/runtime/"):
-      continue
     impact = platform_activation.classify_activation(
       [path], deployment="self_hosted",
     )

--- a/backend/tests/test_deployment_control.py
+++ b/backend/tests/test_deployment_control.py
@@ -52,7 +52,7 @@ def _install_control(tmp_path, monkeypatch):
   inbox = control / "inbox"
   inbox.mkdir(parents=True)
   (control / "status.json").write_text(
-    '{"state":"idle","handoff":"external-cutover-v1","runtime_overlay":"active-runtime-v1"}',
+    '{"state":"idle","handoff":"external-cutover-v1"}',
     encoding="utf-8",
   )
   monkeypatch.setattr(dc, "_control_dir", lambda: control)
@@ -1119,7 +1119,7 @@ async def test_queued_request_masks_the_previous_terminal_status(tmp_path, monke
   control, inbox = _install_control(tmp_path, monkeypatch)
   (control / "status.json").write_text(
     '{"state":"succeeded","operation_id":"old",'
-    '"handoff":"external-cutover-v1","runtime_overlay":"active-runtime-v1"}', encoding="utf-8",
+    '"handoff":"external-cutover-v1"}', encoding="utf-8",
   )
   (inbox / "request.json").write_text(json.dumps({
     "version": 1, "expected_sha": "e" * 40,

--- a/backend/tests/test_mobius_rebuild_host.py
+++ b/backend/tests/test_mobius_rebuild_host.py
@@ -40,9 +40,9 @@ def test_installer_enables_boot_time_reconciliation():
   assert "Before=mobius-rebuild.path" in source
   assert "WantedBy=multi-user.target" in source
   assert "systemctl enable mobius-rebuild-reconcile.service" in source
-  assert 'bootstrap-runtime "$CID"' in source
-  assert "MOBIUS_RUNTIME_OVERLAY" in source
-  assert "target: /app/runtime" in source
+  assert 'bootstrap-runtime "$CID"' not in source
+  assert "MOBIUS_RUNTIME_OVERLAY" not in source
+  assert "target: /app/runtime" not in source
   assert "FROZEN_SOURCE=/etc/mobius-rebuild/compose.yml" in source
   assert '"com.docker.compose.project.environment_file"' in source
   assert 'ARGS+=(--env-file "$file")' in source
@@ -100,32 +100,24 @@ def test_frozen_config_rejects_symlinked_input(tmp_path, monkeypatch):
     host.validate_config(value, trusted_uid=os.getuid())
 
 
-def test_served_generation_accepts_pending_source_but_requires_exact_overlay(
-  monkeypatch,
-):
-  def version(payload):
-    return subprocess.CompletedProcess(
-      [], 0, stdout=payload, stderr="",
+def test_served_generation_requires_the_image_runtime(monkeypatch):
+  def execute(args, **_kwargs):
+    payload = '{"sha":"' + "a" * 40 + '"}' if "curl" in args else "[]"
+    return subprocess.CompletedProcess(args, 0, stdout=payload, stderr="")
+
+  monkeypatch.setattr(host.subprocess, "run", execute)
+  host.verify_served_generation("cid", "a" * 40)
+
+  def mounted(args, **_kwargs):
+    payload = (
+      '{"sha":"' + "a" * 40 + '"}' if "curl" in args else
+      '[{"Destination":"/app/runtime"}]'
     )
+    return subprocess.CompletedProcess(args, 0, stdout=payload, stderr="")
 
-  monkeypatch.setattr(
-    host.subprocess, "run",
-      lambda *_args, **_kwargs: version(
-      '{"sha":"' + "a" * 40 + '","protected_runtime_state":"stale",'
-      '"protected_runtime":{"deployed_sha256":"' + "b" * 64 + '"}}',
-    ),
-  )
-  host.verify_served_generation("cid", "a" * 40, "b" * 64)
-
-  monkeypatch.setattr(
-    host.subprocess, "run",
-    lambda *_args, **_kwargs: version(
-      '{"sha":"' + "a" * 40 + '","protected_runtime":'
-      '{"deployed_sha256":"' + "c" * 64 + '"}}',
-    ),
-  )
-  with pytest.raises(RuntimeError, match="prepared generation"):
-    host.verify_served_generation("cid", "a" * 40, "b" * 64)
+  monkeypatch.setattr(host.subprocess, "run", mounted)
+  with pytest.raises(RuntimeError, match="image's protected runtime"):
+    host.verify_served_generation("cid", "a" * 40)
 
 
 def test_replacement_verifies_provenance_before_retiring_chat_handoff():
@@ -147,17 +139,6 @@ def _worker_paths(tmp_path: Path, monkeypatch):
   monkeypatch.setattr(host, "LOCK", state / "replace.lock")
   monkeypatch.setattr(host, "STATUS", state / "status.json")
   monkeypatch.setattr(host, "IMAGES", state / "images.json")
-  monkeypatch.setattr(host, "RUNTIME_GENERATIONS", state / "runtime-generations")
-  monkeypatch.setattr(host, "RUNTIME_STATE", state / "runtime.json")
-  monkeypatch.setattr(host, "RUNTIME_RESOLUTIONS", state / "runtime-resolutions")
-  monkeypatch.setattr(host, "RUNTIME_RESOLUTION", state / "runtime-resolution.json")
-  runtime = host.RUNTIME_GENERATIONS / f"runtime-{'a' * 16}-{'b' * 8}"
-  runtime.mkdir(parents=True)
-  (runtime / "identity_broker.py").write_text("active\n", encoding="utf-8")
-  digest, _files = host._runtime_snapshot(runtime)
-  host._write_runtime_state(
-    host.RuntimeGeneration(runtime.name, runtime, digest), None,
-  )
   data = tmp_path / "data"
   data.mkdir()
   config = {
@@ -167,378 +148,8 @@ def _worker_paths(tmp_path: Path, monkeypatch):
   return config, inbox
 
 
-def _prepared_runtime() -> host.PreparedRuntime:
-  prior_active, prior_rollback = host._read_runtime_state()
-  previous = prior_active
-  candidate_path = host.RUNTIME_GENERATIONS / f"runtime-{'c' * 16}-{'d' * 8}"
-  candidate_path.mkdir(exist_ok=True)
-  (candidate_path / "identity_broker.py").write_text(
-    "merged\n", encoding="utf-8",
-  )
-  digest, _files = host._runtime_snapshot(candidate_path)
-  candidate = host.RuntimeGeneration(candidate_path.name, candidate_path, digest)
-  return host.PreparedRuntime(
-    previous, candidate, ("identity_broker.py",), prior_active, prior_rollback,
-  )
-
-
-def _write_runtime_tree(root: Path, value: str) -> None:
-  root.mkdir(parents=True)
-  (root / "identity_broker.py").write_text(value, encoding="utf-8")
-
-
-def test_runtime_merge_carries_active_edits_onto_incoming_official_tree(
-  tmp_path, monkeypatch,
-):
-  monkeypatch.setattr(host.os, "chown", lambda *_args: None)
-  base = tmp_path / "base"
-  active = tmp_path / "active"
-  incoming = tmp_path / "incoming"
-  result = tmp_path / "result"
-  _write_runtime_tree(base, "alpha=old\nshared=keep\nomega=old\n")
-  _write_runtime_tree(active, "alpha=local\nshared=keep\nomega=old\n")
-  _write_runtime_tree(incoming, "alpha=old\nshared=keep\nomega=official\n")
-
-  digest, carried = host._merge_runtime_trees(base, active, incoming, result)
-
-  assert (result / "identity_broker.py").read_text(encoding="utf-8") == (
-    "alpha=local\nshared=keep\nomega=official\n"
-  )
-  assert carried == ("identity_broker.py",)
-  assert digest == host._runtime_snapshot(result)[0]
-
-
-def test_runtime_merge_blocks_a_real_active_vs_official_conflict(tmp_path):
-  base = tmp_path / "base"
-  active = tmp_path / "active"
-  incoming = tmp_path / "incoming"
-  _write_runtime_tree(base, "route=old\n")
-  _write_runtime_tree(active, "route=local\n")
-  _write_runtime_tree(incoming, "route=official\n")
-
-  with pytest.raises(host.RuntimeOverlayConflict) as exc:
-    host._merge_runtime_trees(base, active, incoming, tmp_path / "result")
-
-  assert exc.value.paths == ("identity_broker.py",)
-
-
-def test_runtime_merge_applies_an_exact_target_bound_reviewed_resolution(
-  tmp_path, monkeypatch,
-):
-  monkeypatch.setattr(host.os, "chown", lambda *_args: None)
-  base = tmp_path / "base"
-  active = tmp_path / "active"
-  incoming = tmp_path / "incoming"
-  reviewed = tmp_path / "reviewed"
-  result = tmp_path / "result"
-  _write_runtime_tree(base, "route=old\nkeep=base\n")
-  _write_runtime_tree(active, "route=local\nkeep=base\n")
-  _write_runtime_tree(incoming, "route=official\nkeep=official\n")
-  _write_runtime_tree(reviewed, "route=combined\nkeep=official\n")
-  digest = host._runtime_snapshot(reviewed)[0]
-  resolution = host.RuntimeResolution(
-    "a" * 40, "b" * 64, "c" * 40, ("identity_broker.py",),
-    digest, reviewed,
-  )
-
-  merged_digest, carried = host._merge_runtime_trees(
-    base, active, incoming, result, resolution,
-  )
-
-  assert (result / "identity_broker.py").read_text(encoding="utf-8") == (
-    "route=combined\nkeep=official\n"
-  )
-  assert carried == ("identity_broker.py",)
-  assert merged_digest == host._runtime_snapshot(result)[0]
-
-
-def test_runtime_merge_applies_a_reviewed_followup_after_a_clean_merge(
-  tmp_path, monkeypatch,
-):
-  monkeypatch.setattr(host.os, "chown", lambda *_args: None)
-  base = tmp_path / "base"
-  active = tmp_path / "active"
-  incoming = tmp_path / "incoming"
-  reviewed = tmp_path / "reviewed"
-  result = tmp_path / "result"
-  _write_runtime_tree(base, "route=official\n")
-  _write_runtime_tree(active, "route=local-v1\n")
-  _write_runtime_tree(incoming, "route=official\n")
-  _write_runtime_tree(reviewed, "route=local-v2\n")
-  resolution = host.RuntimeResolution(
-    "a" * 40, "b" * 64, "c" * 40, ("identity_broker.py",),
-    host._runtime_snapshot(reviewed)[0], reviewed,
-  )
-
-  merged_digest, carried = host._merge_runtime_trees(
-    base, active, incoming, result, resolution,
-  )
-
-  assert (result / "identity_broker.py").read_text(encoding="utf-8") == (
-    "route=local-v2\n"
-  )
-  assert carried == ("identity_broker.py",)
-  assert merged_digest == host._runtime_snapshot(result)[0]
-
-
-def test_runtime_merge_rejects_a_resolution_for_different_conflict_paths(
-  tmp_path,
-):
-  base = tmp_path / "base"
-  active = tmp_path / "active"
-  incoming = tmp_path / "incoming"
-  reviewed = tmp_path / "reviewed"
-  _write_runtime_tree(base, "route=old\n")
-  _write_runtime_tree(active, "route=local\n")
-  _write_runtime_tree(incoming, "route=official\n")
-  reviewed.mkdir()
-  (reviewed / "other.py").write_text("reviewed\n", encoding="utf-8")
-  resolution = host.RuntimeResolution(
-    "a" * 40, "b" * 64, "c" * 40, ("other.py",),
-    host._runtime_snapshot(reviewed)[0], reviewed,
-  )
-
-  with pytest.raises(host.RuntimeOverlayConflict) as exc:
-    host._merge_runtime_trees(
-      base, active, incoming, tmp_path / "result", resolution,
-    )
-
-  assert exc.value.paths == ("identity_broker.py",)
-
-
-def test_prepare_runtime_uses_commit_merge_base_for_a_local_image(
-  tmp_path, monkeypatch,
-):
-  _config, _inbox = _worker_paths(tmp_path, monkeypatch)
-  monkeypatch.setattr(host.os, "chown", lambda *_args: None)
-  repo = tmp_path / "platform"
-  repo.mkdir()
-
-  def git(*args):
-    return subprocess.run(
-      ["git", "-C", str(repo), *args], text=True, capture_output=True, check=True,
-    )
-
-  git("init", "-q")
-  git("config", "user.name", "Test")
-  git("config", "user.email", "test@example.com")
-  runtime = repo / "backend" / "runtime"
-  _write_runtime_tree(
-    runtime, "alpha=old\nkeep=one\nkeep=two\nkeep=three\nomega=old\n",
-  )
-  git("add", "-A")
-  git("commit", "-q", "-m", "base")
-  base = git("rev-parse", "HEAD").stdout.strip()
-
-  git("checkout", "-q", "-b", "local")
-  (runtime / "identity_broker.py").write_text(
-    "alpha=local\nkeep=one\nkeep=two\nkeep=three\nomega=old\n",
-    encoding="utf-8",
-  )
-  git("commit", "-qam", "local runtime")
-  current = git("rev-parse", "HEAD").stdout.strip()
-  local_tree = tmp_path / "local-tree"
-  shutil.copytree(runtime, local_tree)
-
-  git("checkout", "-q", "-b", "official", base)
-  (runtime / "identity_broker.py").write_text(
-    "alpha=old\nkeep=one\nkeep=two\nkeep=three\nomega=official\n",
-    encoding="utf-8",
-  )
-  git("commit", "-qam", "official runtime")
-  incoming = git("rev-parse", "HEAD").stdout.strip()
-  incoming_tree = tmp_path / "incoming-tree"
-  shutil.copytree(runtime, incoming_tree)
-
-  def copy_active(_cid, destination):
-    shutil.copytree(local_tree, destination, dirs_exist_ok=True)
-    return host._normalize_runtime_tree(destination)
-
-  def copy_image(image, destination):
-    source = local_tree if image == "current-image" else incoming_tree
-    shutil.copytree(source, destination, dirs_exist_ok=True)
-    digest = host._normalize_runtime_tree(destination)
-    return digest, {"sha": current if image == "current-image" else incoming}
-
-  monkeypatch.setattr(host, "_copy_container_runtime", copy_active)
-  monkeypatch.setattr(host, "_copy_image_runtime", copy_image)
-
-  prepared = host.prepare_runtime_overlay(
-    "container", "current-image", "incoming-image", repo, incoming,
-  )
-
-  assert prepared.carried_paths == ("identity_broker.py",)
-  assert (prepared.candidate.path / "identity_broker.py").read_text(
-    encoding="utf-8",
-  ) == "alpha=local\nkeep=one\nkeep=two\nkeep=three\nomega=official\n"
-
-
-def test_stage_runtime_resolution_binds_reviewed_file_to_active_tree_and_target(
-  tmp_path, monkeypatch,
-):
+def test_compose_never_mounts_a_generated_runtime(tmp_path, monkeypatch):
   config, _inbox = _worker_paths(tmp_path, monkeypatch)
-  monkeypatch.setattr(host.os, "chown", lambda *_args: None)
-  repo = config["data_dir"] / "platform"
-  repo.mkdir()
-
-  def git(*args):
-    return subprocess.run(
-      ["git", "-C", str(repo), *args], text=True, capture_output=True, check=True,
-    )
-
-  git("init", "-q")
-  git("config", "user.name", "Test")
-  git("config", "user.email", "test@example.com")
-  runtime = repo / "backend" / "runtime"
-  runtime.mkdir(parents=True)
-  (runtime / "restart_ledger.py").write_text("base\n", encoding="utf-8")
-  git("add", "-A")
-  git("commit", "-q", "-m", "base")
-  base = git("rev-parse", "HEAD").stdout.strip()
-
-  git("checkout", "-q", "-b", "local")
-  (runtime / "identity_broker.py").write_text("local\n", encoding="utf-8")
-  git("add", "-A")
-  git("commit", "-q", "-m", "local")
-  current = git("rev-parse", "HEAD").stdout.strip()
-  active_tree = tmp_path / "active-tree"
-  shutil.copytree(runtime, active_tree)
-
-  git("checkout", "-q", "-b", "official", base)
-  (runtime / "identity_broker.py").write_text("official\n", encoding="utf-8")
-  git("add", "-A")
-  git("commit", "-q", "-m", "official")
-  expected = git("rev-parse", "HEAD").stdout.strip()
-  git("checkout", "-q", "-b", "reviewed")
-  (runtime / "identity_broker.py").write_text("combined\n", encoding="utf-8")
-  git("commit", "-qam", "reviewed resolution")
-  source_commit = git("rev-parse", "HEAD").stdout.strip()
-
-  def copy_active(_cid, destination):
-    shutil.copytree(active_tree, destination, dirs_exist_ok=True)
-    return host._normalize_runtime_tree(destination)
-
-  def copy_image(_image, destination):
-    shutil.copytree(active_tree, destination, dirs_exist_ok=True)
-    return host._normalize_runtime_tree(destination), {"sha": current}
-
-  monkeypatch.setattr(host, "app_container", lambda _config: ("a" * 12, "image"))
-  monkeypatch.setattr(host, "_copy_container_runtime", copy_active)
-  monkeypatch.setattr(host, "_copy_image_runtime", copy_image)
-  statuses = []
-  monkeypatch.setattr(
-    host, "write_status", lambda _config, **fields: statuses.append(fields) or fields,
-  )
-
-  resolution = host.stage_runtime_resolution(
-    config, "a" * 12, expected, source_commit,
-  )
-
-  assert resolution.paths == ("identity_broker.py",)
-  assert (resolution.directory / "identity_broker.py").read_text(
-    encoding="utf-8",
-  ) == "combined\n"
-  assert resolution.active_digest == host._runtime_snapshot(active_tree)[0]
-  assert statuses[-1]["code"] == "runtime_overlay_resolved"
-
-
-def test_stage_runtime_resolution_accepts_a_reviewed_clean_followup(
-  tmp_path, monkeypatch,
-):
-  config, _inbox = _worker_paths(tmp_path, monkeypatch)
-  monkeypatch.setattr(host.os, "chown", lambda *_args: None)
-  repo = config["data_dir"] / "platform"
-  repo.mkdir()
-
-  def git(*args):
-    return subprocess.run(
-      ["git", "-C", str(repo), *args], text=True, capture_output=True, check=True,
-    )
-
-  git("init", "-q")
-  git("config", "user.name", "Test")
-  git("config", "user.email", "test@example.com")
-  runtime = repo / "backend" / "runtime"
-  _write_runtime_tree(runtime, "official\n")
-  git("add", "-A")
-  git("commit", "-q", "-m", "official")
-  expected = git("rev-parse", "HEAD").stdout.strip()
-  official_tree = tmp_path / "official-tree"
-  shutil.copytree(runtime, official_tree)
-
-  (runtime / "identity_broker.py").write_text("reviewed-v2\n", encoding="utf-8")
-  git("commit", "-qam", "reviewed followup")
-  source_commit = git("rev-parse", "HEAD").stdout.strip()
-  active_tree = tmp_path / "active-tree"
-  _write_runtime_tree(active_tree, "active-v1\n")
-
-  def copy_active(_cid, destination):
-    shutil.copytree(active_tree, destination, dirs_exist_ok=True)
-    return host._normalize_runtime_tree(destination)
-
-  def copy_image(_image, destination):
-    shutil.copytree(official_tree, destination, dirs_exist_ok=True)
-    return host._normalize_runtime_tree(destination), {"sha": expected}
-
-  monkeypatch.setattr(host, "app_container", lambda _config: ("a" * 12, "image"))
-  monkeypatch.setattr(host, "_copy_container_runtime", copy_active)
-  monkeypatch.setattr(host, "_copy_image_runtime", copy_image)
-  monkeypatch.setattr(host, "write_status", lambda _config, **fields: fields)
-
-  resolution = host.stage_runtime_resolution(
-    config, "a" * 12, expected, source_commit,
-  )
-
-  assert resolution.paths == ("identity_broker.py",)
-  assert (resolution.directory / "identity_broker.py").read_text(
-    encoding="utf-8",
-  ) == "reviewed-v2\n"
-
-
-def test_controller_status_advertises_active_runtime_support(
-  tmp_path, monkeypatch,
-):
-  config, _inbox = _worker_paths(tmp_path, monkeypatch)
-
-  status = host.write_status(config, state="idle")
-
-  assert status["handoff"] == "external-cutover-v1"
-  assert status["runtime_overlay"] == "active-runtime-v1"
-
-
-def test_runtime_resolution_receipt_is_exact_target_and_content_bound(
-  tmp_path, monkeypatch,
-):
-  _config, _inbox = _worker_paths(tmp_path, monkeypatch)
-  monkeypatch.setattr(host.os, "chown", lambda *_args: None)
-  directory = host.RUNTIME_RESOLUTIONS / f"resolution-{'a' * 32}"
-  _write_runtime_tree(directory, "combined\n")
-  digest = host._normalize_runtime_tree(directory)
-  host._atomic_json(host.RUNTIME_RESOLUTION, {
-    "version": 1,
-    "expected_sha": "b" * 40,
-    "active_digest": "c" * 64,
-    "source_commit": "d" * 40,
-    "paths": ["identity_broker.py"],
-    "digest": digest,
-    "directory": directory.name,
-  })
-
-  resolution = host._read_runtime_resolution("b" * 40, "c" * 64)
-
-  assert resolution is not None
-  assert resolution.paths == ("identity_broker.py",)
-  assert host._read_runtime_resolution("e" * 40, "c" * 64) is None
-  resolved_file = directory / "identity_broker.py"
-  resolved_file.chmod(0o644)
-  resolved_file.write_text("changed\n", encoding="utf-8")
-  with pytest.raises(host.RuntimeOverlayError, match="invalid"):
-    host._read_runtime_resolution("b" * 40, "c" * 64)
-
-
-def test_compose_mounts_the_selected_runtime_generation(tmp_path, monkeypatch):
-  config, _inbox = _worker_paths(tmp_path, monkeypatch)
-  selected = host.active_runtime_generation()
   calls = []
 
   def execute(args, **kwargs):
@@ -546,11 +157,36 @@ def test_compose_mounts_the_selected_runtime_generation(tmp_path, monkeypatch):
     return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
 
   monkeypatch.setattr(host.subprocess, "run", execute)
-
-  host.compose(config, "ps", runtime=selected)
+  host.compose(config, "ps")
 
   _args, kwargs = calls[0]
-  assert kwargs["env"]["MOBIUS_RUNTIME_OVERLAY"] == str(selected.path)
+  assert "MOBIUS_RUNTIME_OVERLAY" not in kwargs["env"]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 def test_no_change_does_not_drain_active_chats(tmp_path, monkeypatch):
@@ -582,47 +218,6 @@ def test_no_change_does_not_drain_active_chats(tmp_path, monkeypatch):
   assert statuses[-1]["state"] == "no_change"
 
 
-def test_same_image_applies_a_staged_runtime_followup(tmp_path, monkeypatch):
-  _config, inbox = _worker_paths(tmp_path, monkeypatch)
-  expected = "c" * 40
-  (inbox / "request.json").write_text(
-    f'{{"version":1,"expected_sha":"{expected}"}}', encoding="utf-8",
-  )
-  monkeypatch.setattr(host, "app_container", lambda _config: ("cid", "same"))
-  monkeypatch.setattr(host, "require_pull_space", lambda _image: None)
-  monkeypatch.setattr(host.subprocess, "run", lambda *_args, **_kwargs: None)
-  monkeypatch.setattr(host, "inspect_image", lambda _image, template: (
-    expected if "revision" in template else
-    host.IMAGE_SOURCE if "source" in template else
-    "amd64" if "Architecture" in template else "same"
-  ))
-  monkeypatch.setattr(host, "verify_served_generation", lambda *_args: None)
-  monkeypatch.setattr(host, "_read_runtime_resolution", lambda *_args: object())
-  monkeypatch.setattr(host, "_consume_runtime_resolution", lambda *_args: None)
-  prepared = _prepared_runtime()
-  prepared_calls = []
-  monkeypatch.setattr(
-    host, "prepare_runtime_overlay",
-    lambda *_args: prepared_calls.append(True) or prepared,
-  )
-  monkeypatch.setattr(host, "request_drain", lambda *_args: None)
-  compose_calls = []
-  monkeypatch.setattr(
-    host, "compose",
-    lambda *_args, **kwargs: compose_calls.append(kwargs.get("runtime")),
-  )
-  monkeypatch.setattr(host, "wait_healthy", lambda *_args: True)
-  monkeypatch.setattr(host, "restart_ledger", lambda *_args, **_kwargs: True)
-  monkeypatch.setattr(host, "retain_images", lambda *_args: None)
-  statuses = []
-  monkeypatch.setattr(
-    host, "write_status", lambda _config, **fields: statuses.append(fields) or fields,
-  )
-
-  assert host.run() == 0
-  assert prepared_calls == [True]
-  assert compose_calls == [prepared.candidate]
-  assert statuses[-1]["state"] == "succeeded"
 
 
 def test_request_is_claimed_on_the_control_filesystem(tmp_path, monkeypatch):
@@ -750,41 +345,6 @@ def test_failed_request_claim_is_terminal_and_retryable(tmp_path, monkeypatch):
   assert not request.exists()
 
 
-def test_runtime_overlay_conflict_stops_before_chat_drain(tmp_path, monkeypatch):
-  _config, inbox = _worker_paths(tmp_path, monkeypatch)
-  expected = "8" * 40
-  (inbox / "request.json").write_text(
-    f'{{"version":1,"expected_sha":"{expected}"}}', encoding="utf-8",
-  )
-  monkeypatch.setattr(host, "app_container", lambda _config: ("cid", "old"))
-  monkeypatch.setattr(host, "require_pull_space", lambda _image: None)
-  monkeypatch.setattr(host.subprocess, "run", lambda *_args, **_kwargs: None)
-  monkeypatch.setattr(host, "inspect_image", lambda _image, template: (
-    expected if "revision" in template else
-    host.IMAGE_SOURCE if "source" in template else
-    "amd64" if "Architecture" in template else "new"
-  ))
-  monkeypatch.setattr(
-    host,
-    "prepare_runtime_overlay",
-    lambda *_args: (_ for _ in ()).throw(
-      host.RuntimeOverlayConflict(["identity_broker.py"]),
-    ),
-  )
-  monkeypatch.setattr(
-    host, "request_drain",
-    lambda *_args: (_ for _ in ()).throw(
-      AssertionError("a runtime conflict must stop before chat drain"),
-    ),
-  )
-  statuses = []
-  monkeypatch.setattr(
-    host, "write_status", lambda _config, **fields: statuses.append(fields) or fields,
-  )
-
-  assert host.run() == 1
-  assert statuses[-1]["code"] == "runtime_overlay_conflict"
-  assert "identity_broker.py" in statuses[-1]["message"]
 
 
 def test_replacement_drains_then_rolls_back_after_cutover_error(tmp_path, monkeypatch):
@@ -801,8 +361,6 @@ def test_replacement_drains_then_rolls_back_after_cutover_error(tmp_path, monkey
     host.IMAGE_SOURCE if "source" in template else
     "amd64" if "Architecture" in template else "new"
   ))
-  prepared = _prepared_runtime()
-  monkeypatch.setattr(host, "prepare_runtime_overlay", lambda *_args: prepared)
   order = []
   ready = inbox / "ready"
   monkeypatch.setattr(
@@ -848,8 +406,6 @@ def test_success_reports_when_chat_handoff_receipt_cannot_be_retired(
     host.IMAGE_SOURCE if "source" in template else
     "amd64" if "Architecture" in template else "new"
   ))
-  prepared = _prepared_runtime()
-  monkeypatch.setattr(host, "prepare_runtime_overlay", lambda *_args: prepared)
   monkeypatch.setattr(host, "request_drain", lambda *_args: None)
   monkeypatch.setattr(host, "compose", lambda *_args, **_kwargs: None)
   monkeypatch.setattr(host, "wait_healthy", lambda *_args, **_kwargs: True)

--- a/backend/tests/test_platform_update.py
+++ b/backend/tests/test_platform_update.py
@@ -1767,7 +1767,7 @@ def test_container_replacement_accepts_image_input_covered_by_upstream(
   assert pu.container_replacement_blockers() == []
 
 
-def test_active_runtime_overlay_owns_protected_runtime_blockers(
+def test_protected_runtime_is_an_image_replacement_blocker(
   tmp_path, monkeypatch,
 ):
   marker = tmp_path / "activation.json"
@@ -1779,7 +1779,9 @@ def test_active_runtime_overlay_owns_protected_runtime_blockers(
     image_paths=[],
   )
 
-  assert pu.container_replacement_blockers() == ["Dockerfile"]
+  assert pu.container_replacement_blockers() == [
+    "Dockerfile", "backend/runtime/identity_broker.py",
+  ]
 
 
 def test_stale_protected_runtime_restores_image_activation_without_marker(
@@ -1808,7 +1810,7 @@ def test_stale_protected_runtime_restores_image_activation_without_marker(
   }]
 
 
-def test_replacement_leaves_local_runtime_drift_to_the_active_runtime_overlay(
+def test_replacement_blocks_local_runtime_drift(
   clone_env,
 ):
   _, platform = clone_env
@@ -1818,7 +1820,9 @@ def test_replacement_leaves_local_runtime_drift_to_the_active_runtime_overlay(
     edits={"backend/runtime/identity_broker.py": "local-only\n"},
   )
 
-  assert pu.container_replacement_blockers(official, platform) == []
+  assert pu.container_replacement_blockers(official, platform) == [
+    "backend/runtime/identity_broker.py",
+  ]
 
 
 def test_replacement_blocks_unmarked_local_image_input_drift(clone_env):

--- a/scripts/CONTAINER-REBUILD.md
+++ b/scripts/CONTAINER-REBUILD.md
@@ -77,23 +77,20 @@ The worker:
 
 1. checks Docker free space and pulls `ghcr.io/mobius-os/mobius:sha-<sha>`;
 2. verifies the image source, revision, and amd64 architecture;
-3. snapshots only the root-owned `/app/runtime` bytes already executing,
-   three-way merges any active local override onto the incoming official
-   runtime, and stops before draining chats if the two changed the same lines;
-4. returns `no_change` without disturbing chats if that image and prepared
-   runtime generation are already live;
-5. opens a root-owned one-boot cutover challenge, then asks the running worker
+3. returns `no_change` without disturbing chats if that exact image is already
+   live and its protected runtime comes directly from the image;
+4. opens a root-owned one-boot cutover challenge, then asks the running worker
    to close admission, park active turns, and bind them to that exact id;
-6. accepts the matching app intent without self-stopping, so Compose owns the
+5. accepts the matching app intent without self-stopping, so Compose owns the
    only stop and the authorization cannot be consumed by an intermediate boot;
-7. recreates only `app` from the frozen topology, mounts the prepared runtime
-   generation read-only, and verifies readiness, the exact served image
-   revision, and the exact mounted-runtime digest;
-8. explicitly re-arms the same root receipt for one rollback boot if the new
+6. recreates only `app` from the frozen topology and verifies readiness, the
+   exact served image revision, and that `/app/runtime` is the image's own
+   immutable protected code rather than a host-generated mount;
+7. explicitly re-arms the same root receipt for one rollback boot if the new
    container never becomes serviceable, then retires it after either healthy
    outcome; and
-9. retains only the active and last-good runtime generations, the current
-   helper-owned SHA tag, and one last-good image tag, without a host-wide prune.
+8. retains only the current helper-owned SHA tag and one last-good image tag,
+   without a host-wide prune.
 
 The canonical local `scripts/deploy-prod.sh` uses the same challenge → drain →
 accept contract when the image identity changes. A running image from before
@@ -130,28 +127,11 @@ capable. Once this succeeds, later Railway rebuilds use the normal managed
 challenge, drain, and receipt protocol.
 
 Ordinary local source remains in `/data/platform` and follows the normal merge
-reconciliation after boot. Protected runtime is deliberately narrower: the
-controller carries forward only bytes already active under the previous
-root-owned image boundary. Newer editable `backend/runtime` source remains
-pending and is never promoted to root code merely because an image was
-rebuilt. Dockerfile, dependency, bootstrap-script, and other local-only image
-inputs remain blockers because they have no equivalent active-generation
-receipt.
-
-## Resolving an active-runtime conflict
-
-A real overlap stops before chat drain and reports the exact paths. Resolve the
-file in a reviewed commit that contains the requested official target, then an
-operator may stage only those detected conflict files:
-
-```sh
-sudo /usr/local/libexec/mobius-rebuild-host stage-runtime-resolution \
-  <running-container-id> <official-target-sha> <reviewed-resolution-commit>
-```
-
-The root helper recomputes the conflict from the running `/app/runtime`, the
-two immutable Git histories, and the fixed persistent platform checkout. It
-accepts only the exact conflict path set, binds the staged files to the current
-runtime digest and official target, and does not mutate or restart the live
-container. A later Settings rebuild consumes the receipt only after the
-new container is healthy; a failed rebuild retains it for a safe retry.
+reconciliation after boot. Protected runtime is deliberately simpler:
+`/app/runtime` always comes verbatim from the reviewed image. Identity keys and
+linked state remain under persistent `/data/identity-broker`, but executable
+root code is never merged or carried forward. A local `backend/runtime` change
+therefore follows the same rule as a Dockerfile, dependency, or bootstrap
+change: it must be present in the exact reviewed image or replacement blocks
+before chat drain. A fork that intentionally changes privileged code deploys
+its own locally built image instead of overlaying an official one.

--- a/scripts/install-rebuild-helper.sh
+++ b/scripts/install-rebuild-helper.sh
@@ -125,7 +125,6 @@ umask 077
 install -d -m 0700 /etc/mobius-rebuild /var/lib/mobius-rebuild
 install -D -m 0755 "$ROOT/scripts/mobius-rebuild-host.py" \
   /usr/local/libexec/mobius-rebuild-host
-/usr/local/libexec/mobius-rebuild-host bootstrap-runtime "$CID"
 SNAPSHOT=$(mktemp /etc/mobius-rebuild/compose.XXXXXX)
 if [[ -n $FROZEN_SOURCE ]]; then
   cp "$FROZEN_SOURCE" "$SNAPSHOT"
@@ -139,11 +138,6 @@ cat >/etc/mobius-rebuild/image.override.yml <<'EOF'
 services:
   app:
     image: ${MOBIUS_IMAGE:?MOBIUS_IMAGE is required}
-    volumes:
-      - type: bind
-        source: ${MOBIUS_RUNTIME_OVERLAY:?MOBIUS_RUNTIME_OVERLAY is required}
-        target: /app/runtime
-        read_only: true
 EOF
 chmod 0600 /etc/mobius-rebuild/image.override.yml
 python3 - "$PROJECT" "$DATA_SOURCE" <<'PY'

--- a/scripts/mobius-rebuild-host.py
+++ b/scripts/mobius-rebuild-host.py
@@ -4,20 +4,17 @@
 from __future__ import annotations
 
 import fcntl
-import hashlib
 import json
 import os
 import re
 import shutil
 import subprocess
 import sys
-import tarfile
 import tempfile
 import time
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import NamedTuple
 
 STATE_DIR = Path("/var/lib/mobius-rebuild")
 CONFIG = Path("/etc/mobius-rebuild/config.json")
@@ -26,69 +23,14 @@ OVERRIDE = Path("/etc/mobius-rebuild/image.override.yml")
 STATUS = STATE_DIR / "status.json"
 LOCK = STATE_DIR / "replace.lock"
 IMAGES = STATE_DIR / "images.json"
-RUNTIME_GENERATIONS = STATE_DIR / "runtime-generations"
-RUNTIME_STATE = STATE_DIR / "runtime.json"
-RUNTIME_RESOLUTIONS = STATE_DIR / "runtime-resolutions"
-RUNTIME_RESOLUTION = STATE_DIR / "runtime-resolution.json"
 SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 OPERATION_RE = re.compile(r"^[0-9a-f]{32}$")
 CONTAINER_RE = re.compile(r"^[0-9a-f]{12,64}$")
-GENERATION_RE = re.compile(r"^runtime-[0-9a-f]{16}-[0-9a-f]{8}$")
-RESOLUTION_RE = re.compile(r"^resolution-[0-9a-f]{32}$")
 IMAGE = "ghcr.io/mobius-os/mobius"
 IMAGE_SOURCE = "https://github.com/mobius-os/mobius"
 ROLLBACK_TAG = f"{IMAGE}:mobius-rebuild-last-good"
 ACTIVE_STATES = {"queued", "preparing", "replacing", "verifying"}
 HANDOFF_VERSION = "external-cutover-v1"
-RUNTIME_OVERLAY_VERSION = "active-runtime-v1"
-MAX_RUNTIME_ARCHIVE_BYTES = 32 * 1024 * 1024
-
-
-class RuntimeGeneration(NamedTuple):
-    """One immutable root-owned protected-runtime generation."""
-
-    name: str
-    path: Path
-    digest: str
-
-
-class PreparedRuntime(NamedTuple):
-    """The exact rollback and candidate generations for one replacement."""
-
-    previous: RuntimeGeneration
-    candidate: RuntimeGeneration
-    carried_paths: tuple[str, ...]
-    prior_active: RuntimeGeneration
-    prior_rollback: RuntimeGeneration | None
-
-
-class RuntimeResolution(NamedTuple):
-    """One root-approved conflict resolution bound to an active tree + target."""
-
-    expected_sha: str
-    active_digest: str
-    source_commit: str
-    paths: tuple[str, ...]
-    digest: str
-    directory: Path
-
-
-class RuntimeOverlayError(RuntimeError):
-    code = "runtime_overlay_failed"
-
-
-class RuntimeOverlayConflict(RuntimeOverlayError):
-    code = "runtime_overlay_conflict"
-
-    def __init__(self, paths: list[str]) -> None:
-        self.paths = tuple(paths)
-        visible = ", ".join(paths[:5])
-        if len(paths) > 5:
-            visible += f" and {len(paths) - 5} more"
-        super().__init__(
-            "The active local runtime conflicts with the official update: "
-            + visible
-        )
 
 
 def now() -> str:
@@ -151,522 +93,46 @@ def config() -> dict:
     return validate_config(read_json(CONFIG))
 
 
-def _runtime_snapshot(root: Path) -> tuple[str, dict[str, str]]:
-    """Hash one regular-file runtime tree with the app's provenance contract."""
-    if not root.is_dir() or root.is_symlink():
-        raise RuntimeOverlayError("the protected runtime tree is unavailable")
-    files: dict[str, str] = {}
-    for path in sorted(root.rglob("*")):
-        relative = path.relative_to(root)
-        if "__pycache__" in relative.parts or relative.suffix in {".pyc", ".pyo"}:
-            continue
-        name = relative.as_posix()
-        if path.is_symlink() or (not path.is_dir() and not path.is_file()):
-            raise RuntimeOverlayError(
-                f"the protected runtime contains an unsafe path: {name}"
-            )
-        if path.is_file():
-            files[name] = hashlib.sha256(path.read_bytes()).hexdigest()
-    tree = hashlib.sha256()
-    for name, digest in sorted(files.items()):
-        tree.update(name.encode("utf-8"))
-        tree.update(b"\0")
-        tree.update(digest.encode("ascii"))
-        tree.update(b"\n")
-    return tree.hexdigest(), files
 
 
-def _normalize_runtime_tree(root: Path) -> str:
-    """Remove inert bytecode and freeze a copied tree as root-owned read-only."""
-    if not root.is_dir() or root.is_symlink():
-        raise RuntimeOverlayError("the protected runtime tree is unavailable")
-    for path in sorted(root.rglob("*"), reverse=True):
-        relative = path.relative_to(root)
-        if path.is_symlink():
-            raise RuntimeOverlayError(
-                f"the protected runtime contains an unsafe path: {relative.as_posix()}"
-            )
-        if path.is_dir() and path.name == "__pycache__":
-            shutil.rmtree(path)
-            continue
-        if path.is_file() and path.suffix in {".pyc", ".pyo"}:
-            path.unlink()
-            continue
-        if not path.is_dir() and not path.is_file():
-            raise RuntimeOverlayError(
-                f"the protected runtime contains an unsafe path: {relative.as_posix()}"
-            )
-    digest, _files = _runtime_snapshot(root)
-    for path in sorted(root.rglob("*")):
-        if path.is_dir():
-            os.chmod(path, 0o755)
-        else:
-            executable = bool(path.stat().st_mode & 0o111)
-            os.chmod(path, 0o555 if executable else 0o444)
-        os.chown(path, 0, 0)
-    os.chmod(root, 0o755)
-    os.chown(root, 0, 0)
-    return digest
 
 
-def _copy_container_runtime(cid: str, destination: Path) -> str:
-    destination.mkdir(mode=0o700, parents=True)
-    subprocess.run(
-        ["docker", "cp", f"{cid}:/app/runtime/.", str(destination)],
-        text=True, capture_output=True, check=True,
-    )
-    return _normalize_runtime_tree(destination)
 
 
-def _copy_image_runtime(image: str, destination: Path) -> tuple[str, dict]:
-    """Copy the raw image tree, bypassing any Compose runtime mount."""
-    created = subprocess.run(
-        ["docker", "create", image], text=True, capture_output=True, check=True,
-    ).stdout.strip()
-    if not CONTAINER_RE.fullmatch(created):
-        raise RuntimeOverlayError("Docker returned an invalid image container id")
-    build_info: dict = {}
-    try:
-        digest = _copy_container_runtime(created, destination)
-        info_path = destination.parent / f".{destination.name}-build-info.json"
-        copied = subprocess.run(
-            ["docker", "cp", f"{created}:/app/build-info.json", str(info_path)],
-            text=True, capture_output=True,
-        )
-        if copied.returncode == 0:
-            try:
-                value = read_json(info_path)
-                build_info = value
-            finally:
-                info_path.unlink(missing_ok=True)
-        return digest, build_info
-    finally:
-        subprocess.run(
-            ["docker", "rm", "-f", created], text=True, capture_output=True,
-        )
 
 
-def _extract_git_runtime(repo: Path, revision: str, destination: Path) -> str:
-    """Extract one content-addressed runtime tree without trusting a branch."""
-    if repo.is_symlink() or not (repo / ".git").is_dir() or not SHA_RE.fullmatch(
-        revision
-    ):
-        raise RuntimeOverlayError("the platform runtime provenance is unavailable")
-    with tempfile.TemporaryFile() as payload:
-        result = subprocess.run(
-            ["git", "-c", f"safe.directory={repo}",
-             "-c", "core.hooksPath=/dev/null", "-C", str(repo), "archive",
-             "--format=tar", revision, "backend/runtime"],
-            stdout=payload, stderr=subprocess.PIPE,
-        )
-        if result.returncode != 0:
-            raise RuntimeOverlayError(
-                "the platform checkout does not contain the required runtime provenance"
-            )
-        if payload.tell() > MAX_RUNTIME_ARCHIVE_BYTES:
-            raise RuntimeOverlayError("the protected runtime archive is unexpectedly large")
-        payload.seek(0)
-        destination.mkdir(mode=0o700, parents=True)
-        prefix = "backend/runtime/"
-        with tarfile.open(fileobj=payload, mode="r:") as archive:
-            for member in archive.getmembers():
-                if member.name in {"backend", "backend/runtime"}:
-                    continue
-                if not member.name.startswith(prefix):
-                    raise RuntimeOverlayError("the runtime base archive is invalid")
-                relative = member.name[len(prefix):]
-                if (
-                    not relative
-                    or relative.startswith("/")
-                    or ".." in Path(relative).parts
-                ):
-                    raise RuntimeOverlayError("the runtime base archive is invalid")
-                target = destination / relative
-                if member.isdir():
-                    target.mkdir(mode=0o700, parents=True, exist_ok=True)
-                    continue
-                if not member.isfile():
-                    raise RuntimeOverlayError("the runtime base archive is invalid")
-                target.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
-                source = archive.extractfile(member)
-                if source is None:
-                    raise RuntimeOverlayError("the runtime base archive is invalid")
-                target.write_bytes(source.read())
-                os.chmod(target, member.mode & 0o777)
-    return _normalize_runtime_tree(destination)
 
 
-def _git(repo: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess:
-    env = os.environ.copy()
-    for name in (
-        "GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_OBJECT_DIRECTORY",
-        "GIT_COMMON_DIR", "GIT_NAMESPACE",
-    ):
-        env.pop(name, None)
-    return subprocess.run(
-        ["git", "-c", f"safe.directory={repo}",
-         "-c", "core.hooksPath=/dev/null", "-C", str(repo), *args],
-        text=True, capture_output=True, check=check, env=env,
-    )
 
 
-def _replace_checkout(repo: Path, source: Path) -> None:
-    for child in repo.iterdir():
-        if child.name == ".git":
-            continue
-        if child.is_dir() and not child.is_symlink():
-            shutil.rmtree(child)
-        else:
-            child.unlink()
-    for child in source.iterdir():
-        target = repo / child.name
-        if child.is_dir():
-            shutil.copytree(child, target)
-        else:
-            shutil.copy2(child, target)
-    for path in repo.rglob("*"):
-        if ".git" not in path.parts:
-            os.chmod(path, path.stat().st_mode | 0o200)
 
 
-def _merge_runtime_trees(
-    base: Path, local: Path, incoming: Path, result: Path,
-    resolution: RuntimeResolution | None = None,
-) -> tuple[str, tuple[str, ...]]:
-    """Three-way merge an already-active runtime onto an official runtime."""
-    repo = result.parent / "merge-repo"
-    repo.mkdir(mode=0o700)
-    _git(repo, "init", "-q")
-    _git(repo, "config", "user.name", "Möbius Runtime Controller")
-    _git(repo, "config", "user.email", "runtime-controller@localhost")
-    _replace_checkout(repo, base)
-    _git(repo, "add", "-A", "-f")
-    _git(repo, "commit", "-q", "--allow-empty", "-m", "runtime base")
-    base_sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
-
-    _git(repo, "checkout", "-q", "-b", "active")
-    _replace_checkout(repo, local)
-    _git(repo, "add", "-A", "-f")
-    _git(repo, "commit", "-q", "--allow-empty", "-m", "active local runtime")
-    active_sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
-    carried = tuple(
-        line for line in _git(
-            repo, "diff", "--name-only", base_sha, active_sha,
-        ).stdout.splitlines() if line
-    )
-
-    _git(repo, "checkout", "-q", "-b", "incoming", base_sha)
-    _replace_checkout(repo, incoming)
-    _git(repo, "add", "-A", "-f")
-    _git(repo, "commit", "-q", "--allow-empty", "-m", "incoming official runtime")
-    merged = _git(
-        repo, "merge", "--no-commit", "--no-ff", "active", check=False,
-    )
-    resolution_applied = False
-    if merged.returncode:
-        conflicts = sorted(
-            line for line in _git(
-                repo, "diff", "--name-only", "--diff-filter=U", check=False,
-            ).stdout.splitlines() if line
-        )
-        if conflicts:
-            if resolution is None or tuple(conflicts) != resolution.paths:
-                raise RuntimeOverlayConflict(conflicts)
-            for name in resolution.paths:
-                source = resolution.directory / name
-                target = repo / name
-                if target.is_dir() and not target.is_symlink():
-                    shutil.rmtree(target)
-                elif target.exists() or target.is_symlink():
-                    target.unlink()
-                target.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
-                shutil.copy2(source, target)
-            _git(repo, "add", "-A", "-f")
-            resolution_applied = True
-            unresolved = [
-                line for line in _git(
-                    repo, "diff", "--name-only", "--diff-filter=U", check=False,
-                ).stdout.splitlines() if line
-            ]
-            if unresolved:
-                raise RuntimeOverlayConflict(unresolved)
-            carried = tuple(sorted({*carried, *resolution.paths}))
-        else:
-            raise RuntimeOverlayError(
-                (merged.stderr or merged.stdout or "runtime merge failed").strip()[:300]
-            )
-    if resolution is not None and not resolution_applied:
-        for name in resolution.paths:
-            source = resolution.directory / name
-            target = repo / name
-            if target.is_dir() and not target.is_symlink():
-                shutil.rmtree(target)
-            elif target.exists() or target.is_symlink():
-                target.unlink()
-            target.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
-            shutil.copy2(source, target)
-        _git(repo, "add", "-A", "-f")
-        carried = tuple(sorted({*carried, *resolution.paths}))
-    result.mkdir(mode=0o700)
-    for child in repo.iterdir():
-        if child.name == ".git":
-            continue
-        target = result / child.name
-        if child.is_dir():
-            shutil.copytree(child, target)
-        else:
-            shutil.copy2(child, target)
-    return _normalize_runtime_tree(result), carried
 
 
-def _runtime_generation(value: dict) -> RuntimeGeneration:
-    if not isinstance(value, dict) or set(value) != {"name", "digest"}:
-        raise RuntimeOverlayError("the active runtime receipt is invalid")
-    name = str(value["name"])
-    digest = str(value["digest"])
-    if not GENERATION_RE.fullmatch(name) or not re.fullmatch(r"[0-9a-f]{64}", digest):
-        raise RuntimeOverlayError("the active runtime receipt is invalid")
-    path = RUNTIME_GENERATIONS / name
-    actual, _files = _runtime_snapshot(path)
-    if actual != digest:
-        raise RuntimeOverlayError("the active runtime generation was modified")
-    return RuntimeGeneration(name=name, path=path, digest=digest)
 
 
-def _runtime_record(generation: RuntimeGeneration | None) -> dict | None:
-    if generation is None:
-        return None
-    return {"name": generation.name, "digest": generation.digest}
 
 
-def _read_runtime_state() -> tuple[RuntimeGeneration, RuntimeGeneration | None]:
-    try:
-        value = read_json(RUNTIME_STATE)
-    except (OSError, ValueError, json.JSONDecodeError) as exc:
-        raise RuntimeOverlayError("the active runtime receipt is unavailable") from exc
-    if value.get("version") != 1 or set(value) != {"version", "active", "rollback"}:
-        raise RuntimeOverlayError("the active runtime receipt is invalid")
-    active = _runtime_generation(value["active"])
-    rollback_value = value["rollback"]
-    rollback = _runtime_generation(rollback_value) if rollback_value else None
-    return active, rollback
 
 
-def active_runtime_generation() -> RuntimeGeneration:
-    return _read_runtime_state()[0]
 
 
-def _safe_runtime_path(value: object) -> str:
-    path = Path(str(value))
-    if (
-        path.is_absolute()
-        or not path.parts
-        or ".." in path.parts
-        or any(part in {"", ".git"} for part in path.parts)
-    ):
-        raise RuntimeOverlayError("the staged runtime resolution is invalid")
-    return path.as_posix()
 
 
-def _read_runtime_resolution(
-    expected_sha: str, active_digest: str,
-) -> RuntimeResolution | None:
-    try:
-        value = read_json(RUNTIME_RESOLUTION)
-    except FileNotFoundError:
-        return None
-    except (OSError, ValueError, json.JSONDecodeError) as exc:
-        raise RuntimeOverlayError("the staged runtime resolution is invalid") from exc
-    required = {
-        "version", "expected_sha", "active_digest", "source_commit",
-        "paths", "digest", "directory",
-    }
-    if value.get("version") != 1 or set(value) != required:
-        raise RuntimeOverlayError("the staged runtime resolution is invalid")
-    target = str(value["expected_sha"])
-    active = str(value["active_digest"])
-    source_commit = str(value["source_commit"])
-    resolution_digest = str(value["digest"])
-    directory_name = str(value["directory"])
-    raw_paths = value["paths"]
-    if (
-        not SHA_RE.fullmatch(target)
-        or not re.fullmatch(r"[0-9a-f]{64}", active)
-        or not SHA_RE.fullmatch(source_commit)
-        or not re.fullmatch(r"[0-9a-f]{64}", resolution_digest)
-        or not RESOLUTION_RE.fullmatch(directory_name)
-        or not isinstance(raw_paths, list)
-        or not raw_paths
-    ):
-        raise RuntimeOverlayError("the staged runtime resolution is invalid")
-    paths = tuple(sorted({_safe_runtime_path(item) for item in raw_paths}))
-    if len(paths) != len(raw_paths):
-        raise RuntimeOverlayError("the staged runtime resolution is invalid")
-    directory = RUNTIME_RESOLUTIONS / directory_name
-    trusted_uid = os.geteuid()
-    for path in (RUNTIME_RESOLUTION, directory, *directory.rglob("*")):
-        if path.is_symlink():
-            raise RuntimeOverlayError("the staged runtime resolution is unsafe")
-        stat = path.stat()
-        if stat.st_uid != trusted_uid or stat.st_mode & 0o022:
-            raise RuntimeOverlayError("the staged runtime resolution is unsafe")
-    actual_digest, files = _runtime_snapshot(directory)
-    if actual_digest != resolution_digest or set(files) != set(paths):
-        raise RuntimeOverlayError("the staged runtime resolution is invalid")
-    if target != expected_sha or active != active_digest:
-        return None
-    return RuntimeResolution(
-        target, active, source_commit, paths, resolution_digest, directory,
-    )
 
 
-def _consume_runtime_resolution(expected_sha: str, active_digest: str) -> None:
-    resolution = _read_runtime_resolution(expected_sha, active_digest)
-    if resolution is None:
-        return
-    RUNTIME_RESOLUTION.unlink(missing_ok=True)
-    shutil.rmtree(resolution.directory, ignore_errors=True)
 
 
-def _write_runtime_state(
-    active: RuntimeGeneration, rollback: RuntimeGeneration | None,
-) -> None:
-    _atomic_json(RUNTIME_STATE, {
-        "version": 1,
-        "active": _runtime_record(active),
-        "rollback": _runtime_record(rollback),
-    })
 
 
-def _store_runtime_generation(source: Path) -> RuntimeGeneration:
-    digest, _files = _runtime_snapshot(source)
-    RUNTIME_GENERATIONS.mkdir(mode=0o700, parents=True, exist_ok=True)
-    os.chmod(RUNTIME_GENERATIONS, 0o700)
-    name = f"runtime-{digest[:16]}-{uuid.uuid4().hex[:8]}"
-    path = RUNTIME_GENERATIONS / name
-    shutil.copytree(source, path)
-    stored_digest = _normalize_runtime_tree(path)
-    if stored_digest != digest:
-        shutil.rmtree(path, ignore_errors=True)
-        raise RuntimeOverlayError("the runtime generation changed while being stored")
-    return RuntimeGeneration(name=name, path=path, digest=digest)
 
 
-def _remove_runtime_generation(generation: RuntimeGeneration | None) -> None:
-    if generation is None:
-        return
-    if generation.path.parent != RUNTIME_GENERATIONS or not GENERATION_RE.fullmatch(
-        generation.name
-    ):
-        raise RuntimeOverlayError("refusing to remove an invalid runtime generation")
-    shutil.rmtree(generation.path, ignore_errors=True)
 
 
-def bootstrap_runtime(cid: str) -> RuntimeGeneration:
-    """Adopt the exact runtime already executing when the helper is installed."""
-    if not CONTAINER_RE.fullmatch(cid):
-        raise RuntimeOverlayError("invalid running container id")
-    STATE_DIR.mkdir(mode=0o700, parents=True, exist_ok=True)
-    with tempfile.TemporaryDirectory(dir=STATE_DIR, prefix="runtime-bootstrap-") as raw:
-        tree = Path(raw) / "active"
-        _copy_container_runtime(cid, tree)
-        current = _store_runtime_generation(tree)
-    previous: RuntimeGeneration | None = None
-    old_rollback: RuntimeGeneration | None = None
-    try:
-        previous, old_rollback = _read_runtime_state()
-    except RuntimeOverlayError:
-        pass
-    if previous and previous.digest == current.digest:
-        _remove_runtime_generation(current)
-        return previous
-    _write_runtime_state(current, previous)
-    if old_rollback and (not previous or old_rollback.name != previous.name):
-        _remove_runtime_generation(old_rollback)
-    return current
 
 
-def prepare_runtime_overlay(
-    cid: str, current_image: str, incoming_image: str,
-    repo: Path, expected_sha: str,
-) -> PreparedRuntime:
-    """Prepare a clean merge without reading editable /data platform source."""
-    STATE_DIR.mkdir(mode=0o700, parents=True, exist_ok=True)
-    with tempfile.TemporaryDirectory(dir=STATE_DIR, prefix="runtime-prepare-") as raw:
-        workspace = Path(raw)
-        local = workspace / "active"
-        current_raw = workspace / "current-image"
-        current_source = workspace / "current-source"
-        incoming = workspace / "incoming-image"
-        incoming_source = workspace / "incoming-source"
-        base = workspace / "base"
-        merged = workspace / "merged"
-
-        prior_active, prior_rollback = _read_runtime_state()
-        active_digest = _copy_container_runtime(cid, local)
-        previous = _store_runtime_generation(local)
-        try:
-            current_digest, build_info = _copy_image_runtime(
-                current_image, current_raw,
-            )
-            incoming_digest, _incoming_info = _copy_image_runtime(
-                incoming_image, incoming,
-            )
-            current_sha = str(build_info.get("sha") or "").strip().lower()
-            if not SHA_RE.fullmatch(current_sha) or not SHA_RE.fullmatch(expected_sha):
-                raise RuntimeOverlayError(
-                    "the active image does not expose an exact runtime revision"
-                )
-            if _extract_git_runtime(repo, current_sha, current_source) != current_digest:
-                raise RuntimeOverlayError(
-                    "the active image runtime does not match its recorded revision"
-                )
-            if _extract_git_runtime(
-                repo, expected_sha, incoming_source,
-            ) != incoming_digest:
-                raise RuntimeOverlayError(
-                    "the official image runtime does not match its requested revision"
-                )
-            merge_base = _git(
-                repo, "merge-base", current_sha, expected_sha, check=False,
-            ).stdout.strip()
-            if not SHA_RE.fullmatch(merge_base):
-                raise RuntimeOverlayError(
-                    "the active and official runtimes have no verifiable merge base"
-                )
-            _extract_git_runtime(repo, merge_base, base)
-
-            resolution = _read_runtime_resolution(expected_sha, active_digest)
-            _merged_digest, carried = _merge_runtime_trees(
-                base, local, incoming, merged, resolution,
-            )
-            candidate = _store_runtime_generation(merged)
-        except Exception:
-            _remove_runtime_generation(previous)
-            raise
-    return PreparedRuntime(
-        previous=previous,
-        candidate=candidate,
-        carried_paths=carried,
-        prior_active=prior_active,
-        prior_rollback=prior_rollback,
-    )
 
 
-def activate_runtime_overlay(prepared: PreparedRuntime) -> None:
-    active, rollback = _read_runtime_state()
-    if (
-        active.name != prepared.prior_active.name
-        or (rollback.name if rollback else None)
-        != (prepared.prior_rollback.name if prepared.prior_rollback else None)
-    ):
-        raise RuntimeOverlayError("the active runtime receipt changed during replacement")
-    _write_runtime_state(prepared.candidate, prepared.previous)
-    for retired in (prepared.prior_active, prepared.prior_rollback):
-        if retired and retired.name not in {
-            prepared.previous.name, prepared.candidate.name,
-        }:
-            _remove_runtime_generation(retired)
 
 
 def write_status(config_value: dict, **fields) -> dict:
@@ -674,7 +140,6 @@ def write_status(config_value: dict, **fields) -> dict:
         "supported": True, "operation_id": None, "state": "idle",
         "expected_sha": None, "code": None, "message": None,
         "handoff": HANDOFF_VERSION,
-        "runtime_overlay": RUNTIME_OVERLAY_VERSION,
     }
     try:
         current.update(read_json(STATUS))
@@ -682,7 +147,7 @@ def write_status(config_value: dict, **fields) -> dict:
         pass
     current.update(fields)
     current["handoff"] = HANDOFF_VERSION
-    current["runtime_overlay"] = RUNTIME_OVERLAY_VERSION
+    current.pop("runtime_overlay", None)
     current["updated_at"] = now()
     _atomic_json(STATUS, current)
     _atomic_json(config_value["control_dir"] / "status.json", current, 0o644)
@@ -690,12 +155,9 @@ def write_status(config_value: dict, **fields) -> dict:
 
 
 def compose(config_value: dict, *args: str, image: str | None = None,
-            runtime: RuntimeGeneration | None = None,
             check: bool = True) -> subprocess.CompletedProcess:
     env = os.environ.copy()
     env["MOBIUS_IMAGE"] = image or IMAGE
-    selected = runtime or active_runtime_generation()
-    env["MOBIUS_RUNTIME_OVERLAY"] = str(selected.path)
     return subprocess.run(
         ["docker", "compose", "-p", config_value["project"],
          "-f", str(COMPOSE), "-f", str(OVERRIDE), *args],
@@ -723,131 +185,6 @@ def app_container(config_value: dict) -> tuple[str, str]:
     return cid, inspected.stdout.strip()
 
 
-def stage_runtime_resolution(
-    config_value: dict, cid: str, expected_sha: str, source_commit: str,
-) -> RuntimeResolution:
-    """Stage reviewed conflict files without modifying the running runtime."""
-    if not CONTAINER_RE.fullmatch(cid):
-        raise RuntimeOverlayError("invalid running container id")
-    if not SHA_RE.fullmatch(expected_sha) or not SHA_RE.fullmatch(source_commit):
-        raise RuntimeOverlayError("invalid runtime resolution revision")
-    current_cid, current_image = app_container(config_value)
-    if cid != current_cid:
-        raise RuntimeOverlayError("the runtime resolution targets another container")
-    repo = Path(config_value["data_dir"]) / "platform"
-    if _git(
-        repo, "cat-file", "-e", f"{source_commit}^{{commit}}", check=False,
-    ).returncode:
-        raise RuntimeOverlayError("the reviewed runtime resolution is unavailable")
-    if _git(
-        repo, "merge-base", "--is-ancestor", expected_sha, source_commit,
-        check=False,
-    ).returncode:
-        raise RuntimeOverlayError(
-            "the reviewed runtime resolution does not contain the official target"
-        )
-
-    STATE_DIR.mkdir(mode=0o700, parents=True, exist_ok=True)
-    with tempfile.TemporaryDirectory(
-        dir=STATE_DIR, prefix="runtime-resolution-prepare-",
-    ) as raw:
-        workspace = Path(raw)
-        local = workspace / "active"
-        current_raw = workspace / "current-image"
-        current_source = workspace / "current-source"
-        incoming = workspace / "incoming"
-        base = workspace / "base"
-        attempted = workspace / "attempted"
-        reviewed = workspace / "reviewed"
-        selected = workspace / "selected"
-
-        active_digest = _copy_container_runtime(cid, local)
-        current_digest, build_info = _copy_image_runtime(current_image, current_raw)
-        current_sha = str(build_info.get("sha") or "").strip().lower()
-        if not SHA_RE.fullmatch(current_sha):
-            raise RuntimeOverlayError(
-                "the active image does not expose an exact runtime revision"
-            )
-        if _extract_git_runtime(repo, current_sha, current_source) != current_digest:
-            raise RuntimeOverlayError(
-                "the active image runtime does not match its recorded revision"
-            )
-        _extract_git_runtime(repo, expected_sha, incoming)
-        merge_base = _git(
-            repo, "merge-base", current_sha, expected_sha, check=False,
-        ).stdout.strip()
-        if not SHA_RE.fullmatch(merge_base):
-            raise RuntimeOverlayError(
-                "the active and official runtimes have no verifiable merge base"
-            )
-        _extract_git_runtime(repo, merge_base, base)
-        _extract_git_runtime(repo, source_commit, reviewed)
-        try:
-            _merge_runtime_trees(base, local, incoming, attempted)
-        except RuntimeOverlayConflict as exc:
-            selected_paths = exc.paths
-        else:
-            _attempted_digest, attempted_files = _runtime_snapshot(attempted)
-            _reviewed_digest, reviewed_files = _runtime_snapshot(reviewed)
-            selected_paths = tuple(sorted(
-                name for name in {*attempted_files, *reviewed_files}
-                if attempted_files.get(name) != reviewed_files.get(name)
-            ))
-            if not selected_paths:
-                raise RuntimeOverlayError(
-                    "the reviewed runtime matches the active official merge"
-                )
-
-        for name in selected_paths:
-            source = reviewed / name
-            if source.is_symlink() or not source.is_file():
-                raise RuntimeOverlayError(
-                    f"the reviewed resolution does not contain {name}"
-                )
-            target = selected / name
-            target.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
-            shutil.copy2(source, target)
-        resolution_digest = _normalize_runtime_tree(selected)
-
-        RUNTIME_RESOLUTIONS.mkdir(mode=0o700, parents=True, exist_ok=True)
-        os.chmod(RUNTIME_RESOLUTIONS, 0o700)
-        directory_name = f"resolution-{uuid.uuid4().hex}"
-        directory = RUNTIME_RESOLUTIONS / directory_name
-        shutil.copytree(selected, directory)
-        _normalize_runtime_tree(directory)
-
-    old_directory: Path | None = None
-    try:
-        old_value = read_json(RUNTIME_RESOLUTION)
-        old_name = str(old_value.get("directory") or "")
-        if RESOLUTION_RE.fullmatch(old_name):
-            old_directory = RUNTIME_RESOLUTIONS / old_name
-    except (OSError, ValueError, json.JSONDecodeError):
-        pass
-    paths = tuple(sorted(selected_paths))
-    _atomic_json(RUNTIME_RESOLUTION, {
-        "version": 1,
-        "expected_sha": expected_sha,
-        "active_digest": active_digest,
-        "source_commit": source_commit,
-        "paths": list(paths),
-        "digest": resolution_digest,
-        "directory": directory_name,
-    })
-    if old_directory and old_directory != directory:
-        shutil.rmtree(old_directory, ignore_errors=True)
-    resolution = _read_runtime_resolution(expected_sha, active_digest)
-    if resolution is None:
-        raise RuntimeOverlayError("the staged runtime resolution could not be verified")
-    write_status(
-        config_value,
-        operation_id=None,
-        state="idle",
-        expected_sha=expected_sha,
-        code="runtime_overlay_resolved",
-        message="A reviewed runtime conflict resolution is staged. Replace again when ready.",
-    )
-    return resolution
 
 
 def wait_healthy(config_value: dict, timeout: int = 180) -> bool:
@@ -867,15 +204,8 @@ def wait_healthy(config_value: dict, timeout: int = 180) -> bool:
     return False
 
 
-def verify_served_generation(
-    cid: str, expected_sha: str, runtime_digest: str,
-) -> None:
-    """Prove the image and mounted protected runtime are the requested bytes.
-
-    Desired source under /data may legitimately be newer than the active
-    root-owned overlay, so source parity is not a cutover invariant. The Host
-    instead verifies the deployed digest against its immutable generation.
-    """
+def verify_served_generation(cid: str, expected_sha: str) -> None:
+    """Prove the running container serves the requested immutable image."""
     result = subprocess.run(
         ["docker", "exec", cid, "curl", "-fsS",
          "http://127.0.0.1:8000/api/version"],
@@ -889,12 +219,16 @@ def verify_served_generation(
         raise RuntimeError("the container returned invalid build provenance") from exc
     if not isinstance(version, dict) or version.get("sha") != expected_sha:
         raise RuntimeError("the container is not serving the requested image revision")
-    protected = version.get("protected_runtime")
-    deployed = protected.get("deployed_sha256") if isinstance(protected, dict) else None
-    if deployed != runtime_digest:
-        raise RuntimeError(
-            "the container's protected runtime does not match the prepared generation"
-        )
+    mounts = subprocess.run(
+        ["docker", "container", "inspect", "--format", "{{json .Mounts}}", cid],
+        text=True, capture_output=True, check=True,
+    )
+    try:
+        mounted = json.loads(mounts.stdout)
+    except (TypeError, json.JSONDecodeError) as exc:
+        raise RuntimeError("the container returned invalid mount provenance") from exc
+    if any(item.get("Destination") == "/app/runtime" for item in mounted):
+        raise RuntimeError("the container is not using the image's protected runtime")
 
 
 def _docker_root() -> Path:
@@ -916,8 +250,7 @@ def require_pull_space(current_image: str) -> None:
 
 
 def restart_ledger(config_value: dict, cid: str, command: str,
-                   operation: str, *, image: str | None = None,
-                   runtime: RuntimeGeneration | None = None) -> bool:
+                   operation: str, *, image: str | None = None) -> bool:
     """Run one root ledger command, even when the app is crash-looping."""
     invocation = ["python3", "-P", "/app/runtime/restart_ledger.py",
                   command, operation]
@@ -932,12 +265,9 @@ def restart_ledger(config_value: dict, cid: str, command: str,
     # A failed replacement may not stay alive long enough for docker exec.
     # The prior verified image carries the same frozen helper; mount only the
     # persistent data root and run no entrypoint or application code.
-    selected = runtime or active_runtime_generation()
     result = subprocess.run(
         ["docker", "run", "--rm", "--mount",
          f"type=bind,src={config_value['data_dir']},dst=/data",
-         "--mount",
-         f"type=bind,src={selected.path},dst=/app/runtime,readonly",
          "--entrypoint", "python3", image, *invocation[1:]],
         text=True, capture_output=True,
     )
@@ -1013,10 +343,7 @@ def retain_images(target_ref: str, rollback_image_id: str | None = None) -> None
 
 
 def rollback(config_value: dict, operation: str, expected: str,
-             code: str, detail: str, *,
-             runtime: RuntimeGeneration | None = None,
-             failed_runtime: RuntimeGeneration | None = None,
-             retired_runtimes: tuple[RuntimeGeneration | None, ...] = ()) -> int:
+             code: str, detail: str) -> int:
     write_status(config_value, operation_id=operation, state="verifying",
                  expected_sha=expected, code=code,
                  message="Replacement failed; restoring the previous container.")
@@ -1026,15 +353,14 @@ def rollback(config_value: dict, operation: str, expected: str,
         cid = ""
     handoff_rearmed = restart_ledger(
         config_value, cid, "rearm-cutover", operation, image=ROLLBACK_TAG,
-        runtime=runtime,
     )
     compose(config_value, "up", "-d", "--no-build", "--no-deps",
-            "--force-recreate", "app", image=ROLLBACK_TAG, runtime=runtime)
+            "--force-recreate", "app", image=ROLLBACK_TAG)
     if wait_healthy(config_value, 120):
         cid, _current = app_container(config_value)
         handoff_finalized = restart_ledger(
             config_value, cid, "finalize-cutover", operation,
-            image=ROLLBACK_TAG, runtime=runtime,
+            image=ROLLBACK_TAG,
         )
         if handoff_finalized:
             status_code = code
@@ -1056,12 +382,6 @@ def rollback(config_value: dict, operation: str, expected: str,
         write_status(config_value, operation_id=operation, state="rolled_back",
                      expected_sha=expected, code=status_code,
                      message=message[:300])
-        if runtime is not None:
-            _write_runtime_state(runtime, None)
-        _remove_runtime_generation(failed_runtime)
-        for retired in retired_runtimes:
-            if retired and (runtime is None or retired.name != runtime.name):
-                _remove_runtime_generation(retired)
         return 1
     write_status(config_value, operation_id=operation, state="needs_recovery",
                  expected_sha=expected, code="rollback_failed",
@@ -1086,8 +406,6 @@ def run() -> int:
     image_ref = None
     pulled_recorded = False
     replacement_started = False
-    prepared_runtime: PreparedRuntime | None = None
-    runtime_activated = False
     try:
         with LOCK.open("a+") as lock:
             acquire_lock(lock)
@@ -1127,10 +445,7 @@ def run() -> int:
             digest = inspect_image(image_ref, "{{.Id}}")
             if previous == digest:
                 try:
-                    active_runtime = active_runtime_generation()
-                    verify_served_generation(
-                        cid, expected, active_runtime.digest,
-                    )
+                    verify_served_generation(cid, expected)
                 except RuntimeError as exc:
                     write_status(
                         config_value, operation_id=operation, state="failed",
@@ -1138,23 +453,13 @@ def run() -> int:
                         message=str(exc)[:300],
                     )
                     return 1
-                if _read_runtime_resolution(expected, active_runtime.digest) is None:
-                    retain_images(image_ref, _image_state()["rollback_image_id"])
-                    write_status(
-                        config_value, operation_id=operation, state="no_change",
-                        expected_sha=expected, code=None,
-                        message="This container already uses that official image.",
-                    )
-                    return 0
-            write_status(
-                config_value, operation_id=operation, state="preparing",
-                expected_sha=expected, code=None,
-                message="Merging the active local runtime with the official image.",
-            )
-            prepared_runtime = prepare_runtime_overlay(
-                cid, previous, image_ref,
-                Path(config_value["data_dir"]) / "platform", expected,
-            )
+                retain_images(image_ref, _image_state()["rollback_image_id"])
+                write_status(
+                    config_value, operation_id=operation, state="no_change",
+                    expected_sha=expected, code=None,
+                    message="This container already uses that official image.",
+                )
+                return 0
             subprocess.run(["docker", "tag", previous, ROLLBACK_TAG], check=True,
                            text=True, capture_output=True)
             request_drain(config_value, operation, cid)
@@ -1163,44 +468,26 @@ def run() -> int:
                          message="Rebuilding the container.")
             replacement_started = True
             compose(config_value, "up", "-d", "--no-build", "--no-deps",
-                    "--force-recreate", "app", image=image_ref,
-                    runtime=prepared_runtime.candidate)
+                    "--force-recreate", "app", image=image_ref)
             write_status(config_value, operation_id=operation, state="verifying",
                          expected_sha=expected, message="Checking the new container.")
             if not wait_healthy(config_value):
                 result = rollback(
                     config_value, operation, expected,
                     "health_check_failed", "the new container was unhealthy",
-                    runtime=prepared_runtime.previous,
-                    failed_runtime=prepared_runtime.candidate,
-                    retired_runtimes=(
-                        prepared_runtime.prior_active,
-                        prepared_runtime.prior_rollback,
-                    ),
                 )
                 discard_pulled_image(image_ref)
                 return result
             cid, _current = app_container(config_value)
-            verify_served_generation(
-                cid, expected, prepared_runtime.candidate.digest,
-            )
-            activate_runtime_overlay(prepared_runtime)
-            _consume_runtime_resolution(expected, prepared_runtime.previous.digest)
-            runtime_activated = True
+            verify_served_generation(cid, expected)
             handoff_finalized = restart_ledger(
                 config_value, cid, "finalize-cutover", operation,
-                image=image_ref, runtime=prepared_runtime.candidate,
+                image=image_ref,
             )
             retain_images(image_ref, previous)
             if handoff_finalized:
                 status_code = None
-                if prepared_runtime.carried_paths:
-                    message = (
-                        "Container rebuilt successfully; the active local "
-                        "runtime overlay was carried forward."
-                    )
-                else:
-                    message = "Container rebuilt successfully."
+                message = "Container rebuilt successfully."
             else:
                 status_code = "handoff_finalize_failed"
                 message = (
@@ -1222,22 +509,7 @@ def run() -> int:
         if replacement_started and previous and expected:
             try:
                 result = rollback(config_value, operation, expected,
-                                  "replacement_failed", detail,
-                                  runtime=(
-                                      prepared_runtime.previous
-                                      if prepared_runtime else None
-                                  ),
-                                  failed_runtime=(
-                                      prepared_runtime.candidate
-                                      if prepared_runtime else None
-                                  ),
-                                  retired_runtimes=(
-                                      (
-                                          prepared_runtime.prior_active,
-                                          prepared_runtime.prior_rollback,
-                                      )
-                                      if prepared_runtime else ()
-                                  ))
+                                  "replacement_failed", detail)
                 if image_ref and pulled_recorded:
                     discard_pulled_image(image_ref)
                 return result
@@ -1249,12 +521,8 @@ def run() -> int:
                 return 1
         if image_ref and pulled_recorded:
             discard_pulled_image(image_ref)
-        if prepared_runtime and not runtime_activated:
-            _remove_runtime_generation(prepared_runtime.candidate)
-            _remove_runtime_generation(prepared_runtime.previous)
-        code = exc.code if isinstance(exc, RuntimeOverlayError) else "replacement_failed"
         write_status(config_value, operation_id=operation, state="failed",
-                     expected_sha=expected, code=code, message=detail)
+                     expected_sha=expected, code="replacement_failed", message=detail)
         return 1
     finally:
         claimed.unlink(missing_ok=True)
@@ -1299,36 +567,5 @@ if __name__ == "__main__":
         raise SystemExit(run())
     if len(sys.argv) == 2 and sys.argv[1] == "reconcile" and os.geteuid() == 0:
         raise SystemExit(reconcile())
-    if (
-        len(sys.argv) == 3
-        and sys.argv[1] == "bootstrap-runtime"
-        and os.geteuid() == 0
-    ):
-        STATE_DIR.mkdir(mode=0o700, parents=True, exist_ok=True)
-        with LOCK.open("a+") as lock:
-            acquire_lock(lock)
-            generation = bootstrap_runtime(sys.argv[2])
-        print(generation.digest)
-        raise SystemExit(0)
-    if (
-        len(sys.argv) == 5
-        and sys.argv[1] == "stage-runtime-resolution"
-        and os.geteuid() == 0
-    ):
-        config_value = config()
-        STATE_DIR.mkdir(mode=0o700, parents=True, exist_ok=True)
-        with LOCK.open("a+") as lock:
-            acquire_lock(lock)
-            resolution = stage_runtime_resolution(
-                config_value, sys.argv[2], sys.argv[3], sys.argv[4],
-            )
-        print(json.dumps({
-            "expected_sha": resolution.expected_sha,
-            "active_digest": resolution.active_digest,
-            "source_commit": resolution.source_commit,
-            "paths": list(resolution.paths),
-            "digest": resolution.digest,
-        }, separators=(",", ":")))
-        raise SystemExit(0)
     print("invalid invocation", file=sys.stderr)
     raise SystemExit(2)


### PR DESCRIPTION
## Summary
- run privileged `/app/runtime` code directly from the reviewed image
- remove runtime generations, three-way merging, overlays, bootstrap adoption, and host-only conflict resolution
- preserve identity keys and linked state under `/data/identity-broker`
- block local protected-runtime source changes unless the exact reviewed image contains them

## Why
The former carry-forward layer could keep older privileged code active under a newer official image and made genuine overlaps require a host-only recovery command. The image is now the single authority for root-executed code; persistent data remains untouched.

## Verification
- 226 focused controller/update/deployment tests passed
- 98 fast host-contract tests passed
- shell syntax and Python compile checks passed

Playwright remains available but is not a merge-blocking check.