### PR TITLE
Count activation-tree files as declared in app source completeness check

### DIFF
--- a/backend/app/install.py
+++ b/backend/app/install.py
@@ -1756,9 +1756,18 @@ def _check_source_completeness(
   writes back exactly like a compile failure. External-host references are
   logged as warnings (runtime quality, not install-breaking).
 
-  The caller invokes this only on the synthetic-fetch path, where
-  ``source_tree`` IS the whole declared tree (entry + every fetched
+  The caller invokes this only on the synthetic-fetch path. On a pristine
+  install ``source_tree`` IS the whole declared tree (entry + every fetched
   ``source_files`` entry + the job script), so it is the sole source of bytes.
+  On a merge-reconciled update (clean merge or an owner-resolved conflict
+  replay) the tree is the git-merged LOCAL tree, which legitimately carries
+  owner-added modules the published manifest can never list — so files present
+  in the tree count as declared. That is a strict no-op for pristine installs
+  (their tree already equals the declared set) and it keeps the check's real
+  target: an import reachable from the entry that a synthetic fetch would not
+  materialize at all. Load integrity of the activated tree itself is separately
+  guaranteed by the compile step, which resolves imports from the real
+  worktree.
   Static-asset dests are recorded below their installer-owned ``static/``
   directory so source checks see the exact path compilation sees. For example,
   logical destination ``logo.js`` is importable as ``./static/logo.js``.
@@ -1773,7 +1782,13 @@ def _check_source_completeness(
   result = check_app_source(
     files,
     entry=entry_key,
-    source_files=manifest.get("source_files") or [],
+    # Union the published declaration with the tree being activated: owner-
+    # preserved local modules (merge-reconciled updates) are declared by
+    # presence; on a pristine install the tree equals the declared set, so
+    # this adds nothing. See the docstring.
+    source_files=sorted(
+      set(manifest.get("source_files") or []) | set(source_tree)
+    ),
     job=job_name,
     static_assets=static_source_paths,
   )

--- a/backend/tests/test_apps_install.py
+++ b/backend/tests/test_apps_install.py
@@ -3477,6 +3477,115 @@ def test_resolved_conflict_converges_static_metadata_and_bundle_once(
   assert not (app_dir / ".git" / "mobius-pending-update").exists()
 
 
+def test_preserve_local_resolution_keeps_owner_added_module(
+  client, auth, bypass_url_validation,
+):
+  """A preserve-local resolution whose tree carries an owner-added imported
+  module must finalize: presence in the activated tree counts as declared, so
+  the completeness check cannot 422 on files the published manifest can never
+  list. Pristine installs are unaffected (their tree IS the declared set —
+  see test_multifile_install_rejects_incomplete_source_files)."""
+  from app.models import App
+  from app.database import SessionLocal
+
+  base = "https://resolve-local-module.test/repo/"
+  manifest_v1 = {
+    **MANIFEST_NEWS,
+    "id": "resolve-local-module",
+    "icon": None,
+    "storage_seeds": {},
+    "schedule": None,
+  }
+  responses_v1 = {
+    base + "mobius.json": (200, json.dumps(manifest_v1).encode()),
+    base + "index.jsx": (200, JSX_MULTI.encode()),
+  }
+  with patch(
+    "app.install.httpx.AsyncClient",
+    side_effect=_fake_async_client(responses_v1),
+  ):
+    installed = client.post(
+      "/api/apps/install", headers=auth,
+      json={"manifest_url": base + "mobius.json"},
+    )
+  assert installed.status_code == 201, installed.text
+  app_id = installed.json()["id"]
+
+  data_dir = Path(get_settings().data_dir)
+  app_dir = data_dir / "apps" / "resolve-local-module"
+  jsx_file = app_dir / "index.jsx"
+  # Owner work: a NEW local module wired into the entry — the class of edit
+  # the published manifest can never declare.
+  (app_dir / "wizard.js").write_text("export const WIZARD = 'local module'\n")
+  wired = (
+    "import { WIZARD } from './wizard.js'\n"
+    + JSX_MULTI.replace("{title}", "{title}{WIZARD}")
+  )
+  jsx_file.write_text(wired.replace("ORIGINAL TITLE", "LOCAL TITLE"))
+
+  jsx_v2 = JSX_MULTI.replace("ORIGINAL TITLE", "UPSTREAM TITLE")
+  manifest_v2 = {**manifest_v1, "version": "2.0.0"}
+  responses_v2 = {
+    base + "mobius.json": (200, json.dumps(manifest_v2).encode()),
+    base + "index.jsx": (200, jsx_v2.encode()),
+  }
+  with patch(
+    "app.install.httpx.AsyncClient",
+    side_effect=_fake_async_client(responses_v2),
+  ):
+    conflicted = client.post(
+      "/api/apps/install", headers=auth,
+      json={"manifest_url": base + "mobius.json"},
+    )
+  assert conflicted.status_code == 201, conflicted.text
+  assert conflicted.json()["mode"] == "conflict"
+
+  resolver = client.post(
+    f"/api/apps/{app_id}/conflict-resolver-chat", headers=auth,
+    json={"resolution_policy": "preserve_local"},
+  )
+  assert resolver.status_code == 200, resolver.text
+  # The agent's resolution: upstream's change layered with the owner module.
+  resolved = wired.replace("ORIGINAL TITLE", "UPSTREAM TITLE")
+  jsx_file.write_text(resolved)
+  reviewed = client.post(
+    "/api/apps/resolve-update/review",
+    headers=auth,
+    json={"source_dir": str(app_dir)},
+  )
+  assert reviewed.status_code == 200, reviewed.text
+
+  replay_responses = {
+    base + "index.jsx": (200, jsx_v2.encode()),
+  }
+  with patch(
+    "app.install.httpx.AsyncClient",
+    side_effect=_fake_async_client(replay_responses),
+  ):
+    replayed = client.post(
+      "/api/apps/resolve-update",
+      headers=auth,
+      json={
+        "source_dir": str(app_dir),
+        "reviewed_tree_oid": reviewed.json()["tree_oid"],
+      },
+    )
+  assert replayed.status_code == 200, replayed.text
+  assert replayed.json()["mode"] == "updated"
+
+  assert (
+    app_dir / "wizard.js"
+  ).read_text() == "export const WIZARD = 'local module'\n"
+  db = SessionLocal()
+  try:
+    app = db.query(App).filter(App.id == app_id).first()
+    assert app.version == "2.0.0"
+    assert app.jsx_source == resolved
+  finally:
+    db.close()
+  assert not (app_dir / ".git" / "mobius-pending-update").exists()
+
+
 def test_clean_merge_with_unreadable_bytes_is_treated_as_conflict(
   client, auth, bypass_url_validation, monkeypatch,
 ):


### PR DESCRIPTION
## Problem

A preserve-local update resolution can never finalize when the installed app carries owner-added source modules. `_check_source_completeness` compares every relative import reachable from the entry against the *published* manifest's `source_files` (introduced in #22) — but on a resolve replay (the whole-tree policy flow from #728) or any clean merge of a locally extended app, the activated tree is the git-merged local tree, which legitimately contains modules the published manifest cannot list. The replay is rejected with `422 … has an incomplete source_files manifest — <module>: imported by <file> but not listed`, and the update is permanently stuck: the owner's modules cannot be declared upstream, and the check runs on every finalize attempt.

Hit in the wild: an installed app with a locally built feature (new sibling modules imported from the entry) received a conflicting upstream update; the owner chose to keep local changes; the finalize replay could never pass the completeness check.

## Fix

Union the declared list with the tree being activated. On a pristine install the tree already equals the declared set (entry + fetched `source_files` + job + static dests), so the union adds nothing — an undeclared import is still absent from the tree and still flagged, preserving #22's install-integrity purpose in full. On a merge-reconciled tree, files present in the activation tree count as declared. Load integrity of the activated tree is separately guaranteed by the compile step, which resolves imports from the real worktree.

## Test

`test_preserve_local_resolution_keeps_owner_added_module`: install → owner adds an imported local module → conflicting update → `preserve_local` policy → resolve → replay finalizes, with the module preserved and version/`jsx_source` advanced. The pristine-path rejection (`test_multifile_install_rejects_incomplete_source_files`) stays green.
