### PR TITLE
Keep chat activity errors quiet during recovery

### DIFF
--- a/frontend/src/components/ChatView/ChatView.jsx
+++ b/frontend/src/components/ChatView/ChatView.jsx
@@ -39,11 +39,12 @@ import {
   savedReadingAnchorKey,
 } from './scroll/readingPositions.js'
 import useVoiceInput from './useVoiceInput.js'
-import useOnlineStatus from '../../hooks/useOnlineStatus.js'
+import useOnlineStatus, { useReachabilityPhase } from '../../hooks/useOnlineStatus.js'
 import useRestartPending from '../../hooks/useRestartPending.js'
 import {
   getOnlineSnapshot,
   getRecoverySnapshot,
+  ReachabilityPhase,
   subscribeRecovery,
 } from '../../lib/connectivityStore.js'
 import {
@@ -427,6 +428,7 @@ export default function ChatView({
   // longer disables send offline — it notes the message is queued and lets the
   // outbox flush it, rather than dropping the tap into a dead stream.
   const online = useOnlineStatus()
+  const reachabilityPhase = useReachabilityPhase()
   const restartPending = useRestartPending()
   // Read the query cache synchronously on mount. If we've viewed this chat
   // before, its complete transcript window builds the hidden restoration DOM
@@ -5711,7 +5713,15 @@ export default function ChatView({
           )}
 
           <PeerTimelineRows notes={peerTimeline.slots.get(displayedMessages.length)} chatId={chatId} onInternalNav={internalNav} />
-          <PeerTimelineLoadError error={peerTimeline.error} onRetry={peerTimeline.retry} />
+          <PeerTimelineLoadError
+            error={peerTimeline.error}
+            recoveryActive={
+              peerTimeline.recoveryActive
+              || restartPending
+              || reachabilityPhase !== ReachabilityPhase.ONLINE
+            }
+            onRetry={peerTimeline.retry}
+          />
 
           {/* Steering is accepted locally before the provider control channel
               acknowledges it. Keep the durable rows out of the actionable

--- a/frontend/src/components/ChatView/PeerTimeline.jsx
+++ b/frontend/src/components/ChatView/PeerTimeline.jsx
@@ -30,7 +30,12 @@ export function usePeerTimeline(chatId, messages, enabled, activeTools, activeMi
     if (enabled && hasNextPage && !isFetching && !isError && oldestLoaded >= windowStart) void fetchNextPage()
   }, [enabled, hasNextPage, isFetching, isError, oldestLoaded, windowStart, fetchNextPage])
   const projection = useMemo(() => foldPeerActivity(messages, projectChatActivity(messages, events, chatId, activeTools), chatId, activeMirrorIndex), [messages, events, chatId, activeTools, activeMirrorIndex])
-  return { ...projection, error: query.isError, retry: query.refetch }
+  return {
+    ...projection,
+    error: query.isError,
+    recoveryActive: query.isFetching,
+    retry: query.refetch,
+  }
 }
 
 export function PeerTimelineRows({ notes, chatId, onInternalNav }) {
@@ -52,8 +57,11 @@ export function PeerTimelineRows({ notes, chatId, onInternalNav }) {
   })
 }
 
-export function PeerTimelineLoadError({ error, onRetry }) {
-  if (!error) return null
+export function PeerTimelineLoadError({ error, recoveryActive = false, onRetry }) {
+  // A retained query can carry its previous error while an owning reconnect
+  // refetch is already repairing it. Keep that ordinary transition quiet;
+  // expose the retry only after recovery has settled unsuccessfully.
+  if (!error || recoveryActive) return null
   return <li className="chat__peer-load-error" role="status">
     Chat activity couldn’t refresh. <button type="button" onClick={onRetry}>Try again</button>
   </li>

--- a/frontend/src/components/ChatView/__tests__/activityPositionRender.test.js
+++ b/frontend/src/components/ChatView/__tests__/activityPositionRender.test.js
@@ -3,6 +3,7 @@ import test, { after } from 'node:test'
 import assert from 'node:assert/strict'
 import React from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
+import { QueryClient, QueryObserver } from '@tanstack/react-query'
 import { createServer } from 'vite'
 globalThis.window = { location: { origin: 'http://localhost', href: 'http://localhost/shell/' }, innerWidth: 420 }
 const vite = await createServer({ appType: 'custom', logLevel: 'error', server: { middlewareMode: true, hmr: false, ws: false }, ssr: { noExternal: ['@openai/apps-sdk-ui'] } })
@@ -53,14 +54,81 @@ test('busy-parent helper result renders once at the same recorded frontier', () 
   assert.equal(html.split('aria-label="Helper finished · Review"').length, 2)
 })
 
-test('a genuine activity load failure retains a manual retry', () => {
+test('activity load errors stay quiet while restart recovery is active', () => {
   assert.equal(renderToStaticMarkup(React.createElement(
     PeerTimelineLoadError, { error: false, onRetry: () => {} },
   )), '')
+  assert.equal(renderToStaticMarkup(React.createElement(
+    PeerTimelineLoadError, {
+      error: true, recoveryActive: true, onRetry: () => {},
+    },
+  )), '')
+})
+
+test('a settled activity load failure retains a manual retry', () => {
   const html = renderToStaticMarkup(React.createElement(
-    PeerTimelineLoadError, { error: true, onRetry: () => {} },
+    PeerTimelineLoadError, {
+      error: true, recoveryActive: false, onRetry: () => {},
+    },
   ))
   assert.match(html, /role="status"/)
   assert.match(html, /Chat activity couldn’t refresh/)
   assert.match(html, /<button type="button">Try again<\/button>/)
+})
+
+test('a retained activity error stays quiet through reconnect refetch, then reports only a settled failure', async (t) => {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  t.after(() => client.clear())
+  const key = ['chat-activity', 'restart-transition']
+  let outcome = 'success'
+  let releaseRecovery
+  const observer = new QueryObserver(client, {
+    queryKey: key,
+    retry: false,
+    staleTime: Infinity,
+    queryFn: async () => {
+      if (outcome === 'failure') throw new Error('restart gap')
+      if (outcome === 'recovering') {
+        await new Promise(resolve => { releaseRecovery = resolve })
+      }
+      return { events: [], next_before: null }
+    },
+  })
+  const unsubscribe = observer.subscribe(() => {})
+  t.after(unsubscribe)
+
+  await observer.refetch()
+  outcome = 'failure'
+  await client.invalidateQueries({ queryKey: key })
+  assert.equal(observer.getCurrentResult().isError, true)
+
+  outcome = 'recovering'
+  const recovery = client.invalidateQueries({ queryKey: key })
+  await new Promise(resolve => setImmediate(resolve))
+  const recovering = observer.getCurrentResult()
+  assert.equal(recovering.isError, true)
+  assert.equal(recovering.isFetching, true)
+  assert.equal(renderToStaticMarkup(React.createElement(
+    PeerTimelineLoadError, {
+      error: recovering.isError,
+      recoveryActive: recovering.isFetching,
+      onRetry: () => {},
+    },
+  )), '')
+
+  releaseRecovery()
+  await recovery
+  assert.equal(observer.getCurrentResult().isError, false)
+
+  outcome = 'failure'
+  await client.invalidateQueries({ queryKey: key })
+  const settledFailure = observer.getCurrentResult()
+  assert.equal(settledFailure.isFetching, false)
+  assert.match(renderToStaticMarkup(React.createElement(
+    PeerTimelineLoadError, {
+      error: settledFailure.isError,
+      recoveryActive: settledFailure.isFetching,
+      onRetry: () => {},
+    },
+  )), /Try again/)
 })


### PR DESCRIPTION
## Summary

- Hide retained chat-activity errors while restart or reconnect recovery is actively refetching
- Keep a visible retry when recovery settles without success
- Cover recovery success and settled failure with the real query transition

Follow-up to #1120, which removed routine polling but still allowed a retained refetch error to appear during restart recovery.

## Verification

- `npm run test:lib` (3,283 tests)
- `npm run lint` (0 errors; 37 existing warnings)
- `npm run build`
- Live-browser failure and retry check