### PR TITLE
Harden restart card lifecycle and history

### DIFF
--- a/backend/app/chat_transcript.py
+++ b/backend/app/chat_transcript.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import re
 
 from app.chat_message_identity import assistant_message_index
+from app.events import tool_output_exit_code
 from app.memory_recall import (
   RecallBinding,
   recall_from_command,
@@ -16,12 +17,59 @@ from app.tool_sources import normalize_tool_sources
 
 
 _QUESTION_TOOLS = {"AskUserQuestion", "request_user_input"}
+_RESTART_REQUEST_TOOLS = {
+  "mobius_control:request_restart",
+  "mcp__mobius_control__request_restart",
+}
 _IMAGE_PATH_RE = re.compile(
   r"\.(?:avif|bmp|gif|heic|heif|jpe?g|png|svg|webp)(?:[?#].*)?$",
   re.IGNORECASE,
 )
 _MAX_SOURCE_ROWS_SCANNED = 512
 MAX_ACTIVITY_DETAIL_BLOCKS = 2000
+
+
+def redundant_interaction_tool_indexes(blocks: list[dict]) -> set[int]:
+  """Return tools whose immediately following product card owns the UI."""
+  latest_unowned: dict[str, int | None] = {"question": None, "restart": None}
+  owned: set[int] = set()
+  for index, block in enumerate(blocks):
+    if not isinstance(block, dict):
+      continue
+    if block.get("type") == "tool":
+      tool = block.get("tool")
+      family = (
+        "question" if tool in _QUESTION_TOOLS
+        else "restart" if tool in _RESTART_REQUEST_TOOLS
+        else None
+      )
+      if family is None:
+        continue
+      exit_code = block.get("output_exit_code")
+      if exit_code is None:
+        exit_code = tool_output_exit_code(block.get("output"))
+      failed = (
+        isinstance(exit_code, (int, float))
+        and not isinstance(exit_code, bool)
+        and exit_code != 0
+      )
+      if failed:
+        continue
+      latest_unowned[family] = index
+      continue
+    if block.get("type") != "question":
+      continue
+    action = block.get("platform_action")
+    family = (
+      "restart"
+      if isinstance(action, dict) and action.get("type") == "restart"
+      else "question"
+    )
+    twin = latest_unowned[family]
+    if twin is not None:
+      owned.add(twin)
+      latest_unowned[family] = None
+  return owned
 
 
 def materialized_messages(chat) -> list[dict]:
@@ -437,10 +485,7 @@ def compact_messages_for_detail(
       continue
 
     sources = message_sources_for_detail(message)
-    has_question = any(
-      isinstance(block, dict) and block.get("type") == "question"
-      for block in blocks
-    )
+    redundant_tool_indexes = redundant_interaction_tool_indexes(blocks)
     next_blocks: list[dict] = []
     run: list[tuple[int, dict]] = []
     changed = False
@@ -466,13 +511,7 @@ def compact_messages_for_detail(
         isinstance(block, dict)
         and block.get("type") in {"tool", "thinking"}
       )
-      question_twin = (
-        activity
-        and block.get("type") == "tool"
-        and has_question
-        and block.get("tool") in _QUESTION_TOOLS
-      )
-      if question_twin:
+      if activity and raw_index in redundant_tool_indexes:
         flush()
         changed = True
         continue

--- a/backend/app/chat_waits.py
+++ b/backend/app/chat_waits.py
@@ -282,6 +282,9 @@ def _cancel_active_check(wait_id: str) -> None:
 
 
 def serialize_wait(row: models.ChatWait) -> dict:
+  # Platform activation has no product deadline. Its non-null storage value is
+  # retained only for compatibility with the original shared ChatWait schema.
+  presented_deadline = None if row.kind == "platform_activation" else row.deadline_at
   return {
     "id": row.id,
     "chat_id": row.chat_id,
@@ -292,7 +295,9 @@ def serialize_wait(row: models.ChatWait) -> dict:
     "status": row.status,
     "interval_secs": row.interval_secs,
     "due_at": row.due_at.isoformat() if row.due_at else None,
-    "deadline_at": row.deadline_at.isoformat() if row.deadline_at else None,
+    "deadline_at": (
+      presented_deadline.isoformat() if presented_deadline else None
+    ),
     "next_check_at": (
       row.next_check_at.isoformat() if row.next_check_at else None
     ),
@@ -322,7 +327,10 @@ def build_active_waits_context(db: Session, chat_id: str) -> str:
     "condition_owner": row.condition_owner,
     "kind": row.kind,
     "due_at": row.due_at.isoformat() if row.due_at else None,
-    "deadline_at": row.deadline_at.isoformat() if row.deadline_at else None,
+    "deadline_at": (
+      None if row.kind == "platform_activation"
+      else row.deadline_at.isoformat() if row.deadline_at else None
+    ),
   } for row in rows]
   body = json.dumps(payload, ensure_ascii=True, separators=(",", ":"))
   # Untrusted lifecycle labels cannot terminate the platform-owned carrier.

--- a/backend/app/chat_writer.py
+++ b/backend/app/chat_writer.py
@@ -285,6 +285,24 @@ class CancelActivationWaits(_Command):
   run_token: str = ""
 
 
+class RestartCardStateChanged(Exception):
+  """The submitted Restart choice no longer targets an open durable card.
+
+  This is intentionally distinct from `_PersistFailed`: callers may repair a
+  stale browser projection from authoritative chat state, while a failed write
+  must remain retryable and must never be presented as a settled card.
+  """
+
+
+class RestartCardActionConflict(Exception):
+  """The card is still visible, but its exact Restart authority is unusable.
+
+  The route returns this as an actionable 409 rather than pretending a retry
+  can repair it or that authoritative chat state has already settled it. The
+  card's writing surface remains available to resume the owning agent.
+  """
+
+
 @dataclass
 class ResolvePlatformRestartCard(_Command):
   """Settle one typed Restart choice and claim its exact side effect.
@@ -2212,7 +2230,7 @@ class ChatWriterActor:
 
     chat = _active_chat(db, cmd.chat_id)
     if chat is None:
-      raise _PersistFailed("Restart card: chat not found or deleted")
+      raise RestartCardStateChanged("Restart card: chat not found or deleted")
 
     messages = copy.deepcopy(list(chat.messages or []))
     matched: dict | None = None
@@ -2229,12 +2247,16 @@ class ChatWriterActor:
           break
       if matched is not None:
         break
+    if matched is None:
+      raise RestartCardStateChanged("Restart card: card is no longer present")
     action, question, labels = _platform_restart_card_envelope(
       matched, "Restart card",
     )
     restart_id = action["restart_option_id"]
     if cmd.selected_option_id not in labels:
-      raise _PersistFailed("Restart card: selected option is not authorized")
+      raise RestartCardActionConflict(
+        "Use one of this Restart card's current choices."
+      )
 
     wait = db.query(models.ChatWait).filter(
       models.ChatWait.id == action["wait_id"],
@@ -2243,12 +2265,16 @@ class ChatWriterActor:
       models.ChatWait.kind == "platform_activation",
     ).first()
     if wait is None or wait.condition_json != action["requirement"]:
-      raise _PersistFailed("Restart card: linked activation wait is invalid")
+      raise RestartCardActionConflict(
+        "This Restart request is no longer active. Tell the agent to check it again."
+      )
 
     prior_selected = matched.get("selected_options")
     if matched.get("answers"):
       if prior_selected != {"restart": [cmd.selected_option_id]}:
-        raise _PersistFailed("Restart card: card already settled differently")
+        raise RestartCardStateChanged(
+          "Restart card: card already settled differently"
+        )
       execution = db.get(models.PlatformRestartExecution, action["action_id"])
       db.rollback()
       return {
@@ -2269,7 +2295,9 @@ class ChatWriterActor:
       or wait.resume_delivered_at is not None
       or wait.status not in ("armed", "met", "expired", "failed")
     ):
-      raise _PersistFailed("Restart card: card is no longer accepting actions")
+      raise RestartCardStateChanged(
+        "Restart card: card is no longer accepting actions"
+      )
 
     now = now_naive_utc()
     selected_restart = cmd.selected_option_id == restart_id
@@ -2290,8 +2318,8 @@ class ChatWriterActor:
       wait.action_approved_at = now
       if wait.status in ("expired", "failed"):
         db.rollback()
-        raise _PersistFailed(
-          "Restart card: activation outcome is uncertain; request a fresh card"
+        raise RestartCardActionConflict(
+          "This Restart request needs to be checked again. Tell the agent what happened."
         )
       verdict, _detail = activation_wait_verdict(db, wait)
       if verdict == "met":
@@ -2302,8 +2330,9 @@ class ChatWriterActor:
       else:
         if not requirement_matches_current_source(action["requirement"]):
           db.rollback()
-          raise _PersistFailed(
-            "Restart card: committed source changed; request a fresh card"
+          raise RestartCardActionConflict(
+            "Möbius changed since this card was created. Tell the agent to check it "
+            "and request a fresh Restart card."
           )
         execution = db.get(models.PlatformRestartExecution, action["action_id"])
         if execution is None:

--- a/backend/app/events.py
+++ b/backend/app/events.py
@@ -29,6 +29,9 @@ from app.tool_sources import (
 # only distinguishes success from failure, and an unknown non-failure reads as
 # done rather than as the failed (red) dot.
 _TERMINAL_SUBAGENT_STATUSES = frozenset({"done", "failed", "killed", "stopped"})
+_TOOL_OUTPUT_COMMON_KEYS = frozenset({
+  "result", "content", "text", "summary", "output", "data",
+})
 
 
 def _normalize_subagent_status(status: str | None) -> str:
@@ -366,8 +369,40 @@ def _tool_output_exit_code(content: str, parsed):
   return int(m.group(1)) if m else None
 
 
+def _nested_tool_output_exit_code(content: str, parsed):
+  """Read direct or common-wrapped output from one already-parsed value."""
+  direct = _tool_output_exit_code(content, parsed)
+  if direct is not None:
+    return direct
+
+  # Some providers wrap the real tool payload in one common single-key
+  # envelope, sometimes as another JSON string. Match the bounded frontend
+  # compatibility path so an old failed request cannot disappear only after
+  # server-side projection.
+  value = parsed
+  for _depth in range(4):
+    if not isinstance(value, dict) or len(value) != 1:
+      return None
+    key = next(iter(value))
+    if key not in _TOOL_OUTPUT_COMMON_KEYS:
+      return None
+    value = value[key]
+    if isinstance(value, str):
+      stripped = value.lstrip()
+      if stripped[:1] not in ("{", "["):
+        return None
+      try:
+        value = json.loads(value)
+      except (ValueError, TypeError):
+        return None
+    nested = _tool_output_exit_code("", value)
+    if nested is not None:
+      return nested
+  return None
+
+
 def tool_output_exit_code(content: object):
-  """Return a typed command exit code from any sized tool output."""
+  """Return a typed command exit code from any supported tool envelope."""
   if not isinstance(content, str):
     return None
   parsed = None
@@ -377,7 +412,7 @@ def tool_output_exit_code(content: object):
       parsed = json.loads(content)
     except (ValueError, TypeError):
       parsed = None
-  return _tool_output_exit_code(content, parsed)
+  return _nested_tool_output_exit_code(content, parsed)
 
 
 def excerpt_tool_output(content: str):
@@ -396,7 +431,7 @@ def excerpt_tool_output(content: str):
       parsed = json.loads(content)
     except (ValueError, TypeError):
       parsed = None
-  exit_code = _tool_output_exit_code(content, parsed)
+  exit_code = _nested_tool_output_exit_code(content, parsed)
   if parsed is not None:
     excerpt = json.dumps(_truncate_json_strings(parsed), ensure_ascii=True)
     # Boundedness ceiling: a JSON value whose size is in its STRUCTURE (many

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -594,8 +594,9 @@ class ChatWait(Base):
   interval_secs = Column(Integer, nullable=False, default=300)
   # Command/timer waits never rot silently: on deadline the chat is woken with
   # `deadline_expired` so the agent decides what to do next. Platform
-  # activation rows share this required column but deliberately do not expire;
-  # their owner card remains until answer, cancellation, or a later ready boot.
+  # activation rows share this required legacy storage column but deliberately
+  # do not expose or enforce it; their owner card remains until answer,
+  # cancellation, or a later ready boot.
   deadline_at = Column(DateTime, nullable=False)
   # armed -> met | expired | failed | cancelled. `failed` means the check
   # itself broke (distinct from a valid silent exit-1 "not yet"). Terminal

--- a/backend/app/routes/chat_waits.py
+++ b/backend/app/routes/chat_waits.py
@@ -119,4 +119,9 @@ def cancel(
   # token may cancel any.
   if principal.chat_id is not None and principal.chat_id != row.chat_id:
     raise HTTPException(status_code=403, detail="Not this chat's wait.")
+  if row.kind == "platform_activation":
+    raise HTTPException(
+      status_code=409,
+      detail="Use the Restart card or Stop the chat instead.",
+    )
   return serialize_wait(cancel_wait(db, row))

--- a/backend/app/routes/chats.py
+++ b/backend/app/routes/chats.py
@@ -1708,6 +1708,7 @@ def get_chat_activity_detail(
     historical_tool_output_ids,
     materialized_messages,
     project_messages_for_detail,
+    redundant_interaction_tool_indexes,
   )
 
   if principal.scope == "app":
@@ -1725,19 +1726,13 @@ def get_chat_activity_detail(
   if not isinstance(blocks, list) or end > len(blocks):
     raise HTTPException(status_code=404, detail="Activity range not found.")
 
+  redundant_tool_indexes = redundant_interaction_tool_indexes(blocks)
   selected = [
     (raw_index, block)
     for raw_index, block in enumerate(blocks[start:end], start=start)
     if isinstance(block, dict)
     and block.get("type") in {"tool", "thinking"}
-    and not (
-      block.get("type") == "tool"
-      and block.get("tool") in {"AskUserQuestion", "request_user_input"}
-      and any(
-        isinstance(candidate, dict) and candidate.get("type") == "question"
-        for candidate in blocks
-      )
-    )
+    and raw_index not in redundant_tool_indexes
   ]
   detail_message = {
     "role": "assistant",

--- a/backend/app/routes/chats_stream.py
+++ b/backend/app/routes/chats_stream.py
@@ -40,7 +40,9 @@ from app.chat_writer import (
   cid_of,
   ensure_user_cid,
   get_writer,
+  RestartCardActionConflict,
   ResolvePlatformRestartCard,
+  RestartCardStateChanged,
 )
 from app.chat_steering import (
   has_live_steerable_turn,
@@ -660,8 +662,11 @@ async def send_message(
               chat_id, body.question_id, exc,
             )
             raise HTTPException(
-              status_code=409,
-              detail="This Restart card is stale or no longer accepting a response.",
+              status_code=410,
+              detail={
+                "code": "question_state_changed",
+                "message": "This Restart card has already been settled.",
+              },
             ) from exc
       event = {
         "type": "answers_applied",
@@ -710,14 +715,34 @@ async def send_message(
               selected_option_id=selections["restart"][0],
             )
           ))
-        except Exception as exc:
+        except RestartCardStateChanged as exc:
           log.info(
             "Restart card resolution refused chat_id=%s question_id=%s: %s",
             chat_id, body.question_id, exc,
           )
           raise HTTPException(
+            status_code=410,
+            detail={
+              "code": "question_state_changed",
+              "message": "This Restart card has already been settled.",
+            },
+          ) from exc
+        except RestartCardActionConflict as exc:
+          raise HTTPException(
             status_code=409,
-            detail="This Restart card is stale or no longer authorized.",
+            detail={
+              "code": "restart_action_conflict",
+              "message": str(exc),
+            },
+          ) from exc
+        except Exception as exc:
+          log.exception(
+            "Restart card resolution failed chat_id=%s question_id=%s",
+            chat_id, body.question_id,
+          )
+          raise HTTPException(
+            status_code=503,
+            detail="Möbius could not save that Restart choice. Please try again.",
           ) from exc
     try:
       event = {

--- a/backend/tests/test_chat_transcript_compact.py
+++ b/backend/tests/test_chat_transcript_compact.py
@@ -463,6 +463,136 @@ def test_compact_route_defers_activity_detail_until_expansion(client, auth):
   assert entries[1]["item"]["output"] == "hello"
 
 
+def test_restart_card_owns_its_tool_in_compact_and_expanded_activity(client, auth):
+  messages = [{
+    "role": "assistant",
+    "blocks": [
+      {"type": "tool", "tool": "Bash", "tool_use_id": "bash-1"},
+      {"type": "tool", "tool": "Bash", "tool_use_id": "bash-2"},
+      {"type": "tool", "tool": "Bash", "tool_use_id": "bash-3"},
+      {
+        "type": "tool", "tool": "mcp__mobius_control__request_restart",
+        "tool_use_id": "restart-tool",
+      },
+      {
+        "type": "question", "question_id": "restart-card",
+        "questions": [{"id": "restart", "question": "Restart?", "options": []}],
+        "platform_action": {"type": "restart", "version": 2},
+      },
+    ],
+  }]
+  created = client.post(
+    "/api/chats", headers=auth,
+    json={"title": "Compact Restart ownership", "messages": messages},
+  )
+  chat_id = created.json()["id"]
+
+  compact = client.get(
+    f"/api/chats/{chat_id}?limit=20&compact=1", headers=auth,
+  )
+  assert compact.status_code == 200
+  activity = compact.json()["messages"][0]["blocks"][0]
+  assert activity["type"] == "activity"
+  assert activity["tool_count"] == 3
+  assert [entry["item"]["tool"] for entry in activity["entries"]] == [
+    "Bash", "Bash",
+  ]
+
+  detail = client.get(
+    f"/api/chats/{chat_id}/activity-detail"
+    "?message_index=0&start=0&end=4",
+    headers=auth,
+  )
+  assert detail.status_code == 200
+  assert [entry["item"]["tool"] for entry in detail.json()["entries"]] == [
+    "Bash", "Bash", "Bash",
+  ]
+
+
+def test_restart_card_keeps_an_earlier_failed_request_visible(client, auth):
+  messages = [{
+    "role": "assistant",
+    "blocks": [
+      {
+        "type": "tool", "tool": "mcp__mobius_control__request_restart",
+        "tool_use_id": "failed-restart", "status": "done",
+        "output": "Working tree is dirty", "output_exit_code": 1,
+      },
+      {
+        "type": "tool", "tool": "mcp__mobius_control__request_restart",
+        "tool_use_id": "successful-restart", "status": "done",
+      },
+      {
+        "type": "question", "question_id": "restart-card",
+        "questions": [{"id": "restart", "question": "Restart?", "options": []}],
+        "platform_action": {"type": "restart", "version": 2},
+      },
+    ],
+  }]
+  created = client.post(
+    "/api/chats", headers=auth,
+    json={"title": "Failed Restart evidence", "messages": messages},
+  )
+  chat_id = created.json()["id"]
+
+  compact = client.get(
+    f"/api/chats/{chat_id}?limit=20&compact=1", headers=auth,
+  ).json()["messages"][0]["blocks"]
+  assert compact[0]["tool"] == "mcp__mobius_control__request_restart"
+  assert compact[0]["tool_use_id"] == "failed-restart"
+
+  detail = client.get(
+    f"/api/chats/{chat_id}/activity-detail"
+    "?message_index=0&start=0&end=2",
+    headers=auth,
+  )
+  assert detail.status_code == 200
+  assert [entry["item"]["tool_use_id"] for entry in detail.json()["entries"]] == [
+    "failed-restart",
+  ]
+
+
+def test_tool_pairing_never_parses_unrelated_tool_output(monkeypatch):
+  from app import chat_transcript
+
+  def unexpected_parse(_output):
+    raise AssertionError("unrelated tool output must not be parsed")
+
+  monkeypatch.setattr(chat_transcript, "tool_output_exit_code", unexpected_parse)
+  assert chat_transcript.redundant_interaction_tool_indexes([
+    {"type": "tool", "tool": "Bash", "output": "large output"},
+  ]) == set()
+
+
+def test_restart_card_never_owns_a_legacy_parse_only_failure(client, auth):
+  messages = [{
+    "role": "assistant",
+    "blocks": [
+      {
+        "type": "tool", "tool": "mcp__mobius_control__request_restart",
+        "tool_use_id": "failed-restart", "status": "done",
+        "output": '{"result":"{\\"exit_code\\":1,\\"stderr\\":\\"failed\\"}"}',
+      },
+      {
+        "type": "question", "question_id": "restart-card",
+        "questions": [{"id": "restart", "question": "Restart?", "options": []}],
+        "platform_action": {"type": "restart", "version": 2},
+      },
+    ],
+  }]
+  created = client.post(
+    "/api/chats", headers=auth,
+    json={"title": "Only failed Restart", "messages": messages},
+  )
+  chat_id = created.json()["id"]
+
+  compact = client.get(
+    f"/api/chats/{chat_id}?limit=20&compact=1", headers=auth,
+  ).json()["messages"][0]["blocks"]
+  assert compact[0]["type"] == "tool"
+  assert compact[0]["tool_use_id"] == "failed-restart"
+
+
 def test_compact_route_defers_reference_metadata_until_expansion(client, auth):
   first = {
     "title": "First title",

--- a/backend/tests/test_events.py
+++ b/backend/tests/test_events.py
@@ -9,6 +9,7 @@ from app.events import (
   build_assistant_message,
   finalize_blocks,
   process_event,
+  tool_output_exit_code,
 )
 from app.tool_sources import MAX_TOOL_SOURCES
 
@@ -18,6 +19,11 @@ def test_text_event_creates_block():
   changed = process_event({"type": "text", "content": "hello"}, blocks)
   assert changed
   assert blocks == [{"type": "text", "content": "hello"}]
+
+
+def test_tool_output_exit_code_unwraps_common_nested_envelopes():
+  output = '{"result":"{\\"exit_code\\":1,\\"stderr\\":\\"failed\\"}"}'
+  assert tool_output_exit_code(output) == 1
 
 
 def test_text_events_concatenate():

--- a/backend/tests/test_platform_restart_cards.py
+++ b/backend/tests/test_platform_restart_cards.py
@@ -213,6 +213,53 @@ def test_restart_activation_wait_does_not_expire_while_owner_is_deciding(monkeyp
     assert wait.next_check_at > now_naive_utc()
 
 
+def test_restart_wait_hides_storage_deadline_from_owner_and_agent_context():
+  from app.chat_waits import build_active_waits_context, serialize_wait
+
+  _qid, wait_id, _run, _requirement = _install("restart-no-visible-expiry")
+  with SessionLocal() as db:
+    wait = db.get(models.ChatWait, wait_id)
+    assert wait.deadline_at is not None  # Legacy shared-schema storage only.
+    assert serialize_wait(wait)["deadline_at"] is None
+    assert '"deadline_at":null' in build_active_waits_context(
+      db, "restart-no-visible-expiry",
+    )
+
+
+def test_generic_wait_cancel_cannot_strand_an_open_restart_card(client, auth):
+  qid, wait_id, _run, _requirement = _install("restart-cancel-boundary")
+
+  response = client.post(f"/api/chat-waits/{wait_id}/cancel", headers=auth)
+
+  assert response.status_code == 409, response.text
+  assert "Restart card" in response.json()["detail"]
+  with SessionLocal() as db:
+    chat = db.get(models.Chat, "restart-cancel-boundary")
+    wait = db.get(models.ChatWait, wait_id)
+    assert chat.pending_question_id == qid
+    assert wait.status == "armed"
+
+
+def test_generic_wait_cancel_cannot_desynchronize_a_deferred_legacy_card(
+  client, auth, monkeypatch,
+):
+  monkeypatch.setattr(
+    "app.platform_restart.requirement_matches_current_source", lambda _r: True,
+  )
+  qid, wait_id, _run, _requirement = _install("restart-deferred-boundary")
+  result = _submit(ResolvePlatformRestartCard(
+    chat_id="restart-deferred-boundary", question_id=qid,
+    selected_option_id="cancel-id",
+  ))
+  assert result["status"] == "deferred"
+
+  response = client.post(f"/api/chat-waits/{wait_id}/cancel", headers=auth)
+
+  assert response.status_code == 409, response.text
+  with SessionLocal() as db:
+    assert db.get(models.ChatWait, wait_id).status == "armed"
+
+
 def test_source_change_after_claim_refuses_side_effect_admission(monkeypatch):
   from app import chat as chat_mod
   from app import restart_util
@@ -423,6 +470,110 @@ def test_route_sends_written_restart_feedback_without_restart_authority(
       "restart-feedback-route-answer",
     ]
     assert read.query(models.PlatformRestartExecution).count() == 0
+
+
+def test_stale_restart_route_signals_authoritative_card_refresh(
+  client, chat, auth, monkeypatch,
+):
+  from concurrent.futures import Future
+  from app.chat_writer import RestartCardStateChanged
+
+  requirement = _requirement("platform-restart:stale-route")
+  block = _card("stale-restart-card", "stale-wait", requirement)
+  monkeypatch.setattr(
+    "app.platform_restart.restart_action_block", lambda _chat, _qid: block,
+  )
+
+  class RefusingWriter:
+    def submit(self, _command):
+      result = Future()
+      result.set_exception(RestartCardStateChanged("card already settled"))
+      return result
+
+  monkeypatch.setattr(chats_stream, "get_writer", lambda: RefusingWriter())
+  response = client.post(
+    f"/api/chats/{chat.id}/messages", headers=auth, json={
+      "content": "", "hidden": True,
+      "question_id": "stale-restart-card",
+      "selected_options": {"restart": ["restart-id"]},
+    },
+  )
+
+  assert response.status_code == 410, response.text
+  assert response.json()["detail"]["code"] == "question_state_changed"
+
+
+def test_restart_route_keeps_transient_writer_failure_retryable(
+  client, chat, auth, monkeypatch,
+):
+  from concurrent.futures import Future
+
+  requirement = _requirement("platform-restart:writer-failure")
+  block = _card("writer-failure-card", "writer-failure-wait", requirement)
+  monkeypatch.setattr(
+    "app.platform_restart.restart_action_block", lambda _chat, _qid: block,
+  )
+
+  class FailingWriter:
+    def submit(self, _command):
+      result = Future()
+      result.set_exception(RuntimeError("database temporarily unavailable"))
+      return result
+
+  monkeypatch.setattr(chats_stream, "get_writer", lambda: FailingWriter())
+  response = client.post(
+    f"/api/chats/{chat.id}/messages", headers=auth, json={
+      "content": "", "hidden": True,
+      "question_id": "writer-failure-card",
+      "selected_options": {"restart": ["restart-id"]},
+    },
+  )
+
+  assert response.status_code == 503, response.text
+  assert "try again" in response.json()["detail"].lower()
+
+
+def test_source_changed_restart_route_keeps_written_agent_handoff_available(
+  client, auth, monkeypatch,
+):
+  qid, _wait_id, _run, _requirement = _install("restart-source-changed")
+  monkeypatch.setattr(
+    "app.platform_restart.requirement_matches_current_source", lambda _r: False,
+  )
+
+  response = client.post(
+    "/api/chats/restart-source-changed/messages", headers=auth, json={
+      "content": "", "hidden": True, "question_id": qid,
+      "selected_options": {"restart": ["restart-id"]},
+    },
+  )
+
+  assert response.status_code == 409, response.text
+  assert response.json()["detail"]["code"] == "restart_action_conflict"
+  assert "fresh Restart card" in response.json()["detail"]["message"]
+  with SessionLocal() as db:
+    chat = db.get(models.Chat, "restart-source-changed")
+    assert chat.pending_question_id == qid
+    assert not chat.messages[0]["blocks"][0].get("answers")
+
+
+def test_failed_restart_wait_requires_agent_recheck_instead_of_false_retry(
+  client, auth,
+):
+  qid, _wait_id, _run, _requirement = _install(
+    "restart-failed-wait", status="failed",
+  )
+
+  response = client.post(
+    "/api/chats/restart-failed-wait/messages", headers=auth, json={
+      "content": "", "hidden": True, "question_id": qid,
+      "selected_options": {"restart": ["restart-id"]},
+    },
+  )
+
+  assert response.status_code == 409, response.text
+  assert response.json()["detail"]["code"] == "restart_action_conflict"
+  assert "checked again" in response.json()["detail"]["message"]
 
 
 def test_idle_written_restart_feedback_starts_exactly_one_continuation(

--- a/backend/tests/test_tool_output_stash.py
+++ b/backend/tests/test_tool_output_stash.py
@@ -629,6 +629,22 @@ def test_sink_reduces_large_tagged_output_and_stashes_full(db):
     assert row is not None and row.output == big
 
 
+def test_sink_preserves_exit_code_from_a_large_nested_envelope(db):
+    sink = _sink()
+    nested = json.dumps({"exit_code": 1, "stderr": "x" * 6000})
+    big = json.dumps({"result": nested})
+    assert len(big) > TOOL_OUTPUT_INLINE_THRESHOLD
+    event = {
+        "type": "tool_output", "content": big,
+        "tool_use_id": "tu_nested_failure",
+    }
+
+    sink._reduce_tool_output(event)
+
+    assert event["output_truncated"] is True
+    assert event["output_exit_code"] == 1
+
+
 def test_sink_keeps_a_runner_supplied_exit_code_on_large_plain_output(db):
     sink = _sink()
     sink.publish({

--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -160,6 +160,7 @@ import {
   sendFailureMessage,
   shouldKeepQueuedAfterSendFailure,
 } from './sendFailure.js'
+import { isQuestionStateChangedError } from './sendErrors.js'
 import {
   assistantStreamBelongsToActiveMessage,
   assistantStreamCoversMessage,
@@ -3782,13 +3783,14 @@ export default function ChatView({
       if (showPicker && isModelSelectionRequiredFailure(err)) {
         setModelSelectionRequest(request => request + 1)
       }
-      if (err.message === 'HTTP 410') {
+      if (isQuestionStateChangedError(err)) {
         // The backend refused this answer because the durable transcript no
         // longer has that open question (for example Stop cancelled it, or a
         // newer question superseded it). Refetch authoritative state rather
-        // than keeping the optimistic answer locally.
-        setLiveQuestionId(null)
-        fetchMessages({ force: true })
+        // than keeping the optimistic answer locally. Keep the current card
+        // answerable until that read succeeds; a network failure must not turn
+        // a retryable stale projection into a disabled card.
+        await fetchMessages({ force: true, authoritative: true })
         throw err
       }
       // QuestionCard owns this transient failure notice and retains the

--- a/frontend/src/components/ChatView/MsgContent.jsx
+++ b/frontend/src/components/ChatView/MsgContent.jsx
@@ -247,6 +247,13 @@ function MsgContentInner({
           block.entries, hasRestartCard,
         )
         if (visibleEntries.length === 0) return null
+        const omittedToolCount = (
+          block.entries.filter(({ item }) => item?.type === 'tool').length
+          - visibleEntries.filter(({ item }) => item?.type === 'tool').length
+        )
+        const summaryToolCount = Number.isFinite(block.tool_count)
+          ? Math.max(0, block.tool_count - omittedToolCount)
+          : visibleEntries.filter(({ item }) => item?.type === 'tool').length
         return (
           <div
             key={block.activity_id || `activity-${i}`}
@@ -262,7 +269,10 @@ function MsgContentInner({
                 start: block.start,
                 end: block.end,
               }}
-              summaryToolCount={visibleEntries.filter(({ item }) => item?.type === 'tool').length}
+              // Current projections already omit redundant card tools. For an
+              // older cached projection, subtract only the entries repaired
+              // locally while preserving counts for repeated compacted tools.
+              summaryToolCount={summaryToolCount}
               onInternalNav={onInternalNav}
             />
           </div>
@@ -361,6 +371,7 @@ function MsgContentInner({
               questionId={block.question_id}
               answeredMap={answers}
               platformAction={block.platform_action}
+              submittedOptions={block.selected_options}
               onAnswer={answerable ? onQuestionAnswer : undefined}
               onPrepareAnswer={answerable ? onQuestionSubmitIntent : undefined}
               onCancelAnswer={answerable ? onQuestionSubmitCancel : undefined}

--- a/frontend/src/components/ChatView/QuestionCard.jsx
+++ b/frontend/src/components/ChatView/QuestionCard.jsx
@@ -114,6 +114,7 @@ export default function QuestionCard({
   questionId,
   answeredMap,
   platformAction,
+  submittedOptions,
   onAnswer,
   onPrepareAnswer,
   onCancelAnswer,
@@ -147,6 +148,10 @@ export default function QuestionCard({
   const displayAnswers = answeredMap || {}
   const grouped = questions.length > 1
   const restartAction = isRestartCardAction(platformAction)
+  const writtenRestartAction = restartAction && platformAction?.version === 2
+  const respondedRestartAction = (
+    writtenRestartAction && platformAction?.status === 'responded'
+  )
 
   // ChatView is keyed by chat, so switching away remounts this card. Keep an
   // unsubmitted selection in the same per-tab cache as composer drafts; the
@@ -333,7 +338,15 @@ export default function QuestionCard({
                   ? [answeredValue]
                   : []))
           : []
-        const answeredWithOther = unmatchedAnswers.length > 0
+        const writtenRestartResponse = Boolean(
+          respondedRestartAction
+          && submittedOptions
+          && Object.keys(submittedOptions).length === 0
+        )
+        const writtenAnswer = writtenRestartResponse
+          ? answeredValue
+          : unmatchedAnswers.join(', ')
+        const answeredWithOther = writtenAnswer.length > 0
         const selectionCount = answered
           ? (isMulti ? answeredArr.length : (answeredValue ? 1 : 0))
           : selectedArr.length
@@ -350,7 +363,7 @@ export default function QuestionCard({
                 (□ checkbox for multi, ○ radio for single). */}
             {!completedAction && (!disabled || answered) && (
               <div className="qcard__hint">
-                {restartAction
+                {writtenRestartAction
                   ? 'Restart now, or reply below'
                   : isMulti
                   ? `Select all that apply${selectionCount ? ` · ${selectionCount} selected` : ''}`
@@ -368,7 +381,7 @@ export default function QuestionCard({
               {/* For multi-select answered state, the comma-joined value is
                   parsed above so each chosen option highlights correctly. */}
               {(() => {
-                const visibleOptions = restartAction
+                const visibleOptions = writtenRestartAction
                   ? q.options?.filter(opt => opt.id === platformAction.restart_option_id)
                   : q.options
                 return visibleOptions?.map((opt, oi) => {
@@ -425,20 +438,23 @@ export default function QuestionCard({
                 })
               })()}
             </div>}
-            {!completedAction && (
+            {(!completedAction || respondedRestartAction)
+              && (!restartAction || writtenRestartAction) && (
               <CustomAnswerArea
                 active={isOtherSelected || answeredWithOther}
                 answered={answered}
                 canSubmit={allAnswered}
                 disabled={inactive}
-                placeholder={restartAction ? 'Or tell me what you’d like to do instead…' : undefined}
+                placeholder={writtenRestartAction
+                  ? 'Or tell me what you’d like to do instead…'
+                  : undefined}
                 onChange={text => setOtherText(q.question, text)}
                 onSubmitShortcut={(questionCard) => {
                   if (allAnswered) handleSubmit(questionCard, null)
                 }}
                 question={q.question}
                 value={answered
-                  ? unmatchedAnswers.join(', ')
+                  ? writtenAnswer
                   : (otherTexts[q.question] || '')}
               />
             )}
@@ -471,7 +487,7 @@ export default function QuestionCard({
             }}
             disabled={!canSubmit || disabled || answered || submitting}
           >
-            {submitting ? 'Submitting…' : (answered ? 'Submitted' : restartAction ? 'Continue' : 'Submit')}
+            {submitting ? 'Submitting…' : (answered ? 'Submitted' : writtenRestartAction ? 'Continue' : 'Submit')}
           </button>
         </>
       )}

--- a/frontend/src/components/ChatView/WaitingChip.jsx
+++ b/frontend/src/components/ChatView/WaitingChip.jsx
@@ -85,11 +85,11 @@ export function WaitCard({ wait, expanded, onToggle, onCancel }) {
         { label: 'Condition owner', value: presentation.owner },
         { label: 'Checker', value: presentation.checker },
         { label: 'Activity', value: presentation.activity },
-        { label: 'If it takes too long', value: presentation.timeout },
+        { label: presentation.timeoutLabel, value: presentation.timeout },
         { label: 'Agent usage', value: presentation.usage },
       ]}
     >
-      <button
+      {wait.kind !== 'platform_activation' && <button
         type="button"
         className="chat__wait-cancel"
         onPointerDown={(event) => event.preventDefault()}
@@ -97,7 +97,7 @@ export function WaitCard({ wait, expanded, onToggle, onCancel }) {
       >
         <X width={14} height={14} aria-hidden="true" />
         Stop waiting
-      </button>
+      </button>}
     </HandoffCard>
   )
 }

--- a/frontend/src/components/ChatView/__tests__/activityPositionRender.test.js
+++ b/frontend/src/components/ChatView/__tests__/activityPositionRender.test.js
@@ -64,3 +64,87 @@ test('a genuine activity load failure retains a manual retry', () => {
   assert.match(html, /Chat activity couldn’t refresh/)
   assert.match(html, /<button type="button">Try again<\/button>/)
 })
+
+test('a cached compact Restart tool stays hidden without undercounting steps', () => {
+  const html = render(Message, {
+    msg: {
+      id: 'restart-activity', role: 'assistant', blocks: [
+        {
+          type: 'activity', activity_id: '0:0:8', message_index: 0,
+          start: 0, end: 8, tool_count: 7,
+          entries: [
+            { idx: 0, item: { type: 'tool', tool: 'Bash', status: 'done' } },
+            { idx: 1, item: { type: 'tool', tool: 'mcp__mobius_control__request_restart', status: 'done' } },
+          ],
+        },
+        {
+          type: 'question', question_id: 'restart-card',
+          questions: [{ id: 'restart', question: 'Restart?', options: [] }],
+          platform_action: { type: 'restart', version: 2 },
+        },
+      ],
+    },
+    chatId: 'chat', messageKey: 'restart-activity',
+  }, { tools: new Map(), positions: new Map() })
+
+  assert.match(html, /\(6 steps\)/)
+  assert.doesNotMatch(html, /request_restart/)
+})
+
+test('rendering retains a failed Restart attempt before the card-owned request', () => {
+  const html = render(Message, {
+    msg: {
+      id: 'restart-retry', role: 'assistant', blocks: [
+        {
+          type: 'tool', tool: 'mcp__mobius_control__request_restart',
+          tool_use_id: 'failed', status: 'done', output_exit_code: 1,
+          output: 'Working tree is dirty',
+        },
+        {
+          type: 'tool', tool: 'mcp__mobius_control__request_restart',
+          tool_use_id: 'successful', status: 'done', output: '',
+        },
+        {
+          type: 'question', question_id: 'restart-card',
+          questions: [{ id: 'restart', question: 'Restart?', options: [] }],
+          platform_action: { type: 'restart', version: 2 },
+        },
+      ],
+    },
+    chatId: 'chat', messageKey: 'restart-retry',
+  }, { tools: new Map(), positions: new Map() })
+
+  assert.match(html, /chat__tool--failed/)
+  assert.match(html, /mcp__mobius_control__request_restart/)
+  assert.match(html, /Restart\?/)
+})
+
+test('rendering a compact server projection retains its surviving failed Restart', () => {
+  const html = render(Message, {
+    msg: {
+      id: 'restart-projected', role: 'assistant', blocks: [
+        {
+          type: 'activity', activity_id: '0:0:1', message_index: 0,
+          start: 0, end: 1, tool_count: 1,
+          entries: [{
+            idx: 0, item: {
+              type: 'tool', tool: 'mcp__mobius_control__request_restart',
+              tool_use_id: 'failed', status: 'done', output_exit_code: 1,
+              output: 'Working tree is dirty',
+            },
+          }],
+        },
+        {
+          type: 'question', question_id: 'restart-card',
+          questions: [{ id: 'restart', question: 'Restart?', options: [] }],
+          platform_action: { type: 'restart', version: 2 },
+        },
+      ],
+    },
+    chatId: 'chat', messageKey: 'restart-projected',
+  }, { tools: new Map(), positions: new Map() })
+
+  assert.match(html, /mcp__mobius_control__request_restart/)
+  assert.match(html, /\(1 step\)/)
+  assert.match(html, /Restart\?/)
+})

--- a/frontend/src/components/ChatView/__tests__/questionCardState.test.js
+++ b/frontend/src/components/ChatView/__tests__/questionCardState.test.js
@@ -30,18 +30,18 @@ test('unanswered question cards do not have a stale gray state', () => {
     'unanswered cards should not tell the user the question expired')
   assert.match(component, /\{!completedAction && \(answered \|\| !disabled\) && \([\s\S]*<button[\s\S]*className="qcard__submit"/,
     'submit button should remain in place after an answer is submitted')
-  assert.match(component, /submitting \? 'Submitting…' : \(answered \? 'Submitted' : restartAction \? 'Continue' : 'Submit'\)/,
-    'the retained submit button should explain pending and answered states')
+  assert.match(component, /submitting \? 'Submitting…' : \(answered \? 'Submitted' : writtenRestartAction \? 'Continue' : 'Submit'\)/,
+    'the retained submit button should explain pending and answered states without rewriting legacy Restart cards')
   assert.match(component, /\{!completedAction && \(!disabled \|\| answered\) && \(\s*<div className="qcard__hint"/,
     'selection hints should stay in place after the answer is submitted')
   assert.doesNotMatch(component, /qcard__opt--other/,
     'a custom answer should be a direct writing surface, not an Other option')
-  assert.match(component, /<CustomAnswerArea[\s\S]*?answered=\{answered\}[\s\S]*?value=\{answered[\s\S]*?unmatchedAnswers\.join\(', '\)/,
-    'the custom answer should stay mounted and retain submitted custom text')
-  assert.match(component, /placeholder=\{restartAction \? 'Or tell me what you’d like to do instead…'/,
-    'a Restart card should replace Not now with a written response')
-  assert.match(component, /q\.options\?\.filter\(opt => opt\.id === platformAction\.restart_option_id\)/,
-    'a Restart card should show only its exact Restart now option')
+  assert.match(component, /const writtenAnswer = writtenRestartResponse[\s\S]*?unmatchedAnswers\.join\(', '\)[\s\S]*?<CustomAnswerArea[\s\S]*?answered=\{answered\}[\s\S]*?value=\{answered[\s\S]*?writtenAnswer/,
+    'the custom answer should stay mounted and retain submitted custom text, including a written Restart response that matches an option label')
+  assert.match(component, /writtenRestartAction[\s\S]*\? 'Or tell me what you’d like to do instead…'/,
+    'a version-2 Restart card should replace Not now with a written response')
+  assert.match(component, /writtenRestartAction[\s\S]*q\.options\?\.filter\(opt => opt\.id === platformAction\.restart_option_id\)/,
+    'only a version-2 Restart card should show just its exact Restart now option')
   assert.match(component, /rows=\{1\}/,
     'the custom answer should begin as one compact writing line')
   assert.match(component, /data-chat-inline-editor="question-answer"/,
@@ -110,6 +110,20 @@ test('a failed question submission does not append a transcript row', () => {
     'a transient answer failure must stay on the card, not supersede it',
   )
   assert.match(silentSubmit, /QuestionCard owns this transient failure notice/)
+  assert.match(
+    silentSubmit,
+    /isQuestionStateChangedError\(err\)[\s\S]*await fetchMessages\(\{ force: true, authoritative: true \}\)/,
+    'a stale cached card should replace itself with authoritative settled state',
+  )
+  const reconciliation = silentSubmit.slice(
+    silentSubmit.indexOf('if (isQuestionStateChangedError(err))'),
+    silentSubmit.indexOf('// QuestionCard owns this transient failure notice'),
+  )
+  assert.doesNotMatch(
+    reconciliation,
+    /setLiveQuestionId\(null\)/,
+    'a failed authoritative refresh must leave the stale card answerable for retry',
+  )
 })
 
 test('question submission paints a resumed turn only after the POST commits', () => {

--- a/frontend/src/components/ChatView/__tests__/restartCard.test.js
+++ b/frontend/src/components/ChatView/__tests__/restartCard.test.js
@@ -105,6 +105,78 @@ test('pending Restart card offers one exact action and a written response', () =
 })
 
 
+test('a pending legacy Restart card retains both original choices', () => {
+  const html = renderToStaticMarkup(createElement(QuestionCard, {
+    chatId: 'chat', questionId: 'legacy-question', platformAction: action,
+    questions,
+    disabled: false,
+  }))
+
+  assert.match(html, />Restart now</)
+  assert.match(html, />Not now</)
+  assert.match(html, />Submit</)
+  assert.doesNotMatch(html, /textarea/)
+})
+
+
+test('ordinary questions retain their general written-answer field', () => {
+  const html = renderToStaticMarkup(createElement(QuestionCard, {
+    chatId: 'chat', questionId: 'ordinary-question',
+    questions: [{
+      id: 'ordinary', question: 'Which direction?', options: [
+        { id: 'first', label: 'First' },
+        { id: 'second', label: 'Second' },
+      ],
+    }],
+    disabled: false,
+  }))
+
+  assert.match(html, /Or type your own answer…/)
+  assert.match(html, />Submit</)
+})
+
+
+test('a written Restart response remains visible after settlement', () => {
+  const prompt = 'Restart to load these changes?'
+  const response = 'Please check the rollout first'
+  const html = renderToStaticMarkup(createElement(QuestionCard, {
+    chatId: 'chat', questionId: 'responded-question',
+    platformAction: { ...action, version: 2, status: 'responded' },
+    answeredMap: { [prompt]: response },
+    submittedOptions: {},
+    questions: [{
+      id: 'restart', question: prompt,
+      options: [{ id: 'restart-id', label: 'Restart now' }],
+    }],
+    disabled: true,
+  }))
+
+  assert.match(html, /Response sent/)
+  assert.match(html, new RegExp(`>${response}<`))
+  assert.match(html, /readOnly=""/)
+  assert.doesNotMatch(html, /qcard__opt/)
+})
+
+
+test('written Restart feedback remains visible when it matches the action label', () => {
+  const prompt = 'Restart to load these changes?'
+  const response = 'Restart now'
+  const html = renderToStaticMarkup(createElement(QuestionCard, {
+    chatId: 'chat', questionId: 'responded-label-collision',
+    platformAction: { ...action, version: 2, status: 'responded' },
+    answeredMap: { [prompt]: response },
+    submittedOptions: {},
+    questions: [{
+      id: 'restart', question: prompt,
+      options: [{ id: 'restart-id', label: response }],
+    }],
+    disabled: true,
+  }))
+
+  assert.match(html, />Restart now<\/textarea>/)
+})
+
+
 test('closed Restart card explains the outcome without dead controls', () => {
   const html = renderToStaticMarkup(createElement(QuestionCard, {
     chatId: 'chat', questionId: 'question',

--- a/frontend/src/components/ChatView/__tests__/sendFailure.test.js
+++ b/frontend/src/components/ChatView/__tests__/sendFailure.test.js
@@ -12,7 +12,29 @@ import {
   ChatHttpError,
   ChatTransportError,
   chatHttpError,
+  isQuestionStateChangedError,
 } from '../sendErrors.js'
+
+test('settled question errors trigger authoritative card reconciliation', () => {
+  assert.equal(isQuestionStateChangedError({ status: 410 }), true)
+  assert.equal(isQuestionStateChangedError({ code: 'question_state_changed' }), true)
+  assert.equal(isQuestionStateChangedError({
+    status: 409,
+    detail: 'This Restart card is stale or no longer authorized.',
+  }), true)
+  assert.equal(isQuestionStateChangedError({
+    status: 409,
+    detail: 'This Restart card is stale or no longer accepting a response.',
+  }), true)
+  assert.equal(isQuestionStateChangedError({
+    status: 409,
+    detail: 'This Restart card is stale or no longer ready; please retry.',
+  }), false)
+  assert.equal(isQuestionStateChangedError({
+    status: 409,
+    detail: "Use one of the Restart card's current buttons.",
+  }), false)
+})
 
 test('send failures distinguish connection, timeout, service, and generic errors', () => {
   assert.match(

--- a/frontend/src/components/ChatView/__tests__/streamReducers.test.js
+++ b/frontend/src/components/ChatView/__tests__/streamReducers.test.js
@@ -673,6 +673,33 @@ test('suppresses the mobius-control call when its Restart card is present', () =
   assert.deepEqual([...suppressedQuestionToolIndices(blocks)], [0])
 })
 
+test('a Restart card suppresses only its latest matching request', () => {
+  const blocks = [
+    { type: 'tool', tool: 'mobius_control:request_restart', output_exit_code: 1 },
+    { type: 'tool', tool: 'mobius_control:request_restart', status: 'done' },
+    { type: 'question', question_id: 'restart-1', questions: [],
+      platform_action: { type: 'restart', version: 2 } },
+  ]
+  assert.deepEqual([...suppressedQuestionToolIndices(blocks)], [1])
+})
+
+test('a Restart card never suppresses a surviving failed request', () => {
+  const blocks = [
+    { type: 'tool', tool: 'mobius_control:request_restart', output_exit_code: 1 },
+    { type: 'question', question_id: 'restart-1', questions: [],
+      platform_action: { type: 'restart', version: 2 } },
+  ]
+  assert.deepEqual([...suppressedQuestionToolIndices(blocks)], [])
+})
+
+test('tool pairing never reads unrelated tool output', () => {
+  const unrelated = { type: 'tool', tool: 'Bash' }
+  Object.defineProperty(unrelated, 'output', {
+    get() { throw new Error('unrelated tool output must not be parsed') },
+  })
+  assert.deepEqual([...suppressedQuestionToolIndices([unrelated])], [])
+})
+
 test('recognizes both persisted names for the platform Restart request', () => {
   assert.equal(isRestartRequestTool('mobius_control:request_restart'), true)
   assert.equal(isRestartRequestTool('mcp__mobius_control__request_restart'), true)
@@ -686,6 +713,30 @@ test('a pre-grouped long turn hides only the Restart request entry', () => {
   }
   assert.deepEqual(restartCardActivityEntries([bash, restart], true), [bash])
   assert.equal(restartCardActivityEntries([bash, restart], false)[1], restart)
+})
+
+test('a pre-grouped long turn retains an earlier failed Restart request', () => {
+  const failed = {
+    idx: 4, item: {
+      type: 'tool', tool: 'mobius_control:request_restart', output_exit_code: 1,
+    },
+  }
+  const successful = {
+    idx: 5, item: { type: 'tool', tool: 'mobius_control:request_restart' },
+  }
+  assert.deepEqual(
+    restartCardActivityEntries([failed, successful], true),
+    [failed],
+  )
+})
+
+test('a pre-grouped server projection never removes its surviving failure', () => {
+  const failed = {
+    idx: 4, item: {
+      type: 'tool', tool: 'mobius_control:request_restart', output_exit_code: 1,
+    },
+  }
+  assert.deepEqual(restartCardActivityEntries([failed], true), [failed])
 })
 
 test('keeps mobius-control visible without a Restart card', () => {

--- a/frontend/src/components/ChatView/__tests__/waitHistory.test.js
+++ b/frontend/src/components/ChatView/__tests__/waitHistory.test.js
@@ -94,3 +94,26 @@ test('active wait details show the full condition and its owner separately', () 
   assert.match(html, /Condition owner<\/dt><dd>Hosted deployment/)
   assert.match(html, /Stop waiting/)
 })
+
+
+test('a Restart wait has no fake deadline or generic cancellation control', () => {
+  const html = renderToStaticMarkup(createElement(WaitCard, {
+    wait: {
+      id: 'activation-wait',
+      kind: 'platform_activation',
+      description: 'Load committed changes',
+      condition_owner: 'Möbius startup',
+      interval_secs: 60,
+      deadline_at: '2026-09-19T01:00:00',
+    },
+    expanded: true,
+    onToggle: () => {},
+    onCancel: () => {},
+  }))
+
+  assert.match(html, /Wake-up/)
+  assert.match(html, /Restart card has no time limit/)
+  assert.doesNotMatch(html, /If it takes too long/)
+  assert.doesNotMatch(html, /Stop waiting/)
+  assert.doesNotMatch(html, /Sep/)
+})

--- a/frontend/src/components/ChatView/sendErrors.js
+++ b/frontend/src/components/ChatView/sendErrors.js
@@ -32,3 +32,17 @@ export async function chatHttpError(response) {
   } catch {}
   return new ChatHttpError(response.status, { code, detail })
 }
+
+export function isQuestionStateChangedError(error) {
+  if (Number(error?.status) === 410) return true
+  if (error?.code === 'question_state_changed') return true
+  // Rolling-update compatibility: the older server used exactly these two
+  // generic 409 messages for settled cards. Keep current and future validation
+  // failures retryable rather than inferring lifecycle from a shared prefix.
+  return Number(error?.status) === 409
+    && typeof error?.detail === 'string'
+    && (
+      error.detail === 'This Restart card is stale or no longer accepting a response.'
+      || error.detail === 'This Restart card is stale or no longer authorized.'
+    )
+}

--- a/frontend/src/components/ChatView/streamReducers.js
+++ b/frontend/src/components/ChatView/streamReducers.js
@@ -32,6 +32,7 @@ import {
   boundedMessageSource,
   enrichMessageSource,
 } from './messageSources.js'
+import { toolBlockFailed } from './toolResultFormat.js'
 
 // Tool names whose tool events describe an AskUserQuestion-style
 // call: Claude's AskUserQuestion and Codex's request_user_input.
@@ -330,9 +331,17 @@ export function isRestartRequestTool(tool) {
 
 export function restartCardActivityEntries(entries, hasRestartCard) {
   if (!hasRestartCard || !Array.isArray(entries)) return entries
-  return entries.filter(({ item }) => !(
-    item?.type === 'tool' && isRestartRequestTool(item.tool)
-  ))
+  let twinIndex = -1
+  entries.forEach(({ item }, index) => {
+    if (
+      item?.type === 'tool'
+      && isRestartRequestTool(item.tool)
+      && !toolBlockFailed(item)
+    ) twinIndex = index
+  })
+  return twinIndex < 0
+    ? entries
+    : entries.filter((_, index) => index !== twinIndex)
 }
 
 /**
@@ -349,11 +358,9 @@ export function restartCardActivityEntries(entries, hasRestartCard) {
  * at render time so the persisted view matches the live view, with no
  * backend migration (it fixes already-persisted old chats too).
  *
- * A question-tool block is suppressed only when the message also contains
- * a question block — the card is the canonical rendering of the same call,
- * so the tool twin is pure noise. Non-question tools (Bash, Grep) and
- * question-tool blocks in a message with no card (a defensive edge that
- * shouldn't occur) are left untouched.
+ * Pair each card with the latest matching tool before it. Earlier failed
+ * attempts stay visible, while the successful call represented by the card
+ * is pure noise. The one-pass pairing mirrors the backend projection.
  *
  * @param {Array<object>} blocks  a persisted message's blocks
  * @returns {Set<number>} indices into `blocks` to skip when rendering
@@ -361,15 +368,22 @@ export function restartCardActivityEntries(entries, hasRestartCard) {
 export function suppressedQuestionToolIndices(blocks) {
   const suppressed = new Set()
   if (!Array.isArray(blocks)) return suppressed
-  const hasQuestionCard = blocks.some(b => b?.type === 'question')
-  if (!hasQuestionCard) return suppressed
-  const hasRestartCard = blocks.some(b => (
-    b?.type === 'question' && b?.platform_action?.type === 'restart'
-  ))
+  const latestUnowned = { question: null, restart: null }
   blocks.forEach((b, i) => {
-    if (b?.type === 'tool' && isQuestionTool(b.tool)) suppressed.add(i)
-    if (hasRestartCard && b?.type === 'tool' && isRestartRequestTool(b.tool)) {
-      suppressed.add(i)
+    if (b?.type === 'tool') {
+      const family = isQuestionTool(b.tool)
+        ? 'question'
+        : isRestartRequestTool(b.tool) ? 'restart' : null
+      if (family === null || toolBlockFailed(b)) return
+      latestUnowned[family] = i
+      return
+    }
+    if (b?.type !== 'question') return
+    const family = b?.platform_action?.type === 'restart' ? 'restart' : 'question'
+    const twin = latestUnowned[family]
+    if (twin !== null) {
+      suppressed.add(twin)
+      latestUnowned[family] = null
     }
   })
   return suppressed

--- a/frontend/src/components/ChatView/waitingPresentation.js
+++ b/frontend/src/components/ChatView/waitingPresentation.js
@@ -67,6 +67,7 @@ export function resourcePausePresentation(block) {
 }
 
 export function waitPresentation(wait) {
+  const activation = wait.kind === 'platform_activation'
   const cadence = cadenceLabel(wait)
   const next = clockLabel(wait.next_check_at)
   const due = clockLabel(wait.due_at)
@@ -85,7 +86,10 @@ export function waitPresentation(wait) {
     summary,
     checker: `Möbius · ${cadence}${wait.kind !== 'timer' && next ? ` · next at ${next}` : ''}`,
     activity,
-    timeout: `This chat wakes to investigate at ${dateTimeLabel(wait.deadline_at)}`,
+    timeoutLabel: activation ? 'Wake-up' : 'If it takes too long',
+    timeout: activation
+      ? 'A later ready restart wakes this chat; the Restart card has no time limit'
+      : `This chat wakes to investigate at ${dateTimeLabel(wait.deadline_at)}`,
     usage: 'No model tokens while checking · one turn when it wakes',
   }
 }


### PR DESCRIPTION
## Summary

- remove the fake deadline and generic cancellation path from Restart activation waits
- preserve written Restart feedback and the original choices on legacy cards
- reconcile stale post-restart cards with authoritative chat state while keeping real failures retryable
- hide only the exact tool call represented by a question card, retaining failed attempts and accurate activity counts in both compact and expanded history

## Context

Follow-up to #1120. An expanding-scope post-merge review and a live stale-card reproduction found lifecycle and history edges that were not covered by the original change. This keeps the simpler product model while making the owning boundaries explicit: Restart cards own Restart decisions, Chat Stop owns cancellation, and transcript projection owns redundant tool suppression.

A settled card now repairs an old browser view from authoritative state instead of exposing a dead retry. Still-visible authority conflicts keep the written agent handoff available, while genuine persistence failures remain retryable. Transcript projection pairs each card with its nearest matching tool in one linear pass, retains earlier failed attempts for diagnosis, and repairs compact cached counts locally.

## Verification

- 214 focused backend Restart, wait, transcript, event, and output-reduction checks
- complete frontend unit suite
- production frontend build
- lint with no errors
- expanding-scope independent review across correctness, maintainability, simplicity, accessibility, performance, security/privacy, and compatibility
