### PR TITLE
Resume Autopilot after reviewed blocker resolution

### DIFF
--- a/backend/app/contribution_autopilot.py
+++ b/backend/app/contribution_autopilot.py
@@ -14,7 +14,8 @@ The lifecycle, per (app_id, record_id):
   agent  ─▶  /update (validated push) / /reply ─▶ /complete ─▶ idle, round logged
   crash   ─▶  lease expires ─▶ next retry marks it stale and reclaims it
   2 consecutive stale/failed rounds, or five-round limit reached ─▶ escalate
-  escalate ─▶ human_required attention + owner notification, claim released
+  escalate ─▶ blocked + human_required warning, claim revoked but grant retained
+  fresh reviewed repair + cleared warning ─▶ recovery returns the grant to idle
   merged / closed ─▶ close_out, autopilot ends
 
 Round identity is the ``run_id`` (a fresh uuid per claim): every agent-called
@@ -120,6 +121,10 @@ def stamp_grant(
     )
     db.add(row)
   else:
+    if row.state == "blocked":
+      _release_claim(row)
+      row.rounds_used = 0
+      row.consecutive_failures = 0
     row.enabled = True
     row.granted_at = now
     row.granted_head_sha = head_sha
@@ -165,6 +170,7 @@ def _lease_expired(row: models.ContributionAutopilot) -> bool:
 
 def _release_claim(row: models.ContributionAutopilot) -> None:
   row.state = "idle"
+  row.blocked_at = None
   row.run_id = None
   row.attention_key = None
   row.claimed_event_at = None
