### PR TITLE
Fix opaque embedded chat resources in WebKit

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -454,6 +454,14 @@ def _static_embed_csp_for_scope(scope) -> str:
   return static_embed_csp(settings.frontend_origin, delivery_origin)
 
 
+def _chat_embed_csp_for_scope(scope) -> str:
+  """Let the loopback test harness exercise the real opaque chat embed."""
+  delivery_origin = _loopback_delivery_origin(scope)
+  if delivery_origin is None:
+    return _CHAT_EMBED_CSP
+  return chat_embed_csp(settings.frontend_origin, delivery_origin)
+
+
 def _app_frame_csp_for_scope(scope) -> str:
   """Let the loopback test harness exercise the real opaque app frame."""
   delivery_origin = _loopback_delivery_origin(scope)
@@ -553,9 +561,7 @@ class _SecurityHeadersMiddleware:
       elif published_site:
         csp = _PUBLISHED_SITE_CSP
       elif chat_embed:
-        delivery_origin = _loopback_delivery_origin(scope)
-        csp = (chat_embed_csp(settings.frontend_origin, delivery_origin)
-               if delivery_origin else _CHAT_EMBED_CSP)
+        csp = _chat_embed_csp_for_scope(scope)
       elif app_frame:
         csp = _app_frame_csp_for_scope(scope)
       elif artifact_output:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -52,7 +52,7 @@ from app.frontend_assets import (
 from app.memory_observability import record_memory_checkpoint
 from app.runtime_provenance import protected_runtime_status
 from app.response_policy import (
-  CHAT_EMBED_CSP,
+  chat_embed_csp,
   PUBLISHED_SITE_CSP,
   absolute_csp_origin,
   app_frame_csp,
@@ -397,6 +397,7 @@ _ARTIFACT_OUTPUT_PATH = re.compile(
 # credential boundary: packaged code already executes in the opaque document,
 # and it still cannot reach the shell's localStorage, cookies, or owner token.
 _STATIC_EMBED_CSP = static_embed_csp(settings.frontend_origin)
+_CHAT_EMBED_CSP = chat_embed_csp(settings.frontend_origin)
 _SHELL_CSP = shell_csp(os.environ.get("MOBIUS_SERVICE_GATEWAY_ORIGIN", ""))
 _SERVICE_GATEWAY_ORIGIN = os.environ.get("MOBIUS_SERVICE_GATEWAY_ORIGIN", "")
 _BROWSER_API_ORIGIN = os.environ.get("API_BASE_URL", "")
@@ -552,7 +553,9 @@ class _SecurityHeadersMiddleware:
       elif published_site:
         csp = _PUBLISHED_SITE_CSP
       elif chat_embed:
-        csp = CHAT_EMBED_CSP
+        delivery_origin = _loopback_delivery_origin(scope)
+        csp = (chat_embed_csp(settings.frontend_origin, delivery_origin)
+               if delivery_origin else _CHAT_EMBED_CSP)
       elif app_frame:
         csp = _app_frame_csp_for_scope(scope)
       elif artifact_output:

--- a/backend/app/response_policy.py
+++ b/backend/app/response_policy.py
@@ -117,15 +117,27 @@ def shell_csp(gateway_origin: str = "") -> str:
   )
 
 
-CHAT_EMBED_CSP = (
-  "default-src 'self'; "
-  "script-src 'self' 'unsafe-inline' https://esm.sh; "
-  "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "
-  "font-src 'self' https://fonts.gstatic.com https://cdn.openai.com; "
-  "connect-src 'self'; "
-  "img-src 'self' data: blob:; "
-  "frame-src 'self'"
-)
+def chat_embed_csp(frontend_origin: str, delivery_origin: str = "") -> str:
+  """Explicit resource origins for chat nested inside an opaque app frame.
+
+  WebKit cannot resolve CSP 'self' against the inherited opaque origin. Name
+  the same trusted site instead; do not grant allow-same-origin or broaden
+  the one-use capability/session authentication boundary.
+  """
+  sources = [_validated_frontend_origin(frontend_origin)]
+  delivery = absolute_csp_origin(delivery_origin)
+  if delivery is not None and delivery not in sources:
+    sources.append(delivery)
+  source = " ".join(sources)
+  return (
+    f"default-src {source}; "
+    f"script-src {source} 'unsafe-inline' https://esm.sh; "
+    f"style-src {source} 'unsafe-inline' https://fonts.googleapis.com; "
+    f"font-src {source} https://fonts.gstatic.com https://cdn.openai.com; "
+    f"connect-src {source}; "
+    f"img-src {source} data: blob:; "
+    f"frame-src {source}"
+  )
 
 
 def static_embed_csp(

--- a/backend/tests/test_security_headers.py
+++ b/backend/tests/test_security_headers.py
@@ -7,9 +7,9 @@ from fastapi.testclient import TestClient
 
 from app import main
 from app.main import (
-  _PUBLISHED_SITE_CSP, _SHELL_CSP, _STATIC_EMBED_CSP, app,
+  _PUBLISHED_SITE_CSP, _SHELL_CSP, _STATIC_EMBED_CSP, _CHAT_EMBED_CSP, app,
 )
-from app.response_policy import CHAT_EMBED_CSP, app_frame_csp
+from app.response_policy import chat_embed_csp, app_frame_csp
 
 
 def _headers(path="/api/health"):
@@ -167,7 +167,7 @@ def test_embedded_chat_allows_opaque_origin_app_ancestor():
   # The route itself is inert: no chat id or credential is accepted in its URL.
   h = _headers("/shell/embed/chat")
   assert "x-frame-options" not in h
-  assert h.get("content-security-policy") == CHAT_EMBED_CSP
+  assert h.get("content-security-policy") == _CHAT_EMBED_CSP
   assert h.get("x-content-type-options") == "nosniff"
   assert h.get("strict-transport-security")
 
@@ -252,7 +252,7 @@ def test_bundled_caddy_keeps_only_gateway_specific_response_policy():
   # Direct origin policies retain the exact scoped differences Caddy used to
   # mirror by hand.
   assert "frame-ancestors 'self'" in _SHELL_CSP
-  assert "frame-ancestors" not in CHAT_EMBED_CSP
+  assert "frame-ancestors" not in _CHAT_EMBED_CSP
   assert "sandbox allow-scripts" in _STATIC_EMBED_CSP
   assert "allow-same-origin" not in _STATIC_EMBED_CSP
   service_csp = next(
@@ -405,3 +405,28 @@ def test_opaque_app_preflight_allows_versioned_storage_requests():
     for header in actual.headers["access-control-expose-headers"].split(",")
   }
   assert "etag" in exposed
+
+
+def test_chat_embed_uses_absolute_sources_for_opaque_webkit_frame():
+  origin = "https://app.example.test"
+  policy = chat_embed_csp(origin)
+  for directive in ("default-src", "script-src", "style-src", "font-src",
+                    "connect-src", "img-src", "frame-src"):
+    sources = policy.split(f"{directive} ", 1)[1].split(";", 1)[0].split()
+    assert origin in sources
+    assert "'self'" not in sources
+    assert "*" not in sources
+  assert "allow-same-origin" not in policy
+  assert "frame-ancestors" not in policy
+  assert "'unsafe-eval'" not in policy
+  assert "localhost" not in policy
+
+
+def test_chat_embed_loopback_delivery_is_exact_and_not_host_header_trusted():
+  client = TestClient(app, base_url="http://127.0.0.1:8000",
+                      client=("127.0.0.1", 50000))
+  policy = client.get("/shell/embed/chat").headers["content-security-policy"]
+  assert policy == chat_embed_csp(main.settings.frontend_origin, "http://127.0.0.1:8000")
+  assert client.get("/shell/embed/chat", headers={"Host": "evil.example"}).headers["content-security-policy"] == _CHAT_EMBED_CSP
+  remote = TestClient(app, base_url="http://127.0.0.1:8000", client=("203.0.113.4", 50000))
+  assert remote.get("/shell/embed/chat").headers["content-security-policy"] == _CHAT_EMBED_CSP


### PR DESCRIPTION
## Summary

- Generate the embedded-chat content policy with explicit trusted resource origins instead of `self`.
- Add the exact loopback delivery origin only for verified loopback requests.
- Keep opaque-frame isolation intact without granting same-origin access or trusting the Host header.

## Why

WebKit cannot reliably resolve CSP `self` inside the inherited opaque origin used by app-embedded chats. The result is a blank or broken embedded chat even though its one-use capability exchange is valid.

Naming the existing trusted frontend origin fixes resource loading without weakening the opaque-origin credential boundary.

## Testing

- Focused embedded-chat and security-header tests pass.
