### PR TITLE
Allow account selection in broker OAuth state

### DIFF
--- a/backend/runtime/identity_broker.py
+++ b/backend/runtime/identity_broker.py
@@ -542,8 +542,14 @@ class Broker:
       "state", "owner", "verifier", "instance_id", "public_key_jwk",
       "redirect_uri", "expires_at",
     }
+    allowed = required | {"select_account"}
     if (
-      set(value) != required
+      not required.issubset(value)
+      or not set(value).issubset(allowed)
+      or (
+        "select_account" in value
+        and not isinstance(value["select_account"], bool)
+      )
       or not OAUTH_STATE_RE.fullmatch(str(value.get("state") or ""))
       or value.get("instance_id") != self.instance_id
       or not isinstance(value.get("expires_at"), (int, float))

--- a/backend/tests/test_identity_broker.py
+++ b/backend/tests/test_identity_broker.py
@@ -380,6 +380,40 @@ def test_browser_oauth_state_is_root_persisted_multi_worker_safe_and_single_use(
     other_worker.close()
 
 
+def test_browser_oauth_state_preserves_explicit_account_selection(broker):
+  state = "state_" + ("s" * 40)
+  value = {
+    "state": state,
+    "owner": "owner",
+    "verifier": "verifier_" + ("v" * 40),
+    "instance_id": broker.instance_id,
+    "public_key_jwk": broker.public_jwk(),
+    "redirect_uri": "https://example.test/api/auth/provider/mobius/callback",
+    "expires_at": time.time() + 300,
+    "select_account": True,
+  }
+
+  broker.save_oauth_state(value)
+
+  assert broker.consume_oauth_state(state) == value
+
+
+def test_browser_oauth_state_rejects_invalid_account_selection(broker):
+  value = {
+    "state": "state_" + ("s" * 40),
+    "owner": "owner",
+    "verifier": "verifier_" + ("v" * 40),
+    "instance_id": broker.instance_id,
+    "public_key_jwk": broker.public_jwk(),
+    "redirect_uri": "https://example.test/api/auth/provider/mobius/callback",
+    "expires_at": time.time() + 300,
+    "select_account": "yes",
+  }
+
+  with pytest.raises(ValueError, match="invalid OAuth state"):
+    broker.save_oauth_state(value)
+
+
 def test_mobius_uid_cannot_read_broker_files_or_root_process_environment(broker):
   if os.geteuid() != 0:
     pytest.skip("requires root to exercise the production UID boundary")


### PR DESCRIPTION
## Summary
- allow the optional boolean `select_account` marker through the root-owned OAuth state broker
- preserve strict rejection of unknown keys and non-boolean marker values
- cover persistence and invalid input behavior

## Verification
- `scripts/wt-pytest.sh backend/tests/test_identity_broker.py backend/tests/test_auth.py -q` (64 passed, 1 skipped)