### PR TITLE
Recover shell state after browser resume

### DIFF
--- a/frontend/src/components/Shell/__tests__/scheduleAfterBrowserPaint.test.js
+++ b/frontend/src/components/Shell/__tests__/scheduleAfterBrowserPaint.test.js
@@ -26,6 +26,26 @@ function frameHarness() {
   }
 }
 
+function lifecycleTarget(extra = {}) {
+  const listeners = new Map()
+  return {
+    ...extra,
+    addEventListener(type, listener) {
+      if (!listeners.has(type)) listeners.set(type, new Set())
+      listeners.get(type).add(listener)
+    },
+    removeEventListener(type, listener) {
+      listeners.get(type)?.delete(listener)
+    },
+    emit(type) {
+      for (const listener of listeners.get(type) || []) listener()
+    },
+    listenerCount(type) {
+      return listeners.get(type)?.size || 0
+    },
+  }
+}
+
 test('chat promotion follows one prepared browser paint opportunity', () => {
   const frames = frameHarness()
   let promoted = false
@@ -56,4 +76,57 @@ test('a superseded staging chat cannot promote after cancellation', () => {
   frames.paintFrame()
   assert.equal(promotions, 0)
   assert.equal(frames.pending(), 0)
+})
+
+test('a hidden tab re-arms the complete paint proof when it returns', () => {
+  const frames = frameHarness()
+  const documentTarget = lifecycleTarget({ visibilityState: 'visible' })
+  const windowTarget = lifecycleTarget()
+  let promotions = 0
+
+  scheduleAfterBrowserPaint(
+    () => { promotions += 1 },
+    callback => frames.request(callback),
+    id => frames.cancel(id),
+    { documentTarget, windowTarget },
+  )
+
+  frames.paintFrame()
+  assert.equal(frames.pending(), 1, 'the second frame is waiting to promote')
+
+  documentTarget.visibilityState = 'hidden'
+  documentTarget.emit('visibilitychange')
+  assert.equal(frames.pending(), 0, 'the suspended frame is retired')
+
+  documentTarget.visibilityState = 'visible'
+  documentTarget.emit('visibilitychange')
+  frames.paintFrame()
+  assert.equal(promotions, 0, 'the returned tab still paints beneath the cover')
+  frames.paintFrame()
+
+  assert.equal(promotions, 1)
+  assert.equal(documentTarget.listenerCount('visibilitychange'), 0)
+  assert.equal(windowTarget.listenerCount('pageshow'), 0)
+})
+
+test('pageshow replaces a lost paint callback without double promotion', () => {
+  const frames = frameHarness()
+  const documentTarget = lifecycleTarget({ visibilityState: 'visible' })
+  const windowTarget = lifecycleTarget()
+  let promotions = 0
+
+  scheduleAfterBrowserPaint(
+    () => { promotions += 1 },
+    callback => frames.request(callback),
+    id => frames.cancel(id),
+    { documentTarget, windowTarget },
+  )
+
+  windowTarget.emit('pageshow')
+  frames.paintFrame()
+  frames.paintFrame()
+  windowTarget.emit('pageshow')
+  frames.paintFrame()
+
+  assert.equal(promotions, 1)
 })

--- a/frontend/src/components/Shell/scheduleAfterBrowserPaint.js
+++ b/frontend/src/components/Shell/scheduleAfterBrowserPaint.js
@@ -1,13 +1,79 @@
 // Nested animation frames leave one browser paint opportunity between layout
 // readiness and promotion without guessing at a device-specific timeout.
+//
+// Browsers pause animation frames while a tab is hidden. Some mobile/WebKit
+// lifecycle paths can retire a queued frame while the document is suspended,
+// so a one-shot pair must not be the sole owner of a launch-cover handoff.
+// Re-arm the complete two-frame proof on every real foreground boundary: the
+// destination still paints once beneath its cover, and a discarded callback
+// can never strand that cover over an otherwise healthy shell.
 export function scheduleAfterBrowserPaint(
   callback,
   requestFrame = requestAnimationFrame,
   cancelFrame = cancelAnimationFrame,
+  {
+    documentTarget = typeof document === 'undefined' ? null : document,
+    windowTarget = typeof window === 'undefined' ? null : window,
+  } = {},
 ) {
-  let frame = requestFrame(() => {
-    frame = requestFrame(callback)
-  })
+  let frame = null
+  let generation = 0
+  let settled = false
 
-  return () => cancelFrame(frame)
+  const visible = () => documentTarget?.visibilityState !== 'hidden'
+
+  function cancelPendingFrame() {
+    generation += 1
+    if (frame !== null) cancelFrame(frame)
+    frame = null
+  }
+
+  function removeLifecycleListeners() {
+    documentTarget?.removeEventListener?.('visibilitychange', onVisibilityChange)
+    windowTarget?.removeEventListener?.('pageshow', onPageShow)
+  }
+
+  function finish() {
+    if (settled) return
+    settled = true
+    frame = null
+    removeLifecycleListeners()
+    callback()
+  }
+
+  function schedule() {
+    if (settled || !visible()) return
+    cancelPendingFrame()
+    const owner = generation
+    frame = requestFrame(() => {
+      if (settled || owner !== generation || !visible()) return
+      frame = requestFrame(() => {
+        if (settled || owner !== generation || !visible()) return
+        finish()
+      })
+    })
+  }
+
+  function onVisibilityChange() {
+    if (!visible()) {
+      cancelPendingFrame()
+      return
+    }
+    schedule()
+  }
+
+  function onPageShow() {
+    if (visible()) schedule()
+  }
+
+  documentTarget?.addEventListener?.('visibilitychange', onVisibilityChange)
+  windowTarget?.addEventListener?.('pageshow', onPageShow)
+  schedule()
+
+  return () => {
+    if (settled) return
+    settled = true
+    cancelPendingFrame()
+    removeLifecycleListeners()
+  }
 }

--- a/frontend/src/lib/__tests__/connectivityStore.test.js
+++ b/frontend/src/lib/__tests__/connectivityStore.test.js
@@ -218,6 +218,31 @@ test('hidden verification defers without publishing a false Checking state', asy
   stop()
 })
 
+test('healthy verification keeps the last reachable verdict while its probe settles', async () => {
+  let resolveProbe
+  let probes = 0
+  const h = harness(() => {
+    probes += 1
+    if (probes === 1) return Promise.resolve({ status: 204 })
+    return new Promise(resolve => { resolveProbe = resolve })
+  })
+  let notifications = 0
+  const stop = h.store.subscribe(() => { notifications += 1 })
+  await flush()
+
+  const verification = h.store.verify()
+  assert.equal(probes, 2)
+  assert.equal(h.store.getPhaseSnapshot(), ReachabilityPhase.ONLINE,
+    'a transport reconnect is not a server outage verdict')
+  assert.equal(notifications, 0, 'the shell status dot must not flash before verification')
+
+  resolveProbe({ status: 204 })
+  assert.equal(await verification, true)
+  assert.equal(h.store.getPhaseSnapshot(), ReachabilityPhase.ONLINE)
+  assert.equal(notifications, 0)
+  stop()
+})
+
 test('foreground recovery does not wait for or accept a suspended probe', async () => {
   let probes = 0
   let rejectSuspended
@@ -232,7 +257,7 @@ test('foreground recovery does not wait for or accept a suspended probe', async 
   await flush()
 
   const suspended = h.store.verify()
-  assert.equal(h.store.getPhaseSnapshot(), ReachabilityPhase.CHECKING)
+  assert.equal(h.store.getPhaseSnapshot(), ReachabilityPhase.ONLINE)
   assert.equal(probes, 2)
 
   h.documentTarget.visibilityState = 'hidden'

--- a/frontend/src/lib/__tests__/connectivityStore.test.js
+++ b/frontend/src/lib/__tests__/connectivityStore.test.js
@@ -189,11 +189,66 @@ test('hidden tabs pause recovery and visibility requests one coalesced check', a
   h.documentTarget.visibilityState = 'hidden'
   h.documentTarget.emit('visibilitychange')
   assert.equal(h.timers.countDelay(RECOVERY_RETRY_MIN_MS), 0)
-  assert.equal(h.timers.countDelay(FAILURE_GRACE_MS), 1, 'failure history is not reset')
+  assert.equal(h.timers.countDelay(FAILURE_GRACE_MS), 0, 'background time cannot confirm an outage')
   h.documentTarget.visibilityState = 'visible'
   h.documentTarget.emit('visibilitychange')
   await flush()
   assert.equal(h.timers.countDelay(FAILURE_GRACE_MS), 1)
+  stop()
+})
+
+test('hidden verification defers without publishing a false Checking state', async () => {
+  let probes = 0
+  const h = harness(async () => { probes += 1; return { status: 204 } })
+  const stop = h.store.subscribe(() => {})
+  await flush()
+  assert.equal(probes, 1)
+
+  h.documentTarget.visibilityState = 'hidden'
+  h.documentTarget.emit('visibilitychange')
+  assert.equal(await h.store.verify(), true)
+  assert.equal(h.store.getPhaseSnapshot(), ReachabilityPhase.ONLINE)
+  assert.equal(probes, 1, 'the hidden transport is not probed')
+
+  h.documentTarget.visibilityState = 'visible'
+  h.documentTarget.emit('visibilitychange')
+  await flush()
+  assert.equal(probes, 2, 'foreground return owns one fresh probe')
+  assert.equal(h.store.getPhaseSnapshot(), ReachabilityPhase.ONLINE)
+  stop()
+})
+
+test('foreground recovery does not wait for or accept a suspended probe', async () => {
+  let probes = 0
+  let rejectSuspended
+  const h = harness(() => {
+    probes += 1
+    if (probes === 2) {
+      return new Promise((_, reject) => { rejectSuspended = reject })
+    }
+    return Promise.resolve({ status: 204 })
+  })
+  const stop = h.store.subscribe(() => {})
+  await flush()
+
+  const suspended = h.store.verify()
+  assert.equal(h.store.getPhaseSnapshot(), ReachabilityPhase.CHECKING)
+  assert.equal(probes, 2)
+
+  h.documentTarget.visibilityState = 'hidden'
+  h.documentTarget.emit('visibilitychange')
+  h.documentTarget.visibilityState = 'visible'
+  h.documentTarget.emit('visibilitychange')
+  await flush()
+
+  assert.equal(probes, 3)
+  assert.equal(h.store.getPhaseSnapshot(), ReachabilityPhase.ONLINE)
+
+  rejectSuspended(new TypeError('suspended transport failed late'))
+  await suspended
+  await flush()
+  assert.equal(h.store.getPhaseSnapshot(), ReachabilityPhase.ONLINE,
+    'the detached failure cannot overwrite foreground truth')
   stop()
 })
 

--- a/frontend/src/lib/connectivityStore.js
+++ b/frontend/src/lib/connectivityStore.js
@@ -312,16 +312,19 @@ export function createConnectivityStore({
   }
 
   function verify() {
-    // Callers invoke verification only after transport evidence such as a
-    // failed request or an unexpected stream close. Surface that uncertainty
-    // immediately; the bounded probe owns the final reachability verdict.
+    // Callers invoke verification after transport evidence such as a failed
+    // request or an unexpected stream close. That evidence belongs to one
+    // transport, not necessarily to the server: keep the last reachable verdict
+    // while the bounded health probe decides. Publishing Checking before the
+    // probe made every healthy stream reconnect flash the shell status dot.
+    // A failed probe still enters Checking through applyProbe(), starts the
+    // failure grace window, and eventually confirms Offline.
     // A hidden tab is the exception: browsers intentionally suspend its
     // transports and timers, so defer to the monitor's foreground boundary
     // instead of publishing a false Checking state that can become stranded.
     if (documentTarget?.visibilityState === 'hidden') {
       return Promise.resolve(publicOnline(state))
     }
-    publish(reduceReachability(state, { type: 'checking' }))
     if (monitor) return monitor.check()
     if (standaloneCheck) return standaloneCheck
     const startedRevision = evidenceRevision

--- a/frontend/src/lib/connectivityStore.js
+++ b/frontend/src/lib/connectivityStore.js
@@ -155,6 +155,7 @@ export function createConnectivityStore({
 
     let cancelled = false
     let activeCheck = null
+    let checkGeneration = 0
     let rerun = false
     let failureTimer = null
     let retryTimer = null
@@ -222,24 +223,38 @@ export function createConnectivityStore({
       scheduleRetry()
       return false
     }
-    function check() {
+    // A browser may suspend an in-flight fetch while a tab is backgrounded.
+    // Detach that attempt at the lifecycle boundary so foreground recovery is
+    // never serialized behind a promise the browser may no longer settle.
+    // The generation guard also prevents a late failure from overwriting the
+    // fresh foreground verdict.
+    function abandonActiveCheck() {
+      checkGeneration += 1
+      activeCheck = null
+      rerun = false
+    }
+    function check({ fresh = false } = {}) {
+      if (fresh && activeCheck) abandonActiveCheck()
       if (activeCheck) {
         rerun = true
         return activeCheck
       }
       const startedRevision = evidenceRevision
-      activeCheck = probeReachable()
-        .then(reachable => cancelled
+      const generation = ++checkGeneration
+      const current = probeReachable()
+        .then(reachable => cancelled || generation !== checkGeneration
           ? reachable
           : applyProbe(reachable, startedRevision))
         .finally(() => {
+          if (activeCheck !== current) return
           activeCheck = null
           if (rerun && !cancelled) {
             rerun = false
             void check()
           }
         })
-      return activeCheck
+      activeCheck = current
+      return current
     }
     function requestCheck() {
       if (!visible()) return
@@ -247,10 +262,15 @@ export function createConnectivityStore({
     }
     function onVisibilityChange() {
       if (!visible()) {
+        // Background suspension is not evidence that the server went away.
+        // Retire both the pending verdict and its deadline; foreground return
+        // starts one independent probe instead of inheriting stale work.
+        clearFailureDeadline()
         clearRetry()
+        abandonActiveCheck()
         return
       }
-      requestCheck()
+      void check({ fresh: true })
     }
 
     const current = {
@@ -295,6 +315,12 @@ export function createConnectivityStore({
     // Callers invoke verification only after transport evidence such as a
     // failed request or an unexpected stream close. Surface that uncertainty
     // immediately; the bounded probe owns the final reachability verdict.
+    // A hidden tab is the exception: browsers intentionally suspend its
+    // transports and timers, so defer to the monitor's foreground boundary
+    // instead of publishing a false Checking state that can become stranded.
+    if (documentTarget?.visibilityState === 'hidden') {
+      return Promise.resolve(publicOnline(state))
+    }
     publish(reduceReachability(state, { type: 'checking' }))
     if (monitor) return monitor.check()
     if (standaloneCheck) return standaloneCheck


### PR DESCRIPTION
## Summary
- re-arm the shell paint handoff after browser suspension or page restoration
- replace suspended reachability probes with fresh foreground checks
- add regressions for hidden-tab and restored-page lifecycle paths

## Testing
- `node --test frontend/src/components/Shell/__tests__/scheduleAfterBrowserPaint.test.js frontend/src/lib/__tests__/connectivityStore.test.js`
- `npm run lint`
- `npm run build`