### PR TITLE
Keep composer tools inside the visible keyboard pane

### DIFF
--- a/frontend/src/components/ChatView/ComposerPopover.jsx
+++ b/frontend/src/components/ChatView/ComposerPopover.jsx
@@ -54,13 +54,8 @@ import {
 } from './chatArtifacts.js'
 import { api, apiFetch } from '../../api/client.js'
 import { chatAppArtifactQueries, chatQueries } from '../../hooks/queries.js'
-import { popoverMaxHeight, nearestClipTop } from './composerPopoverHeight.js'
+import { measurePopoverMaxHeight } from './composerPopoverHeight.js'
 import { focusComposerElement } from './composerFocusPolicy.js'
-import {
-  captureLayoutSpace,
-  clientLengthToLayout,
-  clientPointToLayout,
-} from '../../lib/layoutSpace.js'
 import useModelSelectionPopover from './hooks/useModelSelectionPopover.js'
 import useScrollActivity from './hooks/useScrollActivity.js'
 import { clearProviderSwitch } from './providerSwitch.js'
@@ -272,27 +267,7 @@ export default function ComposerPopover({
     const measure = () => {
       const trigger = triggerRef.current
       if (!trigger) return
-      const rect = trigger.getBoundingClientRect()
-      const rootSpace = captureLayoutSpace(document.documentElement)
-      const pointY = y => clientPointToLayout({ x: 0, y }, rootSpace).y
-      const deltaY = y => clientLengthToLayout(y, rootSpace)
-      const triggerTop = pointY(rect.top)
-      const triggerBottom = pointY(rect.bottom)
-      const viewportTop = deltaY(window.visualViewport?.offsetTop || 0)
-      const viewportHeight = deltaY(window.visualViewport?.height || 0)
-      const clipTop = pointY(nearestClipTop(trigger))
-      setMaxHeight(popoverMaxHeight({
-        triggerTop,
-        // `triggerBottom` + `viewportHeight` are not extra precision — they are
-        // how the helper tells which coordinate space `rect` is in. iOS reports
-        // fixed-layer rects against the VISUAL viewport once the keyboard
-        // offsets it, and subtracting `offsetTop` as well collapsed the panel
-        // to a 14px sliver. See composerPopoverHeight.js.
-        triggerBottom,
-        viewportTop,
-        viewportHeight,
-        clipTop,
-      }))
+      setMaxHeight(measurePopoverMaxHeight(trigger))
     }
     measure()
     // The keyboard animates in/out, and iOS scrolls the layout viewport during
@@ -301,13 +276,18 @@ export default function ComposerPopover({
     window.addEventListener('resize', measure)
     window.visualViewport?.addEventListener('resize', measure)
     window.visualViewport?.addEventListener('scroll', measure)
-    // The textarea can grow while this stays open. That moves the trigger
-    // upward without resizing either viewport, so observe the owning form too.
+    // Observe BOTH owners of the available room. The form can grow, while the
+    // chat pane can shrink without changing the form's size. In particular,
+    // useShellVisualViewport fits the shell on the next animation frame, after
+    // this viewport listener has measured the old layout. Observing only the
+    // form leaves the old cap in place and clips the panel's first controls.
     const resizeObserver = typeof ResizeObserver !== 'undefined'
       ? new ResizeObserver(measure)
       : null
     const form = triggerRef.current?.closest('.chat__form')
     if (form) resizeObserver?.observe(form)
+    const chat = triggerRef.current?.closest('.chat')
+    if (chat) resizeObserver?.observe(chat)
     return () => {
       window.removeEventListener('resize', measure)
       window.visualViewport?.removeEventListener('resize', measure)

--- a/frontend/src/components/ChatView/__tests__/composerPopoverHeight.test.js
+++ b/frontend/src/components/ChatView/__tests__/composerPopoverHeight.test.js
@@ -2,6 +2,7 @@ import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import {
   popoverMaxHeight,
+  measurePopoverMaxHeight,
   visibleTopInRectSpace,
   POPOVER_CAP,
 } from '../composerPopoverHeight.js'
@@ -109,3 +110,37 @@ test('visibleTopInRectSpace ignores an offset the rects already contain', () => 
     triggerBottom: 834, viewportTop: 421, viewportHeight: 0,
   }), 421)
 })
+
+for (const zoom of [1, 0.8, 1.25]) {
+  test(`DOM measurement preserves a panned document's visible boundary at zoom ${zoom}`, t => {
+    const root = {
+      currentCSSZoom: zoom,
+      getBoundingClientRect: () => ({ top: -150 * zoom, left: 0, width: 402 * zoom, height: 336 * zoom }),
+    }
+    const body = {}
+    const doc = { documentElement: root, body }
+    root.ownerDocument = doc
+    const clip = {
+      parentElement: body,
+      getBoundingClientRect: () => ({ top: -150 * zoom }),
+    }
+    const trigger = {
+      parentElement: clip,
+      getBoundingClientRect: () => ({ top: 130 * zoom, bottom: 178 * zoom }),
+    }
+    const oldDocument = globalThis.document
+    const oldWindow = globalThis.window
+    t.after(() => {
+      if (oldDocument === undefined) delete globalThis.document
+      else globalThis.document = oldDocument
+      if (oldWindow === undefined) delete globalThis.window
+      else globalThis.window = oldWindow
+    })
+    globalThis.document = doc
+    globalThis.window = {
+      visualViewport: { height: 336 * zoom, offsetTop: 0 },
+      getComputedStyle: () => ({ overflowY: 'hidden', overflowX: 'hidden' }),
+    }
+    assert.equal(measurePopoverMaxHeight(trigger), 114)
+  })
+}

--- a/frontend/src/components/ChatView/composerPopoverHeight.js
+++ b/frontend/src/components/ChatView/composerPopoverHeight.js
@@ -1,3 +1,5 @@
+import { captureLayoutSpace, clientLengthToLayout } from '../../lib/layoutSpace.js'
+
 /**
  * How tall the composer popover is allowed to be.
  *
@@ -143,4 +145,21 @@ export function popoverMaxHeight({
   // Never more than the measured space: the panel must stay inside the clipping
   // ancestor even when that leaves it very short. See the no-minimum note above.
   return Math.min(cap, Math.floor(Math.max(0, space)))
+}
+
+/** Measure in zoom-normalized CLIENT coordinates, not document-local points.
+ * Translating by the root's top erases a fixed document's upward displacement
+ * while leaving viewport zero unchanged, counting offscreen room as usable.
+ */
+export function measurePopoverMaxHeight(trigger) {
+  const rect = trigger.getBoundingClientRect()
+  const space = captureLayoutSpace(document.documentElement)
+  const normalize = value => clientLengthToLayout(value, space)
+  return popoverMaxHeight({
+    triggerTop: normalize(rect.top),
+    triggerBottom: normalize(rect.bottom),
+    clipTop: normalize(nearestClipTop(trigger)),
+    viewportTop: normalize(window.visualViewport?.offsetTop || 0),
+    viewportHeight: normalize(window.visualViewport?.height || 0),
+  })
 }

--- a/tests/composer-growth-cap.spec.mjs
+++ b/tests/composer-growth-cap.spec.mjs
@@ -129,3 +129,53 @@ test('a short keyboard room compacts the attachment before eclipsing the transcr
   expect(geometry.input).toBeGreaterThanOrEqual(24)
   expect(geometry.pill).toBeLessThanOrEqual(96)
 })
