### PR TITLE
Protect live data from tests and recover account mismatches

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -9,6 +9,7 @@ this module.
 
 import logging
 import os
+import sys
 import threading
 import time
 from contextvars import ContextVar, Token
@@ -38,6 +39,31 @@ _pool_metrics = {
 }
 
 
+def _assert_test_database_isolated() -> None:
+  """Refuse to construct an application engine in an unmarked test process.
+
+  Pytest imports a test module before it registers a module-level
+  ``pytest_plugins`` declaration. An out-of-tree probe can therefore import
+  ``app.database`` while it still inherits the live service environment, then
+  load the normal fixtures whose schema reset drops production tables. Every
+  supported test entrypoint marks its database as disposable before Python
+  starts; anything else must fail before SQLAlchemy creates an engine.
+  """
+  running_tests = (
+    os.environ.get("MOBIUS_TEST_RUNTIME") == "1"
+    or "pytest" in sys.modules
+    or any("pytest" in Path(arg).name for arg in sys.argv[:2])
+  )
+  if (
+    running_tests
+    and os.environ.get("MOBIUS_TEST_DATABASE_ISOLATED") != "1"
+  ):
+    raise RuntimeError(
+      "Refusing to create a database engine in an unisolated test process. "
+      "Use scripts/wt-pytest.sh or the disposable test Compose service."
+    )
+
+
 def set_database_request_label(label: str) -> Token:
   return _request_label.set(label)
 
@@ -48,6 +74,7 @@ def reset_database_request_label(token: Token) -> None:
 
 def _make_engine():
   """Creates the SQLAlchemy engine, ensuring the DB directory exists."""
+  _assert_test_database_isolated()
   settings = get_settings()
   is_sqlite = settings.database_url.startswith("sqlite")
   if settings.database_url.startswith("sqlite:////"):

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -31,7 +31,8 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, HTMLResponse
 from slowapi import Limiter, _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
-from sqlalchemy.exc import OperationalError
+from sqlalchemy import inspect as inspect_database
+from sqlalchemy.exc import OperationalError, SQLAlchemyError
 from starlette.concurrency import run_in_threadpool
 
 from app.config import get_settings
@@ -103,6 +104,7 @@ _BOOT_ID = os.environ.get("MOBIUS_BOOT_ID") or f"{os.getpid()}-{time.time_ns()}"
 # These stay fixed until restart: Recovery may repair the database externally,
 # but only a clean boot can coherently start the skipped database owners.
 _DATABASE_BOOT_RESULT = None
+_DATABASE_RUNTIME_FAILURE = None
 
 
 def _set_database_boot_state(result) -> None:
@@ -110,7 +112,14 @@ def _set_database_boot_state(result) -> None:
   _DATABASE_BOOT_RESULT = result
 
 
+def _set_database_runtime_failure(result: dict | None) -> None:
+  global _DATABASE_RUNTIME_FAILURE
+  _DATABASE_RUNTIME_FAILURE = result
+
+
 def _database_degraded_payload() -> dict | None:
+  if _DATABASE_RUNTIME_FAILURE:
+    return dict(_DATABASE_RUNTIME_FAILURE)
   result = _DATABASE_BOOT_RESULT
   if result is None or result.serviceable:
     return None
@@ -122,6 +131,38 @@ def _database_degraded_payload() -> dict | None:
       "schema_gaps": list(result.schema_gaps),
     }
   return None
