### PR TITLE
Keep phone app previews passive until opened

### DIFF
--- a/backend/scripts/seed-skills/building-apps-quickstart.md
+++ b/backend/scripts/seed-skills/building-apps-quickstart.md
@@ -176,10 +176,11 @@ or to work around a manifest/permission guard.
 The helper validates the manifest and complete source tree, compiles and
 commits that exact revision, returns a compact receipt with `app_id`,
 `preview_path`, and `open_path`, and emits one live-preview action tied to this
-building chat. On every device, that action keeps the partner's focused pane
-untouched: it opens the app in a companion pane when possible, or switches the
-app inside an existing unfocused companion pane. If neither is safe, it parks
-as an inactive tab instead of replacing what the partner is using.
+building chat. That action keeps the partner's focused pane untouched. On a
+phone it leaves Standard/Builder mode and the visible screen unchanged, parking
+the app until the partner taps the preview CTA. On a larger screen it opens the
+app in a companion pane when possible, or switches the app inside an existing
+unfocused companion pane. If neither is safe, it parks as an inactive tab.
 Reuse that numeric ID for preview, storage, notifications, and later actions;
 do not list apps again after a successful apply. Do not send a separate
 `open_item`.

--- a/frontend/src/components/Shell/__tests__/workspacePlacement.test.js
+++ b/frontend/src/components/Shell/__tests__/workspacePlacement.test.js
@@ -283,7 +283,7 @@ test('live preview · phone update: leaves a parked app and pane geometry untouc
     builtAppWorkspaceRequest('a', 9),
     env(ws, { mode: 'phone', rect: { w: 400, h: 800 } }),
   )
-  assert.equal(out, ws, 'a coherent update live-swaps code without opening the preview')
+  assert.deepEqual(out, ws, 'a coherent update live-swaps code without opening the preview')
 
   const appInUse = builderSeed([CHAT('a'), APP(9)])
   const unchanged = resolveWorkspaceRequest(

--- a/frontend/src/components/Shell/__tests__/workspacePlacement.test.js
+++ b/frontend/src/components/Shell/__tests__/workspacePlacement.test.js
@@ -204,7 +204,7 @@ test('attentionForRequest flags a background open by kind, and nothing for foreg
 
   assert.equal(attentionForRequest(null), null)
   assert.equal(attentionForRequest(builtAppWorkspaceRequest('a', 41)), null,
-    'a visible live preview needs no background-attention dot')
+    'the chat CTA carries preview attention without a drawer dot')
 })
 
 // ── resolver: forward-compat / malformed request ────────────────────────────
@@ -237,7 +237,7 @@ test('beside-source + foreground · phone: insert and activate', () => {
   assert.equal(out.panes.p0.activeTabKey, 'app:9', 'foreground activates the item')
 })
 
