### PR TITLE
Preserve explicit effort for app-owned chats

### DIFF
--- a/backend/app/routes/chats.py
+++ b/backend/app/routes/chats.py
@@ -2749,6 +2749,7 @@ class AppChatCreate(BaseModel):
   title: str | None = None
   system_prompt: str | None = Field(default=None, max_length=20000)
   model: str | None = Field(default=None, max_length=256)
+  effort: schemas.AgentEffort | None = None
   provider: str | None = None
   report_date: str | None = None
   report_kind: str | None = Field(default=None, max_length=64)
@@ -2813,6 +2814,7 @@ class AppChatStart(AppChatCreate):
 class AppChatPatch(BaseModel):
   system_prompt: str | None = Field(default=None, max_length=20000)
   model: str | None = Field(default=None, max_length=256)
+  effort: schemas.AgentEffort | None = None
   provider: str | None = None
   scope: str | None = Field(default=None, max_length=_CHAT_SCOPE_MAX)
   scope_label: str | None = Field(default=None, max_length=_CHAT_SCOPE_LABEL_MAX)
@@ -2835,6 +2837,7 @@ def _merge_app_chat_settings(
   *,
   system_prompt: str | None = None,
   model: str | None = None,
+  effort: schemas.AgentEffort | None = None,
   report_date: str | None = None,
   report_kind: str | None = None,
   project_id: str | None = None,
@@ -2858,6 +2861,8 @@ def _merge_app_chat_settings(
       settings["model"] = value
     else:
       raise ValueError("A chat model cannot be cleared.")
+  if effort is not None:
+    settings["effort"] = effort
   # report_date is already ISO-validated by AppChatCreate; chat.py reads it
   # on the first turn to inject the brief this chat is about. report_kind is
   # a free-form tag (e.g. "reflection") that travels alongside it.
@@ -2942,6 +2947,8 @@ def _app_chat_summary(chat: models.Chat, usage: dict) -> dict:
     "provider": chat.provider or "claude",
     "scope": _app_chat_scope(chat),
     "scope_label": _app_chat_scope_label(chat),
+    "model": _coerce_agent_settings(chat.agent_settings_json).get("model"),
+    "effort": _coerce_agent_settings(chat.agent_settings_json).get("effort"),
     "usage": usage,
   }
 
@@ -3094,6 +3101,7 @@ def create_app_chat(
     chat,
     system_prompt=body.system_prompt,
     model=agent_settings["model"],
+    effort=body.effort,
     report_date=body.report_date,
     report_kind=body.report_kind,
     project_id=body.project_id,
@@ -3319,6 +3327,7 @@ async def patch_app_chat(
       chat,
       system_prompt=body.system_prompt,
       model=body.model,
+      effort=body.effort,
       scope=body.scope,
       scope_label=body.scope_label,
     )

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -591,6 +591,13 @@ class ChatStopRequest(BaseModel):
   chat_id: str = ""
 
 
+# One effort vocabulary for owner and app-attributed chat configuration.
+AgentEffort = Literal[
+  "none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra",
+  "ultracode",
+]
+
+
 class AgentSettingsOverride(BaseModel):
   """Per-chat agent settings override. Unknown fields are rejected
   (422) so a typo'd or experimental key can't silently land in the
@@ -619,10 +626,7 @@ class AgentSettingsOverride(BaseModel):
   # non-Opus Claude) surfaces as a 400 at turn time, not at PATCH.
   # Acceptable per the platform's "reversibility over prevention"
   # philosophy.
-  effort: Literal[
-    "none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra",
-    "ultracode",
-  ] | None = None
+  effort: AgentEffort | None = None
   # Per-provider memory of the last-picked effort. The enums are
   # NOT comparable across providers — Codex `medium` is roughly
   # Claude `low`, not Claude `medium` — so the picker has to

--- a/backend/tests/test_app_chat_effort.py
+++ b/backend/tests/test_app_chat_effort.py
@@ -1,7 +1,8 @@
 """Explicit app chat effort uses the normal per-chat setting, never a global default."""
 import pytest
 
-from app import models
+from app import models, providers
+from app.config import get_settings
 from app.routes.chats import AppChatStart
 from test_app_fixtures import create_local_app
 
@@ -39,7 +40,10 @@ def test_app_chat_effort_create_patch_list_and_isolation(client, owner_token, db
   assert changed.json()["agent_settings_json"]["system_prompt"] == "App bootstrap"
   other = client.post("/api/app-chats", headers=auth, json={"provider": "codex", "model": "gpt-6-astra"})
   assert other.status_code == 201
-  assert "effort" not in db.get(models.Chat, other.json()["id"]).agent_settings_json
+  default_settings = providers.snapshot_chat_agent_settings(
+    get_settings().data_dir, "codex", model="gpt-6-astra",
+  )
+  assert db.get(models.Chat, other.json()["id"]).agent_settings_json == default_settings
   # Effort support must not weaken app attribution.
   _, other_token = _make_app(client, owner_token, "different-app")
   denied = client.patch(f"/api/app-chats/{cid}", headers={"Authorization": f"Bearer {other_token}"}, json={"effort": "low"})

--- a/backend/tests/test_app_chat_effort.py
+++ b/backend/tests/test_app_chat_effort.py
@@ -1,0 +1,61 @@
+"""Explicit app chat effort uses the normal per-chat setting, never a global default."""
+import pytest
+
+from app import models
+from app.routes.chats import AppChatStart
+from test_app_fixtures import create_local_app
+
+
+def _make_app(client, owner_token, name):
+  auth = {"Authorization": f"Bearer {owner_token}"}
+  app_id = create_local_app(client, auth, name=name)["id"]
+  token = client.post("/api/auth/app-token", json={"app_id": app_id}, headers=auth).json()["token"]
+  return app_id, token
+
+
+def test_app_chat_effort_create_patch_list_and_isolation(client, owner_token, db):
+  app_id, token = _make_app(client, owner_token, "effort-owner")
+  auth = {"Authorization": f"Bearer {token}"}
+  created = client.post("/api/app-chats", headers=auth, json={
+    "provider": "codex", "model": "gpt-6-astra", "effort": "xhigh",
+    "scope": "assistant", "system_prompt": "App bootstrap",
+  })
+  assert created.status_code == 201, created.text
+  cid = created.json()["id"]
+  row = db.get(models.Chat, cid)
+  assert row.agent_settings_json["effort"] == "xhigh"
+  assert row.agent_settings_json["model"] == "gpt-6-astra"
+  listed = client.get("/api/app-chats?scope=assistant", headers=auth).json()
+  assert listed[0]["id"] == cid
+  assert listed[0]["effort"] == "xhigh"
+  assert listed[0]["model"] == "gpt-6-astra"
+  # An ordinary metadata update must not clear explicit effort.
+  assert client.patch(f"/api/app-chats/{cid}", headers=auth, json={"scope_label": "Assistant"}).status_code == 200
+  db.refresh(row)
+  assert row.agent_settings_json["effort"] == "xhigh"
+  changed = client.patch(f"/api/app-chats/{cid}", headers=auth, json={"effort": "high"})
+  assert changed.status_code == 200, changed.text
+  assert changed.json()["agent_settings_json"]["effort"] == "high"
+  assert changed.json()["agent_settings_json"]["system_prompt"] == "App bootstrap"
+  other = client.post("/api/app-chats", headers=auth, json={"provider": "codex", "model": "gpt-6-astra"})
+  assert other.status_code == 201
+  assert "effort" not in db.get(models.Chat, other.json()["id"]).agent_settings_json
+  # Effort support must not weaken app attribution.
+  _, other_token = _make_app(client, owner_token, "different-app")
+  denied = client.patch(f"/api/app-chats/{cid}", headers={"Authorization": f"Bearer {other_token}"}, json={"effort": "low"})
+  assert denied.status_code in (403, 404)
+  db.refresh(row)
+  assert row.agent_settings_json["effort"] == "high"
+
+
+@pytest.mark.parametrize("effort", ["extra high", "bogus", 42, {}])
+def test_app_chat_rejects_unknown_effort(client, owner_token, effort):
+  _, token = _make_app(client, owner_token, "invalid-effort")
+  auth = {"Authorization": f"Bearer {token}"}
+  r = client.post("/api/app-chats", headers=auth, json={"effort": effort})
+  assert r.status_code == 422
+
+
+def test_scoped_start_carries_the_same_effort_contract():
+  value = AppChatStart(content="hello", scope="assistant", provider="codex", model="gpt-6-astra", effort="xhigh")
+  assert value.model_dump()["effort"] == "xhigh"


### PR DESCRIPTION
## Summary

Apps can choose and retain the effort used for their own chats without changing other chats.

## Verification

- `scripts/wt-pytest.sh backend/tests/test_app_chat_effort.py backend/tests/test_app_chat_contract.py -q`
