### PR TITLE
Keep hidden-chat settlement stable across refresh races

### DIFF
--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -529,13 +529,21 @@ export default function ChatView({
   // does not fall back to Mic while a turn is still running with queued work.
   const [serverRunning, setServerRunning] = useState(() => !!cached?.running)
   const serverRunningRef = useRef(!!cached?.running)
+  // A detail refresh can commit the saved idle transcript just before the
+  // runtime fallback reads the same idle verdict. Keep the fact that this
+  // stream was authoritatively observed running until the stream itself is
+  // retired; the current serverRunning projection is allowed to turn false
+  // first without erasing the proof that makes terminal recovery safe.
+  const serverRunningObservedRef = useRef(!!cached?.running)
   const setServerRunningLocalState = useCallback((v) => {
     const running = !!v
+    if (running) serverRunningObservedRef.current = true
     serverRunningRef.current = running
     setServerRunning(running)
   }, [])
   const setServerRunningState = useCallback((v) => {
     const running = !!v
+    if (!running) serverRunningObservedRef.current = false
     setServerRunningLocalState(running)
     updateChatRuntimeCache(
       queryClient,
@@ -1479,7 +1487,7 @@ export default function ChatView({
         setActiveAssistantMessageId(runtime.activeAssistantMessageId)
       }
       if (shouldRecoverSettledRuntime({
-        runtimeWasObservedRunning: serverRunningRef.current,
+        runtimeWasObservedRunning: serverRunningObservedRef.current,
         runtimeRunning: !!data.running,
         pendingCount: serverPending.length,
         streamStillActive: isStreamingRef.current,
@@ -1517,6 +1525,7 @@ export default function ChatView({
         setSending(true)
       } else if (serverPending.length === 0 && !localAuthoritative) {
         // Stream is dead and the server is idle+empty: clear the stale Stop.
+        serverRunningObservedRef.current = false
         setSending(false)
         sendingRef.current = false
       }
@@ -1921,6 +1930,7 @@ export default function ChatView({
   })
 
   retireSettledStreamRef.current = () => {
+    serverRunningObservedRef.current = false
     disconnect({ clearStreaming: true })
     clearStreamItems()
   }
@@ -3264,6 +3274,7 @@ export default function ChatView({
     // FRESH SEND PATH: no active turn, no queue.
     const localStartRequest = { chatId: String(chatId), cid }
     localStartRequestRef.current = localStartRequest
+    serverRunningObservedRef.current = false
     fetchGenRef.current += 1
     onMessageStartRef.current?.()
     promotedRef.current = false

--- a/frontend/src/components/ChatView/__tests__/streamingRobustness.test.js
+++ b/frontend/src/components/ChatView/__tests__/streamingRobustness.test.js
@@ -352,6 +352,9 @@ test('a hidden-pane finish routes stale local activity through runtime settlemen
   // reconcile callback only coalesces callers onto that same promise.
   const runtimeStart = chatViewSource.indexOf('const refreshRuntimeState = useCallback')
   const recovery = chatViewSource.indexOf('if (shouldRecoverSettledRuntime({', runtimeStart)
+  const observedRunning = chatViewSource.indexOf(
+    'runtimeWasObservedRunning: serverRunningObservedRef.current', recovery,
+  )
   const refresh = chatViewSource.indexOf('const settled = await fetchMessages({', recovery)
   const authoritative = chatViewSource.indexOf('authoritative: true', refresh)
   const retire = chatViewSource.indexOf('retireSettledStreamRef.current?.()', authoritative)
@@ -359,11 +362,21 @@ test('a hidden-pane finish routes stale local activity through runtime settlemen
   assert.ok(
     runtimeStart >= 0
       && recovery > runtimeStart
+      && observedRunning > recovery
+      && observedRunning < refresh
       && refresh > recovery
       && authoritative > refresh
       && retire > authoritative
       && retire < runtimeEnd,
     'idle runtime truth must refresh the final row before retiring stale stream state',
+  )
+  const retirement = chatViewSource.indexOf('retireSettledStreamRef.current = () => {')
+  const clearObservedRunning = chatViewSource.indexOf(
+    'serverRunningObservedRef.current = false', retirement,
+  )
+  assert.ok(
+    retirement >= 0 && clearObservedRunning > retirement,
+    'the observed-running latch must survive idle detail reads until stream retirement',
   )
 })
 

--- a/tests/hidden-chat-settlement.spec.mjs
+++ b/tests/hidden-chat-settlement.spec.mjs
@@ -38,8 +38,11 @@ test('returning to a retained hidden chat settles a missed terminal stream event
     }
   }, { key: paneModel.STORAGE_KEY, workspace: paneModel.serializeWorkspace(ws), chatId: a.id })
 
-  let running = false
-  let messages = []
+  let running = true
+  let messages = [{
+    role: 'user', content: 'Run the settlement check', ts: 1700001000000,
+    blocks: [{ type: 'text', content: 'Run the settlement check' }],
+  }]
   let idleRuntimeReads = 0
   await page.route(new RegExp(`/api/chats/${a.id}(?:\\?.*)?$`), route => {
     if (route.request().method() !== 'GET') return route.fallback()
@@ -53,20 +56,12 @@ test('returning to a retained hidden chat settles a missed terminal stream event
     if (!running && messages.length > 1) idleRuntimeReads += 1
     return route.fulfill({ json: { running, pending_messages: [], pending_question_id: null } })
   })
-  await page.route(new RegExp(`/api/chats/${a.id}/messages$`), route => {
-    const body = route.request().postDataJSON()
-    running = true
-    const message = { role: 'user', content: body.content, cid: body.cid, ts: 1700001000000 }
-    messages = [message]
-    return route.fulfill({ status: 202, json: { status: 'started', message } })
-  })
   await page.clock.install()
   await page.goto(`${BASE}/shell/?chat=${a.id}`, { waitUntil: 'domcontentloaded' })
   const surface = page.locator(`[data-tab-key="chat:${a.id}"]`)
   await expect(surface.getByRole('textbox', { name: 'Message Möbius…' })).toBeVisible()
-  await surface.getByRole('textbox', { name: 'Message Möbius…' }).fill('Run the settlement check')
-  await page.keyboard.press('Enter')
   await expect(surface.locator('.chat__stop')).toBeVisible()
+  await expect(surface.locator('.chat__activity--running')).toBeVisible()
   await page.waitForFunction(() => typeof window.emitSettlementEvent === 'function')
   await page.evaluate(chatId => {
     window.retainedSettlementRoot = document.querySelector(`[data-tab-key="chat:${chatId}"] .chat`)
@@ -88,7 +83,7 @@ test('returning to a retained hidden chat settles a missed terminal stream event
   await expect.poll(() => idleRuntimeReads).toBeGreaterThan(0)
   await expect(surface.getByText('The saved final answer.', { exact: true })).toBeVisible()
   await expect(surface.locator('.chat__stop')).toHaveCount(0)
-  await expect(surface.locator('.chat__thinking')).toHaveCount(0)
+  await expect(surface.locator('.chat__activity--running')).toHaveCount(0)
   expect(await page.evaluate(chatId => (
     window.retainedSettlementRoot === document.querySelector(`[data-tab-key="chat:${chatId}"] .chat`)
   ), a.id)).toBe(true)


### PR DESCRIPTION
## Summary

- Keep the fact that a retained chat stream was observed running until that stream reaches a real terminal boundary.
- Let an idle runtime verdict retire stale activity even when the saved transcript refresh lands first.
- Exercise the retained hidden-pane path from pre-existing live activity.

## Why

Follow-up to #1101. Stressing the retained hidden-chat scenario exposed a narrow ordering race: the saved final answer could appear while the old activity and Stop control remained. An idle detail refresh cleared the current server-running projection just before the runtime fallback checked it, so the fallback lost the prior-running proof needed to retire the stream.

The observed-running latch belongs to the stream lifecycle rather than to one snapshot. It remains guarded from fresh-send races and clears at the existing terminal boundaries.

## Testing

- All 36 streaming-robustness tests pass.
- The retained hidden-chat browser scenario passes 20 consecutive exact-runtime runs with retries disabled.
