### PR TITLE
Use Integrations for OAuth product identity

### DIFF
--- a/backend/app/connector_oauth.py
+++ b/backend/app/connector_oauth.py
@@ -44,6 +44,11 @@ _DEFAULT_ACCESS_TTL = timedelta(hours=1)
 # default TTL and the next refresh corrects it.
 _MAX_ACCESS_TTL_SECONDS = 366 * 24 * 60 * 60
 
+# Keep the owner-facing product identity in one place while the stable
+# connector API and persisted connection vocabulary remain unchanged.
+INTEGRATIONS_PRODUCT_NAME = "Integrations"
+OAUTH_CLIENT_NAME = f"Möbius {INTEGRATIONS_PRODUCT_NAME}"
+
 # Per-connector async refresh locks. One API worker → an asyncio.Lock is a
 # sufficient single-flight guard so two concurrent turns never double-spend a
 # rotating refresh token.
@@ -313,7 +318,7 @@ def client_metadata_document() -> dict:
   url = client_metadata_url()
   return {
     "client_id": url,
-    "client_name": "Möbius Connections",
+    "client_name": OAUTH_CLIENT_NAME,
     "client_uri": get_settings().frontend_origin.rstrip("/"),
     "redirect_uris": [redirect_uri()],
     "token_endpoint_auth_method": "none",
@@ -357,7 +362,7 @@ async def ensure_client(db, discovery: Discovery) -> tuple[str, str | None]:
     "POST",
     discovery.registration_endpoint,
     json_body={
-      "client_name": "Möbius Connections",
+      "client_name": OAUTH_CLIENT_NAME,
       "redirect_uris": [redirect_uri()],
       "token_endpoint_auth_method": "none",
       "grant_types": ["authorization_code", "refresh_token"],

--- a/backend/app/routes/connectors.py
+++ b/backend/app/routes/connectors.py
@@ -1866,7 +1866,8 @@ def _oauth_result_page(*, ok: bool):
   status = "connected" if ok else "failed"
   html = (
     "<!doctype html><html><head><meta charset='utf-8'>"
-    "<title>Connections sign-in</title></head><body style='font-family:"
+    f"<title>{connector_oauth_mod.INTEGRATIONS_PRODUCT_NAME} sign-in</title>"
+    "</head><body style='font-family:"
     "system-ui;background:#12121a;color:#e8e8f0;display:flex;height:100vh;"
     "align-items:center;justify-content:center;margin:0'>"
     f"<p>Sign-in {status}. You can close this window.</p>"

--- a/backend/tests/test_connector_oauth.py
+++ b/backend/tests/test_connector_oauth.py
@@ -254,6 +254,7 @@ def test_oauth_add_signin_broker_and_disconnect(client, auth, db, provider):
   meta = client.get("/api/connectors/oauth/client-metadata.json")
   assert meta.status_code == 200
   assert meta.json()["client_id"] == meta.json()["client_id"]
+  assert meta.json()["client_name"] == "Möbius Integrations"
   assert meta.json()["redirect_uris"][0].endswith("/api/connectors/oauth/callback")
 
   # 3. Start sign-in → authorize URL with PKCE + resource + sealed state.
@@ -281,6 +282,7 @@ def test_oauth_add_signin_broker_and_disconnect(client, auth, db, provider):
     params={"code": "auth-code", "state": state, "iss": AS_ISSUER},
   )
   assert callback.status_code == 200
+  assert "<title>Integrations sign-in</title>" in callback.text
   assert "connected" in callback.text
 
   listed = client.get("/api/connectors", headers=auth).json()["connectors"]


### PR DESCRIPTION
## Summary

- present Möbius Integrations as the OAuth client name
- use Integrations in the OAuth callback window title
- keep existing connector routes and saved connection data working through the canonical app migration

## Verification

- `scripts/wt-pytest.sh backend/tests/test_connector_oauth.py`: 22 passed
- `scripts/test.sh --fast`: 98 passed
- `python3 -m py_compile backend/app/connector_oauth.py backend/app/routes/connectors.py backend/tests/test_connector_oauth.py`
- `git diff --check`