@@ -207,6 +213,7 @@ def _claim_match(
 def _release_values() -> dict:
   return {
     "state": "idle",
+    "blocked_at": None,
     "run_id": None,
     "attention_key": None,
     "claimed_event_at": None,
@@ -309,6 +316,7 @@ def claim_for_round(
   Returns a verdict dict with a ``status`` of:
     - ``"granted"`` (+ ``run_id``, ``row``): claim taken, caller may spawn.
     - ``"not_granted"``: no active grant (no row / paused) — classic flow.
+    - ``"blocked"``: an escalation still awaits a reviewed resolution.
     - ``"duplicate"``: this attention was already handled or is in flight.
     - ``"busy"``: a live (non-expired) round holds the claim.
     - ``"escalate"`` (+ ``reason``): five-round limit reached — caller escalates.
@@ -322,6 +330,8 @@ def claim_for_round(
     row = get_row(db, app_id, record_id)
     if row is None or not row.enabled:
       return {"status": "not_granted"}
+    if row.state == "blocked":
+      return {"status": "blocked"}
     if row.last_handled_attention_key == attention_key:
       return {"status": "duplicate"}
     if (
@@ -612,6 +622,7 @@ def set_enabled(
     return None
   row.enabled = bool(enabled)
   if enabled:
+    _release_claim(row)
     row.rounds_used = 0
     row.consecutive_failures = 0
   else:
@@ -641,26 +652,37 @@ def close_out(db: Session, app_id: int, record_id: str) -> None:
 
 
 def escalate(db: Session, app_id: int, record_id: str) -> bool:
-  """Atomically pause on escalation; True only for the winning notifier."""
+  """Block this grant without changing the owner's on/off choice."""
+  row = get_row(db, app_id, record_id)
+  if row is None:
+    return False
+  now = now_naive_utc()
   result = db.execute(
     update(models.ContributionAutopilot)
     .where(
       models.ContributionAutopilot.app_id == app_id,
       models.ContributionAutopilot.record_id == record_id,
       models.ContributionAutopilot.enabled.is_(True),
+      models.ContributionAutopilot.state != "blocked",
+      models.ContributionAutopilot.updated_at == row.updated_at,
     )
-    .values(
+    .values({
       **_release_values(),
-      enabled=False,
-      consecutive_failures=0,
-      updated_at=now_naive_utc(),
-    )
+      # Keep the exact interrupted event so recovery can settle it without
+      # replaying the same warning. Its run_id is still irrevocably released.
+      "attention_key": row.attention_key,
+      "claimed_event_at": row.claimed_event_at,
+      "state": "blocked",
+      "blocked_at": now,
+      "consecutive_failures": 0,
+      "updated_at": now,
+    })
   )
   won = result.rowcount == 1
   if won:
     # The one moment an autopilot chat needs the owner: surface it in the drawer.
     # Staged into THIS transaction on purpose. The UPDATE above is gated on
-    # ``enabled.is_(True)``, so it wins exactly once and no retry can ever
+    # ``state != blocked``, so it wins exactly once and no retry can ever
     # re-run it; surfacing the chat in a second transaction would let a crash or
     # a locked commit in between leave the record escalated but the chat hidden,
     # with nothing able to repair it.

--- a/backend/app/contribution_autopilot_recovery.py
+++ b/backend/app/contribution_autopilot_recovery.py
@@ -1,0 +1,150 @@
+"""Release reviewed Autopilot blockers under an unchanged owner grant.
+
+The private review record supplies a repair signal, never consent: only an
+enabled, platform-blocked grant can recover. Explicit and legacy disabled
+grants remain disabled. Recovery does not push a private update, retarget a
+grant, or bypass the live PR checks on subsequent public actions.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy import exists, update
+
+from app import contribution_autopilot as autopilot, fs_locks, models
+from app.contribution_records import read_record, record_paths, write_record
+from app.database import SessionLocal
+from app.timeutil import now_naive_utc
+
+log = logging.getLogger(__name__)
+
+
+def _has_reviewed_resolution(row: models.ContributionAutopilot, record: dict) -> bool:
+  """Require a fresh, exact published-head review, not just a dismissed alert."""
+  if (
+    record.get("id") != row.record_id
+    or record.get("repo") != row.target_repo
+    or record.get("type") != "pr"
+    or record.get("status") not in {"open", "draft"}
+    or record.get("needs_attention")
+    or record.get("attention")
+    or row.blocked_at is None
+  ):
+    return False
+  plan = record.get("plan")
+  review = record.get("quality_review")
+  if not isinstance(plan, dict) or not isinstance(review, dict):
+    return False
+  expected = (
+    row.target_repo, row.target_pr_number, row.target_head_repository,
+    row.target_branch, row.target_repo_path,
+  )
+  actual = (
+    plan.get("repo") or record.get("repo"), record.get("number"),
+    record.get("head_repository") or plan.get("head_repository"),
+    plan.get("branch") or record.get("branch"), plan.get("repo_path"),
+  )
+  if any(value in (None, "") for value in expected) or actual != expected:
+    return False
+  reviewed_head = review.get("reviewed_head_sha")
+  if (
+    review.get("state") != "all_clear"
+    or not row.granted_head_sha
+    or not reviewed_head
+    # The publisher may normalize attribution without changing the reviewed
+    # diff. Keep the same public-head equivalence as _personal_ready_target;
+    # the DB grant, not this marker, still pins the actual published head.
+    or reviewed_head not in {
+      row.granted_head_sha, plan.get("attribution_normalized_from"),
+    }
+    or plan.get("head_sha") != row.granted_head_sha
+  ):
+    return False
+  try:
+    reviewed_at = datetime.fromisoformat(
+      str(review.get("reviewed_at") or "").replace("Z", "+00:00")
+    )
+  except ValueError:
+    return False
+  if reviewed_at.tzinfo is None:
+    reviewed_at = reviewed_at.replace(tzinfo=UTC)
+  reviewed_at = reviewed_at.astimezone(UTC).replace(tzinfo=None)
+  return row.blocked_at <= reviewed_at <= now_naive_utc() + timedelta(minutes=5)
+
+
+def _recover_one(app_id: int, record_id: str) -> bool:
+  """Called in a worker while the app's record lock is held."""
+  with SessionLocal() as db:
+    row = autopilot.get_row(db, app_id, record_id)
+    if row is None or not row.enabled or row.state != "blocked":
+      return False
+    path, _ = record_paths(app_id, record_id)
+    record = read_record(path)
+    if not _has_reviewed_resolution(row, record):
+      return False
+    chat = db.get(models.Chat, row.followup_chat_id) if row.followup_chat_id else None
+    if chat is not None and chat.pending_question_id:
+      return False
+    values = {
+      **autopilot._release_values(),
+      "rounds_used": 0,
+      "consecutive_failures": 0,
+      "updated_at": now_naive_utc(),
+    }
+    if row.attention_key:
+      values["last_handled_attention_key"] = row.attention_key
+    if row.claimed_event_at:
+      values["last_handled_event_at"] = max(
+        row.claimed_event_at, row.last_handled_event_at or "",
+      )
+    changed = db.execute(
+      update(models.ContributionAutopilot)
+      .where(
+        models.ContributionAutopilot.app_id == app_id,
+        models.ContributionAutopilot.record_id == record_id,
+        models.ContributionAutopilot.enabled.is_(True),
+        models.ContributionAutopilot.state == "blocked",
+        models.ContributionAutopilot.blocked_at == row.blocked_at,
+        models.ContributionAutopilot.granted_head_sha == row.granted_head_sha,
+        ~exists().where(
+          models.Chat.id == models.ContributionAutopilot.followup_chat_id,
+          models.Chat.pending_question_id.isnot(None),
+        ),
+      )
+      .values(**values)
+    )
+    if changed.rowcount != 1:
+      db.rollback()
+      return False
+    autopilot.stage_followup_drawer_hidden(db, row, True)
+    db.commit()
+    db.refresh(row)
+    record["autopilot"] = autopilot.mirror_block(row)
+    write_record(path, record)
+    return True
+
+
+async def recover_resolved_blocks() -> int:
+  """Join the existing recovery pass; no new timer or background agent."""
+  def blocked_records():
+    with SessionLocal() as db:
+      return db.query(
+        models.ContributionAutopilot.app_id,
+        models.ContributionAutopilot.record_id,
+      ).filter(
+        models.ContributionAutopilot.enabled.is_(True),
+        models.ContributionAutopilot.state == "blocked",
+      ).all()
+
+  recovered = 0
+  for app_id, record_id in await asyncio.to_thread(blocked_records):
+    try:
+      async with fs_locks.app_storage_lock(app_id):
+        recovered += await asyncio.to_thread(_recover_one, app_id, record_id)
+    except Exception:
+      # One missing/deleted/malformed review must not strand healthy siblings.
+      log.warning("Autopilot recovery failed for %s/%s", app_id, record_id, exc_info=True)
+  return recovered

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1960,8 +1960,11 @@ class ContributionAutopilot(Base):
   target_head_repository = Column(String(256), nullable=True, default=None)
   target_branch = Column(String(256), nullable=True, default=None)
   target_repo_path = Column(String(1024), nullable=True, default=None)
-  # "idle" between rounds; "responding" while a round holds the claim.
+  # "idle" between rounds; "responding" while a round holds the claim;
+  # "blocked" while an escalation awaits a reviewed repair. A blocker does
+  # not revoke owner consent; only an explicit Pause disables that grant.
   state = Column(String(16), nullable=False, default="idle")
+  blocked_at = Column(DateTime, nullable=True, default=None)
   # The live claim. run_id is a fresh uuid per round and is the round's whole
   # identity: /update, /reply, /complete, /escalate require the caller to
   # present it, so a zombie agent from a reclaimed round holds a dead id.

--- a/backend/app/routes/github.py
+++ b/backend/app/routes/github.py
@@ -5753,6 +5753,8 @@ async def autopilot_respond(
       return {"status": "not_granted"}
     if live_record.get("status") not in {"open", "draft"}:
       return {"status": "not_granted"}
+  if row.state == "blocked":
+    return {"status": "blocked"}
 
   # Use the owner's existing background-agent choice; no Contribute-specific
   # resource policy lives here.
@@ -5767,6 +5769,8 @@ async def autopilot_respond(
     raise HTTPException(status_code=409, detail=f"Round {status}.")
   if status == "not_granted":
     return {"status": "not_granted"}
+  if status == "blocked":
+    return {"status": "blocked"}
   if status == "escalate":
     await _autopilot_escalate_and_notify(
       db, app_id, record_id, owner_id,

--- a/backend/app/runtime_supervisors.py
+++ b/backend/app/runtime_supervisors.py
@@ -278,6 +278,7 @@ class RuntimeSupervisors:
 
     async def autopilot_lease_recovery_loop():
       from app.contribution_autopilot import sweep_expired_leases
+      from app.contribution_autopilot_recovery import recover_resolved_blocks
 
       def sweep_once() -> int:
         # Session creation belongs in the worker with every operation that uses
@@ -289,6 +290,7 @@ class RuntimeSupervisors:
         await asyncio.sleep(AUTOPILOT_LEASE_RECOVERY_INTERVAL_SECS)
         try:
           await asyncio.to_thread(sweep_once)
+          await recover_resolved_blocks()
         except asyncio.CancelledError:
           raise
         except Exception as exc:

--- a/backend/app/schema_migrations.py
+++ b/backend/app/schema_migrations.py
@@ -3722,6 +3722,23 @@ def _add_delegation_result_incorporation(eng):
     ))
 
 
+def _add_autopilot_blocked_at(eng):
+  """Distinguish new automatic blockers without guessing old pause intent."""
+  from sqlalchemy import inspect as sa_inspect, text
+
+  inspector = sa_inspect(eng)
+  if "contribution_autopilot" not in inspector.get_table_names():
+    return
+  columns = {
+    column["name"] for column in inspector.get_columns("contribution_autopilot")
+  }
+  if "blocked_at" not in columns:
+    with eng.begin() as conn:
+      conn.execute(text(
+        "ALTER TABLE contribution_autopilot ADD COLUMN blocked_at DATETIME NULL"
+      ))
+
+
 _SCHEMA_MIGRATIONS = (
   # Full IDs are permanent identities, not sequence positions. Append new
   # work in execution order; never renumber a shipped ID to reconcile sources.
@@ -3774,6 +3791,7 @@ _SCHEMA_MIGRATIONS = (
   ("0047_chat_activity_positions", _add_chat_activity_positions),
   ("0048_delegation_result_incorporation", _add_delegation_result_incorporation),
   ("0048_typed_platform_activation_waits", _add_typed_platform_activation_waits),
+  ("0049_autopilot_blocked_at", _add_autopilot_blocked_at),
 )
 
 

--- a/backend/tests/fixtures/migration_history.json
+++ b/backend/tests/fixtures/migration_history.json
@@ -50,6 +50,7 @@
     "0046_chat_run_activity_delivery": "d4a2ac353a1fc957385165fca65083264bd142eba9c92033b847d990586704ac",
     "0047_chat_activity_positions": "cab5468cf8eac1a0a6fb5ee2405b07cd157af9241a8e04b98ff1e042242b2b8e",
     "0048_delegation_result_incorporation": "7721d64f39e079ce89efdbe6e7ffec07b79918601a82e2c195c3ef28691562e6",
-    "0048_typed_platform_activation_waits": "527554848dd071bcc9040eb08e23373c240d79b5eae650cb5d32138b97de5c4d"
+    "0048_typed_platform_activation_waits": "527554848dd071bcc9040eb08e23373c240d79b5eae650cb5d32138b97de5c4d",
+    "0049_autopilot_blocked_at": "dac507a7c3f50b993e8d58fbea7e0277223349fe46229a2fd1d6c7d69ac3194c"
   }
 }

--- a/backend/tests/test_autopilot_recovery.py
+++ b/backend/tests/test_autopilot_recovery.py
@@ -1,0 +1,339 @@
+"""Recovery resumes an existing grant, never grants or publishes anything."""
+
+import asyncio
+from datetime import timedelta
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from app import contribution_autopilot as autopilot
+from app import contribution_autopilot_recovery as recovery
+from app import models
+from app.config import get_settings
+from app.contribution_records import read_record, record_paths, write_record
+from app.database import SessionLocal
+from app.timeutil import now_naive_utc
+
+
+HEAD = "a" * 40
+BASE = "b" * 40
+REPO = "mobius-os/app-demo"
+HEAD_REPO = "octocat/app-demo"
+BRANCH = "fix/recovery"
+PR_NUMBER = 7
+PRIOR_EVENT = "2026-07-01T00:00:00.000000Z"
+BLOCKED_EVENT = "2026-07-02T00:00:00.000000Z"
+NEXT_EVENT = "2026-07-03T00:00:00.000000Z"
+
+
+def _iso(value):
+  return value.isoformat() + "Z"
+
+
+@pytest.fixture
+def blocked(db, monkeypatch):
+  app = models.App(
+    name="Recovery test", slug="recovery-test", source_dir="recovery-test",
+    github_access=True,
+  )
+  chat = models.Chat(
+    id="autopilot-recovery-chat", title="Autopilot recovery",
+    agent_settings_json={"drawer_hidden": True},
+  )
+  db.add_all([app, chat])
+  db.commit()
+  record_id = "recoverable-pr"
+  repo_path = (
+    Path(get_settings().data_dir) / "contributions" / record_id / "repo"
+  )
+  (repo_path / ".git").mkdir(parents=True, exist_ok=True)
+  row = autopilot.stamp_grant(
+    db, app.id, record_id, head_sha=HEAD,
+    target_repo=REPO, target_pr_number=PR_NUMBER,
+    target_head_repository=HEAD_REPO, target_branch=BRANCH,
+    target_repo_path=str(repo_path.resolve()),
+  )
+  row.followup_chat_id = chat.id
+  row.rounds_used = 4
+  row.last_handled_attention_key = "prior-review"
+  row.last_handled_event_at = PRIOR_EVENT
+  row.rounds_json = [{"outcome": "handled", "summary": "Earlier review settled."}]
+  db.commit()
+  claimed = autopilot.claim_for_round(
+    db, app.id, record_id,
+    attention_key="review-needing-help", event_at=BLOCKED_EVENT,
+  )
+  assert claimed["status"] == "granted"
+  blocked_at = now_naive_utc() - timedelta(minutes=1)
+  with monkeypatch.context() as clock:
+    clock.setattr(autopilot, "now_naive_utc", lambda: blocked_at)
+    assert autopilot.escalate(db, app.id, record_id)
+  db.expire_all()
+  row = autopilot.get_row(db, app.id, record_id)
+  assert row.enabled is True and row.state == "blocked"
+  assert row.blocked_at == blocked_at
+  record = {
+    "id": record_id, "type": "pr", "status": "open", "repo": REPO,
+    "number": PR_NUMBER, "head_repository": HEAD_REPO,
+    "url": f"https://github.com/{REPO}/pull/{PR_NUMBER}",
+    "needs_attention": False, "attention": None,
+    "plan": {
+      "action": "pr", "repo": REPO, "branch": BRANCH,
+      "repo_path": str(repo_path.resolve()), "base_sha": BASE,
+      "head_sha": HEAD, "diff_sha256": "d" * 64,
+    },
+    "quality_review": {
+      "state": "all_clear", "reviewed_head_sha": HEAD,
+      "reviewed_at": _iso(blocked_at + timedelta(seconds=1)),
+    },
+  }
+  record_path, _ = record_paths(app.id, record_id)
+  write_record(record_path, record)
+  return SimpleNamespace(
+    db=db, app_id=app.id, record_id=record_id, chat_id=chat.id,
+    record_path=record_path, record=record, blocked_at=blocked_at,
+    run_id=claimed["run_id"],
+  )
+
+
+def _recover():
+  return asyncio.run(recovery.recover_resolved_blocks())
+
+
+def _row(case):
+  case.db.expire_all()
+  return autopilot.get_row(case.db, case.app_id, case.record_id)
+
+
+def test_repaired_warning_resumes_once_with_fresh_claim_and_durable_state(blocked):
+  history = list(_row(blocked).rounds_json)
+  assert _recover() == 1
+  assert _recover() == 0
+
+  # Read through a separate session: supervisor recovery owns its commit.
+  with SessionLocal() as reader:
+    row = autopilot.get_row(reader, blocked.app_id, blocked.record_id)
+    assert row.enabled is True and row.state == "idle"
+    assert row.blocked_at is None
+    assert row.run_id is None
+    assert row.rounds_used == 0 and row.consecutive_failures == 0
+    assert row.rounds_json == history
+    assert row.granted_head_sha == HEAD
+    assert not autopilot.verify_claim(row, blocked.run_id)
+    chat = reader.get(models.Chat, blocked.chat_id)
+    assert chat.agent_settings_json["drawer_hidden"] is True
+
+  mirrored = read_record(blocked.record_path)["autopilot"]
+  assert mirrored["enabled"] is True and mirrored["state"] == "idle"
+  assert autopilot.claim_for_round(
+    blocked.db, blocked.app_id, blocked.record_id,
+    attention_key="review-needing-help", event_at=BLOCKED_EVENT,
+  )["status"] == "duplicate"
+  assert _row(blocked).last_handled_event_at == BLOCKED_EVENT
+  verdict = autopilot.claim_for_round(
+    blocked.db, blocked.app_id, blocked.record_id,
+    attention_key="new-review", event_at=NEXT_EVENT,
+  )
+  assert verdict["status"] == "granted"
+  assert verdict["run_id"] != blocked.run_id
+  assert autopilot.verify_claim(_row(blocked), verdict["run_id"])
+  assert not autopilot.verify_claim(_row(blocked), blocked.run_id)
+  assert autopilot.complete_round(
+    blocked.db, blocked.app_id, blocked.record_id,
+    run_id=verdict["run_id"], outcome="handled", summary="New review settled.",
+  )["productive"] is True
+  assert _row(blocked).last_handled_event_at == NEXT_EVENT
+
+
+@pytest.mark.parametrize("status", ["prepared", "submitting", "merged", "closed"])
+def test_nonpublic_or_terminal_record_does_not_resume(blocked, status):
+  blocked.record["status"] = status
+  write_record(blocked.record_path, blocked.record)
+  assert _recover() == 0
+  assert _row(blocked).state == "blocked"
+
+
+@pytest.mark.parametrize("change", [
+  "missing_review", "stale_review", "review_not_clear", "review_head",
+  "plan_head", "needs_attention", "attention", "malformed_reviewed_at",
+])
+def test_cleared_warning_alone_is_not_a_fresh_exact_review(blocked, change):
+  record = blocked.record
+  if change == "missing_review":
+    record.pop("quality_review")
+  elif change == "stale_review":
+    record["quality_review"]["reviewed_at"] = _iso(
+      blocked.blocked_at - timedelta(seconds=1),
+    )
+  elif change == "review_not_clear":
+    record["quality_review"]["state"] = "changes_needed"
+  elif change == "review_head":
+    record["quality_review"]["reviewed_head_sha"] = "e" * 40
+  elif change == "plan_head":
+    # A reviewed PRIVATE fix is not yet the trusted, approved public head.
+    record["plan"]["head_sha"] = "e" * 40
+    record["quality_review"]["reviewed_head_sha"] = "e" * 40
+  elif change == "needs_attention":
+    record["needs_attention"] = True
+  elif change == "attention":
+    record["attention"] = {"type": "human_required", "message": "Still blocked."}
+  elif change == "malformed_reviewed_at":
+    record["quality_review"]["reviewed_at"] = "not-a-time"
+  write_record(blocked.record_path, record)
+  assert _recover() == 0
+  row = _row(blocked)
+  assert row.enabled is True and row.state == "blocked"
+  assert not autopilot.verify_claim(row, blocked.run_id)
+
+
+@pytest.mark.parametrize("field", [
+  "repo", "plan_repo", "number", "head_repository", "branch", "repo_path",
+])
+def test_recovery_cannot_retarget_existing_grant(blocked, field):
+  record = blocked.record
+  if field == "plan_repo":
+    record["repo"] = record["plan"]["repo"] = "another/repository"
+  elif field == "repo":
+    record["repo"] = "another/repository"
+  elif field == "number":
+    record["number"] = PR_NUMBER + 1
+  elif field == "head_repository":
+    record["head_repository"] = "another/app-demo"
+  elif field == "branch":
+    record["plan"]["branch"] = "another-branch"
+  else:
+    record["plan"]["repo_path"] = str(Path(record["plan"]["repo_path"]).parent)
+  write_record(blocked.record_path, record)
+  assert _recover() == 0
+  assert _row(blocked).state == "blocked"
+
+
+@pytest.mark.parametrize("pause", ["manual", "legacy", "terminal"])
+def test_recovery_never_undoes_disabled_owner_or_legacy_grant(blocked, pause):
+  if pause == "manual":
+    autopilot.set_enabled(blocked.db, blocked.app_id, blocked.record_id, False)
+  elif pause == "terminal":
+    autopilot.close_out(blocked.db, blocked.app_id, blocked.record_id)
+  else:
+    row = _row(blocked)
+    row.enabled = False
+    row.state = "idle"
+    row.blocked_at = None
+    blocked.db.commit()
+  # Display values are not authority, even with otherwise valid repair data.
+  blocked.record["autopilot"] = {"enabled": True, "state": "blocked"}
+  write_record(blocked.record_path, blocked.record)
+  assert _recover() == 0
+  assert _row(blocked).enabled is False
+
+
+def test_forged_ledger_without_db_grant_cannot_resume(blocked):
+  blocked.db.delete(_row(blocked))
+  blocked.db.commit()
+  blocked.record["autopilot"] = {"enabled": True, "state": "blocked"}
+  write_record(blocked.record_path, blocked.record)
+  assert _recover() == 0
+  assert _row(blocked) is None
+
+
+def test_unanswered_owner_question_stays_visible_and_blocks_recovery(blocked):
+  chat = blocked.db.get(models.Chat, blocked.chat_id)
+  chat.pending_question_id = "choose-resolution"
+  blocked.db.commit()
+  assert _recover() == 0
+  assert _row(blocked).state == "blocked"
+  blocked.db.expire_all()
+  chat = blocked.db.get(models.Chat, blocked.chat_id)
+  assert chat.pending_question_id == "choose-resolution"
+  assert chat.agent_settings_json["drawer_hidden"] is False
+
+
+def test_approved_head_refresh_does_not_move_escalation_freshness_barrier(blocked):
+  reviewed_at = blocked.record["quality_review"]["reviewed_at"]
+  blocked.record["plan"]["head_sha"] = "f" * 40
+  blocked.record["quality_review"]["reviewed_head_sha"] = "f" * 40
+  write_record(blocked.record_path, blocked.record)
+  assert autopilot.refresh_granted_head(
+    blocked.db, blocked.app_id, blocked.record_id, head_sha="f" * 40,
+  )
+  row = _row(blocked)
+  assert row.blocked_at == blocked.blocked_at
+  assert _iso(row.updated_at) > reviewed_at
+  assert _recover() == 1
+  assert _row(blocked).granted_head_sha == "f" * 40
+
+
+@pytest.mark.parametrize("published", [True, False])
+def test_attribution_only_normalization_requires_confirmed_public_head(blocked, published):
+  blocked.record["plan"]["head_sha"] = "f" * 40
+  blocked.record["plan"]["attribution_normalized_from"] = HEAD
+  write_record(blocked.record_path, blocked.record)
+  if published:
+    autopilot.refresh_granted_head(
+      blocked.db, blocked.app_id, blocked.record_id, head_sha="f" * 40,
+    )
+  assert _recover() == int(published)
+  assert _row(blocked).state == ("idle" if published else "blocked")
+
+
+@pytest.mark.parametrize("interruption", ["manual_pause", "terminal_close", "owner_question"])
+def test_owner_interruption_wins_between_recovery_read_and_compare_swap(
+  blocked, monkeypatch, interruption,
+):
+  original_update = recovery.update
+  raced = False
+
+  def update_after_owner_interruption(model):
+    nonlocal raced
+    # Recovery has already read the grant, review and question state. Commit
+    # the owner's newer action immediately before its conditional UPDATE.
+    if model is models.ContributionAutopilot and not raced:
+      raced = True
+      with SessionLocal() as owner:
+        if interruption == "manual_pause":
+          autopilot.set_enabled(owner, blocked.app_id, blocked.record_id, False)
+        elif interruption == "terminal_close":
+          autopilot.close_out(owner, blocked.app_id, blocked.record_id)
+        else:
+          chat = owner.get(models.Chat, blocked.chat_id)
+          chat.pending_question_id = "new-owner-question"
+          owner.commit()
+    return original_update(model)
+
+  monkeypatch.setattr(recovery, "update", update_after_owner_interruption)
+  assert _recover() == 0
+  assert raced
+  row = _row(blocked)
+  assert not autopilot.verify_claim(row, blocked.run_id)
+  if interruption == "owner_question":
+    assert row.enabled is True and row.state == "blocked"
+    chat = blocked.db.get(models.Chat, blocked.chat_id)
+    assert chat.pending_question_id == "new-owner-question"
+    assert chat.agent_settings_json["drawer_hidden"] is False
+  else:
+    assert row.enabled is False
+    assert row.state == "idle"
+
+
+def test_failed_drawer_commit_rolls_back_recovery_and_can_retry(blocked, monkeypatch):
+  original_hide = autopilot.stage_followup_drawer_hidden
+
+  def stage_hiding_then_fail_commit(db, row, hidden):
+    original_hide(db, row, hidden)
+    if hidden:
+      def failed_commit():
+        raise RuntimeError("injected recovery commit failure")
+      monkeypatch.setattr(db, "commit", failed_commit)
+
+  with monkeypatch.context() as failure:
+    failure.setattr(autopilot, "stage_followup_drawer_hidden", stage_hiding_then_fail_commit)
+    assert _recover() == 0
+  row = _row(blocked)
+  assert row.enabled is True and row.state == "blocked"
+  assert row.blocked_at == blocked.blocked_at
+  chat = blocked.db.get(models.Chat, blocked.chat_id)
+  assert chat.agent_settings_json["drawer_hidden"] is False
+  assert _recover() == 1
+  assert _row(blocked).state == "idle"
+  assert blocked.db.get(models.Chat, blocked.chat_id).agent_settings_json["drawer_hidden"] is True

--- a/backend/tests/test_contribution_autopilot.py
+++ b/backend/tests/test_contribution_autopilot.py
@@ -288,18 +288,22 @@ def test_concurrent_actions_preserve_push_and_both_reply_urls(db, monkeypatch):
   assert set(row.ignored_event_urls_json) == set(urls)
 
 
-def test_escalation_pauses_until_owner_resumes(db):
+def test_escalation_blocks_claims_without_revoking_owner_grant(db):
   autopilot.stamp_grant(db, 1, "rec", head_sha="abc")
   v = autopilot.claim_for_round(
     db, 1, "rec", attention_key="k", event_at="2026-07-01T00:00:00Z",
   )
   autopilot.escalate(db, 1, "rec")
   row = autopilot.get_row(db, 1, "rec")
-  assert row.enabled is False
+  assert row.enabled is True
+  assert row.state == "blocked" and row.blocked_at is not None
   assert autopilot.verify_claim(row, v["run_id"]) is False
   assert autopilot.claim_for_round(
     db, 1, "rec", attention_key="k2", event_at="2026-07-02T00:00:00Z",
-  )["status"] == "not_granted"
+  )["status"] == "blocked"
+  assert autopilot.escalate(db, 1, "rec") is False
+  autopilot.set_enabled(db, 1, "rec", True)
+  assert row.state == "idle" and row.blocked_at is None
 
 
 def test_stale_lease_reclaim_and_double_stale_escalate(db):
@@ -607,7 +611,7 @@ async def test_round_turn_does_not_bypass_pending_owner_question(
 def test_failed_surfacing_leaves_escalation_retryable(db):
   """A crash while surfacing must not consume the one-shot escalate latch.
 
-  ``escalate`` wins exactly once (its UPDATE is gated on ``enabled``), and the
+  ``escalate`` wins exactly once (its UPDATE excludes ``blocked``), and the
   caller only notifies the owner when it wins. If surfacing the chat committed
   separately, a failure between the two commits would leave the record
   escalated, the chat hidden, and the owner never told — with no retry able to
@@ -671,7 +675,7 @@ def test_failed_hiding_leaves_resume_retryable(db):
     autopilot.stage_followup_drawer_hidden = original
 
   db.expire_all()
-  assert autopilot.get_row(db, 1, "rec").enabled is False
+  assert autopilot.get_row(db, 1, "rec").state == "blocked"
   assert _visible_in_owner_drawer(_chat()) is True
 
   autopilot.set_enabled(db, 1, "rec", True)

--- a/backend/tests/test_db_migrations.py
+++ b/backend/tests/test_db_migrations.py
@@ -26,6 +26,25 @@ PREVIOUS_RELEASE_SCHEMA = (
 )
 
 
+def test_autopilot_block_upgrade_preserves_legacy_pause_intent(tmp_path):
+  eng = create_engine(f"sqlite:///{tmp_path / 'autopilot-upgrade.db'}")
+  models.Base.metadata.create_all(eng)
+  with eng.begin() as conn:
+    conn.execute(text("ALTER TABLE contribution_autopilot DROP COLUMN blocked_at"))
+    conn.execute(text(
+      "INSERT INTO contribution_autopilot "
+      "(app_id, record_id, enabled, state, rounds_used, max_rounds, consecutive_failures) "
+      "VALUES (1, 'legacy-pause', 0, 'idle', 2, 5, 0)"
+    ))
+  migrations._add_autopilot_blocked_at(eng)
+  migrations._add_autopilot_blocked_at(eng)
+  with Session(eng) as session:
+    row = session.get(models.ContributionAutopilot, (1, "legacy-pause"))
+    assert row.enabled is False and row.state == "idle"
+    assert row.blocked_at is None
+    assert row.rounds_used == 2
+
+
 def _migration_versions_before(target: str) -> list[str]:
   """Select historical setup by identity, independent of future appends."""
   versions = [version for version, _migration in migrations._SCHEMA_MIGRATIONS]
@@ -1511,6 +1530,7 @@ def test_run_migrations_records_an_inspectable_append_only_history(tmp_path):
     "0047_chat_activity_positions",
     "0048_delegation_result_incorporation",
     "0048_typed_platform_activation_waits",
+    "0049_autopilot_blocked_at",
   ]
   assert second == first
 

--- a/backend/tests/test_runtime_supervisors.py
+++ b/backend/tests/test_runtime_supervisors.py
@@ -293,6 +293,7 @@ async def test_stalled_delegation_wake_cannot_block_other_recovery(
   import app.broadcast as broadcast_module
   import app.chat as chat_module
   import app.contribution_autopilot as autopilot_module
+  import app.contribution_autopilot_recovery as autopilot_recovery_module
   import app.delegations as delegations_module
   import app.routes.github as github_module
   import app.runtime_supervisors as supervisors_module
@@ -301,6 +302,7 @@ async def test_stalled_delegation_wake_cannot_block_other_recovery(
   startup_recovered = asyncio.Event()
   attached_recovered = asyncio.Event()
   lease_recovered = asyncio.Event()
+  blocker_recovered = asyncio.Event()
   wake_started = asyncio.Event()
   block_wake = asyncio.Event()
   main_thread = threading.get_ident()
@@ -335,6 +337,10 @@ async def test_stalled_delegation_wake_cannot_block_other_recovery(
     loop.call_soon_threadsafe(lease_recovered.set)
     return 0
 
+  async def recover_blockers():
+    blocker_recovered.set()
+    return 0
+
   monkeypatch.setattr(broadcast_module, "get_system_broadcast", lambda: broadcast)
   monkeypatch.setattr(supervisors_module, "SessionLocal", session_factory)
   monkeypatch.setattr(
@@ -357,6 +363,7 @@ async def test_stalled_delegation_wake_cannot_block_other_recovery(
     delegations_module, "wake_parents_for_completed_delegations", wake_parents,
   )
   monkeypatch.setattr(autopilot_module, "sweep_expired_leases", sweep)
+  monkeypatch.setattr(autopilot_recovery_module, "recover_resolved_blocks", recover_blockers)
 
   supervisors = _supervisors()
   await supervisors._start_chat_supervisors()
@@ -364,6 +371,7 @@ async def test_stalled_delegation_wake_cannot_block_other_recovery(
   await asyncio.wait_for(startup_recovered.wait(), timeout=1)
   await asyncio.wait_for(attached_recovered.wait(), timeout=1)
   await asyncio.wait_for(lease_recovered.wait(), timeout=1)
+  await asyncio.wait_for(blocker_recovered.wait(), timeout=1)
 
   assert not block_wake.is_set()
   assert "delegation-startup-recovery" in supervisors._tasks


### PR DESCRIPTION
## Problem

Autopilot escalation disabled the same grant used for an explicit owner pause. Repairing the PR and clearing its warning therefore left Autopilot off until someone manually resumed it.

## Change

- Represent an automatic escalation as a blocked grant, preserving the owner's enabled choice while revoking the interrupted round.
- Reuse the existing periodic recovery pass to resume after a fresh all-clear review of the confirmed published head and a cleared warning.
- Keep manual pauses, legacy disabled grants, unresolved owner questions, private/unpublished repairs, and mismatched PR targets blocked from automatic recovery.
- Reset the bounded round budget after resolution, settle the interrupted event, and preserve the existing public-action authorization checks.
- Add an idempotent nullable-column migration without guessing historical pause intent.

Attribution-only publication normalization is accepted only when the grant still pins the actual published head.

## Prior work

Builds on [#942](https://github.com/mobius-os/mobius/pull/942), which settles legitimate no-change rounds, and [#984](https://github.com/mobius-os/mobius/pull/984), which recovers expired leases. Neither distinguishes an automatic repair hold from an owner pause or resumes a reviewed resolution.

## Verification

- Focused Autopilot lifecycle, recovery, loop, migration/history, and runtime supervisor tests
- Focused GitHub route tests covering Autopilot and approved PR updates
- `scripts/test.sh --fast`
- Append-only migration history check, Python compilation, and `git diff --check`

The full hosted checks remain the authoritative integration gate.
