### PR TITLE
Ignore generated files in image drift checks

### DIFF
--- a/backend/app/platform_update.py
+++ b/backend/app/platform_update.py
@@ -1350,12 +1350,28 @@ def image_input_drift(repo: Path = PLATFORM_REPO) -> list[str] | None:
     current = platform_activation.image_input_hashes(repo)
   except OSError:
     return None
+  # The image build can leave generated output inside broad baked-runtime
+  # prefixes (for example frontend assets and Python bytecode).  Those files
+  # are not authored source and may differ from the live checkout even when
+  # its Git state is clean.  Compare tracked files plus intentionally
+  # unignored local additions; ignored build output must not manufacture a
+  # permanent image-rebuild warning.  A Git failure keeps the older
+  # fail-closed comparison rather than hiding possible source drift.
+  authored = _git(
+    "ls-files", "--cached", "--others", "--exclude-standard", "-z",
+    repo=repo, check=False,
+  )
+  candidates = set(baked) | set(current)
+  if authored.returncode == 0:
+    candidates &= {
+      path for path in authored.stdout.split("\0") if path
+    }
   # Successful in-place installs replace the image baseline only for the
   # exact dependency input bytes they installed. A later edit becomes pending
   # again, while restarting the server does not resurrect completed work.
   installed = _dependency_receipt()
   return sorted(
-    path for path in set(baked) | set(current)
+    path for path in candidates
     if installed.get(path, baked.get(path)) != current.get(path)
   )
 

--- a/backend/tests/test_platform_update.py
+++ b/backend/tests/test_platform_update.py
@@ -2963,6 +2963,25 @@ def test_successful_live_dependency_sync_survives_restart_not_new_container(
   assert pu.image_input_drift(platform) == ["backend/requirements.lock"]
 
 
+def test_image_input_drift_ignores_generated_files_but_keeps_local_source(
+  clone_env, monkeypatch,
+):
+  _, platform = clone_env
+  runtime = platform / "backend/runtime"
+  runtime.mkdir(parents=True)
+  baked = platform_activation.image_input_hashes(platform)
+  ignored = runtime / "__pycache__/broker.cpython-312.pyc"
+  ignored.parent.mkdir()
+  ignored.write_bytes(b"local bytecode")
+  local_source = runtime / "local.py"
+  local_source.write_text("VALUE = 'local'\n")
+
+  baked[str(ignored.relative_to(platform))] = "0" * 64
+  monkeypatch.setattr(pu, "_build_info", lambda: {"image_inputs": baked})
+
+  assert pu.image_input_drift(platform) == ["backend/runtime/local.py"]
+
+
 def test_failed_dependency_sync_invalidates_previous_success_receipt(
   clone_env, monkeypatch,
 ):


### PR DESCRIPTION
## Summary
- exclude Git-ignored build output from image-input drift checks
- keep tracked files and intentional unignored local additions fail-closed
- add regression coverage for ignored bytecode and local protected-runtime source

## Verification
- 27 focused platform activation and update tests passed