### PR TITLE
Keep disclosure expansion fixed in place

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -582,7 +582,7 @@ installing Möbius.
 
 ## Chat scroll + steer contract
 
-**Owner-authoritative contract — v1.25 (2026-08-24).** This section is the
+**Owner-authoritative contract — v1.26 (2026-09-12).** This section is the
 canonical source of truth for how a chat scrolls and steers. When implementation,
 comments, and this contract disagree, the implementation/comments are the bug:
 fix behavior to match this contract. If a real case is unspecified or the desired
@@ -621,6 +621,10 @@ and attaches their rule ids to new diagnostic chats. The Playwright lock-in spec
   scroll box, now-hidden blank room is removed from the spacer first. In
   `FOLLOW_BOTTOM` this keeps the visible content fixed while room remains; after
   the spacer reaches zero, only the overflow that no longer fits moves upward.
+  Growth wholly above the latest user row moves that row and the list together,
+  so the formula and the reservation are unchanged; no layout pass may retire
+  or restore room on its own, because any later pass recomputes the same
+  formula and a one-off exception reappears as blank space at the tail.
   A `PIN_USER_MSG` has one reachability exception: while the box is narrowed by
   a same-width software keyboard, it reserves against the largest same-width
   scroll box already observed. Closing the keyboard therefore cannot clamp the
@@ -902,6 +906,7 @@ path means routing it through the same entries rather than inventing another rul
 | Later send submitted anywhere else | hold or stale follow | `ANCHOR_AT`/existing hold | None |
 | Reader reaches or explicitly swipes toward physical bottom | any | `FOLLOW_BOTTOM` | User-owned; follow the one physical tail, including remaining reservation |
 | Composer press or edit begins at physical bottom | any hold | `FOLLOW_BOTTOM` | No immediate write; the next owned layout follows the existing physical tail |
+| Disclosure expands | any hold, including follow | `ANCHOR_AT` at the tapped header | Freeze the chosen header so the screen does not move; the R1 reservation is left exactly as the formula computes it. Collapse keeps the existing mode |
 | Reader scrolls manually away from bottom | any | `ANCHOR_AT` | User-owned |
 | Reply grows while an armed live pin still has reserved room | pin hold | same pin hold | Keep prompt fixed |
 | Streaming reply consumes the armed pin reservation | pin hold | `FOLLOW_BOTTOM` | Follow physical tail |

--- a/frontend/src/components/ChatView/ChatView.css
+++ b/frontend/src/components/ChatView/ChatView.css
@@ -1279,6 +1279,9 @@
   font-size: 12px; /* floor raised from 10.5px */
   color: var(--muted); /* CONTRACT: low-contrast text on opaque fill */
   max-height: 200px;
+  /* The output owns a bounded internal scroller so its contents stay visible.
+     The cap keeps that reading surface inside the disclosure; the transcript
+     and its tail reservation never absorb the hidden overflow. */
   overflow-y: auto;
   line-height: 1.5;
 }

--- a/frontend/src/components/ChatView/__tests__/toolBlockPresentation.test.js
+++ b/frontend/src/components/ChatView/__tests__/toolBlockPresentation.test.js
@@ -47,6 +47,15 @@ test('tool call labels participate in native transcript text selection', () => {
   )
 })
 
