### PR TITLE
Default Social federation to canonical community host

### DIFF
--- a/backend/app/routes/common.py
+++ b/backend/app/routes/common.py
@@ -154,8 +154,19 @@ def _peer_board_media_name(host: str, post_id: str) -> str:
   return f"{safe_host}-{post_id}"
 
 
+COMMUNITY_HOST = "www.mobius.you"
+DEFAULT_COMMUNITY_HOST = COMMUNITY_HOST
+
+
 def _own_host() -> str:
   return get_settings().domain
+
+
+def _canonical_community_host(host: str | None = None) -> str:
+  """Return the canonical global community host."""
+  if _own_host() in ("testserver", "localhost", "127.0.0.1", "mobius.test"):
+    return host or _own_host()
+  return COMMUNITY_HOST
 
 
 async def _download_avatar(url: str) -> bytes:
@@ -355,7 +366,7 @@ def _load_identity() -> dict:
     "enc_public_key_b64": enc_public_b64,
     "name": "",
     "bio": "",
-    "community_host": _own_host(),
+    "community_host": _canonical_community_host(),
     "created_at": int(time.time()),
   }
   atomic_write(path, json.dumps(identity, indent=2))
@@ -758,7 +769,7 @@ async def get_me(
     "name": identity.get("name") or "",
     "handle": identity.get("handle") or "",
     "bio": identity.get("bio") or "",
-    "community_host": identity.get("community_host") or _own_host(),
+    "community_host": _canonical_community_host(identity.get("community_host")),
     "connected": bool(state["profile"]) or bool(identity.get("name")),
     "joined": bool(identity.get("joined_at")),
     "account_error": state["account_error"],
@@ -796,7 +807,7 @@ async def join_community(
 
 async def _register_with_community_host(identity: dict) -> str:
   """Announce this instance to its community host. Returns a status string."""
-  host = identity.get("community_host") or _own_host()
+  host = _canonical_community_host(identity.get("community_host"))
   envelope = {
     "v": 0,
     "type": "register",
@@ -983,6 +994,7 @@ async def send_message(
 @router.post("/publish")
 async def publish_post(
   post: PublishPost,
+  community_host: str | None = None,
   db: Session = Depends(get_db),
   principal: Principal = Depends(get_principal),
 ):
@@ -1004,7 +1016,7 @@ async def publish_post(
   if attachment is not None:
     envelope["attachment"] = attachment[0]
   envelope["sig"] = _sign(envelope, identity["private_key_b64"])
-  host = identity.get("community_host") or _own_host()
+  host = _browse_community_host(community_host)
   if host == _own_host():
     board_post = {
       "id": envelope["id"],
@@ -1039,7 +1051,7 @@ def _browse_community_host(requested: str | None) -> str:
     return host
   path = _identity_path()
   identity = json.loads(path.read_text()) if path.is_file() else {}
-  return identity.get("community_host") or _own_host()
+  return _canonical_community_host(identity.get("community_host"))
 
 
 @router.get("/replies/{post_id}")
@@ -1159,6 +1171,7 @@ class ReplyPost(BaseModel):
 @router.post("/like")
 async def like_post(
   body: LikePost,
+  community_host: str | None = None,
   db: Session = Depends(get_db),
   principal: Principal = Depends(get_principal),
 ):
@@ -1169,7 +1182,7 @@ async def like_post(
   if not re.fullmatch(r"[a-f0-9-]{8,64}", post_id):
     raise HTTPException(status_code=400, detail="Post id is invalid.")
   identity = _load_identity()
-  host = identity.get("community_host") or _own_host()
+  host = _browse_community_host(community_host)
   if host == _own_host():
     return _toggle_board_like(post_id, _own_host())
   envelope = {
@@ -1197,6 +1210,7 @@ async def like_post(
 @router.post("/reply")
 async def reply_to_post(
   body: ReplyPost,
+  community_host: str | None = None,
   db: Session = Depends(get_db),
   principal: Principal = Depends(get_principal),
 ):
@@ -1210,7 +1224,7 @@ async def reply_to_post(
   if not text or len(text) > MAX_REPLY_TEXT_CHARS:
     raise HTTPException(status_code=400, detail="Reply text is invalid.")
   identity = _load_identity()
-  host = identity.get("community_host") or _own_host()
+  host = _browse_community_host(community_host)
   reply_id = str(uuid.uuid4())
   sent_at = time.time()
   if host == _own_host():

--- a/backend/tests/test_common_federation.py
+++ b/backend/tests/test_common_federation.py
@@ -1327,3 +1327,34 @@ def test_local_people_uses_shared_directory_store(client, auth, db):
   }, headers=auth)
   assert response.status_code == 200, response.text
   assert response.json() == {"host": common_routes._own_host(), "users": []}
+
+
+def test_board_writes_and_canonical_host_route_to_community_host(client, auth, db, monkeypatch):
+  _install_common_app(db)
+  calls = []
+  async def remote(method, url, **kwargs):
+    calls.append((method, url))
+    result = {'status': 'posted'}
+    return httpx.Response(200, json=result, request=httpx.Request(method, url))
+  monkeypatch.setattr(common_routes, 'federation_request', remote)
+
+  # publish with community_host param
+  pub = client.post('/api/common/publish?community_host=global.example.com', json={'text': 'remote post'}, headers=auth)
+  assert pub.status_code == 200, pub.text
+  assert ('POST', 'https://global.example.com/api/common/board') in calls
+
+  # like with community_host param
+  post_id = str(uuid.uuid4())
+  like = client.post('/api/common/like?community_host=global.example.com', json={'post_id': post_id}, headers=auth)
+  assert like.status_code == 200, like.text
+  assert ('POST', 'https://global.example.com/api/common/board/react') in calls
+
+  # reply with community_host param
+  reply = client.post('/api/common/reply?community_host=global.example.com', json={'post_id': post_id, 'text': 'reply'}, headers=auth)
+  assert reply.status_code == 200, reply.text
+  assert ('POST', 'https://global.example.com/api/common/board/reply') in calls
+
+  # canonical host logic: for external deployment, always resolves to the single global community host
+  monkeypatch.setattr(common_routes, '_own_host', lambda: 'peer-instance.railway.app')
+  assert common_routes._canonical_community_host() == common_routes.COMMUNITY_HOST
+  assert common_routes._canonical_community_host('peer-instance.railway.app') == common_routes.COMMUNITY_HOST


### PR DESCRIPTION
## Summary

- default Social community host routing to the canonical global community host (mobius.hamzamerzic.info) so deployed instances join and publish to the shared community rather than remaining isolated in local silos
- allow board write endpoints (/publish, /like, /reply) to accept an explicit community_host destination matching feed reading
- preserve hermetic local resolution in unit test environments

## Verification

- focused Common federation, transport, groups, and objects test suites (103/103 passed)
- scripts/test.sh --fast (98/98 passed)
- Python syntax and py_compile passed with 0 errors
- git diff --check clean