### PR TITLE
Identify Connect runner HTTP requests

### DIFF
--- a/backend/app/connect_runner.py
+++ b/backend/app/connect_runner.py
@@ -43,6 +43,10 @@ LAUNCHD_LABEL = "sh.mobius.connect"
 LAUNCHD_PLIST = os.path.expanduser("~/Library/LaunchAgents/%s.plist" % LAUNCHD_LABEL)
 SYSTEMD_UNIT = os.path.expanduser("~/.config/systemd/user/mobius-connect.service")
 RUNNER_PROTOCOL_VERSION = 4
+RUNNER_USER_AGENT = (
+    "mobius-connect/%s (+https://github.com/mobius-os/mobius)"
+    % RUNNER_PROTOCOL_VERSION
+)
 _POWERSHELL_STDIN_BOOTSTRAP = (
     "$encoded=[Console]::In.ReadToEnd();"
     "$script=[Text.Encoding]::UTF8.GetString("
@@ -100,6 +104,14 @@ class _NoRedirect(urllib.request.HTTPRedirectHandler):
 
 
 def _open_url(request, *, timeout, context=None):
+    # urllib otherwise identifies itself as Python-urllib/<version>, which
+    # browser-integrity filters commonly reject.  Keep every Connect request
+    # identifiable at this one transport boundary, including the self-update
+    # path that supplies a URL string rather than a pre-built Request.
+    if not isinstance(request, urllib.request.Request):
+        request = urllib.request.Request(request)
+    if not request.has_header("User-agent"):
+        request.add_header("User-Agent", RUNNER_USER_AGENT)
     handlers = [_NoRedirect()]
     if context is not None:
         handlers.append(urllib.request.HTTPSHandler(context=context))

--- a/backend/tests/test_connect.py
+++ b/backend/tests/test_connect.py
@@ -1732,6 +1732,40 @@ def test_connect_runner_rejects_urls_that_can_leak_or_redirect_credentials(url):
     connect_runner._validated_base_url(url)
 
 
+def test_connect_runner_identifies_every_urllib_request(monkeypatch):
+  opened = []
+
+  class Opener:
+    def open(self, request, timeout):
+      opened.append((request, timeout))
+      return object()
+
+  monkeypatch.setattr(
+    connect_runner.urllib.request,
+    "build_opener",
+    lambda *_handlers: Opener(),
+  )
+
+  connect_runner._open_url(
+    "https://mobius.example/api/connect/runner",
+    timeout=30,
+  )
+  explicit = connect_runner.urllib.request.Request(
+    "https://mobius.example/api/connect/pair",
+    headers={"User-Agent": "connect-test/1"},
+  )
+  connect_runner._open_url(explicit, timeout=15)
+
+  generated, generated_timeout = opened[0]
+  assert isinstance(generated, connect_runner.urllib.request.Request)
+  assert generated.get_header("User-agent") == (
+    "mobius-connect/4 (+https://github.com/mobius-os/mobius)"
+  )
+  assert generated_timeout == 30
+  assert opened[1][0].get_header("User-agent") == "connect-test/1"
+  assert opened[1][1] == 15
+
+
 def test_connect_runner_never_redirects_an_authenticated_request():
   request = connect_runner.urllib.request.Request(
     "https://mobius.example/api/connect/result",


### PR DESCRIPTION
## Summary

Connect requests identify themselves consistently without changing authentication or redirect protections.

## Verification

- `scripts/wt-pytest.sh backend/tests/test_connect.py -q`
