### PR TITLE
Honor executable scheduled-job interpreters

### DIFF
--- a/backend/scripts/app-job-runner.py
+++ b/backend/scripts/app-job-runner.py
@@ -360,7 +360,15 @@ def _execute_job(
     job_state = DATA_DIR / "apps" / str(app_id) / "job-state"
     job_state.mkdir(parents=True, exist_ok=True)
     child_env["APP_JOB_STATE_DIR"] = str(job_state)
-    command = ["bash", str(runtime_job), str(app_id)]
+    # Accepted jobs are executable scripts, not necessarily shell programs
+    # (the App Store's update checker is Python). Honor their reviewed shebang;
+    # retain the Bash fallback for older installed jobs whose executable bit
+    # was not preserved by their source package.
+    command = (
+      [str(runtime_job), str(app_id)]
+      if os.access(runtime_job, os.X_OK)
+      else ["bash", str(runtime_job), str(app_id)]
+    )
     # Uninstall sends TERM to this entire process group. Keep the supervisor
     # alive to retain its lease while a TERM-ignoring child needs the existing
     # KILL fallback; exec resets the child's caught handler to the default.

--- a/backend/scripts/app-job-runner.py
+++ b/backend/scripts/app-job-runner.py
@@ -362,11 +362,13 @@ def _execute_job(
     child_env["APP_JOB_STATE_DIR"] = str(job_state)
     # Accepted jobs are executable scripts, not necessarily shell programs
     # (the App Store's update checker is Python). Honor their reviewed shebang;
-    # retain the Bash fallback for older installed jobs whose executable bit
-    # was not preserved by their source package.
+    # retain the Bash fallback for legacy shell jobs without a shebang or
+    # whose executable bit was not preserved by their source package.
+    with runtime_job.open("rb") as script:
+      has_shebang = script.read(2) == b"#!"
     command = (
       [str(runtime_job), str(app_id)]
-      if os.access(runtime_job, os.X_OK)
+      if has_shebang and os.access(runtime_job, os.X_OK)
       else ["bash", str(runtime_job), str(app_id)]
     )
     # Uninstall sends TERM to this entire process group. Keep the supervisor

--- a/backend/tests/test_app_jobs.py
+++ b/backend/tests/test_app_jobs.py
@@ -403,7 +403,9 @@ def test_wrapper_runs_job_only_after_live_check(tmp_path, monkeypatch):
   ])
 
   assert runner.run() == 0
-  assert calls[0][0][0] == ["bash", str(Path(_accepted_context(source)["runtime_dir"]) / job.name), "57"]
+  assert calls[0][0][0] == [
+    "bash", str(Path(_accepted_context(source)["runtime_dir"]) / job.name), "57",
+  ]
   child_env = calls[0][1]["env"]
   assert child_env["APP_TOKEN"] == "app-token"
   assert child_env["APP_JOB_STATE_DIR"].endswith("/apps/57/job-state")
@@ -411,6 +413,72 @@ def test_wrapper_runs_job_only_after_live_check(tmp_path, monkeypatch):
   assert "AGENT_TOKEN" not in child_env
   assert len(calls[0][1]["pass_fds"]) == 1
   assert signal.getsignal(signal.SIGTERM) is prior_sigterm