-test('live preview · phone: opens a companion pane without replacing its source chat', () => {
+test('live preview · phone: stays in Standard and parks until the CTA is tapped', () => {
   const ws = {
     ...paneModel.setViewMode(builderSeed([CHAT('a')]), 'single'),
     singleScreen: { kind: 'chat', id: 'a' },
@@ -247,39 +247,43 @@ test('live preview · phone: opens a companion pane without replacing its source
     builtAppWorkspaceRequest('a', 9),
     env(ws, { mode: 'phone', rect: { w: 400, h: 800 } }),
   )
-  assert.equal(out.viewMode, 'panes', 'the live preview reveals the Builder world')
-  assert.equal(paneModel.paneIdsInOrder(out).length, 2,
-    'the app gets its own phone pane instead of joining the chat pane')
-  assert.equal(out.panes[out.focusedPaneId].activeTabKey, 'chat:a',
-    'the source chat keeps keyboard focus')
-  const appPane = paneModel.paneOf(out, 'app:9')
-  assert.ok(appPane)
-  assert.notEqual(appPane.id, out.focusedPaneId)
-  assert.equal(appPane.activeTabKey, 'app:9', 'the preview is active in its own pane')
+  assert.equal(out.viewMode, 'single', 'an unsolicited preview never enters Builder')
+  assert.deepEqual(out.singleScreen, { kind: 'chat', id: 'a' },
+    'the phone keeps showing the chat')
+  assert.equal(paneModel.paneIdsInOrder(out).length, 1, 'no companion pane is created')
+  assert.deepEqual(keysOf(out.panes.p0), ['chat:a', 'app:9'],
+    'the app is available in Builder without being shown')
+  assert.equal(out.panes.p0.activeTabKey, 'chat:a',
+    'the preview CTA remains the only path that opens the app')
 })
 
-test('live preview · phone update: moves a parked app out before revealing it', () => {
+test('live preview · phone: preserves the hidden Builder layout and focus', () => {
+  const ws = {
+    ...twoPaneWs([CHAT('a')], [APP(5)], { focused: 'p1' }),
+    viewMode: 'single',
+    singleScreen: { kind: 'chat', id: 'a' },
+  }
+  const out = resolveWorkspaceRequest(
+    ws,
+    builtAppWorkspaceRequest('a', 9),
+    env(ws, { mode: 'phone', rect: { w: 400, h: 800 } }),
+  )
+  assert.equal(out.viewMode, 'single')
+  assert.deepEqual(out.layout, ws.layout, 'the existing split geometry is untouched')
+  assert.equal(out.focusedPaneId, 'p1', 'the hidden Builder focus is untouched')
+  assert.equal(out.panes.p0.activeTabKey, 'chat:a', 'the source tab remains active')
+  assert.deepEqual(keysOf(out.panes.p0), ['chat:a', 'app:9'],
+    'the preview is parked without creating another pane')
+})
+
+test('live preview · phone update: leaves a parked app and pane geometry untouched', () => {
   const ws = paneModel.setActiveTab(builderSeed([CHAT('a'), APP(9)]), 'p0', 'chat:a')
   const out = resolveWorkspaceRequest(
     ws,
     builtAppWorkspaceRequest('a', 9),
     env(ws, { mode: 'phone', rect: { w: 400, h: 800 } }),
   )
-  assert.equal(paneModel.paneIdsInOrder(out).length, 2)
-  assert.equal(out.panes[out.focusedPaneId].activeTabKey, 'chat:a',
-    'later coherent updates do not interrupt the focused chat')
-  const appPane = paneModel.paneOf(out, 'app:9')
-  assert.notEqual(appPane.id, out.focusedPaneId)
-  assert.equal(appPane.activeTabKey, 'app:9')
-
-  const parked = resolveWorkspaceRequest(
-    ws,
-    builtAppWorkspaceRequest('a', 9),
-    env(ws, { mode: 'phone', rect: { w: 400, h: 350 } }),
-  )
-  assert.equal(parked.panes.p0.activeTabKey, 'chat:a',
-    'without room for a companion, the app stays parked behind the chat')
-  assert.equal(parked.focusedPaneId, 'p0')
+  assert.equal(out, ws, 'a coherent update live-swaps code without opening the preview')
 
   const appInUse = builderSeed([CHAT('a'), APP(9)])
   const unchanged = resolveWorkspaceRequest(

--- a/frontend/src/components/Shell/__tests__/workspacePlacement.test.js
+++ b/frontend/src/components/Shell/__tests__/workspacePlacement.test.js
@@ -276,6 +276,26 @@ test('live preview · phone: preserves the hidden Builder layout and focus', () 
     'the preview is parked without creating another pane')
 })
 
+test('live preview · phone: parks in the focused pane when its source is absent', () => {
+  const ws = {
+    ...twoPaneWs([CHAT('old')], [APP(5)], { focused: 'p1' }),
+    viewMode: 'single',
+    singleScreen: { kind: 'chat', id: 'new' },
+  }
+  const out = resolveWorkspaceRequest(
+    ws,
+    builtAppWorkspaceRequest('new', 9),
+    env(ws, { mode: 'phone', rect: { w: 400, h: 800 } }),
+  )
+  assert.equal(out.viewMode, ws.viewMode, 'the preview never enters Builder')
+  assert.deepEqual(out.singleScreen, ws.singleScreen, 'the Standard screen is untouched')
+  assert.equal(out.focusedPaneId, ws.focusedPaneId, 'hidden Builder focus is untouched')
+  assert.equal(out.panes.p1.activeTabKey, ws.panes.p1.activeTabKey,
+    'the focused pane keeps its active tab')
+  assert.deepEqual(keysOf(out.panes.p1), ['app:5', 'app:9'],
+    'the app is parked as an inactive tab in the focused pane')
+})
+
 test('live preview · phone update: leaves a parked app and pane geometry untouched', () => {
   const ws = paneModel.setActiveTab(builderSeed([CHAT('a'), APP(9)]), 'p0', 'chat:a')
   const out = resolveWorkspaceRequest(

--- a/frontend/src/components/Shell/workspacePlacement.js
+++ b/frontend/src/components/Shell/workspacePlacement.js
@@ -11,10 +11,10 @@ export const PLACE_WITH_SOURCE = 'with-source'
 export const PLACE_WITH_FOCUS = 'with-focus'
 export const ACTIVATE_IN_BACKGROUND = 'background'
 export const ACTIVATE_FOREGROUND = 'foreground'
-// A live build preview is non-displacing on every device: it may reveal or
-// switch the app in a companion pane, but it never replaces the active tab in
-// the pane that owns keyboard focus. This is an internal lifecycle intent, not
-// an `open_item` wire value.
+// A live build preview is non-displacing on every device. Larger screens may
+// reveal or switch it in an unfocused companion pane; phones only park it until
+// the owner taps the preview CTA. This is an internal lifecycle intent, not an
+// `open_item` wire value.
 export const ACTIVATE_LIVE_PREVIEW = 'live-preview'
 
 const PLACEMENTS = new Set([PLACE_BESIDE_SOURCE, PLACE_WITH_SOURCE, PLACE_WITH_FOCUS])
@@ -286,22 +286,45 @@ export function resolveWorkspaceRequest(ws, request, env = {}) {
     && tabKey(ws.singleScreen) === sourceKey
   )
 
-  // A preview may enter Builder when the owner is already looking at its source:
-  // the source remains the foreground surface and the app can bloom beside it.
-  // If the owner has moved elsewhere in Standard, keep that surface untouched
-  // and park the preview in the hidden Builder tree for an explicit later open.
+  // A preview may enter Builder on a larger screen when the owner is already
+  // looking at its source: the source remains foreground and the app can bloom
+  // beside it. Phones never leave Standard for an unsolicited preview; the CTA
+  // is the explicit open affordance there. If the owner has moved elsewhere in
+  // Standard, keep that surface untouched on every device and park the preview.
   let working = (
     preview
+    && mode !== 'phone'
     && (world === 'panes' || singleShowsSource)
   )
     ? paneModel.setViewMode(ws, 'panes')
     : ws
-  const itemKey = tabKey(item)
 
   // Keep the relational source in the Builder tree, but never surface it over
   // another active tab. The one safe activation is Standard → Builder while
   // Standard already shows that exact source, preserving what the owner sees.
+  const itemKey = tabKey(item)
   let sourcePane = source ? paneModel.paneOf(working, tabKey(source)) : null
+
+  // A phone preview is only an availability signal. Keep Standard/Builder mode,
+  // pane geometry, the active surface, and focus exactly as the owner left them;
+  // merely park a new app beside its source so the visible CTA can open it on an
+  // explicit tap. An already-known app needs no workspace mutation because its
+  // mounted frame will live-swap independently when visible.
+  if (preview && mode === 'phone') {
+    if (paneModel.paneOf(working, itemKey)) return working
+    if (source && sourcePane) {
+      return insertBesideSource(working, item, sourcePane, source, {
+        activate: false,
+        focus: false,
+      })
+    }
+    return paneModel.openTab(working, item, {
+      paneId: working.focusedPaneId,
+      activate: false,
+      focus: false,
+    })
+  }
+
   if (preview && source) {
     if (!sourcePane) {
       working = paneModel.openTab(working, source, {
@@ -377,10 +400,9 @@ export function resolveWorkspaceRequest(ws, request, env = {}) {
   }
 
   // beside-source, the device-aware table.
-  if (mode === 'phone' && !preview) {
-    // Generic phone placements keep their existing tab-stack behavior. A live
-    // preview continues into the companion/split ladder below so it can become
-    // visible without replacing the focused chat.
+  if (mode === 'phone') {
+    // Generic phone placements keep their tab-stack behavior. Live previews
+    // returned through the passive phone branch above.
     return insertBesideSource(working, item, sourcePane, source, {
       activate: activateItem,
       focus: focusItem,

--- a/tests/workspace-panes.spec.mjs
+++ b/tests/workspace-panes.spec.mjs
@@ -1339,6 +1339,60 @@ test.describe('Workspace view-mode toggle', () => {
     await expect(page.getByRole('button', { name: /Use (panes|single screen)/ })).toHaveCount(0)
   })
 
+  test('a phone build preview stays in Standard until its CTA is tapped', async ({ page }) => {
+    await boot(page, PHONE)
+    const chat = await createTaggedChat(page, 'phonePreview')
+    const appId = 990111
+    await mockApps(page, [{ id: appId, name: 'Phone Preview', chatId: chat.id }])
+    const standard = paneModel.setSingleScreen(
+      paneModel.setViewMode(
+        paneModel.seedFromFlatTabs([{ kind: 'chat', id: chat.id }]),
+        'single',
+      ),
+      { kind: 'chat', id: chat.id },
+    )
+    await seedWorkspace(page, standard)
+
+    let firstSystemConnection = true
+    await page.route('**/api/events/system', route => {
+      const events = firstSystemConnection
+        ? [
+            { type: 'system_stream_open' },
+            { type: 'app_preview_ready', appId, chatId: chat.id },
+          ]
+        : [{ type: 'system_stream_open' }]
+      firstSystemConnection = false
+      return route.fulfill({
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache' },
+        body: events.map(event => `data: ${JSON.stringify(event)}\n\n`).join(''),
+      })
+    })
+
+    await page.goto(`${BASE}/shell/?chat=${chat.id}`, { waitUntil: 'domcontentloaded' })
+    const cta = page.getByRole('button', { name: 'Open Phone Preview' })
+    await expect(cta).toBeVisible({ timeout: 8000 })
+    await expect.poll(async () => whichPaneHas(await readWs(page), `app:${appId}`), {
+      timeout: 8000,
+      message: 'the preview event parked the app in Builder',
+    }).toBe('p0')
+
+    const afterPreview = await readWs(page)
+    expect(afterPreview.viewMode).toBe('single')
+    expect(afterPreview.singleScreen).toEqual({ kind: 'chat', id: String(chat.id) })
+    expect(afterPreview.panes.p0.activeTabKey).toBe(`chat:${chat.id}`)
+    expect(Object.keys(afterPreview.panes)).toHaveLength(1)
+    await expect(page.locator('.workspace__chrome')).toHaveCount(0)
+    await expect(page.locator('.shell__view--paned')).toHaveCount(0)
+
+    await cta.click()
+    await expect.poll(async () => (await readWs(page)).singleScreen, {
+      timeout: 3000,
+      message: 'the explicit preview CTA opens the app',
+    }).toEqual({ kind: 'app', id: String(appId) })
+    expect((await readWs(page)).viewMode).toBe('single')
+  })
+
   test('closing the final legacy Builder tab returns to a visible Standard chat', async ({ page }) => {
     await boot(page, WIDE)
     const current = await createTaggedChat(page, 'vmFinalClose')


### PR DESCRIPTION
## Summary

- Keep unsolicited app build previews parked on phones instead of switching into the split-pane workspace.
- Preserve the existing Standard screen, hidden pane layout, and focus until the owner taps the preview action.
- Keep the larger-screen companion-pane behavior unchanged and document the device-specific contract.

## Why

A completed mini-app build could silently switch a phone into Builder mode and split the screen even though the owner had not tapped **Open preview**. The preview event is an availability signal; on a phone, opening the app should remain an explicit action.

## Testing

- All 45 focused workspace-placement tests pass.
- Added browser coverage for the full preview-event-to-explicit-open flow; hosted CI remains the browser gate.