+
+// The shell applies VisualViewport geometry on an animation frame. A menu
+// listening to the viewport event alone measures BEFORE that layout change;
+// its form stays the same height, leaving its top controls clipped. This
+// exercises the event/observer ordering, not just the height arithmetic.
+for (const openFirst of [true, false]) {
+  test(`tools stay reachable when keyboard ${openFirst ? 'opens after' : 'is open before'} the menu`, async ({ page }) => {
+    await page.setViewportSize({ width: 402, height: 812 })
+    const { painted, composer } = await openNewChat(page, `tools-keyboard-${openFirst}`)
+    const trigger = painted.locator('.composer-plus > button')
+    const panel = painted.getByRole('dialog', { name: 'Chat options', exact: true })
+    await composer.focus()
+    if (openFirst) await trigger.click()
+
+    // Shrink only the visual viewport, like an overlay keyboard. The native
+    // layout viewport stays 812px; the real shell hook must fit the chat pane.
+    await page.evaluate(() => {
+      Object.defineProperty(window.visualViewport, 'height', { configurable: true, value: 450 })
+      window.visualViewport.dispatchEvent(new Event('resize'))
+    })
+    await expect.poll(async () => (await composerGeometry(page))?.chat ?? 812).toBeLessThan(450)
+    if (!openFirst) await trigger.click()
+
+    const fits = () => panel.evaluate(menu => {
+      const rect = menu.getBoundingClientRect()
+      const chat = menu.closest('.chat').getBoundingClientRect()
+      const anchor = menu.parentElement.querySelector('button').getBoundingClientRect()
+      return rect.height > 100 && rect.top >= chat.top + 7 && rect.bottom <= anchor.top - 7
+    })
+    await expect.poll(fits).toBe(true)
+    await expect(composer).toBeFocused()
+
+    // All menu content remains in ONE usable scrollport, including the first
+    // Attach row after visiting the end of a long model/settings list.
+    await panel.evaluate(menu => { menu.scrollTop = menu.scrollHeight })
+    await panel.evaluate(menu => { menu.scrollTop = 0 })
+    await expect(panel.getByRole('button', { name: /Attach files/ })).toBeInViewport()
+
+    // A pane-only resize has no viewport event and still changes the room.
+    await painted.locator('.chat').evaluate(chat => { chat.style.height = '330px' })
+    await expect.poll(fits).toBe(true)
+    await painted.locator('.chat').evaluate(chat => { chat.style.removeProperty('height') })
+    await page.evaluate(() => {
+      delete window.visualViewport.height
+      window.visualViewport.dispatchEvent(new Event('resize'))
+    })
+    await expect.poll(fits).toBe(true)
+    await expect(composer).toBeFocused()
+  })
+}


### PR DESCRIPTION
## Summary

- Measure the composer tools menu in zoom-normalized client coordinates.
- Recalculate when either the composer form or its chat pane changes size.
- Cover panned/zoomed viewport geometry and keyboard-before/menu-before ordering.

## Why

On mobile browsers, especially iOS and embedded WebKit, visual-viewport offsets and delayed pane resizing could be counted twice or measured in mismatched coordinate spaces. That collapsed the tools menu or clipped its first controls behind the keyboard.

The measurement now lives in one helper that uses the same coordinate basis for the trigger, clipping pane, and visual viewport.

## Testing

- All 12 focused popover-geometry tests pass.
- Browser coverage is included for both keyboard/menu event orders and pane-only resizing; hosted CI remains the browser gate.