+
+
+def _probe_runtime_database_schema() -> dict | None:
+  """Detect destructive schema loss after a previously healthy boot.
+
+  The boot verdict is intentionally sticky, but it cannot describe a database
+  changed by another process after startup. The deployment healthcheck calls
+  this bounded catalog probe every 30 seconds. A failure is sticky until a
+  clean restart because database-owning background services may already be in
+  an incoherent state even if an operator repairs the file underneath them.
+  """
+  if _DATABASE_RUNTIME_FAILURE:
+    return dict(_DATABASE_RUNTIME_FAILURE)
+  try:
+    present = set(inspect_database(engine).get_table_names())
+  except SQLAlchemyError as exc:
+    logging.getLogger(__name__).error(
+      "runtime database readiness probe failed: %s", exc,
+    )
+    failure = {"reason": "database_runtime_unavailable"}
+    _set_database_runtime_failure(failure)
+    return failure
+  missing = sorted(set(Base.metadata.tables) - present)
+  if not missing:
+    return None
+  logging.getLogger(__name__).critical(
+    "runtime database schema lost %d mapped tables: %s",
+    len(missing), ", ".join(missing[:10]),
+  )
+  failure = {"reason": "database_runtime_schema_missing"}
+  _set_database_runtime_failure(failure)
+  return failure
 
 
 def _router_degraded_payload() -> dict | None:
@@ -942,7 +983,11 @@ def health_strict(response: Response):
   contract plus the chat-persistence writer contract.
   """
   response.headers["Cache-Control"] = "no-store"
-  degraded = _database_degraded_payload() or _router_degraded_payload()
+  degraded = (
+    _database_degraded_payload()
+    or _probe_runtime_database_schema()
+    or _router_degraded_payload()
+  )
   if degraded:
     response.status_code = 503
     return {"status": degraded["reason"], **degraded}
@@ -965,7 +1010,11 @@ def browser_bootstrap():
 
 def service_readiness() -> dict:
   """One readiness verdict for HTTP probes and boot activation receipts."""
-  degraded = _database_degraded_payload() or _router_degraded_payload()
+  degraded = (
+    _database_degraded_payload()
+    or _probe_runtime_database_schema()
+    or _router_degraded_payload()
+  )
   if degraded:
     return {"ready": False, **degraded}
   from app.chat_writer import writer_readiness

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -840,7 +840,7 @@ _MOBIUS_HANDOFF_TTL_SECONDS = 60
 
 
 async def _begin_mobius_pkce(
-  identity: dict, owner_username: str,
+  identity: dict, owner_username: str, *, select_account: bool = False,
 ) -> tuple[str, str]:
   """Register a broker PKCE pending for `identity`; return (authorization_url, state)."""
   state = secrets.token_urlsafe(32)
@@ -858,19 +858,26 @@ async def _begin_mobius_pkce(
     "instance_id": identity["instance_id"],
     "public_key_jwk": identity["public_key_jwk"],
     "redirect_uri": redirect_uri,
+    # Preserve whether this is the one automatic recovery attempt after the
+    # launcher returned a valid receipt for a different cached account. The
+    # callback uses it to prevent an account-selection loop.
+    "select_account": select_account,
     "expires_at": time.time() + _MOBIUS_OAUTH_TTL_SECONDS,
   }
   await _mobius_broker_request("POST", "/identity/oauth/start", pending)
+  authorization_params = {
+    "instance_id": identity["instance_id"],
+    "state": state,
+    "redirect_uri": redirect_uri,
+    "code_challenge": challenge,
+    "key_thumbprint": identity["key_thumbprint"],
+  }
+  if select_account:
+    authorization_params["prompt"] = "select_account"
   authorization_url = (
     _mobius_authorization_issuer()
     + "/identity/authorize?"
-    + urlencode({
-      "instance_id": identity["instance_id"],
-      "state": state,
-      "redirect_uri": redirect_uri,
-      "code_challenge": challenge,
-      "key_thumbprint": identity["key_thumbprint"],
-    })
+    + urlencode(authorization_params)
   )
   return authorization_url, state
 
@@ -984,6 +991,37 @@ def _mobius_login_error_redirect() -> RedirectResponse:
     "mobius_login_state", path=_MOBIUS_CALLBACK_PATH
   )
   return response
+
+
+def _mobius_account_selection_redirect() -> RedirectResponse:
+  """Retry once through the launcher's explicit account-selection flow."""
+  response = RedirectResponse(
+    url="/api/auth/mobius/login/start?select_account=true", status_code=303,
+  )
+  response.headers["Cache-Control"] = "no-store"
+  response.headers["Referrer-Policy"] = "no-referrer"
+  response.delete_cookie(
+    "mobius_login_state", path=_MOBIUS_CALLBACK_PATH
+  )
+  return response
+
+
+def _mobius_account_mismatch_redirect() -> RedirectResponse:
+  """Explain a mismatch after the explicit account chooser was already used."""
+  response = RedirectResponse(
+    url="/shell/?mobius_login_account_mismatch=1", status_code=303,
+  )
+  response.headers["Cache-Control"] = "no-store"
+  response.headers["Referrer-Policy"] = "no-referrer"
+  response.delete_cookie(
+    "mobius_login_state", path=_MOBIUS_CALLBACK_PATH
+  )
+  return response
+
+
+def _mobius_subject_fingerprint(subject: object) -> str:
+  """Return a log-safe correlation key for an opaque account subject."""
+  return hashlib.sha256(str(subject or "").encode("utf-8")).hexdigest()[:16]
 
 
 def _mobius_enroll_error_redirect() -> RedirectResponse:
