### PR TITLE
Avoid broker requests before an account is linked

### DIFF
--- a/backend/app/providers.py
+++ b/backend/app/providers.py
@@ -1659,6 +1659,14 @@ async def _fetch_provider_models(
   if provider_id == "codex":
     return await _fetch_codex_models(data_dir)
   if provider_id == "mobius":
+    # An unlinked Möbius account has no broker model capability. Probing the
+    # protected inference route anyway turns that expected state into a noisy
+    # 401 every time the registry cache expires. Ask the provider's owning
+    # identity check first and serve the same curated fallback without making
+    # an unauthorized request; once linked, the broker remains the live source.
+    mobius = PROVIDERS["mobius"]
+    if await asyncio.to_thread(mobius.check_auth, data_dir) is not None:
+      return _fallback_models("mobius")
     import httpx
     async with httpx.AsyncClient(timeout=5.0) as client:
       response = await client.get("http://127.0.0.1:8765/v1/models")

--- a/backend/tests/test_model_registry.py
+++ b/backend/tests/test_model_registry.py
@@ -156,6 +156,28 @@ def test_mobius_effort_scale_uses_the_public_product_model():
   ]
 
 
+@pytest.mark.asyncio
+async def test_unlinked_mobius_registry_skips_protected_broker_request(
+  tmp_path, monkeypatch,
+):
+  """Disconnected identity is expected state, not a broker 401 failure."""
+  monkeypatch.setattr(
+    providers.MobiusProvider,
+    "check_auth",
+    lambda self, _data_dir: "not linked",
+  )
+
+  class ForbiddenClient:
+    def __init__(self, *args, **kwargs):
+      raise AssertionError("unlinked model discovery must not call the broker")
+
+  monkeypatch.setattr(httpx, "AsyncClient", ForbiddenClient)
+
+  rows = await providers._fetch_provider_models("mobius", str(tmp_path))
+  assert [row["id"] for row in rows] == providers.KNOWN_MODELS["mobius"]
+  assert [row["label"] for row in rows] == ["Spark", "Evolve"]
+
+
 # --- Expired-token refresh (the 401 root cause) -----------------------
 
 


### PR DESCRIPTION
## Summary

An unlinked account uses the available model list without repeatedly making unauthorized requests.

## Verification

- `scripts/wt-pytest.sh backend/tests/test_model_registry.py -q`