+test('tool output owns a bounded internal scroller', () => {
+  const start = chatCss.search(/(?:^|\n)\.chat__tool-detail \{/)
+  assert.ok(start >= 0, 'the generic output preview has one bounded rule')
+  const rule = chatCss.slice(start, chatCss.indexOf('}', start) + 1)
+  assert.match(rule, /max-height:\s*200px/)
+  assert.match(rule, /overflow-y:\s*auto/,
+    'tool output must stay inspectable inside its own bounded surface')
+})
+
 test('tool detail is a third nested level with labeled command and output', () => {
   assert.match(toolBlock, /\{isShell \? 'Command' : 'Input'\}/)
   assert.match(toolBlock, /\{isShell \? 'Output' : 'Result'\}/)

--- a/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
+++ b/frontend/src/components/ChatView/__tests__/useScrollMode.test.js
@@ -30,6 +30,7 @@ import {
   modeForForegroundReturn,
   modeForQuestionSubmission,
   modeForQueuedSubmission,
+  modeForScrollTransition,
   modeAfterQuestionResponseStart,
   modeAfterReaderGesture,
   modeAfterSpacerResize,
@@ -37,7 +38,7 @@ import {
   nestedReaderTargetOwnsInput,
   readerInputClaimsPhysicalTail,
   readerInputEscapeDirection,
-  readerInputActivatesDisclosure,
+  readerInputDisclosureTarget,
   readerInputMayScroll,
   readerInputNeedsFrameRelease,
   readerScrollEscapeDirection,
@@ -265,8 +266,11 @@ test('a composer press or direct edit requests follow only at the physical tail'
 })
 
 test('disclosure activation is recognized as an anchor-latching reading action', () => {
+  const disclosureHeader = {}
   const disclosureTarget = {
-    closest: selector => selector.includes('button.chat__activity-header') ? {} : null,
+    closest: selector => selector.includes('button.chat__activity-header')
+      ? disclosureHeader
+      : null,
   }
   const ordinaryTarget = { closest: () => null }
   const staticStatusTarget = {
@@ -274,29 +278,32 @@ test('disclosure activation is recognized as an anchor-latching reading action',
     closest: selector => selector.startsWith('button.') ? null : {},
   }
 
-  assert.equal(readerInputActivatesDisclosure(
-    'pointerdown', '', disclosureTarget), true)
-  assert.equal(readerInputActivatesDisclosure(
-    'pointerdown', '', disclosureTarget, 2), false,
+  assert.equal(readerInputDisclosureTarget(
+    'pointerdown', '', disclosureTarget), disclosureHeader)
+  assert.equal(readerInputDisclosureTarget(
+    'pointerdown', '', disclosureTarget, 2), null,
   'opening a context menu must not manufacture reading intent')
-  assert.equal(readerInputActivatesDisclosure(
-    'touchstart', '', disclosureTarget), true)
-  assert.equal(readerInputActivatesDisclosure(
-    'keydown', 'Enter', disclosureTarget), true)
-  assert.equal(readerInputActivatesDisclosure(
-    'keydown', ' ', disclosureTarget), true)
-  assert.equal(readerInputActivatesDisclosure(
-    'keydown', 'a', disclosureTarget), false)
-  assert.equal(readerInputActivatesDisclosure(
-    'wheel', '', disclosureTarget), false)
-  assert.equal(readerInputActivatesDisclosure(
-    'pointerdown', '', ordinaryTarget), false)
-  assert.equal(readerInputActivatesDisclosure(
-    'pointerdown', '', staticStatusTarget), false,
+  assert.equal(readerInputDisclosureTarget(
+    'touchstart', '', disclosureTarget), disclosureHeader)
+  assert.equal(readerInputDisclosureTarget(
+    'keydown', 'Enter', disclosureTarget), disclosureHeader)
+  assert.equal(readerInputDisclosureTarget(
+    'keydown', ' ', disclosureTarget), disclosureHeader)
+  assert.equal(readerInputDisclosureTarget(
+    'click', '', disclosureTarget), disclosureHeader,
+  'assistive activation may arrive without a preceding pointer or key event')
+  assert.equal(readerInputDisclosureTarget(
+    'keydown', 'a', disclosureTarget), null)
+  assert.equal(readerInputDisclosureTarget(
+    'wheel', '', disclosureTarget), null)
+  assert.equal(readerInputDisclosureTarget(
+    'pointerdown', '', ordinaryTarget), null)
+  assert.equal(readerInputDisclosureTarget(
+    'pointerdown', '', staticStatusTarget), null,
   'a non-interactive status row must not stop live follow')
 })
 
-test('disclosure toggles follow only in FOLLOW_BOTTOM and otherwise hold the reader anchor', () => {
+test('disclosure collapse keeps follow while other held states keep their anchor', () => {
   const row = {
     dataset: { key: 'assistant-1' },
     offsetTop: 420,
@@ -309,11 +316,61 @@ test('disclosure toggles follow only in FOLLOW_BOTTOM and otherwise hold the rea
   }
   const follow = { kind: 'FOLLOW_BOTTOM' }
   assert.equal(modeForDisclosureToggle(scrollEl, follow), follow,
-    'autoscroll remains the sole authority while following the tail')
+    'collapse retains follow because it reveals no new reading surface')
   assert.deepEqual(
     modeForDisclosureToggle(scrollEl, { kind: 'PIN_USER_MSG', cid: 'c1' }),
     { kind: 'ANCHOR_AT', key: 'assistant-1', offset: -80 },
-    'outside autoscroll the visible reading position is frozen before resize',
+    'an existing reading hold stays anchored through a collapse',
+  )
+})
+
+test('expanding a disclosure holds its header instead of dragging to the tail', () => {
+  const row = {
+    dataset: { key: 'assistant-1' },
+    offsetTop: 900,
+    offsetHeight: 300,
+  }
+  const disclosure = { closest: () => row }
+  const atTail = {
+    scrollTop: 1397,
+    scrollHeight: 2000,
+    clientHeight: 600,
+    querySelectorAll: () => [row],
+  }
+  const follow = { kind: 'FOLLOW_BOTTOM' }
+  const pin = { kind: 'PIN_USER_MSG', cid: 'c1' }
+  assert.deepEqual(
+    modeForDisclosureToggle(atTail, follow, {
+      target: disclosure,
+      nextOpen: true,
+    }),
+    { kind: 'ANCHOR_AT', key: 'assistant-1', offset: -497 },
+    'opening a long block freezes the tapped header before it grows',
+  )
+  assert.deepEqual(
+    modeForDisclosureToggle(atTail, pin, { target: disclosure, nextOpen: true }),
+    { kind: 'ANCHOR_AT', key: 'assistant-1', offset: -497 },
+    'a held reader also freezes the tapped header',
+  )
+  assert.deepEqual(
+    modeForScrollTransition(pin, { kind: 'FOLLOW_BOTTOM' }, 'reader:disclosure-toggle'),
+    pin,
+    'disclosure activation may not manufacture follow intent',
+  )
+  assert.deepEqual(
+    modeForDisclosureToggle(atTail, follow, {
+      target: disclosure,
+      nextOpen: false,
+    }),
+    follow,
+    'collapse keeps the existing tail policy',
+  )
+
+  const aboveTail = { ...atTail, scrollTop: 800 }
+  assert.deepEqual(
+    modeForDisclosureToggle(aboveTail, pin, { target: disclosure, nextOpen: true }),
+    { kind: 'ANCHOR_AT', key: 'assistant-1', offset: 100 },
+    'off-tail expansion still freezes the visible reading anchor',
   )
 })
 
@@ -1810,6 +1867,49 @@ test('tool expansion consumes reservation and collapse restores the exact defici
   assert.equal(collapsed, 611)
   assert.equal(expanded, 0)
   assert.equal(collapsedAgain, collapsed)
+})
+
+test('a latest user row wholly above the viewport retires stale tail room', () => {
+  const scrollEl = makeSpacerScrollEl({ clientHeight: 600, scrollTop: 1200 })
+  // Formula without the leave-viewport check would still reserve 96px.
+  const listEl = { offsetHeight: 1700 }
+  const latestUserMsgEl = {
+    offsetTop: 900,
+    offsetHeight: 80,
+    dataset: { cid: 'latest' },
+  }
+
+  assert.equal(
+    _computeSpacerH(
+      scrollEl,
+      listEl,
+      latestUserMsgEl,
+      { kind: 'FOLLOW_BOTTOM' },
+    ),
+    0,
+    'content growth above an already-left latest row must not strand blank tail room',
+  )
+})
+
+test('a latest user row below the viewport keeps its stable pre-approach range', () => {
+  const scrollEl = makeSpacerScrollEl({ clientHeight: 600 })
+  scrollEl.scrollTop = 0
+  const listEl = { offsetHeight: 1400 }
+  const latestUserMsgEl = {
+    offsetTop: 900,
+    offsetHeight: 80,
+    dataset: { cid: 'latest' },
+  }
+
+  assert.equal(
+    _computeSpacerH(
+      scrollEl,
+      listEl,
+      latestUserMsgEl,
+      { kind: 'FOLLOW_BOTTOM' },
+    ),
+    96,
+  )
 })
 
 test('spacer reservation returns zero before there is a user message', () => {

--- a/frontend/src/components/ChatView/scroll/policy.js
+++ b/frontend/src/components/ChatView/scroll/policy.js
@@ -393,19 +393,21 @@ export function nestedReaderTargetOwnsInput({
  * scroll event. Snapshotting the current message anchor before its body changes
  * prevents a stale FOLLOW_BOTTOM mode from replaying after pointerup and
  * dragging a near-foot activity header down into the newly-opened timeline. */
-export function readerInputActivatesDisclosure(
+export function readerInputDisclosureTarget(
   type,
   key = '',
   target = null,
   pointerButton = 0,
 ) {
+  const activates = (type === 'pointerdown' && pointerButton === 0)
+    || type === 'touchstart'
+    || type === 'click'
+    || (type === 'keydown' && ['Enter', ' ', 'Spacebar'].includes(key))
+  if (!activates) return null
   const disclosure = target?.closest?.(
     'button.chat__activity-header, button.chat__activity-think-toggle, button.chat__tool-header, button.chat__marker-header',
   )
-  if (!disclosure) return false
-  return (type === 'pointerdown' && pointerButton === 0)
-    || type === 'touchstart'
-    || (type === 'keydown' && ['Enter', ' ', 'Spacebar'].includes(key))
+  return disclosure || null
 }
 
 
@@ -494,12 +496,26 @@ export function modeForChatExit(scrollEl) {
 
 
 /** A disclosure toggle obeys the existing reading mode instead of inventing a
- * second scroll policy. FOLLOW_BOTTOM stays live and follows the resized tail;
- * every non-follow mode freezes the exact visible message anchor before the
- * disclosure changes height. Repeating the same toggle therefore has the same
- * result until the reader explicitly changes scroll mode. */
-export function modeForDisclosureToggle(scrollEl, currentMode) {
-  if (currentMode?.kind === 'FOLLOW_BOTTOM') return currentMode
+ * second scroll policy. Collapse stays in FOLLOW_BOTTOM because removing
+ * detail does not reveal a new reading location. Expansion is a reading
+ * action: freeze the exact tapped header before its body changes height, even
+ * from FOLLOW_BOTTOM, so an older long block cannot pull the reader to the
+ * newly enlarged tail. Other modes always freeze their current anchor; the R1
+ * reservation remains the same pure geometry calculation in every mode. */
+export function modeForDisclosureToggle(
+  scrollEl,
+  currentMode,
+  { target = null, nextOpen = false } = {},
+) {
+  if (currentMode?.kind === 'FOLLOW_BOTTOM') {
+    if (!nextOpen) return currentMode
+    const disclosure = target?.closest?.(
+      'button.chat__activity-header, button.chat__activity-think-toggle, button.chat__tool-header, button.chat__marker-header',
+    )
+    return anchorModeForElement(scrollEl, disclosure)
+      || anchorModeFromScroll(scrollEl)
+      || currentMode
+  }
   return anchorModeFromScroll(scrollEl) || currentMode
 }
 

--- a/frontend/src/components/ChatView/useScrollMode.js
+++ b/frontend/src/components/ChatView/useScrollMode.js
@@ -114,7 +114,7 @@ import {
   modeForQueuedSubmission,
   modeForScrollTransition,
   nestedReaderTargetOwnsInput,
-  readerInputActivatesDisclosure,
+  readerInputDisclosureTarget,
   readerInputClaimsPhysicalTail,
   readerInputEscapeDirection,
   readerInputMayScroll,
@@ -1172,6 +1172,11 @@ export default function useScrollMode({
         scrollEl, listEl, lastUserEl, modeRef.current,
         { pinViewportHeight: observedScrollViewportRef.current.pinHeight },
       )
+      // The reservation is a pure function of tail geometry (R1). Growth above
+      // the latest user row moves that row and the list together, so the
+      // formula keeps the same room; an earlier "retire it for one pass" patch
+      // made every later layout pass restore that room, which read as blank
+      // space appearing below the chat after a disclosure.
       spacerEl.style.height = `${h}px`
       // A wheel/touch/key gesture begins before the browser emits its first
       // scroll event. Do not let spacer geometry perform pin→follow in that
@@ -1752,12 +1757,13 @@ export default function useScrollMode({
       persistMode()
     }
     const onUserInput = (event) => {
-      const activatesDisclosure = readerInputActivatesDisclosure(
+      const disclosureTarget = readerInputDisclosureTarget(
         event?.type,
         event?.key,
         event?.target,
         event?.button,
       )
+      const activatesDisclosure = !!disclosureTarget
       if (!activatesDisclosure
           && !readerInputMayScroll(event?.type, event?.key)) return
       const inputDirection = readerInputEscapeDirection(event?.type, {
@@ -1831,11 +1837,15 @@ export default function useScrollMode({
         })
       }
       if (activatesDisclosure) {
-        // A disclosure tap obeys the mode the reader already chose. FOLLOW_BOTTOM
-        // remains the sole tail authority; every other mode latches the visible
-        // anchor BEFORE React changes body height. The gesture gate below defers
-        // ResizeObserver writes until pointerup, then replays that same policy.
-        const nextMode = modeForDisclosureToggle(scrollEl, modeRef.current)
+        // Expansion latches the chosen header BEFORE React changes body height,
+        // including from FOLLOW_BOTTOM; collapse retains the existing mode. The
+        // gesture gate below defers ResizeObserver writes until pointerup, then
+        // replays that same policy.
+        const nextMode = modeForDisclosureToggle(scrollEl, modeRef.current, {
+          target: disclosureTarget,
+          nextOpen: !!disclosureTarget
+            && disclosureTarget.getAttribute('aria-expanded') !== 'true',
+        })
         if (nextMode && nextMode !== modeRef.current) {
           readerLocationExplicitRef.current = true
           transitionMode(nextMode, 'reader:disclosure-toggle')
@@ -1860,10 +1870,11 @@ export default function useScrollMode({
       // Thunk, not an object literal: these property reads force a synchronous
       // layout, and only wheel/scroll-key branches consume them. See
       // readerInputNeedsFrameRelease.
-      // Space/Enter on a disclosure button cannot natively scroll; preserve its
-      // existing one-frame release rather than waiting for the safety cap.
-      const keyboardDisclosure = activatesDisclosure && event?.type === 'keydown'
-      if (keyboardDisclosure || readerInputNeedsFrameRelease(
+      // Space/Enter and a zero-detail assistive click cannot natively scroll;
+      // release them next frame rather than waiting for the safety cap.
+      const releaseOnlyDisclosure = activatesDisclosure
+        && (event?.type === 'keydown' || event?.type === 'click')
+      if (releaseOnlyDisclosure || readerInputNeedsFrameRelease(
           event?.type,
           readInputGeometry,
           event?.key,
@@ -1877,6 +1888,14 @@ export default function useScrollMode({
     const onWheelInput = isPerfProbeEnabled()
       ? (event) => perfTime('scroll.wheel', () => onUserInput(event))
       : onUserInput
+    // Browser accessibility activation can dispatch `click` without the
+    // pointer/key event that normally reaches onUserInput first. Handle only
+    // that zero-detail path here; physical clicks already own the gesture from
+    // pointerdown, and keyboard clicks normally own it from keydown.
+    const onSyntheticDisclosureClick = (event) => {
+      if (event.detail !== 0 || gesture.disclosureOwns) return
+      onUserInput(event)
+    }
 
     // Scroll-START latency, measured rather than inferred. Lag at the moment a
     // finger lands is a different failure from steady-state jank and has a
@@ -2036,6 +2055,9 @@ export default function useScrollMode({
     scrollEl.addEventListener('pointermove', onPointerMoveInput, { passive: true })
     scrollEl.addEventListener('wheel', onWheelInput, { passive: true })
     scrollEl.addEventListener('keydown', onUserInput, { passive: true })
+    scrollEl.addEventListener(
+      'click', onSyntheticDisclosureClick, { passive: true },
+    )
     scrollEl.addEventListener('focusin', onInlineEditorFocus, { passive: true })
     scrollEl.addEventListener('focusout', onInlineEditorBlur, { passive: true })
     scrollEl.addEventListener('beforeinput', captureInlineEditorInput, { passive: true })
@@ -2172,6 +2194,7 @@ export default function useScrollMode({
       scrollEl.removeEventListener('pointermove', onPointerMoveInput)
       scrollEl.removeEventListener('wheel', onWheelInput)
       scrollEl.removeEventListener('keydown', onUserInput)
+      scrollEl.removeEventListener('click', onSyntheticDisclosureClick)
       scrollEl.removeEventListener('focusin', onInlineEditorFocus)
       scrollEl.removeEventListener('focusout', onInlineEditorBlur)
       scrollEl.removeEventListener('beforeinput', captureInlineEditorInput)

--- a/frontend/src/lib/__tests__/useScrollModeLifecycle.test.js
+++ b/frontend/src/lib/__tests__/useScrollModeLifecycle.test.js
@@ -244,6 +244,83 @@ test('nested controls cannot relatch the transcript while they own the input', (
   }
 })
 
+test('an assistive disclosure click freezes follow before the body expands', () => {
+  const restoreBrowser = installBrowserEnvironment()
+  try {
+    const { hook, listeners, scroll, assistant } = mountTailController(
+      'assistive-disclosure-click',
+    )
+    hook.result.current.followLatest()
+    assert.equal(scroll.dataset.scrollMode, 'FOLLOW_BOTTOM')
+
+    const disclosure = fakeElement({
+      dataset: { scrollAnchorKey: 'tool-header' },
+      offsetHeight: 32,
+      parentElement: assistant,
+      getAttribute(name) { return name === 'aria-expanded' ? 'false' : null },
+      getBoundingClientRect() {
+        return { top: 300, bottom: 332, height: 32 }
+      },
+      closest(selector) {
+        if (selector.startsWith('button.chat__')) return this
+        if (selector === '.chat__msg[data-key]') return assistant
+        return null
+      },
+    })
+    assistant.children = [disclosure]
+    const before = scroll.scrollTop
+
+    listeners.get('click')({ type: 'click', detail: 0, target: disclosure })
+
+    assert.equal(scroll.dataset.scrollMode, 'ANCHOR_AT',
+      'a zero-detail click latches the chosen header like touch and keyboard')
+    assert.equal(scroll.scrollTop, before,
+      'preparing the expansion never moves the viewport')
+    hook.unmount()
+  } finally {
+    restoreBrowser()
+  }
+})
+
+// R1: the reservation is a pure function of tail geometry. Growth wholly above
+// the latest user row moves the row and the list together, so the same room
+// remains on every pass. A one-pass "retire" left the next layout pass to
+// restore the room, which read as blank space appearing below the chat.
+for (const [label, enter, expectedMode] of [
+  ['follow mode', hook => hook.result.current.followLatest(), 'FOLLOW_BOTTOM'],
+  ['a held anchor', hook => hook.result.current.anchorPagination('assistant-tail', 0), 'ANCHOR_AT'],
+]) {
+  test(`growth above the latest user row keeps the same reservation in ${label}`, () => {
+    const observers = []
+    const restoreBrowser = installBrowserEnvironment({ observers })
+    try {
+      const { hook, scroll, list, args } = mountTailController(
+        `disclosure-reservation-${expectedMode}`,
+      )
+      enter(hook)
+      assert.equal(scroll.dataset.scrollMode, expectedMode)
+
+      list.offsetHeight = 300
+      observers[0].callback([{ target: list }])
+      assert.equal(args.spacerRef.current.style.height, '200px')
+
+      // One expansion wholly above the row: row and list grow by the same 100px.
+      // The row started at offsetTop 0, where the pin target clamps at 0; from
+      // 100 the target is 100 - PIN_OFFSET(4), so the exact formula yields 196.
+      scroll.querySelector('.chat__msg--user[data-cid="user-1"]').offsetTop = 100
+      list.offsetHeight = 400
+      observers[0].callback([{ target: list }])
+      assert.equal(args.spacerRef.current.style.height, '196px',
+        'the formula is stable across passes; no pass may retire or restore room')
+      observers[0].callback([{ target: list }])
+      assert.equal(args.spacerRef.current.style.height, '196px')
+      hook.unmount()
+    } finally {
+      restoreBrowser()
+    }
+  })
+}
+
 test('question response resumes the exact follow intent captured at submit', () => {
   const observers = []
   const restoreBrowser = installBrowserEnvironment({ observers })

--- a/tests/spacer.spec.mjs
+++ b/tests/spacer.spec.mjs
@@ -704,7 +704,7 @@ test.describe('SSE streaming (real React path)', () => {
     await expect(tool.locator('.chat__tool-spin')).toHaveCount(0)
   })
 
-  test('16b. Near-foot activity taps follow deterministically while live descendants churn', async ({ page }) => {
+  test('16b. Near-foot activity expansion holds its header while descendants churn', async ({ page }) => {
     const events = [
       { type: 'catch_up_done' },
       // Put the final activity disclosure close to the viewport foot once the
@@ -755,11 +755,11 @@ test.describe('SSE streaming (real React path)', () => {
     expect(before.relativeTop).toBeGreaterThan(before.viewport * 0.55)
     expect(before.relativeTop).toBeLessThan(before.viewport - 20)
 
-    // Simulate status/output churn inside an open live activity timeline. In
-    // FOLLOW_BOTTOM, the scroll controller remains the sole authority: opening
-    // follows the taller real-content tail and closing returns to the prior
-    // tail. Repeated equal states must land identically despite descendant
-    // mutations; that is the autoscroll half of the idempotent-toggle contract.
+    // Simulate status/output churn inside an open live activity timeline.
+    // Expansion deliberately leaves FOLLOW_BOTTOM and freezes the chosen
+    // header. Repeated opens and closes must keep that same screen coordinate;
+    // an open body grows below it instead of dragging the viewport to the new
+    // tail, while collapse naturally restores the old physical tail.
     await page.evaluate(() => {
       window.__disclosureChurn = setInterval(() => {
         const timeline = [...document.querySelectorAll('[data-chat-surface="painted"] .chat__activity-timeline')].at(-1)
@@ -772,7 +772,6 @@ test.describe('SSE streaming (real React path)', () => {
     })
 
     try {
-      let openTop = null
       for (let i = 0; i < 10; i++) {
         await header.click()
         await page.evaluate(() => new Promise(r =>
@@ -785,16 +784,14 @@ test.describe('SSE streaming (real React path)', () => {
             gap: s.scrollHeight - s.scrollTop - s.clientHeight,
           }
         })
-        expect(after.gap, `toggle ${i + 1} left the tail`).toBeLessThanOrEqual(4)
+        expect(Math.abs(after.top - before.top), `toggle ${i + 1} moved the header`)
+          .toBeLessThanOrEqual(2)
         if (i % 2 === 0) {
-          if (openTop == null) {
-            openTop = after.top
-            expect(openTop).toBeLessThan(before.top - 20)
-          } else {
-            expect(Math.abs(after.top - openTop), `open ${i + 1} drift`).toBeLessThanOrEqual(2)
-          }
+          expect(after.gap, `open ${i + 1} followed the enlarged tail`)
+            .toBeGreaterThan(20)
         } else {
-          expect(Math.abs(after.top - before.top), `closed ${i + 1} drift`).toBeLessThanOrEqual(2)
+          expect(after.gap, `close ${i + 1} did not restore the prior tail`)
+            .toBeLessThanOrEqual(4)
         }
       }
     } finally {


### PR DESCRIPTION
## Summary
- Freeze the activated tool or activity header before its detail expands, including from the followed tail.
- Preserve long tool output and recalled Memory notes as bounded, vertically scrollable reading surfaces.
- Keep tail reservation geometry pure across layout passes so expansion cannot create recurring blank room.
- Cover pointer, touch, keyboard, and zero-detail assistive activation through one disclosure-target policy.

## Testing
- `npm test` — 3,411 tests passed.
- `npm run lint` — 0 errors (37 existing warnings).
- `npm run build` — production and service-worker builds passed.
- Chromium mobile/touch reproduction at 426×860: expansion kept `scrollTop` byte-identical with and without reserved room; zero-detail assistive activation did the same.