### PR TITLE
Make app identity follow repository renames

### DIFF
--- a/backend/app/app_git.py
+++ b/backend/app/app_git.py
@@ -2456,6 +2456,14 @@ def origin_url(source_dir: str | Path) -> str | None:
   return value if proc.returncode == 0 and value else None
 
 
+def set_origin_url(source_dir: str | Path, url: str) -> None:
+  """Replace one existing app checkout's origin with a reviewed successor."""
+  repo = Path(source_dir)
+  if not is_repo(repo) or origin_url(repo) is None:
+    raise RuntimeError("source repository has no origin")
+  _run(repo, "remote", "set-url", "origin", url)
+
+
 def has_origin(source_dir: str | Path) -> bool:
   """Whether this app repo has a real `origin` remote.
 

--- a/backend/app/github_contributions.py
+++ b/backend/app/github_contributions.py
@@ -375,12 +375,28 @@ def publication_handoff_spec(
     raise ContributionSubmitError(
       "The reviewed package belongs to a different local app."
     )
-  if target.manifest_url is not None and not install._catalog_identity_matches(
-    target.manifest_url, identity.manifest_url, manifest_id,
-  ):
-    raise ContributionSubmitError(
-      "This installed app is already connected to a different package."
+  if target.manifest_url is not None:
+    try:
+      predecessor_source, _ = install._reviewed_predecessor_source(
+        reviewed_manifest, identity.manifest_url,
+      )
+    except HTTPException as exc:
+      raise ContributionSubmitError(str(exc.detail)) from exc
+    predecessor_matches = bool(
+      previous_id
+      and install._catalog_identity_matches(
+        target.manifest_url, predecessor_source, previous_id,
+      )
     )
+    if not (
+      install._catalog_identity_matches(
+        target.manifest_url, identity.manifest_url, manifest_id,
+      )
+      or predecessor_matches
+    ):
+      raise ContributionSubmitError(
+        "This installed app is already connected to a different package."
+      )
 
   return PublicationHandoffSpec(
     **asdict(identity),

--- a/backend/app/install.py
+++ b/backend/app/install.py
@@ -287,7 +287,7 @@ def _derive_repo_ref(manifest_url: str) -> tuple[str, str] | None:
   parts = [unquote(part) for part in parsed.path.split("/") if part]
   if (
     parsed.scheme != "https"
-    or parsed.hostname != "raw.githubusercontent.com"
+    or parsed.netloc != "raw.githubusercontent.com"
     or len(parts) != 4
   ):
     return None
@@ -389,6 +389,64 @@ def _trusted_catalog_origin_url(url_or_base: str) -> str | None:
   if len(parts) != 2:
     return None
   return f"https://github.com/{parts[0]}/{parts[1]}.git"
+
+
+def _github_root_manifest_identity(url_or_base: str) -> tuple[str, str] | None:
+  """Return owner/repository for one root raw-GitHub manifest URL."""
+  if not isinstance(url_or_base, str) or not url_or_base:
+    return None
+  parsed = urlparse(_canonical_base(url_or_base))
+  if (
+    parsed.scheme != "https"
+    or parsed.hostname != "raw.githubusercontent.com"
+    or parsed.username is not None
+    or parsed.password is not None
+  ):
+    return None
+  parts = [unquote(part) for part in parsed.path.split("/") if part]
+  if len(parts) != 3 or ".." in parts:
+    return None
+  owner, repo, ref = parts
+  if any(
+    part in ("", ".", "..") or part.startswith("-") or "\\" in part
+    for part in (owner, repo, ref)
+  ):
+    return None
+  return owner.lower(), repo.lower()
+
+
+def _github_origin_url(url_or_base: str) -> str | None:
+  identity = _github_root_manifest_identity(url_or_base)
+  if identity is None:
+    return None
+  owner, repo = identity
+  return f"https://github.com/{owner}/{repo}.git"
+
+
+def _reviewed_predecessor_source(
+  manifest: dict, source_for_key: str,
+) -> tuple[str, tuple[str, str] | None]:
+  """Resolve a package rename without allowing cross-owner adoption."""
+  previous_source = manifest.get("previous_manifest_url")
+  if not previous_source:
+    return source_for_key, None
+  current_identity = _github_root_manifest_identity(source_for_key)
+  previous_identity = _github_root_manifest_identity(previous_source)
+  if (
+    current_identity is None
+    or previous_identity is None
+    or current_identity[0] != previous_identity[0]
+  ):
+    raise HTTPException(
+      400,
+      "Manifest repository renames must use root GitHub manifests owned by "
+      "the same account.",
+    )
+  old_origin = _github_origin_url(previous_source)
+  new_origin = _github_origin_url(source_for_key)
+  if old_origin is None or new_origin is None:
+    raise HTTPException(400, "Manifest repository rename is invalid.")
+  return previous_source, (old_origin, new_origin)
 
 
 def _trusted_origin_catalog_identity_matches(
@@ -1972,6 +2030,7 @@ class InstallTarget:
   trusted_catalog_origin: bool
   canonical_manifest_url: str
   force_core_store_update: bool
+  origin_migration: tuple[str, str] | None
 
 
 @dataclass
@@ -2254,22 +2313,25 @@ def _select_install_target(
   )
 
   adopting_previous_id = False
+  origin_migration = None
   if existing is None:
-    # A rename is explicit and source-bound: previous_id is looked up under the
-    # same canonical package base, never by a globally reusable slug.
+    # A rename is explicit and source-bound. Ordinarily previous_id is looked
+    # up under the same package base; previous_manifest_url may name an old
+    # repository owned by the same GitHub account.
     prev_id = manifest.get("previous_id")
     if prev_id:
-      prev_canonical = _canonical_identity_key(source_for_key, prev_id)
-      existing = (
-        db.query(models.App)
-        .filter(
-          models.App.manifest_url == prev_canonical,
-          models.App.deleted_at.is_(None),
-        )
-        .first()
+      predecessor_source, origin_migration = _reviewed_predecessor_source(
+        manifest, source_for_key,
       )
+      existing = _find_install_identity_row(
+        db, source_url=predecessor_source, manifest_id=prev_id,
+      )
+      if existing is not None and existing.deleted_at is not None:
+        existing = None
       if existing:
         adopting_previous_id = True
+      else:
+        origin_migration = None
 
   required_app_id = (
     expected_app_id
@@ -2296,6 +2358,7 @@ def _select_install_target(
     ),
     canonical_manifest_url=canonical_manifest_url,
     force_core_store_update=force_core_store_update,
+    origin_migration=origin_migration,
   )
 
 
@@ -2492,6 +2555,30 @@ async def _prepare_app_row(
         app.slug = target_slug
         app.source_dir = target_source_dir
         app.manifest_url = canonical_manifest_url
+        if target.origin_migration and app_git.has_origin(target_source_dir):
+          old_origin, new_origin = target.origin_migration
+          current_origin = app_git.origin_url(target_source_dir)
+          normalized_origin = (
+            current_origin.rstrip("/").lower() if current_origin else None
+          )
+          if normalized_origin and normalized_origin not in {
+            old_origin.rstrip("/").lower(), new_origin.rstrip("/").lower(),
+          }:
+            raise HTTPException(
+              409, "Installed app origin no longer matches its rename source.",
+            )
+          if (
+            normalized_origin
+            and normalized_origin
+            != new_origin.rstrip("/").lower()
+          ):
+            app_git.set_origin_url(target_source_dir, new_origin)
+            journal.rollback_actions.append(
+              lambda p=target_source_dir, u=current_origin:
+              app_git.set_origin_url(p, u)
+              if Path(p).is_dir() and app_git.has_origin(p)
+              else None
+            )
         db.flush()
       elif old_source_dir and Path(old_source_dir).is_dir():
         warnings.append(

--- a/backend/app/manifest_contract.py
+++ b/backend/app/manifest_contract.py
@@ -191,6 +191,25 @@ def validate_manifest_contract(manifest) -> None:
     validate_slug_field(previous_id, "previous_id")
     if previous_id == mid:
       _fail("Manifest `previous_id` must differ from `id`.")
+  previous_manifest_url = manifest.get("previous_manifest_url")
+  if previous_manifest_url is not None:
+    if previous_id is None:
+      _fail("Manifest `previous_manifest_url` requires `previous_id`.")
+    if not isinstance(previous_manifest_url, str) or not previous_manifest_url:
+      _fail("Manifest `previous_manifest_url` must be a non-empty string.")
+    parsed_previous = urlparse(previous_manifest_url)
+    if (
+      parsed_previous.scheme != "https"
+      or not parsed_previous.netloc
+      or parsed_previous.username is not None
+      or parsed_previous.password is not None
+      or parsed_previous.query
+      or parsed_previous.fragment
+    ):
+      _fail(
+        "Manifest `previous_manifest_url` must be an absolute HTTPS URL "
+        "without credentials, query, or fragment."
+      )
 
   validate_repo_relative_path(manifest["entry"], "entry")
   if manifest["entry"] != "index.jsx":

--- a/backend/app/routes/apps.py
+++ b/backend/app/routes/apps.py
@@ -1594,8 +1594,22 @@ async def update_candidate_preview(
     else install._canonical_base(installed_manifest_url) + "/mobius.json"
   )
   fetched = await install.fetch_upstream_source(fetch_manifest_url)
-  if manifest_url is not None and not install._catalog_identity_matches(
-    installed_manifest_url, manifest_url, fetched.manifest["id"],
+  predecessor_source, _ = install._reviewed_predecessor_source(
+    fetched.manifest, manifest_url or fetch_manifest_url,
+  )
+  predecessor_matches = bool(
+    fetched.manifest.get("previous_id")
+    and install._catalog_identity_matches(
+      installed_manifest_url,
+      predecessor_source,
+      fetched.manifest["previous_id"],
+    )
+  )
+  if manifest_url is not None and not (
+    install._catalog_identity_matches(
+      installed_manifest_url, manifest_url, fetched.manifest["id"],
+    )
+    or predecessor_matches
   ):
     raise HTTPException(
       409, "Requested update source does not match the installed app.",

--- a/backend/tests/test_apps_install.py
+++ b/backend/tests/test_apps_install.py
@@ -4290,7 +4290,9 @@ def test_update_preview_conflict_returns_real_markers_without_live_mutation(
 # --------------------------------------------------------------------------
 
 
-def _simple_manifest(app_id, version="1.0.0", previous_id=None):
+def _simple_manifest(
+  app_id, version="1.0.0", previous_id=None, previous_manifest_url=None,
+):
   """A minimal installable manifest (no schedule/icon/seeds) for the
   adoption tests, so the response map only needs mobius.json + index.jsx."""
   m = {
@@ -4303,6 +4305,8 @@ def _simple_manifest(app_id, version="1.0.0", previous_id=None):
   }
   if previous_id is not None:
     m["previous_id"] = previous_id
+  if previous_manifest_url is not None:
+    m["previous_manifest_url"] = previous_manifest_url
   return m
 
 
@@ -4398,6 +4402,99 @@ def test_install_validates_previous_id_field(client, auth, bypass_url_validation
   r2 = _install_simple(client, auth, base2, self_ref)
   assert r2.status_code == 400, r2.text
   assert "previous_id" in r2.text
+
+  # A repository predecessor is meaningful only as part of an id rename.
+  missing_id = _simple_manifest(
+    "renamed", previous_manifest_url="https://example.test/old/mobius.json",
+  )
+  r3 = _install_simple(client, auth, "https://prev-missing.test/repo/", missing_id)
+  assert r3.status_code == 400, r3.text
+  assert "requires `previous_id`" in r3.text
+
+  # Credentials, mutable query parameters, and non-HTTPS predecessors are not
+  # durable package identities.
+  bad_url = _simple_manifest(
+    "renamed", previous_id="old",
+    previous_manifest_url="http://user:pass@example.test/old?ref=main",
+  )
+  r4 = _install_simple(client, auth, "https://prev-url.test/repo/", bad_url)
+  assert r4.status_code == 400, r4.text
+  assert "absolute HTTPS URL" in r4.text
+
+
+def test_rename_adopts_predecessor_across_same_owner_repository_move(
+  client, auth, bypass_url_validation,
+):
+  """A package and repository rename preserves the row, storage, and data."""
+  old_base = "https://raw.githubusercontent.com/acme/app-old/main/"
+  new_base = "https://raw.githubusercontent.com/acme/app-new/main/"
+
+  # Keep the fixture hermetic: repository identity is exercised, while source
+  # materialization uses the installer's synthetic Git path.
+  with patch("app.install._derive_repo_ref", return_value=None):
+    first = _install_simple(client, auth, old_base, _simple_manifest("old"))
+    assert first.status_code == 201, first.text
+    app_id = first.json()["id"]
+    old_source = Path(get_settings().data_dir) / "apps" / "old"
+    subprocess.run(
+      [
+        "git", "remote", "add", "origin",
+        "https://github.com/acme/app-old.git",
+      ],
+      cwd=old_source,
+      check=True,
+    )
+    storage_file = (
+      Path(get_settings().data_dir) / "apps" / str(app_id) / "data.json"
+    )
+    storage_file.parent.mkdir(parents=True, exist_ok=True)
+    storage_file.write_text('{"kept": true}')
+
+    renamed = _install_simple(
+      client,
+      auth,
+      new_base,
+      _simple_manifest(
+        "new",
+        version="2.0.0",
+        previous_id="old",
+        previous_manifest_url=old_base + "mobius.json",
+      ),
+    )
+
+  assert renamed.status_code == 201, renamed.text
+  assert renamed.json()["mode"] == "update"
+  assert renamed.json()["id"] == app_id
+  assert renamed.json()["slug"] == "new"
+  assert storage_file.read_text() == '{"kept": true}'
+  new_source = Path(get_settings().data_dir) / "apps" / "new"
+  assert not old_source.exists()
+  assert subprocess.check_output(
+    ["git", "remote", "get-url", "origin"], cwd=new_source, text=True,
+  ).strip() == "https://github.com/acme/app-new.git"
+
+
+def test_repository_move_cannot_adopt_package_from_another_owner(
+  client, auth, bypass_url_validation,
+):
+  old_base = "https://raw.githubusercontent.com/alice/app-old/main/"
+  new_base = "https://raw.githubusercontent.com/bob/app-new/main/"
+  with patch("app.install._derive_repo_ref", return_value=None):
+    first = _install_simple(client, auth, old_base, _simple_manifest("old"))
+    assert first.status_code == 201, first.text
+    refused = _install_simple(
+      client,
+      auth,
+      new_base,
+      _simple_manifest(
+        "new",
+        previous_id="old",
+        previous_manifest_url=old_base + "mobius.json",
+      ),
+    )
+
+  assert refused.status_code == 400, refused.text
+  assert "owned by the same account" in refused.text
 
 
 def test_rename_adopts_predecessor_row_and_moves_source_dir(


### PR DESCRIPTION
## Summary

- let an app declare its exact predecessor manifest when its package and GitHub repository are renamed
- preserve the numeric app record and saved data while moving the source slug and updating its Git origin
- make Store previews and reviewed publication handoffs understand the same migration
- reject cross-owner adoption and roll back origin changes with the rest of a failed install

## Verification

- focused rename tests: 7 passed
- full `backend/tests/test_apps_install.py`: 163 passed
- `scripts/test.sh --fast`: 98 passed
- Python compilation and `git diff --check`
