### PR TITLE
Settle hidden chats from runtime truth

### DIFF
--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -2002,11 +2002,14 @@ export default function ChatView({
           || localStartRequestRef.current?.chatId === String(chatId)
         ) && !externalClaimedRunRef.current
         if (locallyActive) {
-          // The local optimistic turn remains authoritative for its suffix,
-          // but completed history still needs server reconciliation. Without
-          // this fetch, an under-promoted previous reply stays missing for the
-          // lifetime of the open tab.
-          await fetchMessages({ force: true })
+          // A hidden retained pane can miss the terminal stream event while
+          // Shell still records the run finish. Re-enter the runtime owner
+          // here: it protects an unacknowledged fresh send, but an idle server
+          // verdict after an observed run authoritatively refreshes the final
+          // transcript and retires the stale stream. The old non-authoritative
+          // detail read deliberately preserved local activity, so the pane
+          // could return with its shimmer and Stop control stuck on.
+          await reconcileRuntimeState()
           continue
         }
 
@@ -2058,7 +2061,14 @@ export default function ChatView({
         queueMicrotask(reconcileExternalActivity)
       }
     }
-  }, [chatId, connectToStream, embedded, fetchMessages, isStreamingRef])
+  }, [
+    chatId,
+    connectToStream,
+    embedded,
+    fetchMessages,
+    isStreamingRef,
+    reconcileRuntimeState,
+  ])
   useEffect(() => {
     if (hidden || provisionalNewChat) return
     reconcileExternalActivity()

--- a/frontend/src/components/ChatView/__tests__/streamingRobustness.test.js
+++ b/frontend/src/components/ChatView/__tests__/streamingRobustness.test.js
@@ -336,6 +336,37 @@ test('terminal stream finish promotes before clearing streaming state', () => {
   assert.equal(messages.at(-1).content, 'final answer')
 })
 
+test('a hidden-pane finish routes stale local activity through runtime settlement', () => {
+  const start = chatViewSource.indexOf('const reconcileExternalActivity = useCallback')
+  const end = chatViewSource.indexOf('\n  const ensureRuntimeStreamConnected', start)
+  const reconciliation = chatViewSource.slice(start, end)
+  const activeBranchStart = reconciliation.indexOf('if (locallyActive)')
+  const activeBranchEnd = reconciliation.indexOf('\n        }', activeBranchStart)
+  const activeBranch = reconciliation.slice(activeBranchStart, activeBranchEnd)
+
+  assert.match(activeBranch, /await reconcileRuntimeState\(\)/,
+    'a retained local stream must reach the authoritative idle recovery path')
+  assert.doesNotMatch(activeBranch, /fetchMessages\(/,
+    'the non-authoritative transcript read intentionally preserves local activity')
+  // Runtime recovery now lives in the bounded request owner; the public
+  // reconcile callback only coalesces callers onto that same promise.
+  const runtimeStart = chatViewSource.indexOf('const refreshRuntimeState = useCallback')
+  const recovery = chatViewSource.indexOf('if (shouldRecoverSettledRuntime({', runtimeStart)
+  const refresh = chatViewSource.indexOf('const settled = await fetchMessages({', recovery)
+  const authoritative = chatViewSource.indexOf('authoritative: true', refresh)
+  const retire = chatViewSource.indexOf('retireSettledStreamRef.current?.()', authoritative)
+  const runtimeEnd = chatViewSource.indexOf('\n  const handleCompactionStored', runtimeStart)
+  assert.ok(
+    runtimeStart >= 0
+      && recovery > runtimeStart
+      && refresh > recovery
+      && authoritative > refresh
+      && retire > authoritative
+      && retire < runtimeEnd,
+    'idle runtime truth must refresh the final row before retiring stale stream state',
+  )
+})
+
 // ---------------------------------------------------------------------------
 // Fix 2: doSendSilent re-entrancy guard (sendSilentInFlightRef)
 // ---------------------------------------------------------------------------

--- a/tests/hidden-chat-settlement.spec.mjs
+++ b/tests/hidden-chat-settlement.spec.mjs
@@ -84,7 +84,7 @@ test('returning to a retained hidden chat settles a missed terminal stream event
     blocks: [{ type: 'text', content: 'The saved final answer.' }],
   }]
   running = false
-  await page.evaluate(chatId => window.emitSettlementEvent({ type: 'chat_run_finished', chat_id: chatId }), a.id)
+  await page.evaluate(chatId => window.emitSettlementEvent({ type: 'chat_run_finished', chatId }), a.id)
   await page.getByRole('button', { name: 'Show all panes' }).click()
   await expect.poll(() => idleRuntimeReads).toBeGreaterThan(0)
   await expect(surface.getByText('The saved final answer.', { exact: true })).toBeVisible()

--- a/tests/hidden-chat-settlement.spec.mjs
+++ b/tests/hidden-chat-settlement.spec.mjs
@@ -60,6 +60,7 @@ test('returning to a retained hidden chat settles a missed terminal stream event
     messages = [message]
     return route.fulfill({ status: 202, json: { status: 'started', message } })
   })
+  await page.clock.install()
   await page.goto(`${BASE}/shell/?chat=${a.id}`, { waitUntil: 'domcontentloaded' })
   const surface = page.locator(`[data-tab-key="chat:${a.id}"]`)
   await expect(surface.getByRole('textbox', { name: 'Message Möbius…' })).toBeVisible()
@@ -76,9 +77,7 @@ test('returning to a retained hidden chat settles a missed terminal stream event
 
   // Freeze interval recovery: only the observed finish + reveal can settle this
   // test, not a later runtime polling tick masking broken event wiring.
-  const frozenTime = new Date()
-  await page.clock.install({ time: frozenTime })
-  await page.clock.pauseAt(frozenTime)
+  await page.clock.pauseAt(new Date(Date.now() + 1000))
   messages = [...messages, {
     role: 'assistant', content: 'The saved final answer.', ts: 1700001000001,
     blocks: [{ type: 'text', content: 'The saved final answer.' }],

--- a/tests/hidden-chat-settlement.spec.mjs
+++ b/tests/hidden-chat-settlement.spec.mjs
@@ -1,0 +1,96 @@
+import { test, expect } from '@playwright/test'
+import { attachCleanup, createTaggedChat } from './_chatTracker.mjs'
+import * as paneModel from '../frontend/src/components/Shell/paneModel.js'
+
+const BASE = process.env.MOBIUS_URL || 'http://localhost:8001'
+attachCleanup()
+test.use({ serviceWorkers: 'block', viewport: { width: 1400, height: 900 } })
+
+test('returning to a retained hidden chat settles a missed terminal stream event', async ({ page }) => {
+  await page.goto(BASE, { waitUntil: 'domcontentloaded' })
+  const a = await createTaggedChat(page, 'hidden-settlement')
+  const b = await createTaggedChat(page, 'visible-sibling')
+  let ws = paneModel.setViewMode(paneModel.seedFromFlatTabs([
+    { kind: 'chat', id: a.id }, { kind: 'chat', id: b.id },
+  ]), 'panes')
+  ws = paneModel.moveTab(ws, `chat:${b.id}`, { root: true, edge: 'right' })
+  ws = paneModel.focusPane(ws, 'p0')
+  await page.addInitScript(({ key, workspace, chatId }) => {
+    localStorage.setItem(key, workspace)
+    const realFetch = window.fetch.bind(window)
+    const encoder = new TextEncoder()
+    window.fetch = (input, init) => {
+      const path = new URL(String(input?.url || input), location.origin).pathname
+      if (path === '/api/events/system' || path === `/api/chats/${chatId}/stream`) {
+        return Promise.resolve(new Response(new ReadableStream({
+          start(controller) {
+            const emit = event => controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`))
+            if (path === '/api/events/system') window.emitSettlementEvent = emit
+            else {
+              emit({ type: 'thinking', content: 'Waiting for the saved result.' })
+              emit({ type: 'catch_up_done' })
+              // Deliberately never deliver the terminal event or close this stream.
+            }
+          },
+        }), { headers: { 'Content-Type': 'text/event-stream' } }))
+      }
+      return realFetch(input, init)
+    }
+  }, { key: paneModel.STORAGE_KEY, workspace: paneModel.serializeWorkspace(ws), chatId: a.id })
+
+  let running = false
+  let messages = []
+  let idleRuntimeReads = 0
+  await page.route(new RegExp(`/api/chats/${a.id}(?:\\?.*)?$`), route => {
+    if (route.request().method() !== 'GET') return route.fallback()
+    return route.fulfill({ json: {
+      id: a.id, title: 'Hidden settlement', provider: 'codex',
+      messages, total: messages.length, offset: 0, running,
+      pending_messages: [], pending_question_id: null,
+    } })
+  })
+  await page.route(new RegExp(`/api/chats/${a.id}/runtime(?:\\?.*)?$`), route => {
+    if (!running && messages.length > 1) idleRuntimeReads += 1
+    return route.fulfill({ json: { running, pending_messages: [], pending_question_id: null } })
+  })
+  await page.route(new RegExp(`/api/chats/${a.id}/messages$`), route => {
+    const body = route.request().postDataJSON()
+    running = true
+    const message = { role: 'user', content: body.content, cid: body.cid, ts: 1700001000000 }
+    messages = [message]
+    return route.fulfill({ status: 202, json: { status: 'started', message } })
+  })
+  await page.goto(`${BASE}/shell/?chat=${a.id}`, { waitUntil: 'domcontentloaded' })
+  const surface = page.locator(`[data-tab-key="chat:${a.id}"]`)
+  await expect(surface.getByRole('textbox', { name: 'Message Möbius…' })).toBeVisible()
+  await surface.getByRole('textbox', { name: 'Message Möbius…' }).fill('Run the settlement check')
+  await page.keyboard.press('Enter')
+  await expect(surface.locator('.chat__stop')).toBeVisible()
+  await page.waitForFunction(() => typeof window.emitSettlementEvent === 'function')
+  await page.evaluate(chatId => {
+    window.retainedSettlementRoot = document.querySelector(`[data-tab-key="chat:${chatId}"] .chat`)
+  }, a.id)
+  expect(await page.evaluate(() => Boolean(window.retainedSettlementRoot))).toBe(true)
+  await page.locator('[data-pane-strip="p1"]').getByRole('button', { name: 'Focus pane' }).click()
+  await expect(surface).toBeHidden()
+
+  // Freeze interval recovery: only the observed finish + reveal can settle this
+  // test, not a later runtime polling tick masking broken event wiring.
+  const frozenTime = new Date()
+  await page.clock.install({ time: frozenTime })
+  await page.clock.pauseAt(frozenTime)
+  messages = [...messages, {
+    role: 'assistant', content: 'The saved final answer.', ts: 1700001000001,
+    blocks: [{ type: 'text', content: 'The saved final answer.' }],
+  }]
+  running = false
+  await page.evaluate(chatId => window.emitSettlementEvent({ type: 'chat_run_finished', chat_id: chatId }), a.id)
+  await page.getByRole('button', { name: 'Show all panes' }).click()
+  await expect.poll(() => idleRuntimeReads).toBeGreaterThan(0)
+  await expect(surface.getByText('The saved final answer.', { exact: true })).toBeVisible()
+  await expect(surface.locator('.chat__stop')).toHaveCount(0)
+  await expect(surface.locator('.chat__thinking')).toHaveCount(0)
+  expect(await page.evaluate(chatId => (
+    window.retainedSettlementRoot === document.querySelector(`[data-tab-key="chat:${chatId}"] .chat`)
+  ), a.id)).toBe(true)
+})


### PR DESCRIPTION
## Summary

- Reconcile a retained hidden chat through the authoritative runtime owner when it still looks locally active.
- Refresh the final transcript before retiring stale streaming state.
- Update the regression check for the current runtime-refresh structure.

## Why

A hidden pane can miss a terminal stream event while the shell still observes the run finishing. Returning to that chat previously used a transcript read that intentionally preserved local activity, leaving stale shimmer and a Stop control even though no work remained.

Routing the recovery through the existing runtime reconciliation path protects genuine fresh sends while letting an observed idle verdict settle stale state correctly.

## Testing

- All 36 streaming-robustness tests pass.
