### PR TITLE
Reconcile lifecycle snapshots during startup recovery

### DIFF
--- a/backend/app/agent_lifecycle.py
+++ b/backend/app/agent_lifecycle.py
@@ -21,6 +21,7 @@ import hashlib
 from datetime import UTC, datetime
 from typing import Any
 
+from sqlalchemy import func
 from sqlalchemy.exc import IntegrityError
 
 from app import models
@@ -268,3 +269,54 @@ def record_event(db, values: dict[str, Any]) -> bool:
         return False
     raise exc
   return True
+
+
+def reconcile_run_updates(db) -> int:
+  """Append current ChatRun snapshots missing from the lifecycle cursor.
+
+  The cursor is intentionally append-only. Older startup recovery used SQL
+  ``UPDATE`` statements, which bypass SQLAlchemy's mapper listener and left a
+  handful of terminal runs represented forever by their earlier ``running``
+  snapshot. Repair those historical gaps without rewriting either history;
+  the newest appended snapshot becomes the authoritative projection.
+  """
+  update = models.AgentLifecycleRunUpdate
+  latest = (
+    db.query(
+      update.chat_run_id.label("chat_run_id"),
+      func.max(update.id).label("update_id"),
+    )
+    .group_by(update.chat_run_id)
+    .subquery()
+  )
+  rows = (
+    db.query(models.ChatRun, update)
+    .outerjoin(latest, latest.c.chat_run_id == models.ChatRun.id)
+    .outerjoin(update, update.id == latest.c.update_id)
+    .all()
+  )
+  stale = [
+    run for run, snapshot in rows
+    if (
+      snapshot is None
+      or snapshot.chat_id != run.chat_id
+      or snapshot.provider != run.provider
+      or snapshot.status != run.status
+      or snapshot.started_at != run.started_at
+      or snapshot.ended_at != run.ended_at
+    )
+  ]
+  observed_at = now_naive_utc()
+  for run in stale:
+    db.add(update(
+      chat_id=run.chat_id,
+      chat_run_id=run.id,
+      provider=run.provider,
+      status=run.status,
+      started_at=run.started_at,
+      ended_at=run.ended_at,
+      observed_at=observed_at,
+    ))
+  if stale:
+    db.commit()
+  return len(stale)

--- a/backend/app/chat_writer.py
+++ b/backend/app/chat_writer.py
@@ -3153,19 +3153,18 @@ class ChatWriterActor:
       if run_id != cmd.restart_run_id
     )
     if interrupted_ids:
-      db.execute(
-        update(ChatRun)
-        .where(
+      interrupted_runs = db.query(ChatRun).filter(
           ChatRun.chat_id == cmd.chat_id,
           ChatRun.id.in_(interrupted_ids),
           ChatRun.status == "running",
-        )
-        .values(
-          status="interrupted",
-          ended_at=cmd.recovered_at,
-          restart_nonce=None,
-        )
-      )
+      ).all()
+      for run in interrupted_runs:
+        # Mapper-owned assignment keeps the append-only lifecycle cursor in
+        # the same transaction as startup recovery. A Core UPDATE bypassed
+        # that listener and stranded the last projection at ``running``.
+        run.status = "interrupted"
+        run.ended_at = cmd.recovered_at
+        run.restart_nonce = None
       from app.chat_failure_activity import mark_failed
       mark_failed(
         db,
@@ -3174,20 +3173,16 @@ class ChatWriterActor:
         failed_at=cmd.recovered_at,
       )
     if cmd.restart_run_id:
-      db.execute(
-        update(ChatRun)
-        .where(
+      restart_run = db.query(ChatRun).filter(
           ChatRun.chat_id == cmd.chat_id,
           ChatRun.id == cmd.restart_run_id,
           ChatRun.status == "running",
-        )
-        .values(
-          status="parked",
-          parked_until=cmd.recovered_at,
-          park_reason="restart",
-          # Preserve restart_nonce: the reset sweep authenticates it again.
-        )
-      )
+      ).first()
+      if restart_run is not None:
+        restart_run.status = "parked"
+        restart_run.parked_until = cmd.recovered_at
+        restart_run.park_reason = "restart"
+        # Preserve restart_nonce: the reset sweep authenticates it again.
     if not _commit_or_rollback(db):
       raise _PersistFailed("ReconcileStartupChat did not persist")
     return True

--- a/backend/app/startup.py
+++ b/backend/app/startup.py
@@ -311,6 +311,17 @@ def _reconcile_startup_chats(context: StartupContext) -> None:
     raise
 
 
