### PR TITLE
Fail closed on malformed Reviewer revisions

### DIFF
--- a/backend/app/routes/reviewer.py
+++ b/backend/app/routes/reviewer.py
@@ -94,8 +94,12 @@ def _reviewer_assert_live_revision(
   repository: str, number: int, head_sha: str, base_sha: str,
 ) -> dict:
   pull = _reviewer_live_pr(repository, number)
-  live_head = str((pull.get("head") or {}).get("sha") or "").lower()
-  live_base = str((pull.get("base") or {}).get("sha") or "").lower()
+  head = pull.get("head")
+  base = pull.get("base")
+  if not isinstance(head, dict) or not isinstance(base, dict):
+    raise HTTPException(502, "GitHub returned an invalid pull request response.")
+  live_head = str(head.get("sha") or "").lower()
+  live_base = str(base.get("sha") or "").lower()
   if (
     pull.get("state") != "open" or live_head != head_sha.lower()
     or live_base != base_sha.lower()

--- a/backend/tests/test_reviewer_automation.py
+++ b/backend/tests/test_reviewer_automation.py
@@ -459,14 +459,77 @@ def test_manual_ambiguous_github_result_is_not_retried(
   assert claim.status == "uncertain"
 
 
-def test_reviewer_live_pr_rejects_invalid_target_before_any_github_call():
+@pytest.mark.parametrize("repository,number", [
+  ("not a repo", 1),
+  ("mobius-os/mobius", 0),
+  ("a/b/c", 3),
+])
+def test_reviewer_live_pr_rejects_invalid_target_before_any_github_call(
+  monkeypatch, repository, number,
+):
   """The validation branch must run (and reject) before any GitHub call —
   it is the code path CI lint once caught as an undefined name."""
-  from fastapi import HTTPException
-  from app.routes.reviewer import _reviewer_live_pr
-  for repo, number in (("not a repo", 1), ("mobius-os/mobius", 0), ("a/b/c", 3)):
-    try:
-      _reviewer_live_pr(repo, number)
-      raise AssertionError(f"accepted invalid target {repo}#{number}")
-    except HTTPException as exc:
-      assert exc.status_code == 422
+  from app.routes import reviewer
+
+  monkeypatch.setattr(
+    reviewer, "_gh", lambda *_: pytest.fail("invalid target reached GitHub"),
+  )
+  with pytest.raises(HTTPException) as error:
+    reviewer._reviewer_live_pr(repository, number)
+  assert error.value.status_code == 422
+
+
+@pytest.mark.parametrize("state,head,base,expected", [
+  ("open", "a" * 40, "b" * 40, None),
+  ("closed", "a" * 40, "b" * 40, 409),
+  ("open", "c" * 40, "b" * 40, 409),
+  ("open", "a" * 40, "c" * 40, 409),
+])
+def test_live_revision_revalidates_actual_github_response(
+  monkeypatch, state, head, base, expected,
+):
+  from app.routes import reviewer
+
+  calls = []
+  pull = {"state": state, "head": {"sha": head}, "base": {"sha": base}}
+
+  def gh(*args):
+    calls.append(args[1:])
+    return SimpleNamespace(stdout=json.dumps(pull))
+
+  monkeypatch.setattr(reviewer, "_gh", gh)
+  if expected:
+    with pytest.raises(HTTPException) as error:
+      reviewer._reviewer_assert_live_revision(
+        "owner/repo", 17, "a" * 40, "b" * 40,
+      )
+    assert error.value.status_code == expected
+  else:
+    assert reviewer._reviewer_assert_live_revision(
+      "owner/repo", 17, "a" * 40, "b" * 40,
+    ) == pull
+  assert calls == [("api", "repos/owner/repo/pulls/17")]
+
+
+@pytest.mark.parametrize("response", ["not json", "[]"])
+def test_live_revision_rejects_invalid_github_response(monkeypatch, response):
+  from app.routes import reviewer
+
+  monkeypatch.setattr(
+    reviewer, "_gh", lambda *_: SimpleNamespace(stdout=response),
+  )
+  with pytest.raises(HTTPException) as error:
+    reviewer._reviewer_live_pr("owner/repo", 17)
+  assert error.value.status_code == 502
+
+
+def test_live_revision_handles_github_read_failure(monkeypatch):
+  from app.routes import reviewer
+
+  def unavailable(*_):
+    raise RuntimeError("read unavailable")
+
+  monkeypatch.setattr(reviewer, "_gh", unavailable)
+  with pytest.raises(HTTPException) as error:
+    reviewer._reviewer_live_pr("owner/repo", 17)
+  assert error.value.status_code == 502

--- a/backend/tests/test_reviewer_automation.py
+++ b/backend/tests/test_reviewer_automation.py
@@ -511,7 +511,12 @@ def test_live_revision_revalidates_actual_github_response(
   assert calls == [("api", "repos/owner/repo/pulls/17")]
 
 
-@pytest.mark.parametrize("response", ["not json", "[]"])
+@pytest.mark.parametrize("response", [
+  "not json",
+  "[]",
+  '{"state":"open","head":"not-an-object","base":{"sha":"bbbb"}}',
+  '{"state":"open","head":{"sha":"aaaa"},"base":"not-an-object"}',
+])
 def test_live_revision_rejects_invalid_github_response(monkeypatch, response):
   from app.routes import reviewer
 
@@ -519,7 +524,9 @@ def test_live_revision_rejects_invalid_github_response(monkeypatch, response):
     reviewer, "_gh", lambda *_: SimpleNamespace(stdout=response),
   )
   with pytest.raises(HTTPException) as error:
-    reviewer._reviewer_live_pr("owner/repo", 17)
+    reviewer._reviewer_assert_live_revision(
+      "owner/repo", 17, "a" * 40, "b" * 40,
+    )
   assert error.value.status_code == 502
 
 


### PR DESCRIPTION
## Summary

- Exercise Reviewer pull-request validation across matching, closed, moved, malformed, and unavailable GitHub responses.
- Reject malformed nested head or base objects before comparing revision identities.
- Keep incomplete revision data on the explicit fail-closed path before any comment can be sent.

## Why

Follow-up to #1103. Its top-level response check rejected non-objects, but nested head and base values were still assumed to be objects. A structurally malformed response could therefore raise an internal exception instead of returning the deliberate upstream-validation error.

This keeps the authority boundary small: Reviewer still revalidates the exact repository, pull request, head, and base immediately around a comment, and ambiguity never becomes permission.

## Testing

- scripts/wt-pytest.sh backend/tests/test_reviewer_automation.py backend/tests/test_model_registry.py backend/tests/test_db_migrations.py -q (131 passed)