+
+
+def test_wrapper_honors_python_job_shebang(tmp_path, monkeypatch):
+  runner = _load_runner()
+  data_dir = tmp_path / "data"
+  source = data_dir / "apps" / "store"
+  source.mkdir(parents=True)
+  job = source / "notify-updates.py"
+  job.write_text("#!/usr/bin/env python3\nraise SystemExit(0)\n")
+  job.chmod(0o755)
+  context = _accepted_context(source)
+  monkeypatch.setattr(runner, "DATA_DIR", data_dir)
+  monkeypatch.setattr(runner, "_mint_app_token", lambda _app_id: "app-token")
+  monkeypatch.setattr(runner, "_app_is_live", lambda *_args: True)
+  monkeypatch.setattr(runner, "_job_context", lambda *_args: context)
+  monkeypatch.setattr(runner.os, "getsid", lambda _pid: os.getpid())
+  calls = []
+  monkeypatch.setattr(
+    runner.subprocess,
+    "Popen",
+    lambda *args, **kwargs: (
+      calls.append((args, kwargs))
+      or types.SimpleNamespace(wait=lambda: 0)
+    ),
+  )
+  monkeypatch.setattr(runner.sys, "argv", [
+    "app-job-runner.py", "57", str(job),
+  ])
+
+  assert runner.run() == 0
+  runtime_job = Path(context["runtime_dir"]) / job.name
+  assert calls[0][0][0] == [str(runtime_job), "57"]
+
+
+def test_wrapper_keeps_bash_fallback_for_non_executable_jobs(
+  tmp_path, monkeypatch,
+):
+  runner = _load_runner()
+  data_dir = tmp_path / "data"
+  source = data_dir / "apps" / "legacy"
+  source.mkdir(parents=True)
+  job = source / "job.sh"
+  job.write_text("exit 0\n")
+  context = _accepted_context(source)
+  runtime_job = Path(context["runtime_dir"]) / job.name
+  runtime_job.chmod(0o644)
+  monkeypatch.setattr(runner, "DATA_DIR", data_dir)
+  monkeypatch.setattr(runner, "_mint_app_token", lambda _app_id: "app-token")
+  monkeypatch.setattr(runner, "_app_is_live", lambda *_args: True)
+  monkeypatch.setattr(runner, "_job_context", lambda *_args: context)
+  monkeypatch.setattr(runner.os, "getsid", lambda _pid: os.getpid())
+  calls = []
+  monkeypatch.setattr(
+    runner.subprocess,
+    "Popen",
+    lambda *args, **kwargs: (
+      calls.append((args, kwargs))
+      or types.SimpleNamespace(wait=lambda: 0)
+    ),
+  )
+  monkeypatch.setattr(runner.sys, "argv", [
+    "app-job-runner.py", "57", str(job),
+  ])
+
+  assert runner.run() == 0
+  assert calls[0][0][0] == ["bash", str(runtime_job), "57"]
 
 
 def test_scheduled_job_emits_owner_authenticated_outcome_after_child_exit(

--- a/backend/tests/test_app_jobs.py
+++ b/backend/tests/test_app_jobs.py
@@ -447,8 +447,9 @@ def test_wrapper_honors_python_job_shebang(tmp_path, monkeypatch):
   assert calls[0][0][0] == [str(runtime_job), "57"]
 
 
-def test_wrapper_keeps_bash_fallback_for_non_executable_jobs(
-  tmp_path, monkeypatch,
+@pytest.mark.parametrize("executable", [False, True])
+def test_wrapper_keeps_bash_fallback_for_legacy_jobs(
+  tmp_path, monkeypatch, executable,
 ):
   runner = _load_runner()
   data_dir = tmp_path / "data"
@@ -458,7 +459,7 @@ def test_wrapper_keeps_bash_fallback_for_non_executable_jobs(
   job.write_text("exit 0\n")
   context = _accepted_context(source)
   runtime_job = Path(context["runtime_dir"]) / job.name
-  runtime_job.chmod(0o644)
+  runtime_job.chmod(0o755 if executable else 0o644)
   monkeypatch.setattr(runner, "DATA_DIR", data_dir)
   monkeypatch.setattr(runner, "_mint_app_token", lambda _app_id: "app-token")
   monkeypatch.setattr(runner, "_app_is_live", lambda *_args: True)


### PR DESCRIPTION
## Summary

Scheduled Python scripts run with their declared interpreter while older shell jobs remain supported.

## Verification

- `scripts/wt-pytest.sh backend/tests/test_app_jobs.py -q`