+def _reconcile_agent_lifecycle(context: StartupContext) -> None:
+  from app.agent_lifecycle import reconcile_run_updates
+
+  with SessionLocal() as db:
+    repaired = reconcile_run_updates(db)
+  if repaired:
+    context.logger.info(
+      "repaired %d stale agent lifecycle run projection(s)", repaired,
+    )
+
+
 def _reap_staging_bundles(_context: StartupContext) -> None:
   from app.compiler import reap_staging_bundles
 
@@ -565,6 +576,7 @@ DATABASE_STARTUP_TASKS = (
     _reconcile_startup_chats,
     checkpoint="startup_state_reconciled",
   ),
+  StartupTask("reconcile agent lifecycle", _reconcile_agent_lifecycle),
   StartupTask("reap staging bundles", _reap_staging_bundles),
   StartupTask(
     "reconcile compiled bundles",

--- a/backend/tests/test_agent_lifecycle.py
+++ b/backend/tests/test_agent_lifecycle.py
@@ -5,12 +5,16 @@ from concurrent.futures import Future
 from datetime import datetime, timedelta
 
 import pytest
-from sqlalchemy import text
+from sqlalchemy import text, update
 from sqlalchemy.exc import IntegrityError
 
 from app import models
 from app import chat_event_sink
-from app.agent_lifecycle import normalize_chat_event, record_event
+from app.agent_lifecycle import (
+  normalize_chat_event,
+  reconcile_run_updates,
+  record_event,
+)
 from app.chat_event_sink import ChatEventSink
 from test_app_fixtures import create_local_app
 from app.memory_recall import EMPTY_RECALL_BINDING
@@ -221,6 +225,30 @@ def test_sqlite_run_update_cursor_is_never_reused_after_tail_delete(db):
   run.ended_at = datetime(2026, 7, 22, 10, 2, 0)
   db.commit()
   assert db.query(models.AgentLifecycleRunUpdate.id).scalar() > first_id
+
+
+def test_reconcile_run_updates_appends_terminal_snapshot_after_core_update(db):
+  _, run = _chat_run(db)
+  ended_at = datetime(2026, 7, 22, 10, 2, 0)
+  db.execute(
+    update(models.ChatRun)
+    .where(models.ChatRun.id == run.id)
+    .values(status="interrupted", ended_at=ended_at)
+  )
+  db.commit()
+  latest_before = db.query(models.AgentLifecycleRunUpdate).order_by(
+    models.AgentLifecycleRunUpdate.id.desc()
+  ).first()
+  assert latest_before.status == "running"
+
+  assert reconcile_run_updates(db) == 1
+  latest_after = db.query(models.AgentLifecycleRunUpdate).order_by(
+    models.AgentLifecycleRunUpdate.id.desc()
+  ).first()
+  assert latest_after.id > latest_before.id
+  assert latest_after.status == "interrupted"
+  assert latest_after.ended_at == ended_at
+  assert reconcile_run_updates(db) == 0
 
 
 def test_chat_run_delete_emits_tombstone_with_foreign_keys_enabled(db):

--- a/backend/tests/test_chat_runs.py
+++ b/backend/tests/test_chat_runs.py
@@ -675,6 +675,14 @@ def test_startup_reconciliation_marks_unplanned_loss_but_not_planned_restart():
     recovered_at=recovered_at,
   )).result(timeout=5)
   assert _runs("r6-unplanned")["rt-unplanned"] == ("interrupted", True)
+  db = SessionLocal()
+  try:
+    latest = db.query(models.AgentLifecycleRunUpdate).filter_by(
+      chat_run_id="rt-unplanned",
+    ).order_by(models.AgentLifecycleRunUpdate.id.desc()).first()
+    assert latest.status == "interrupted"
+  finally:
+    db.close()
   assert _failure_activity("r6-unplanned") == {
     "run_id": "rt-unplanned",
     "version": 1,
@@ -693,6 +701,14 @@ def test_startup_reconciliation_marks_unplanned_loss_but_not_planned_restart():
     recovered_at=recovered_at,
   )).result(timeout=5)
   assert _runs("r6-restart")["rt-restart"] == ("parked", False)
+  db = SessionLocal()
+  try:
+    latest = db.query(models.AgentLifecycleRunUpdate).filter_by(
+      chat_run_id="rt-restart",
+    ).order_by(models.AgentLifecycleRunUpdate.id.desc()).first()
+    assert latest.status == "parked"
+  finally:
+    db.close()
   assert _failure_activity("r6-restart") is None
 
 


### PR DESCRIPTION
## Summary

Interrupted and restarting runs stop appearing active after their durable status has changed.

## Verification

- `scripts/wt-pytest.sh backend/tests/test_agent_lifecycle.py backend/tests/test_chat_runs.py -q`