@@ -1114,7 +1152,9 @@ async def _complete_mobius_enrollment(
 @router.get("/mobius/login/start")
 @_limiter.limit("5/minute")
 async def mobius_web_login_start(
-  request: Request, db: Session = Depends(get_db),
+  request: Request,
+  select_account: bool = False,
+  db: Session = Depends(get_db),
 ):
   """Begin the owner's mobius.you login as a plain top-level navigation.
 
@@ -1134,7 +1174,9 @@ async def mobius_web_login_start(
   # redirect_uri (_valid_identity_redirect hardcodes it), so the login
   # rides the shared /provider/mobius/callback and is told apart there by
   # the browser-binding cookie.
-  url, state = await _begin_mobius_pkce(identity, owner.username)
+  url, state = await _begin_mobius_pkce(
+    identity, owner.username, select_account=select_account,
+  )
   response = RedirectResponse(url=url, status_code=303)
   # One-use browser binding: the callback requires this cookie to equal the
   # echoed state, so a callback link opened in a different browser cannot
@@ -1178,7 +1220,17 @@ async def _complete_mobius_web_login(
   # Common receipt validation binds the issuer, audience, instance, and expiry;
   # this load-bearing check additionally binds login to the stored owner.
   if not same_subject:
-    return _mobius_login_error_redirect()
+    # Subjects are credentials-adjacent opaque identifiers, so log only stable
+    # fingerprints. This makes an account migration distinguishable from a
+    # connectivity failure without disclosing either identifier.
+    log.warning(
+      "mobius login subject mismatch stored=%s authenticated=%s",
+      _mobius_subject_fingerprint(owner.sso_subject),
+      _mobius_subject_fingerprint(claims["sub"]),
+    )
+    if not pending.get("select_account"):
+      return _mobius_account_selection_redirect()
+    return _mobius_account_mismatch_redirect()
 
   # Re-load and re-check the current row before minting any credential: a
   # host-side flip back to local (or a subject change) between the first check

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -31,6 +31,7 @@ os.environ["DATA_DIR"] = _tmp
 os.environ["DOMAIN"] = "localhost"
 os.environ["FRONTEND_ORIGIN"] = "http://localhost:5173"
 os.environ["MOBIUS_TEST_RUNTIME"] = "1"
+os.environ["MOBIUS_TEST_DATABASE_ISOLATED"] = "1"
 # Fail closed when pytest is launched from inside a running production
 # container. DATA_DIR isolates Python file writes, but subprocess-facing
 # defaults historically still pointed at the live service and /data/apps.

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -51,6 +51,75 @@ def _mobius_login_handoff(db, *, epoch=0):
   return owner, token
 
 
+def test_mobius_subject_fingerprint_is_stable_and_non_disclosing():
+  from app.routes.auth import _mobius_subject_fingerprint
+
+  subject = "user_private-account-id"
+  fingerprint = _mobius_subject_fingerprint(subject)
+
+  assert fingerprint == hashlib.sha256(subject.encode()).hexdigest()[:16]
+  assert subject not in fingerprint
+  assert len(fingerprint) == 16
+
+
+def test_mobius_pkce_account_selection_is_explicit_and_loop_bounded(monkeypatch):
+  import asyncio
+  from app.routes import auth as auth_routes
+
+  saved = {}
+
+  async def broker_request(method, route, payload=None):
+    assert (method, route) == ("POST", "/identity/oauth/start")
+    saved.update(payload)
+    return {"saved": True}
+
+  monkeypatch.setattr(auth_routes, "_mobius_broker_request", broker_request)
+  url, _ = asyncio.run(auth_routes._begin_mobius_pkce(
+    {
+      "instance_id": "mob_self_testinstance",
+      "public_key_jwk": {"kty": "OKP"},
+      "key_thumbprint": "a" * 64,
+    },
+    "owner",
+    select_account=True,
+  ))
+
+  params = urllib.parse.parse_qs(urllib.parse.urlparse(url).query)
+  assert params["prompt"] == ["select_account"]
+  assert saved["select_account"] is True
+  assert auth_routes._mobius_account_selection_redirect().headers["location"] == (
+    "/api/auth/mobius/login/start?select_account=true"
+  )
+  assert auth_routes._mobius_account_mismatch_redirect().headers["location"] == (
+    "/shell/?mobius_login_account_mismatch=1"
+  )
+
+
+def test_mobius_web_login_mismatch_retries_once_then_stops(monkeypatch, db):
+  import asyncio
+  from app.routes import auth as auth_routes
+
+  _mobius_login_handoff(db)
+
+  async def exchange(_pending, _code):
+    return "receipt", {"sub": "a-different-mobius-account"}
+
+  monkeypatch.setattr(auth_routes, "_exchange_mobius_receipt", exchange)
+  pending = {"select_account": False}
+  first = asyncio.run(
+    auth_routes._complete_mobius_web_login(db, pending, "authorization-code")
+  )
+  pending["select_account"] = True
+  second = asyncio.run(
+    auth_routes._complete_mobius_web_login(db, pending, "authorization-code")
+  )
+
+  assert first.headers["location"] == (
+    "/api/auth/mobius/login/start?select_account=true"
+  )
+  assert second.headers["location"] == "/shell/?mobius_login_account_mismatch=1"
+
+
 
 def test_setup_creates_owner(client):
   r = client.post("/api/auth/setup", json={

--- a/backend/tests/test_database_test_isolation.py
+++ b/backend/tests/test_database_test_isolation.py
@@ -1,0 +1,20 @@
+"""A test process cannot inherit an unmarked application database."""
+
+import pytest
+
+from app import database
+
+
+def test_test_database_requires_disposable_runtime_marker(monkeypatch):
+  monkeypatch.setenv("MOBIUS_TEST_RUNTIME", "1")
+  monkeypatch.delenv("MOBIUS_TEST_DATABASE_ISOLATED", raising=False)
+
+  with pytest.raises(RuntimeError, match="unisolated test process"):
+    database._assert_test_database_isolated()
+
+
+def test_disposable_runtime_marker_allows_test_database(monkeypatch):
+  monkeypatch.setenv("MOBIUS_TEST_RUNTIME", "1")
+  monkeypatch.setenv("MOBIUS_TEST_DATABASE_ISOLATED", "1")
+
+  database._assert_test_database_isolated()

--- a/backend/tests/test_readiness.py
+++ b/backend/tests/test_readiness.py
@@ -45,6 +45,44 @@ def test_ready_returns_200_when_writer_running(client):
   assert body["boot_id"]
 
 
+def test_runtime_schema_loss_fails_readiness_and_stays_degraded(
+  client, monkeypatch,
+):
+  """A table drop after boot must invalidate the container healthcheck."""
+  class MissingTableInspector:
+    @staticmethod
+    def get_table_names():
+      return [
+        name for name in main_module.Base.metadata.tables
+        if name != "owner"
+      ]
+
+  main_module._set_database_runtime_failure(None)
+  monkeypatch.setattr(
+    main_module, "inspect_database", lambda _engine: MissingTableInspector(),
+  )
+  try:
+    ready = client.get("/api/ready")
+    assert ready.status_code == 503
+    assert ready.json() == {
+      "ready": False,
+      "reason": "database_runtime_schema_missing",
+    }
+    # Sticky until restart: a later catalog result cannot make skipped or
+    # damaged database owners serviceable inside this process.
+    monkeypatch.setattr(
+      main_module,
+      "inspect_database",
+      lambda _engine: pytest.fail("sticky failure unexpectedly re-probed"),
+    )
+    assert client.get("/api/ready").status_code == 503
+    health = client.get("/api/health")
+    assert health.status_code == 200
+    assert health.json()["status"] == "database_runtime_schema_missing"
+  finally:
+    main_module._set_database_runtime_failure(None)
+
+
 def test_schema_gap_fails_serviceability_but_not_reachability(client):
   """A mapped-column gap must keep every deployment probe fail-closed."""
   gap = "apps.paused_capabilities"

--- a/backend/tests/test_test_entrypoint.py
+++ b/backend/tests/test_test_entrypoint.py
@@ -51,6 +51,15 @@ def test_host_runner_checks_backend_node_surface_not_full_frontend_tree():
   assert "npm ls --depth=0" not in source
 
 
+def test_host_runner_isolates_database_before_pytest_collects_modules():
+  source = HOST_RUNNER.read_text()
+  pytest_call = source.index('"$PYTHON" -m pytest')
+  assert source.index('TEST_RUNTIME_ROOT="$(mktemp -d') < pytest_call
+  assert 'DATABASE_URL="sqlite:///$TEST_RUNTIME_ROOT/test.db"' in source
+  assert 'DATA_DIR="$TEST_RUNTIME_ROOT/data"' in source
+  assert "MOBIUS_TEST_DATABASE_ISOLATED=1" in source
+
+
 def test_image_runtime_reports_when_its_python_lock_differs():
   source = HOST_RUNNER.read_text()
   assert 'cmp -s "$ROOT/backend/requirements.lock" /app/requirements.lock' in source

--- a/backend/tests/test_verify_test_runtime.py
+++ b/backend/tests/test_verify_test_runtime.py
@@ -100,12 +100,21 @@ def test_healthcheck_marks_only_the_mounted_checkout_safe(monkeypatch):
 def test_test_compose_pins_runtime_to_mounted_checkout():
   compose = (ROOT / "docker-compose.test.yml").read_text(encoding="utf-8")
   assert "MOBIUS_TEST_RUNTIME=1" in compose
+  assert "MOBIUS_TEST_DATABASE_ISOLATED=1" in compose
   assert "MOBIUS_TEST_PLATFORM_SOURCE=/workspace" in compose
   assert "BUILD_SHA=${GITHUB_SHA:-unknown}" in compose
   assert "./:/workspace:ro" in compose
   assert 'python3", "/app/scripts/verify_test_runtime.py"' in compose
   pytest_service = compose.split("\n  pytest:\n", 1)[1].split("\nvolumes:\n", 1)[0]
   assert "\n    init: true\n" in pytest_service
+
+
+def test_manual_e2e_verifier_requires_explicit_database_isolation():
+  verifier = (
+    ROOT / "scripts" / "verify-manual-e2e-runtime.py"
+  ).read_text(encoding="utf-8")
+  assert "MOBIUS_TEST_DATABASE_ISOLATED=1" in verifier
+  assert 'env.get("MOBIUS_TEST_DATABASE_ISOLATED")' in verifier
 
 
 def test_test_wrapper_isolates_compose_and_rejects_stale_images():

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -55,6 +55,7 @@ services:
       # GITHUB_SHA to Compose automatically; local runs still seed their current
       # checkout and validate it against its own HEAD.
       - MOBIUS_TEST_RUNTIME=1
+      - MOBIUS_TEST_DATABASE_ISOLATED=1
       - MOBIUS_TEST_PLATFORM_SOURCE=/workspace
       - BUILD_SHA=${GITHUB_SHA:-unknown}
       - MOBIUS_SERVICE_GATEWAY_ORIGIN=http://services.localhost:${TEST_PORT:-8001}
@@ -108,6 +109,7 @@ services:
       - DATA_DIR=/tmp/testdata
       - FRONTEND_ORIGIN=http://localhost:5173
       - MOBIUS_TEST_RUNTIME=1
+      - MOBIUS_TEST_DATABASE_ISOLATED=1
       - MOBIUS_BUILD_INFO_PATH=/workspace/.test-build-info-does-not-exist.json
       # Execute the current checkout's checker source with the dependency tree
       # baked into the verified test image; the /workspace bind intentionally

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -94,6 +94,7 @@ function retryMobiusLogin() {
   const current = new URL(window.location.href)
   current.searchParams.delete('mobius_login')
   current.searchParams.delete('mobius_login_error')
+  current.searchParams.delete('mobius_login_account_mismatch')
   window.location.replace(current.pathname + current.search + current.hash)
 }
 
@@ -170,6 +171,7 @@ function AppRoot() {
     const params = new URLSearchParams(window.location.search)
     if (params.get('mobius_login') === '1') mobiusLoginSignal = 'handoff'
     if (params.get('mobius_login_error') === '1') mobiusLoginSignal = 'error'
+    if (params.get('mobius_login_account_mismatch') === '1') mobiusLoginSignal = 'account-mismatch'
     installPass = readInstallPass(window.location.search, STANDALONE_APP)
   } catch { /* ignore */ }
   const initialStatus = resumeStep
@@ -180,9 +182,11 @@ function AppRoot() {
             ? 'install-pass'
             : (mobiusLoginSignal === 'handoff'
                 ? 'mobius-login'
-                : (mobiusLoginSignal === 'error'
+                : (mobiusLoginSignal === 'account-mismatch'
+                    ? 'mobius-login-account-mismatch'
+                    : (mobiusLoginSignal === 'error'
                     ? 'mobius-login-error'
-                    : 'loading'))))
+                    : 'loading')))))
   const [status, setStatus] = useState(initialStatus)
   const [shellVisualReady, setShellVisualReady] = useState(false)
   const markShellVisualReady = useCallback(() => {
@@ -337,6 +341,13 @@ function AppRoot() {
     <StartupError
       title="Couldn’t sign in"
       message="Your Möbius account could not be confirmed. Try again from this browser."
+      onRetry={retryMobiusLogin}
+    />
+  )
+  if (status === 'mobius-login-account-mismatch') return (
+    <StartupError
+      title="Choose the account for this Möbius"
+      message="This instance belongs to a different Möbius account. Try again and choose the account that owns it."
       onRetry={retryMobiusLogin}
     />
   )

--- a/scripts/verify-manual-e2e-runtime.py
+++ b/scripts/verify-manual-e2e-runtime.py
@@ -6,7 +6,8 @@ Run this *after uvicorn is healthy but before auth.setup or any fixture write*:
   GATE="$(mktemp -d /tmp/mobius-manual-e2e.XXXXXX)"
   export DATA_DIR="$GATE"
   export DATABASE_URL="sqlite:///$GATE/db/ultimate.db"
-  export MOBIUS_TEST_RUNTIME=1 MOEBIUS_SKIP_BOOTSTRAP=1
+  export MOBIUS_TEST_RUNTIME=1 MOBIUS_TEST_DATABASE_ISOLATED=1
+  export MOEBIUS_SKIP_BOOTSTRAP=1
   # start uvicorn and capture its PID, then:
   python3 scripts/verify-manual-e2e-runtime.py --gate "$GATE" --pid "$UVICORN_PID"
 
@@ -83,6 +84,12 @@ def main() -> None:
   test_runtime = env.get("MOBIUS_TEST_RUNTIME")
   if test_runtime != "1":
     _fail(f"uvicorn MOBIUS_TEST_RUNTIME is {test_runtime!r}, not '1'")
+  database_isolated = env.get("MOBIUS_TEST_DATABASE_ISOLATED")
+  if database_isolated != "1":
+    _fail(
+      "uvicorn must set MOBIUS_TEST_DATABASE_ISOLATED=1 after assigning its "
+      f"disposable database (got {database_isolated!r})"
+    )
   skip_bootstrap = env.get("MOEBIUS_SKIP_BOOTSTRAP")
   if skip_bootstrap != "1":
     _fail(

--- a/scripts/wt-pytest.sh
+++ b/scripts/wt-pytest.sh
@@ -21,6 +21,20 @@
 # only fills it in when unset.
 set -uo pipefail
 
+# Isolate the database before Python imports anything. A test module outside
+# backend/tests is collected before that directory's conftest.py, so relying on
+# conftest to replace an inherited production DATABASE_URL is too late: a
+# module-level `from app.database import ...` has already bound the engine.
+TEST_RUNTIME_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/mobius-wt-pytest.XXXXXX")" \
+  || { echo "wt-pytest: could not create isolated runtime" >&2; exit 1; }
+cleanup_test_runtime() {
+  case "$TEST_RUNTIME_ROOT" in
+    "${TMPDIR:-/tmp}"/mobius-wt-pytest.*) rm -rf -- "$TEST_RUNTIME_ROOT" ;;
+    *) echo "wt-pytest: refusing unsafe cleanup target: $TEST_RUNTIME_ROOT" >&2 ;;
+  esac
+}
+trap cleanup_test_runtime EXIT HUP INT TERM
+
 ROOT="$(git rev-parse --show-toplevel)" || {
   echo "wt-pytest: not inside a git checkout" >&2; exit 1; }
 # Main checkout = parent of the SHARED git dir; equals $ROOT in the main
@@ -133,8 +147,12 @@ TEST_ENV=(env \
   GIT_CEILING_DIRECTORIES="$ROOT" \
   DOMAIN=localhost \
   FRONTEND_ORIGIN=http://localhost:5173 \
+  DATABASE_URL="sqlite:///$TEST_RUNTIME_ROOT/test.db" \
+  DATA_DIR="$TEST_RUNTIME_ROOT/data" \
+  MOBIUS_APP_BASE="$TEST_RUNTIME_ROOT/data/apps" \
   RAILWAY_PUBLIC_DOMAIN= \
   MOBIUS_TEST_RUNTIME=1 \
+  MOBIUS_TEST_DATABASE_ISOLATED=1 \
   MOEBIUS_SKIP_BOOTSTRAP=1 \
   API_BASE_URL=http://127.0.0.1:9 \
   PATH="$NODE_BIN_DIR:${PATH:-}" \
@@ -143,8 +161,9 @@ TEST_ENV=(env \
   SECRET_KEY="${SECRET_KEY:-$(python3 -c 'import secrets;print(secrets.token_hex(32))')}")
 
 if [ "${#PYTEST_ARGS[@]}" -eq 0 ]; then
-  exec "${TEST_ENV[@]}" "$PYTHON" -m pytest -p no:cacheprovider
+  "${TEST_ENV[@]}" "$PYTHON" -m pytest -p no:cacheprovider
+  exit $?
 fi
 
-exec "${TEST_ENV[@]}" "$PYTHON" -m pytest -p no:cacheprovider \
+"${TEST_ENV[@]}" "$PYTHON" -m pytest -p no:cacheprovider \
   "${PYTEST_ARGS[@]}"


### PR DESCRIPTION
## Summary
- isolate pytest database/data paths before Python imports and refuse unmarked test processes
- make readiness probe the live schema and fail closed after runtime database faults
- log only non-disclosing identity fingerprints for account mismatches
- retry a mismatched Möbius login once with explicit account selection, then stop with dedicated UI copy

## Verification
- focused database-safety suite: 53 passed
- authentication suite: 38 passed
- frontend unit suite: passed
- production frontend build: passed
- destructive sentinel reproduction confirmed the production-path database remained untouched
- live readiness and SQLite quick_check verified